### PR TITLE
Allow to customize the fetchPolicy with interceptors

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -77,3 +77,4 @@ fun <D : Operation.Data> Operation<D>.composeJsonResponse(
     }
   }
 }
+

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -35,13 +35,19 @@ public final class com/apollographql/apollo3/cache/normalized/ApolloStoreKt {
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Key;
 	public synthetic fun <init> (JJJJZLcom/apollographql/apollo3/exception/CacheMissException;Lcom/apollographql/apollo3/exception/ApolloException;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JJZLjava/lang/String;Ljava/lang/String;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getCacheEndMillis ()J
-	public final fun getCacheException ()Lcom/apollographql/apollo3/exception/CacheMissException;
 	public final fun getCacheHit ()Z
+	public final fun getCacheMissException ()Lcom/apollographql/apollo3/exception/CacheMissException;
 	public final fun getCacheStartMillis ()J
+	public final fun getHit ()Z
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
+	public final fun getMillisEnd ()J
+	public final fun getMillisStart ()J
+	public final fun getMissedField ()Ljava/lang/String;
+	public final fun getMissedKey ()Ljava/lang/String;
 	public final fun getNetworkEndMillis ()J
 	public final fun getNetworkException ()Lcom/apollographql/apollo3/exception/ApolloException;
 	public final fun getNetworkStartMillis ()J
@@ -54,8 +60,8 @@ public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Builder 
 	public fun <init> ()V
 	public final fun build ()Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
 	public final fun cacheEndMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
-	public final fun cacheException (Lcom/apollographql/apollo3/exception/CacheMissException;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public final fun cacheHit (Z)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun cacheMissException (Lcom/apollographql/apollo3/exception/CacheMissException;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public final fun cacheStartMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public final fun networkEndMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public final fun networkException (Lcom/apollographql/apollo3/exception/ApolloException;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -34,17 +34,32 @@ public final class com/apollographql/apollo3/cache/normalized/ApolloStoreKt {
 
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Key Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Key;
-	public fun <init> (JJZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (JJJJZLcom/apollographql/apollo3/exception/CacheMissException;Lcom/apollographql/apollo3/exception/ApolloException;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
-	public final fun getHit ()Z
+	public final fun getCacheEndMillis ()J
+	public final fun getCacheException ()Lcom/apollographql/apollo3/exception/CacheMissException;
+	public final fun getCacheHit ()Z
+	public final fun getCacheStartMillis ()J
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public final fun getMillisEnd ()J
-	public final fun getMillisStart ()J
-	public final fun getMissedField ()Ljava/lang/String;
-	public final fun getMissedKey ()Ljava/lang/String;
+	public final fun getNetworkEndMillis ()J
+	public final fun getNetworkException ()Lcom/apollographql/apollo3/exception/ApolloException;
+	public final fun getNetworkStartMillis ()J
 	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
+	public final fun newBuilder ()Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;
+}
+
+public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
+	public final fun cacheEndMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun cacheException (Lcom/apollographql/apollo3/exception/CacheMissException;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun cacheHit (Z)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun cacheStartMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun networkEndMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun networkException (Lcom/apollographql/apollo3/exception/ApolloException;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
+	public final fun networkStartMillis (J)Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 }
 
 public final class com/apollographql/apollo3/cache/normalized/CacheInfo$Key : com/apollographql/apollo3/api/ExecutionContext$Key {
@@ -64,6 +79,13 @@ public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java
 	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 }
 
+public final class com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors {
+	public static final fun getCacheFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
+	public static final fun getCacheOnlyInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
+	public static final fun getNetworkFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
+	public static final fun getNetworkOnlyInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
+}
+
 public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun -logCacheMisses (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun -logCacheMisses$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -78,12 +100,14 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun doNotStore (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 	public static final fun executeCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun fetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
+	public static final fun fetchPolicyInterceptor (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Ljava/lang/Object;
 	public static final fun getApolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
 	public static final fun getCacheInfo (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
 	public static final fun isFromCache (Lcom/apollographql/apollo3/api/ApolloResponse;)Z
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/ApolloCall;
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/api/ApolloRequest$Builder;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public static final fun refetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
+	public static final fun refetchPolicyInterceptor (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Ljava/lang/Object;
 	public static final fun store (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -39,7 +39,6 @@ public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/ap
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getCacheEndMillis ()J
-	public final fun getCacheHit ()Z
 	public final fun getCacheMissException ()Lcom/apollographql/apollo3/exception/CacheMissException;
 	public final fun getCacheStartMillis ()J
 	public final fun getHit ()Z
@@ -51,6 +50,7 @@ public final class com/apollographql/apollo3/cache/normalized/CacheInfo : com/ap
 	public final fun getNetworkEndMillis ()J
 	public final fun getNetworkException ()Lcom/apollographql/apollo3/exception/ApolloException;
 	public final fun getNetworkStartMillis ()J
+	public final fun isCacheHit ()Z
 	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
 	public final fun newBuilder ()Lcom/apollographql/apollo3/cache/normalized/CacheInfo$Builder;
 	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheMissLoggingInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/CacheMissLoggingInterceptor.kt
@@ -13,11 +13,11 @@ import kotlinx.coroutines.flow.onEach
 class CacheMissLoggingInterceptor(private val log: (String) -> Unit) : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     return chain.proceed(request).onEach {
-      if (it.cacheInfo?.missedKey != null) {
+      if (it.cacheInfo?.cacheMissException != null) {
         log(
             CacheMissException.message(
-                it.cacheInfo?.missedKey,
-                it.cacheInfo?.missedField
+                it.cacheInfo?.cacheMissException?.key ,
+                it.cacheInfo?.cacheMissException?.fieldName
             )
         )
       }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -229,8 +229,6 @@ internal val <D : Mutation.Data> ApolloRequest<D>.optimisticData
 internal val <D : Operation.Data> ApolloRequest<D>.cacheHeaders
   get() = executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE
 
-internal val <D : Operation.Data> ApolloRequest<D>.watch
-  get() = executionContext[WatchContext]?.value ?: false
 
 
 class CacheInfo(

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -18,11 +18,6 @@ import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.internal.ApolloCacheInterceptor
-import com.apollographql.apollo3.cache.normalized.internal.CacheFirstInterceptor
-import com.apollographql.apollo3.cache.normalized.internal.CacheOnlyInterceptor
-import com.apollographql.apollo3.cache.normalized.internal.FetchPolicyRouterInterceptor
-import com.apollographql.apollo3.cache.normalized.internal.NetworkFirstInterceptor
-import com.apollographql.apollo3.cache.normalized.internal.NetworkOnlyInterceptor
 import com.apollographql.apollo3.cache.normalized.internal.WatcherInterceptor
 import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.exception.ApolloException
@@ -425,18 +420,18 @@ internal class IsRefetching(val value: Boolean) : ExecutionContext.Element {
   companion object Key : ExecutionContext.Key<IsRefetching>
 }
 
-fun <D : Operation.Data> ApolloRequest.Builder<D>.fetchFromCache(fetchFromCache: Boolean) = apply {
+internal fun <D : Operation.Data> ApolloRequest.Builder<D>.fetchFromCache(fetchFromCache: Boolean) = apply {
   addExecutionContext(FetchFromCacheContext(fetchFromCache))
 }
 
-fun <D : Operation.Data> ApolloRequest.Builder<D>.isRefetching(isRefetching: Boolean) = apply {
+internal fun <D : Operation.Data> ApolloRequest.Builder<D>.isRefetching(isRefetching: Boolean) = apply {
   addExecutionContext(IsRefetching(isRefetching))
 }
 
-val <D : Operation.Data> ApolloRequest<D>.fetchFromCache
+internal val <D : Operation.Data> ApolloRequest<D>.fetchFromCache
   get() = executionContext[FetchFromCacheContext]?.value ?: false
 
 
-val <D : Operation.Data> ApolloRequest<D>.isRefetching
+internal val <D : Operation.Data> ApolloRequest<D>.isRefetching
   get() = executionContext[IsRefetching]?.value ?: false
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -261,8 +261,8 @@ internal val <D : Operation.Data> ApolloRequest<D>.watch
   get() = executionContext[WatchContext]?.value ?: false
 
 /**
- * @param cacheHit true if this was a cache hit
- * @param cacheException the exception while reading the cache. Note that it's possible to have [cacheHit] == false && [cacheException] == null
+ * @param isCacheHit true if this was a cache hit
+ * @param cacheException the exception while reading the cache. Note that it's possible to have [isCacheHit] == false && [cacheException] == null
  * if no cache read was attempted
  */
 class CacheInfo private constructor(
@@ -270,7 +270,7 @@ class CacheInfo private constructor(
     val cacheEndMillis: Long,
     val networkStartMillis: Long,
     val networkEndMillis: Long,
-    val cacheHit: Boolean,
+    val isCacheHit: Boolean,
     val cacheMissException: CacheMissException?,
     val networkException: ApolloException?,
 ) : ExecutionContext.Element {
@@ -287,7 +287,7 @@ class CacheInfo private constructor(
       cacheEndMillis = millisEnd,
       networkStartMillis = 0,
       networkEndMillis = 0,
-      cacheHit = hit,
+      isCacheHit = hit,
       cacheMissException = missedKey?.let { CacheMissException(it, missedField) },
       networkException = null
   )
@@ -305,7 +305,7 @@ class CacheInfo private constructor(
 
   @Deprecated("Use cacheHit instead", ReplaceWith("cacheHit"))
   val hit: Boolean
-    get() = cacheHit
+    get() = isCacheHit
 
   @Deprecated("Use cacheMissException?.key instead", ReplaceWith("cacheMissException?.key"))
   val missedKey: String?
@@ -323,7 +323,7 @@ class CacheInfo private constructor(
         .cacheEndMillis(cacheEndMillis)
         .networkStartMillis(networkStartMillis)
         .networkEndMillis(networkEndMillis)
-        .cacheHit(cacheHit)
+        .cacheHit(isCacheHit)
         .networkException(networkException)
   }
 
@@ -370,7 +370,7 @@ class CacheInfo private constructor(
         cacheEndMillis = cacheEndMillis,
         networkStartMillis = networkStartMillis,
         networkEndMillis = networkEndMillis,
-        cacheHit = cacheHit,
+        isCacheHit = cacheHit,
         cacheMissException = cacheMissException,
         networkException = networkException
     )
@@ -379,7 +379,7 @@ class CacheInfo private constructor(
 
 val <D : Operation.Data> ApolloResponse<D>.isFromCache: Boolean
   get() {
-    return cacheInfo?.cacheHit == true
+    return cacheInfo?.isCacheHit == true
   }
 
 val <D : Operation.Data> ApolloResponse<D>.cacheInfo

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -374,7 +374,6 @@ fun <D : Operation.Data> ApolloRequest.Builder<D>.fetchFromCache(fetchFromCache:
   addExecutionContext(FetchFromCacheContext(fetchFromCache))
 }
 
-
 val <D : Operation.Data> ApolloRequest<D>.fetchFromCache
-  get() = executionContext[FetchFromCacheContext] ?: false
+  get() = executionContext[FetchFromCacheContext]?.value ?: false
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -80,7 +80,7 @@ val CacheFirstInterceptor = object : ApolloInterceptor {
                 .cacheInfo(
                     networkResponse.cacheInfo!!
                         .newBuilder()
-                        .cacheException(cacheException as? CacheMissException)
+                        .cacheMissException(cacheException as? CacheMissException)
                         .build()
                 )
                 .build()

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -1,16 +1,11 @@
-@file:Suppress("SENSELESS_COMPARISON")
+@file:JvmName("FetchPolicyInterceptors")
 
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized
 
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
-import com.apollographql.apollo3.cache.normalized.cacheInfo
-import com.apollographql.apollo3.cache.normalized.fetchFromCache
-import com.apollographql.apollo3.cache.normalized.fetchPolicyInterceptor
-import com.apollographql.apollo3.cache.normalized.isRefetching
-import com.apollographql.apollo3.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.CacheMissException
@@ -19,14 +14,13 @@ import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.singleOrNull
+import kotlin.jvm.JvmName
 
 /**
  *
  */
-internal val CacheOnlyInterceptor = object : ApolloInterceptor {
+val CacheOnlyInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     return chain.proceed(
         request = request
@@ -37,7 +31,7 @@ internal val CacheOnlyInterceptor = object : ApolloInterceptor {
   }
 }
 
-internal val NetworkOnlyInterceptor = object : ApolloInterceptor {
+val NetworkOnlyInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     return chain.proceed(request)
   }
@@ -46,7 +40,7 @@ internal val NetworkOnlyInterceptor = object : ApolloInterceptor {
 /**
  * An interceptor that goes to cache first and then to the network if it fails
  */
-internal val CacheFirstInterceptor = object : ApolloInterceptor {
+val CacheFirstInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     return flow {
       var cacheException: ApolloException? = null
@@ -102,7 +96,7 @@ internal val CacheFirstInterceptor = object : ApolloInterceptor {
   }
 }
 
-internal val NetworkFirstInterceptor = object : ApolloInterceptor {
+val NetworkFirstInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     return flow {
       var cacheException: ApolloException? = null
@@ -158,7 +152,7 @@ internal val NetworkFirstInterceptor = object : ApolloInterceptor {
   }
 }
 
-val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
+internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {
       // Subscriptions and Mutations do not support fetchPolicies

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.singleOrNull
 import kotlin.jvm.JvmName
 
 /**
- *
+ * An interceptor that goes to the cache only
  */
 val CacheOnlyInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -264,10 +264,10 @@ internal class ApolloCacheInterceptor(
     return CacheResult(
         response = response,
         cacheInfo = CacheInfo(
-            millisStart = millisStart,
-            millisEnd = currentTimeMillis(),
-            hit = response != null,
-            missedKey = cacheMissException?.key,
+            cacheStartMillis = millisStart,
+            cacheEndMillis = currentTimeMillis(),
+            cacheException = response != null,
+            networkException = cacheMissException?.key,
             missedField = cacheMissException?.fieldName
         ),
         error = exception

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -171,12 +171,6 @@ internal class ApolloCacheInterceptor(
     }
   }
 
-  private class CacheResult<D : Query.Data>(
-      val response: ApolloResponse<D>?,
-      val cacheInfo: CacheInfo,
-      val error: Throwable?,
-  )
-
   private suspend fun <D : Query.Data> readFromCache(
       request: ApolloRequest<D>,
       customScalarAdapters: CustomScalarAdapters,
@@ -199,6 +193,7 @@ internal class ApolloCacheInterceptor(
             CacheInfo.Builder()
                 .cacheStartMillis(startMillis)
                 .cacheEndMillis(currentTimeMillis())
+                .cacheHit(true)
                 .build()
         )
         .build()

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/FetchPolicyInterceptors.kt
@@ -1,0 +1,151 @@
+package com.apollographql.apollo3.cache.normalized.internal
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.cache.normalized.cacheInfo
+import com.apollographql.apollo3.cache.normalized.fetchFromCache
+import com.apollographql.apollo3.exception.ApolloCompositeException
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.CacheMissException
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
+import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.singleOrNull
+
+/**
+ *
+ */
+internal class CacheOnlyInterceptor : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return chain.proceed(
+        request = request
+            .newBuilder()
+            .fetchFromCache(true)
+            .build()
+    )
+  }
+}
+
+internal class NetworkOnlyInterceptor : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return chain.proceed(request)
+  }
+}
+
+/**
+ * An interceptor that goes to cache first and then to the network if it fails
+ */
+internal class CacheFirstInterceptor : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return flow {
+      var cacheException: ApolloException? = null
+      var networkException: ApolloException? = null
+
+      val cacheResponse = chain.proceed(
+          request = request
+              .newBuilder()
+              .fetchFromCache(true)
+              .build()
+      ).catch {
+        if (it is ApolloException) {
+          cacheException = it
+        } else {
+          throw it
+        }
+      }.singleOrNull()
+
+      if (cacheResponse != null) {
+        emit(cacheResponse)
+        return@flow
+      }
+
+      val networkResponse = chain.proceed(
+          request = request
+      ).catch {
+        if (it is ApolloException) {
+          networkException = it
+        } else {
+          throw it
+        }
+      }.singleOrNull()
+
+      if (networkResponse != null) {
+        emit(
+            networkResponse.newBuilder()
+                .cacheInfo(
+                    networkResponse.cacheInfo!!
+                        .newBuilder()
+                        .cacheException(cacheException as? CacheMissException)
+                        .build()
+                )
+                .build()
+        )
+        return@flow
+      }
+
+      throw ApolloCompositeException(
+          cacheException,
+          networkException
+      )
+    }
+  }
+}
+
+internal class NetworkFirstInterceptor : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return flow {
+      var cacheException: ApolloException? = null
+      var networkException: ApolloException? = null
+
+      val networkResponse = chain.proceed(
+          request = request
+      ).catch {
+        if (it is ApolloException) {
+          networkException = it
+        } else {
+          throw it
+        }
+      }.singleOrNull()
+
+      if (networkResponse != null) {
+        emit(networkResponse)
+        return@flow
+      }
+
+      val cacheResponse = chain.proceed(
+          request = request
+              .newBuilder()
+              .fetchFromCache(true)
+              .build()
+      ).catch {
+        if (it is ApolloException) {
+          cacheException = it
+        } else {
+          throw it
+        }
+      }.singleOrNull()
+
+      if (cacheResponse != null) {
+        emit(
+            cacheResponse.newBuilder()
+                .cacheInfo(
+                    cacheResponse.cacheInfo!!
+                        .newBuilder()
+                        .networkException(networkException)
+                        .build()
+                )
+                .build()
+        )
+        return@flow
+      }
+
+      throw ApolloCompositeException(
+          networkException,
+          cacheException,
+      )
+    }
+  }
+}

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -35,6 +35,7 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
     check(request.operation is Query) {
       "It's impossible to watch a mutation or subscription"
     }
+
     val customScalarAdapters = request.executionContext[CustomScalarAdapters]!!
     val refetchPolicy: FetchPolicy = request.refetchPolicy
     var watchedKeys: Set<String>? = null

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -57,12 +57,13 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
             watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()
           }.map {
             chain.proceed(request.newBuilder().isRefetching(true).build())
-          }.catch {
-            if (it !is ApolloException) {
-              // Re-throw cancellation exceptions
-              throw it
-            }
-            // Else just ignore errors
+                .catch {
+                  if (it !is ApolloException) {
+                    // Re-throw cancellation exceptions
+                    throw it
+                  }
+                  // Else just ignore errors
+                }
           }.flattenConcatPolyfill()
               .onEach { response ->
                 if (response.data != null) {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -6,10 +6,8 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.dependentKeys
 import com.apollographql.apollo3.cache.normalized.isRefetching
-import com.apollographql.apollo3.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -26,14 +26,14 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 
-class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
+internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (!request.watch) {
       return chain.proceed(request)
     }
 
     check(request.operation is Query) {
-      "It's impossible to watch a subscription"
+      "It's impossible to watch a mutation or subscription"
     }
     val customScalarAdapters = request.executionContext[CustomScalarAdapters]!!
     val refetchPolicy: FetchPolicy = request.refetchPolicy

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -1,0 +1,67 @@
+package com.apollographql.apollo3.cache.normalized.internal
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Query
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.api.dependentKeys
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
+import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.onEach
+
+class WatcherInterceptor(val store: ApolloStore, val refetchPolicy: FetchPolicy) : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    check(request.operation is Query)
+    val customScalarAdapters = request.executionContext[CustomScalarAdapters]!!
+
+    var watchedKeys: Set<String>? = null
+
+    return chain.proceed(request)
+        .map { it as ApolloResponse<D>? }
+        .catch {
+          // Watchers ignore errors, but we still need to start watching the store
+          emit(null)
+        }.onEach { response ->
+          if (response?.data != null) {
+            watchedKeys = store.normalize(request.operation, response.data!!, customScalarAdapters).values.dependentKeys()
+          }
+        }.onCompletion {
+          store.changedKeys.filter { changedKeys ->
+            watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()
+          }.map {
+            chain.proceed(request.newBuilder().fetchPolicy(refetchPolicy).build())
+          }.catch {
+            // Watchers ignore errors
+          }.apolloFlattenConcat()
+              .onEach { response ->
+                if (response.data != null) {
+                  watchedKeys = store.normalize(request.operation, response.data!!, customScalarAdapters).values.dependentKeys()
+                }
+              }.collect {
+                emit(it)
+              }
+        }.filterNotNull()
+  }
+}
+
+/**
+ * A copy/paste of the kotlinx.coroutines version until it becomes stable
+ *
+ * This is taken from 1.5.2 and replacing `unsafeFlow {}` with `flow {}`
+ */
+private fun <T> Flow<Flow<T>>.apolloFlattenConcat(): Flow<T> = flow {
+  collect { value -> emitAll(value) }
+}

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -278,6 +278,8 @@ public final class com/apollographql/apollo3/network/http/HttpInfo : com/apollog
 	public final fun getEndMillis ()J
 	public final fun getHeaders ()Ljava/util/List;
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
+	public final fun getMillisEnd ()J
+	public final fun getMillisStart ()J
 	public final fun getStartMillis ()J
 	public final fun getStatusCode ()I
 	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -275,10 +275,10 @@ public final class com/apollographql/apollo3/network/http/HttpInfo : com/apollog
 	public fun <init> (JJILjava/util/List;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
+	public final fun getEndMillis ()J
 	public final fun getHeaders ()Ljava/util/List;
 	public fun getKey ()Lcom/apollographql/apollo3/api/ExecutionContext$Key;
-	public final fun getMillisEnd ()J
-	public final fun getMillisStart ()J
+	public final fun getStartMillis ()J
 	public final fun getStatusCode ()I
 	public fun minusKey (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun plus (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ExecutionContext;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -22,8 +22,6 @@ class ApolloCall<D : Operation.Data> internal constructor(
   override var sendApqExtensions: Boolean? = null
   override var sendDocument: Boolean? = null
   override var enableAutoPersistedQueries: Boolean? = null
-  var interceptors = mutableListOf<ApolloInterceptor>()
-
   override fun addExecutionContext(executionContext: ExecutionContext) = apply {
     this.executionContext = this.executionContext + executionContext
   }
@@ -57,15 +55,6 @@ class ApolloCall<D : Operation.Data> internal constructor(
   override fun canBeBatched(canBeBatched: Boolean?) = apply {
     this.canBeBatched = canBeBatched
     if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
-  }
-
-  fun addInterceptor(interceptor: ApolloInterceptor) {
-    this.interceptors += interceptor
-  }
-
-  fun interceptors(interceptors: List<ApolloInterceptor>) {
-    this.interceptors.clear()
-    this.interceptors.addAll(interceptors)
   }
 
   fun copy(): ApolloCall<D> {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.api.MutableExecutionOptions
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.single
 
@@ -21,6 +22,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
   override var sendApqExtensions: Boolean? = null
   override var sendDocument: Boolean? = null
   override var enableAutoPersistedQueries: Boolean? = null
+  var interceptors = mutableListOf<ApolloInterceptor>()
 
   override fun addExecutionContext(executionContext: ExecutionContext) = apply {
     this.executionContext = this.executionContext + executionContext
@@ -57,6 +59,14 @@ class ApolloCall<D : Operation.Data> internal constructor(
     if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
   }
 
+  fun addInterceptor(interceptor: ApolloInterceptor) {
+    this.interceptors += interceptor
+  }
+
+  fun interceptors(interceptors: List<ApolloInterceptor>) {
+    this.interceptors.clear()
+    this.interceptors.addAll(interceptors)
+  }
 
   fun copy(): ApolloCall<D> {
     return ApolloCall(apolloClient, operation)

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.network.http
 import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.http.HttpHeader
 
-class HttpInfo(
+class HttpInfo @Deprecated("HttpInfo is only to be constructed internally. Declare your own class if needed") constructor(
     val startMillis: Long,
     val endMillis: Long,
     val statusCode: Int,

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
@@ -9,6 +9,15 @@ class HttpInfo(
     val statusCode: Int,
     val headers: List<HttpHeader>
 ) : ExecutionContext.Element {
+
+  @Deprecated("Use startMillis instead", ReplaceWith("startMillis"))
+  val millisStart: Long
+    get() = startMillis
+
+  @Deprecated("Use endMillis instead", ReplaceWith("endMillis"))
+  val millisEnd: Long
+    get() = endMillis
+
   override val key: ExecutionContext.Key<*>
     get() = Key
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpExecutionContext.kt
@@ -4,8 +4,8 @@ import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.http.HttpHeader
 
 class HttpInfo(
-    val millisStart: Long,
-    val millisEnd: Long,
+    val startMillis: Long,
+    val endMillis: Long,
     val statusCode: Int,
     val headers: List<HttpHeader>
 ) : ExecutionContext.Element {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -85,8 +85,8 @@ private constructor(
               .requestUuid(request.requestUuid)
               .addExecutionContext(
                   HttpInfo(
-                      millisStart = millisStart,
-                      millisEnd = currentTimeMillis(),
+                      startMillis = millisStart,
+                      endMillis = currentTimeMillis(),
                       statusCode = httpResponse.statusCode,
                       headers = httpResponse.headers
                   )

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -80,6 +80,7 @@ private constructor(
         }
       }
 
+      @Suppress("DEPRECATION")
       emit(
           response.newBuilder()
               .requestUuid(request.requestUuid)

--- a/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/http/KtorHttpEngine.kt
+++ b/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/http/KtorHttpEngine.kt
@@ -13,6 +13,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.request
 import io.ktor.http.HttpHeaders
 import io.ktor.util.flattenEntries
+import io.ktor.utils.io.CancellationException
 import okio.Buffer
 
 actual class DefaultHttpEngine constructor(private val connectTimeoutMillis: Long, private val readTimeoutMillis: Long) : HttpEngine {
@@ -51,7 +52,9 @@ actual class DefaultHttpEngine constructor(private val connectTimeoutMillis: Lon
           .body(responseBufferedSource)
           .addHeaders(response.headers.flattenEntries().map { HttpHeader(it.first, it.second) })
           .build()
-
+    } catch (e: CancellationException) {
+      // Cancellation Exception is passthrough
+      throw e
     } catch (t: Throwable) {
       throw ApolloNetworkException(t.message, t)
     }

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -6,9 +6,7 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.composeJsonResponse
-import com.apollographql.apollo3.api.json.internal.buildJsonString
-import com.apollographql.apollo3.api.obj
-import com.apollographql.apollo3.api.toJsonString
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.CacheFirstInterceptor
 import com.apollographql.apollo3.cache.normalized.CacheOnlyInterceptor
@@ -24,8 +22,6 @@ import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloCompositeException
 import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
-import com.apollographql.apollo3.integration.normalizer.adapter.CharacterNameByIdQuery_ResponseAdapter
-import com.apollographql.apollo3.integration.normalizer.adapter.HeroNameQuery_ResponseAdapter
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo3.mockserver.MockResponse

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -284,7 +284,7 @@ class FetchPolicyTest {
         .execute()
 
     /**
-     * Because the query was disjoint, the watcher will see a cache miss and not receive anything
+     * Because the query was disjoint, the watcher will see a cache miss and not receive anything.
      * Because initially the refetchPolicy uses CacheOnly, no network request will be made
      */
     try {

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -15,7 +15,6 @@ import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.executeCacheAndNetwork
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.isFromCache
-import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.cache.normalized.refetchPolicyInterceptor
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
@@ -60,6 +59,7 @@ class FetchPolicyTest {
 
   private suspend fun tearDown() {
     mockServer.stop()
+    apolloClient.dispose()
   }
 
   @Test
@@ -237,11 +237,6 @@ class FetchPolicyTest {
       }
     }
 
-    val apolloClient = ApolloClient.Builder()
-        .serverUrl(mockServer.url())
-        .normalizedCache(MemoryCacheFactory())
-        .build()
-
     val channel = Channel<ApolloResponse<HeroNameQuery.Data>>()
 
     val job = launch {
@@ -309,7 +304,6 @@ class FetchPolicyTest {
     mockServer.takeRequest()
     mockServer.takeRequest()
 
-    apolloClient.dispose()
     channel.cancel()
   }
 }

--- a/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -43,7 +43,6 @@ class ParseResponseBodyTest {
     assertEquals(firstPlanet?.filmConnection?.films?.get(0)?.fragments?.filmFragment?.producers, listOf("Gary Kurtz", "Rick McCallum"))
   }
 
-  @OptIn(ApolloInternal::class)
   @Test
   @Throws(Exception::class)
   fun operationJsonWriter() {
@@ -58,7 +57,9 @@ class ParseResponseBodyTest {
      * operationBased models do not respect the order of fields
      * when fragments are involved so just check for Map equivalence
      */
+    @OptIn(ApolloInternal::class)
     val expectedMap = Buffer().writeUtf8(expected).jsonReader().readAny()
+    @OptIn(ApolloInternal::class)
     val actualMap = Buffer().writeUtf8(actual).jsonReader().readAny()
 
     assertEquals(expectedMap, actualMap)


### PR DESCRIPTION
Splits `ApolloCacheInterceptor` into

* `WatcherInterceptor`
* `FetchPolicyRouterInterceptor`
* `ApolloCacheInterceptor`


This allows to set interceptors for a specific FetchPolicy. See https://github.com/apollographql/apollo-kotlin/issues/3689 for more details
