### PR TITLE
Mention the apollo-idling-resource artifact in the migration docs

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -623,6 +623,15 @@ val apolloClient = ApolloClient.Builder()
     .build()
 ```
 
+The idlingResource function is hosted under the [new artifact](https://github.com/apollographql/apollo-kotlin/blob/d881829a652d5745a593197fc5384db5f08f2760/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt#L60-L63) `apollo-idling-resource`.
+Add the new dependency like so:
+
+```kotlin
+dependencies {
+  testImplementation("com.apollographql.apollo3:apollo-idling-resource:$version")
+}
+```
+
 ### BigDecimal
 
 By default, Apollo Android 2.x internally maps all numbers to a custom `BigDecimal` value.

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -623,7 +623,7 @@ val apolloClient = ApolloClient.Builder()
     .build()
 ```
 
-The idlingResource function is hosted under the [new artifact](https://github.com/apollographql/apollo-kotlin/blob/d881829a652d5745a593197fc5384db5f08f2760/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt#L60-L63) `apollo-idling-resource`.
+The [idlingResource function](https://github.com/apollographql/apollo-kotlin/blob/v3.0.0-rc03/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt#L60-L63) is hosted under the new artifact `apollo-idling-resource`.
 Add the new dependency like so:
 
 ```kotlin


### PR DESCRIPTION
The new dependency required for idlingResource isn't mentioned in the migration docs.
As always, feel free to edit/improve the wording or remove the link that I added to the function if you don't want to maintain the link (currently points at the rc03 version).