### PR TITLE
Avoid key field checks on children of fragment spreads

### DIFF
--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/check_key_fields.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/check_key_fields.kt
@@ -100,7 +100,13 @@ private fun CheckKeyFieldsScope.collectFields(
         }
 
         val fragmentDefinition = allFragmentDefinitions[it.name]!!
-        collectFields(fragmentDefinition.selectionSet.selections, fragmentDefinition.typeCondition.name, implementedTypes)
+        collectFields(
+            fragmentDefinition.selectionSet.selections.map {
+              if (it is GQLField) it.copy(selectionSet = GQLSelectionSet(emptyList())) else it
+            },
+            fragmentDefinition.typeCondition.name,
+            implementedTypes
+        )
       }
     }
   }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/FragmentKeyFieldsTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/FragmentKeyFieldsTest.kt
@@ -1,0 +1,52 @@
+package com.apollographql.apollo3.compiler.fragmentKeyfields
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.ast.GQLFragmentDefinition
+import com.apollographql.apollo3.ast.GQLOperationDefinition
+import com.apollographql.apollo3.ast.checkKeyFields
+import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.transformation.addRequiredFields
+import com.apollographql.apollo3.compiler.introspection.toSchema
+import okio.buffer
+import okio.source
+import org.junit.Assert.fail
+import org.junit.Test
+import java.io.File
+
+@OptIn(ApolloExperimental::class)
+class FragmentKeyFieldsTest {
+  @Test
+  fun test() {
+    val schema = File("src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/schema.graphqls").toSchema()
+    val definitions = File("src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/operations.graphql")
+        .source()
+        .buffer()
+        .parseAsGQLDocument()
+        .valueAssertNoErrors()
+        .definitions
+    val operation = definitions.filterIsInstance<GQLOperationDefinition>()
+        .first()
+        .let {
+          addRequiredFields(it, schema)
+        }
+
+    val fragments = definitions.filterIsInstance<GQLFragmentDefinition>().map {
+      addRequiredFields(it, schema)
+    }
+
+    try {
+      checkKeyFields(operation, schema, fragments.associateBy { it.name })
+    } catch (e: Exception) {
+      e.message
+      fail("no exception was expected")
+    }
+
+    try {
+      checkKeyFields(fragments.first { it.name == "AuthorFragment" }, schema, fragments.associateBy { it.name })
+      fail("an exception was expected")
+    } catch (e: Exception) {
+      e.message
+      assert(e.message?.contains("are not queried") == true)
+    }
+  }
+}

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/operations.graphql
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/operations.graphql
@@ -1,0 +1,21 @@
+query GetNode {
+  node {
+    ...BookFragment
+  }
+}
+
+fragment BookFragment on Book {
+  id
+  isbn
+  author {
+    ...AuthorFragment
+  }
+}
+
+fragment AuthorFragment on Author {
+  id
+  name
+  node2 {
+    id
+  }
+}

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/schema.graphqls
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/fragmentKeyfields/schema.graphqls
@@ -1,0 +1,28 @@
+type Query {
+  node: Node
+}
+
+interface Node @typePolicy(keyFields: "id") {
+  id: String!
+}
+
+type Book implements Node @typePolicy(keyFields: "isbn") {
+  id: String!
+  isbn: String!
+  author: Author!
+}
+
+type Author {
+  id: String!
+  name: String!
+  node2: Node2!
+}
+
+interface Node2 @typePolicy(keyFields: "id") {
+  id: String!
+}
+
+type Locale implements Node2 @typePolicy(keyFields: "country") {
+  id: String!
+  country: String!
+}


### PR DESCRIPTION
In the collectFields method when collecting fields from a GQLFragmentSpread, it seems like only the top-level fields are capable of satisfying the key field requirements of its parent, and so all of the fields in its selection set should have their children removed.

Also, adding tests for fragment spread key field checking.