### PR TITLE
Add a Data.toJson that uses reflection to lookup the adapter

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -697,6 +697,11 @@ public abstract interface class com/apollographql/apollo3/api/Upload {
 	public abstract fun writeTo (Lokio/BufferedSink;)V
 }
 
+public final class com/apollographql/apollo3/api/_DataKt {
+	public static final fun toJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
+	public static synthetic fun toJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)V
+}
+
 public final class com/apollographql/apollo3/api/http/ByteStringHttpBody : com/apollographql/apollo3/api/http/HttpBody {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lokio/ByteString;)V

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
@@ -1,0 +1,27 @@
+package com.apollographql.apollo3.api
+
+import com.apollographql.apollo3.api.json.JsonWriter
+
+private fun Operation.Data.adapter(): Adapter<Operation.Data> {
+  val name = this::class.java.name
+
+  val operationQualifiedName = name.removeSuffix("${'$'}Data")
+  val operationName = operationQualifiedName.substringAfterLast(".")
+  val packageName = operationQualifiedName.substringBeforeLast(".")
+
+  val adapterName = "$packageName.adapter.${operationName}_ResponseAdapter${'$'}Data"
+
+  val clazz = Class.forName(adapterName)
+
+  val field = clazz.getDeclaredField("INSTANCE")
+
+  @Suppress("UNCHECKED_CAST")
+  val adapter = field.get(null) as Adapter<Operation.Data>
+
+  return adapter.obj()
+}
+
+fun Operation.Data.toJson(jsonWriter: JsonWriter, customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty) {
+  adapter().toJson(jsonWriter, customScalarAdapters, this)
+}
+

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Test.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Test.kt
@@ -1,7 +1,0 @@
-package com.apollographql.apollo3.api
-
-object Test {
-  object Nested {
-
-  }
-}

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Test.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/Test.kt
@@ -1,0 +1,7 @@
+package com.apollographql.apollo3.api
+
+object Test {
+  object Nested {
+
+  }
+}

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
   add("gr8Classpath", "org.conscrypt:conscrypt-openjdk-uber:2.5.2")
 
   add("shade", "org.jetbrains.kotlin:kotlin-stdlib")
-  add("shade", projects.apolloApi)
   add("shade", projects.apolloCompiler)
   add("shade", projects.apolloAst)
 

--- a/tests/integration-tests/src/jvmTest/kotlin/test/ToJsonTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/ToJsonTest.kt
@@ -1,0 +1,26 @@
+package test
+
+import com.apollographql.apollo3.api.json.internal.buildJsonString
+import com.apollographql.apollo3.api.toJson
+import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ToJsonTest {
+  /**
+   * Tests that we can serialize a `Operation.Data` instance without an `Operation` instance
+   */
+  @Test
+  fun toJsonTest() {
+    val data = HeroNameQuery.Data(
+        HeroNameQuery.Hero(
+            "Luke"
+        )
+    )
+
+    val output = buildJsonString {
+      data.toJson(this)
+    }
+    assertEquals("{\"hero\":{\"name\":\"Luke\"}}", output)
+  }
+}


### PR DESCRIPTION
A helper function to get a Json from a `Data` instance. This is a band-aid until we get better and multiplatform mockserver APIs