### PR TITLE
Fix broken github.io documentation links

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -21,7 +21,7 @@ module.exports = {
           null: [
             'index',
             'migration/3.0',
-            '[Kdoc](https://apollographql.github.io/apollo-android/kdoc/)',
+            '[Kdoc](https://apollographql.github.io/apollo-kotlin/kdoc/)',
           ],
           'Tutorial': [
             'tutorial/00-introduction',

--- a/docs/source/advanced/http-engine.mdx
+++ b/docs/source/advanced/http-engine.mdx
@@ -15,7 +15,7 @@ You can use a different HTTP client with Apollo Kotlin by creating a custom clas
 
 ## The `HttpEngine` interface
 
-The [HttpEngine interface](https://apollographql.github.io/apollo-android/kdoc/apollo-runtime/com.apollographql.apollo3.network.http/-http-engine/index.html) defines two functions: `execute` and `dispose`. Here's an example implementation that also includes a couple of helper methods:
+The [HttpEngine interface](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-runtime/com.apollographql.apollo3.network.http/-http-engine/index.html) defines two functions: `execute` and `dispose`. Here's an example implementation that also includes a couple of helper methods:
 
 ```kotlin
 class MyHttpEngine(val wrappedClient: MyClient) : HttpEngine {
@@ -64,7 +64,7 @@ This example uses an asynchronous `wrappedClient` that runs the network request 
 
 ## Using your `HttpEngine`
 
-After you create your `HttpEngine` implementation, you can register it with your [`ApolloClient`](https://apollographql.github.io/apollo-android/kdoc/apollo-runtime/com.apollographql.apollo3/-apollo-client/index.html) instance using [`ApolloClient.Builder.httpEngine`](https://apollographql.github.io/apollo-android/kdoc/apollo-runtime/com.apollographql.apollo3/-apollo-client/-builder/http-engine.html):
+After you create your `HttpEngine` implementation, you can register it with your [`ApolloClient`](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-runtime/com.apollographql.apollo3/-apollo-client/index.html) instance using [`ApolloClient.Builder.httpEngine`](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-runtime/com.apollographql.apollo3/-apollo-client/-builder/http-engine.html):
 
 ```kotlin
 // Use your HttpEngine

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -212,7 +212,7 @@ apollo {
 }
 ```
 
-If you need different GraphQL operations for different variants, you can create multiple services for each Android variant using [apollo.createAllAndroidVariantServices](https://apollographql.github.io/apollo-android/kdoc/apollo-gradle-plugin/com.apollographql.apollo3.gradle.api/-apollo-extension/create-all-android-variant-services.html).
+If you need different GraphQL operations for different variants, you can create multiple services for each Android variant using [apollo.createAllAndroidVariantServices](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-gradle-plugin/com.apollographql.apollo3.gradle.api/-apollo-extension/create-all-android-variant-services.html).
 
 
 #### Package name
@@ -299,7 +299,7 @@ apolloClient.subscription(subscription).toFlow()
 
 ### Custom Scalar adapters
 
-Apollo Kotlin 3 ships an optional [apollo-adapters](https://apollographql.github.io/apollo-android/kdoc/apollo-adapters/com.apollographql.apollo3.adapter/index.html) artifact that includes adapters for common scalar types like:
+Apollo Kotlin 3 ships an optional [apollo-adapters](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-adapters/com.apollographql.apollo3.adapter/index.html) artifact that includes adapters for common scalar types like:
 
 * `InstantAdapter` for `kotlinx.datetime.Instant` ISO8601 dates
 * `LocalDateAdapter` for `kotlinx.datetime.LocalDate` ISO8601 dates


### PR DESCRIPTION
In conjunction with the 3.0 release, this repository was recently
renamed from apollo-android to apollo-kotlin.

Primary HTTP redirects from
https://github.com/apollographql/apollo-android to
https://github.com/apollographql/apollo-kotlin are working well.

However, redirects are *not* working on the github.io documentation
site. Specifically, https://apollographql.github.io/apollo-android (and
its child paths) are *not* redirecting correctly to
https://apollographql.github.io/apollo-kotlin.

One mitigation to this is to start using the new paths within the docs
content itself.