### PR TITLE
move json helpers out of internal

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -789,6 +789,17 @@ public final class com/apollographql/apollo3/api/json/-JsonReaders {
 	public static final fun jsonReader (Lokio/BufferedSource;)Lcom/apollographql/apollo3/api/json/JsonReader;
 }
 
+public final class com/apollographql/apollo3/api/json/-JsonWriters {
+	public static final fun buildJsonByteString (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lokio/ByteString;
+	public static synthetic fun buildJsonByteString$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lokio/ByteString;
+	public static final fun buildJsonMap (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun buildJsonString (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
+	public static synthetic fun buildJsonString$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun writeAny (Lcom/apollographql/apollo3/api/json/JsonWriter;Ljava/lang/Object;)V
+	public static final fun writeArray (Lcom/apollographql/apollo3/api/json/JsonWriter;Lkotlin/jvm/functions/Function1;)V
+	public static final fun writeObject (Lcom/apollographql/apollo3/api/json/JsonWriter;Lkotlin/jvm/functions/Function1;)V
+}
+
 public final class com/apollographql/apollo3/api/json/BufferedSinkJsonWriter : com/apollographql/apollo3/api/json/JsonWriter {
 	public static final field Companion Lcom/apollographql/apollo3/api/json/BufferedSinkJsonWriter$Companion;
 	public fun <init> (Lokio/BufferedSink;)V
@@ -977,14 +988,6 @@ public final class com/apollographql/apollo3/api/json/MapJsonWriter$State$Map : 
 	public final fun getMap ()Ljava/util/Map;
 	public final fun getName ()Ljava/lang/String;
 	public final fun setName (Ljava/lang/String;)V
-}
-
-public final class com/apollographql/apollo3/api/json/internal/-JsonWriters {
-	public static final fun buildJsonByteString (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lokio/ByteString;
-	public static synthetic fun buildJsonByteString$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lokio/ByteString;
-	public static final fun buildJsonMap (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
-	public static final fun buildJsonString (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/String;
-	public static synthetic fun buildJsonString$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/test/TestResolverKt {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
@@ -7,8 +7,8 @@ import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.json.MapJsonReader.Companion.buffer
 import com.apollographql.apollo3.api.json.MapJsonWriter
-import com.apollographql.apollo3.api.json.internal.buildJsonString
-import com.apollographql.apollo3.api.json.internal.writeAny
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeAny
 import com.apollographql.apollo3.api.json.readAny
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -4,7 +4,7 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
-import com.apollographql.apollo3.api.json.internal.writeAny
+import com.apollographql.apollo3.api.json.writeAny
 import okio.Buffer
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmName

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.internal.ResponseParser
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.api.json.internal.writeObject
+import com.apollographql.apollo3.api.json.writeObject
 import okio.use
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -8,11 +8,11 @@ import com.apollographql.apollo3.api.Upload
 import com.apollographql.apollo3.api.http.internal.urlEncode
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.json.internal.FileUploadAwareJsonWriter
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.buildJsonMap
-import com.apollographql.apollo3.api.json.internal.buildJsonString
-import com.apollographql.apollo3.api.json.internal.writeAny
-import com.apollographql.apollo3.api.json.internal.writeObject
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.buildJsonMap
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeAny
+import com.apollographql.apollo3.api.json.writeObject
 import com.benasher44.uuid.uuid4
 import okio.BufferedSink
 import okio.ByteString

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonWriters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonWriters.kt
@@ -1,21 +1,15 @@
 @file:JvmName("-JsonWriters")
 
-package com.apollographql.apollo3.api.json.internal
+package com.apollographql.apollo3.api.json
 
 import com.apollographql.apollo3.annotations.ApolloInternal
-import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
-import com.apollographql.apollo3.api.json.JsonNumber
-import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.api.json.MapJsonWriter
 import okio.Buffer
 import okio.ByteString
-import okio.ByteString.Companion.encodeUtf8
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 import kotlin.jvm.JvmName
 
-@ApolloInternal
 fun JsonWriter.writeAny(value: Any?) {
   when (value) {
     null -> nullValue()
@@ -48,7 +42,6 @@ fun JsonWriter.writeAny(value: Any?) {
 }
 
 @OptIn(ExperimentalContracts::class)
-@ApolloInternal
 inline fun JsonWriter.writeObject(crossinline block: JsonWriter.() -> Unit) {
   contract {
     callsInPlace(block, InvocationKind.EXACTLY_ONCE)
@@ -60,7 +53,6 @@ inline fun JsonWriter.writeObject(crossinline block: JsonWriter.() -> Unit) {
 }
 
 @OptIn(ExperimentalContracts::class)
-@ApolloInternal
 inline fun JsonWriter.writeArray(crossinline block: JsonWriter.() -> Unit) {
   contract {
     callsInPlace(block, InvocationKind.EXACTLY_ONCE)

--- a/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
+++ b/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.LongAdapter
 import com.apollographql.apollo3.api.json.MapJsonWriter
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -14,8 +14,8 @@ import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.writeArray
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.writeArray
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.internal.BackgroundDispatcher
@@ -197,9 +197,9 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
           throw ApolloException("batched query response contains a null item")
         }
         @OptIn(ApolloInternal::class)
-        buildJsonByteString {
-          AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
-        }
+        (buildJsonByteString {
+      AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
+    })
       }
     } catch (e: ApolloException) {
       exception = e

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/AppSyncWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/AppSyncWsProtocol.kt
@@ -7,8 +7,8 @@ import com.apollographql.apollo3.api.NullableAnyAdapter
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer.Companion.appendQueryParameters
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.writeAny
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.writeAny
 import com.apollographql.apollo3.api.toJsonString
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import kotlinx.coroutines.CoroutineScope

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WsProtocol.kt
@@ -6,12 +6,11 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.buildJsonString
-import com.apollographql.apollo3.api.json.internal.writeAny
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeAny
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import okio.Buffer
 
 /**

--- a/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
+++ b/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
@@ -8,8 +8,8 @@ import com.apollographql.apollo3.api.http.ByteStringHttpBody
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.writeObject
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery

--- a/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.http.valueOf
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer

--- a/tests/integration-tests/src/jvmTest/kotlin/test/CookiesTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/CookiesTest.kt
@@ -2,7 +2,7 @@ package test
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer

--- a/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -2,9 +2,8 @@ package test
 
 import codegen.models.AllPlanetsQuery
 import com.apollographql.apollo3.annotations.ApolloInternal
-import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.parseJsonResponse

--- a/tests/models-operation-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -3,7 +3,7 @@ package test
 import codegen.models.AllPlanetsQuery
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.parseJsonResponse

--- a/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -5,7 +5,7 @@ import codegen.models.AllPlanetsQuery.Data.AllPlanets.Planet.Companion.planetFra
 import codegen.models.AllPlanetsQuery.Data.AllPlanets.Planet.FilmConnection.Film.Companion.filmFragment
 import codegen.models.fragment.PlanetFragment
 import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.mpp.platform

--- a/tests/no-query-document/src/test/kotlin/test/NoQueryDocumentTest.kt
+++ b/tests/no-query-document/src/test/kotlin/test/NoQueryDocumentTest.kt
@@ -3,14 +3,13 @@ package test
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
-import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.ByteStringHttpBody
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
-import com.apollographql.apollo3.api.json.internal.buildJsonByteString
-import com.apollographql.apollo3.api.json.internal.writeObject
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.mockserver.MockResponse


### PR DESCRIPTION
We're referencing them in the doc and hopefully they are well-defined enough so we can live with them in the long run