### PR TITLE
Add an easy way to log cache misses 

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -1050,10 +1050,15 @@ public final class com/apollographql/apollo3/exception/AutoPersistedQueriesNotSu
 }
 
 public final class com/apollographql/apollo3/exception/CacheMissException : com/apollographql/apollo3/exception/ApolloException {
+	public static final field Companion Lcom/apollographql/apollo3/exception/CacheMissException$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getFieldName ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
+}
+
+public final class com/apollographql/apollo3/exception/CacheMissException$Companion {
+	public final fun message (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/exception/HttpCacheMissException : com/apollographql/apollo3/exception/ApolloException {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -79,8 +79,8 @@ class ApolloParseException(message: String? = null, cause: Throwable? = null) : 
  * If [fieldName] is null, it means a reference to an object could not be resolved
  */
 class CacheMissException(val key: String, val fieldName: String? = null) : ApolloException(message = message(key, fieldName)) {
-  private companion object {
-    private fun message(key: String?, fieldName: String?): String {
+  companion object {
+    fun message(key: String?, fieldName: String?): String {
       return if (fieldName == null) {
         "Object '$key' not found"
       } else {

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -50,6 +50,11 @@ public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/ap
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
 }
 
+public final class com/apollographql/apollo3/cache/normalized/CacheMissLoggingInterceptor : com/apollographql/apollo3/interceptor/ApolloInterceptor {
+	public fun <init> (Lkotlin/jvm/functions/Function1;)V
+	public fun intercept (Lcom/apollographql/apollo3/api/ApolloRequest;Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java/lang/Enum {
 	public static final field CacheFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field CacheOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
@@ -60,6 +65,8 @@ public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java
 }
 
 public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
+	public static final fun -logCacheMisses (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public static synthetic fun -logCacheMisses$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun apolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
 	public static final fun cacheHeaders (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Ljava/lang/Object;
 	public static final fun clearNormalizedCache (Lcom/apollographql/apollo3/ApolloClient;)Z

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheMissLoggingInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheMissLoggingInterceptor.kt
@@ -1,0 +1,31 @@
+package com.apollographql.apollo3.cache.normalized
+
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
+import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.exception.CacheMissException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onEach
+
+class CacheMissLoggingInterceptor(private val log: (String) -> Unit) : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return chain.proceed(request).onEach {
+      if (it.cacheInfo?.missedKey != null) {
+        log(
+            CacheMissException.message(
+                it.cacheInfo?.missedKey,
+                it.cacheInfo?.missedField
+            )
+        )
+      }
+    }.catch { throwable ->
+      if (throwable is CacheMissException) {
+        log(throwable.message.toString())
+      }
+      throw throwable
+    }
+  }
+}

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -73,6 +73,16 @@ fun ApolloClient.Builder.normalizedCache(
   return store(ApolloStore(normalizedCacheFactory, cacheKeyGenerator, cacheResolver), writeToCacheAsynchronously)
 }
 
+@JvmName("-logCacheMisses")
+fun ApolloClient.Builder.logCacheMisses(
+    log: (String) -> Unit = { println(it) }
+): ApolloClient.Builder {
+  check(interceptors.none { it is ApolloCacheInterceptor }) {
+    "Apollo: logCacheMisses() must be called before setting up your normalized cache"
+  }
+  return addInterceptor(CacheMissLoggingInterceptor(log))
+}
+
 fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: Boolean = false): ApolloClient.Builder {
   return addInterceptor(ApolloCacheInterceptor(store)).writeToCacheAsynchronously(writeToCacheAsynchronously)
 }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -225,8 +225,9 @@ internal class ApolloCacheInterceptor(
 
         val networkException: ApolloException?
         try {
-          return readOneFromNetwork(request, chain, customScalarAdapters)
-              .withCacheInfo(cacheResult.cacheInfo)
+          val response = readOneFromNetwork(request, chain, customScalarAdapters)
+
+          return response.withCacheInfo(cacheResult.cacheInfo)
         } catch (e: ApolloException) {
           networkException = e
         }

--- a/tests/integration-tests/src/jvmTest/kotlin/test/CacheMissLoggingInterceptorTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/CacheMissLoggingInterceptorTest.kt
@@ -1,0 +1,79 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.cache.normalized.CacheMissLoggingInterceptor
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.logCacheMisses
+import com.apollographql.apollo3.cache.normalized.normalizedCache
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.integration.normalizer.HeroAppearsInQuery
+import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.testing.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * We're only doing this on the JVM because it saves time and the CacheMissLoggingInterceptor
+ * touches mutable data from different threads
+ */
+class CacheMissLoggingInterceptorTest {
+
+  @Test
+  fun cacheMissLogging() = runTest {
+    val recordedLogs = mutableListOf<String>()
+    val mockServer = MockServer()
+    val apolloClient = ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .logCacheMisses {
+          synchronized(recordedLogs) {
+            recordedLogs.add(it)
+          }
+        }
+        .normalizedCache(MemoryCacheFactory())
+        .build()
+
+    mockServer.enqueue("""
+      {
+        "data": {
+          "hero": {
+            "name": "Luke"
+          }
+        }
+      }
+    """.trimIndent())
+    apolloClient.query(HeroNameQuery()).execute()
+    try {
+      apolloClient.query(HeroAppearsInQuery()).fetchPolicy(FetchPolicy.CacheOnly).execute()
+      error("An exception was expected")
+    } catch (_: ApolloException) {
+    }
+
+    assertEquals(
+        listOf(
+            "Object 'QUERY_ROOT' has no field named 'hero'",
+            "Object 'hero' has no field named 'appearsIn'"
+        ),
+        recordedLogs
+    )
+    mockServer.stop()
+    apolloClient.dispose()
+  }
+
+  @Test
+  fun logCacheMissesMustBeCalledFirst() {
+    try {
+      ApolloClient.Builder()
+          .normalizedCache(MemoryCacheFactory())
+          .logCacheMisses()
+          .build()
+      error("We expected an exception")
+    } catch (e: Exception) {
+      assertTrue(e.message?.contains("logCacheMisses() must be called before setting up your normalized cache") == true)
+    }
+  }
+}


### PR DESCRIPTION
For users coming from 2.x and relying on `ApolloLogger`, they can now use

```kotlin
ApolloClient.Builder()
   .logCacheMisses()
```