### PR TITLE
Allow new builder with shortcuts

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -37,7 +37,7 @@ public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apol
 
 public final class com/apollographql/apollo3/ApolloClient : com/apollographql/apollo3/api/ExecutionOptions {
 	public static final field Companion Lcom/apollographql/apollo3/ApolloClient$Companion;
-	public synthetic fun <init> (Lcom/apollographql/apollo3/network/NetworkTransport;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/network/NetworkTransport;Ljava/util/List;Lcom/apollographql/apollo3/api/ExecutionContext;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/network/NetworkTransport;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/network/NetworkTransport;Ljava/util/List;Lcom/apollographql/apollo3/api/ExecutionContext;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun dispose ()V
 	public final fun executeAsFlow (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -80,6 +80,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun build ()Lcom/apollographql/apollo3/ApolloClient;
 	public fun canBeBatched (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun canBeBatched (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public final fun copy ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun customScalarAdapters (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -560,12 +560,14 @@ private constructor(
           .sendDocument(sendDocument)
           .enableAutoPersistedQueries(enableAutoPersistedQueries)
           .canBeBatched(canBeBatched)
+      _networkTransport?.let { builder.networkTransport(it) }
       httpServerUrl?.let { builder.httpServerUrl(it) }
       httpEngine?.let { builder.httpEngine(it) }
       httpExposeErrorBody?.let { builder.httpExposeErrorBody(it) }
       for (httpInterceptor in httpInterceptors) {
         builder.addHttpInterceptor(httpInterceptor)
       }
+      subscriptionNetworkTransport?.let { builder.subscriptionNetworkTransport(it) }
       webSocketServerUrl?.let { builder.webSocketServerUrl(it) }
       webSocketEngine?.let { builder.webSocketEngine(it) }
       webSocketReconnectWhen?.let { builder.webSocketReconnectWhen(it) }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -542,7 +542,8 @@ private constructor(
           enableAutoPersistedQueries = enableAutoPersistedQueries,
           canBeBatched = canBeBatched,
 
-          // Keep a reference to this Builder shortcuts so newBuilder() behaves as expected
+          // Keep a reference to the Builder so we can keep track of `httpEngine` and other properties that 
+          // are important to rebuild `networkTransport` (and potentially others)
           builder = this,
       )
     }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -57,19 +57,7 @@ private constructor(
     override val sendDocument: Boolean?,
     override val enableAutoPersistedQueries: Boolean?,
     override val canBeBatched: Boolean?,
-
-    // Builder shortcuts for networkTransport
-    private val httpServerUrl: String?,
-    private val httpEngine: HttpEngine?,
-    private val httpInterceptors: List<HttpInterceptor>,
-    private val httpExposeErrorBody: Boolean?,
-
-    // Builder shortcuts for subscriptionNetworkTransport
-    private val webSocketServerUrl: String?,
-    private val webSocketEngine: WebSocketEngine?,
-    private val webSocketReconnectWhen: ((Throwable) -> Boolean)?,
-    private val webSocketIdleTimeoutMillis: Long?,
-    private val wsProtocolFactory: WsProtocol.Factory?,
+    private val builder: Builder,
 ) : ExecutionOptions {
   private val concurrencyInfo: ConcurrencyInfo
 
@@ -554,82 +542,14 @@ private constructor(
           enableAutoPersistedQueries = enableAutoPersistedQueries,
           canBeBatched = canBeBatched,
 
-          // Keep a reference to builder shortcuts so newBuilder() behaves as expected
-          httpServerUrl = httpServerUrl,
-          httpEngine = httpEngine,
-          httpInterceptors = httpInterceptors,
-          httpExposeErrorBody = httpExposeErrorBody,
-          webSocketServerUrl = webSocketServerUrl,
-          webSocketEngine = webSocketEngine,
-          webSocketReconnectWhen = webSocketReconnectWhen,
-          webSocketIdleTimeoutMillis = webSocketIdleTimeoutMillis,
-          wsProtocolFactory = wsProtocolFactory,
+          // Keep a reference to this Builder shortcuts so newBuilder() behaves as expected
+          builder = this,
       )
     }
   }
 
   fun newBuilder(): Builder {
-    return Builder()
-        .apply {
-          // Builder shortcuts for networkTransport.
-          // If any of these are set, we don't pass networkTransport, as it's built in the Builder.
-          var passNetworkTransport = true
-          if (httpServerUrl != null) {
-            httpServerUrl(httpServerUrl)
-            passNetworkTransport = false
-          }
-          if (httpEngine != null) {
-            httpEngine(httpEngine)
-            passNetworkTransport = false
-          }
-          if (httpInterceptors.isNotEmpty()) {
-            for (httpInterceptor in httpInterceptors) {
-              addHttpInterceptor(httpInterceptor)
-            }
-            passNetworkTransport = false
-          }
-          if (httpExposeErrorBody != null) {
-            httpExposeErrorBody(httpExposeErrorBody)
-            passNetworkTransport = false
-          }
-          if (passNetworkTransport) networkTransport(networkTransport)
-
-          // Builder shortcuts for subscriptionNetworkTransport.
-          // If any of these are set, we don't pass subscriptionNetworkTransport, as it's built in the Builder.
-          var passSubscriptionNetworkTransport = true
-          if (webSocketServerUrl != null) {
-            webSocketServerUrl(webSocketServerUrl)
-            passSubscriptionNetworkTransport = false
-          }
-          if (webSocketEngine != null) {
-            webSocketEngine(webSocketEngine)
-            passSubscriptionNetworkTransport = false
-          }
-          if (webSocketReconnectWhen != null) {
-            webSocketReconnectWhen(webSocketReconnectWhen)
-            passSubscriptionNetworkTransport = false
-          }
-          if (webSocketIdleTimeoutMillis != null) {
-            webSocketIdleTimeoutMillis(webSocketIdleTimeoutMillis)
-            passSubscriptionNetworkTransport = false
-          }
-          if (wsProtocolFactory != null) {
-            wsProtocol(wsProtocolFactory)
-            passSubscriptionNetworkTransport = false
-          }
-
-          if (passSubscriptionNetworkTransport) subscriptionNetworkTransport(subscriptionNetworkTransport)
-        }
-        .customScalarAdapters(customScalarAdapters)
-        .interceptors(interceptors)
-        .requestedDispatcher(requestedDispatcher)
-        .executionContext(executionContext)
-        .httpMethod(httpMethod)
-        .httpHeaders(httpHeaders)
-        .sendApqExtensions(sendApqExtensions)
-        .sendDocument(sendDocument)
-        .enableAutoPersistedQueries(enableAutoPersistedQueries)
-        .canBeBatched(canBeBatched)
+    return builder
   }
 
   companion object {

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -546,10 +546,36 @@ private constructor(
           builder = this,
       )
     }
+
+    fun copy(): Builder {
+      val builder = Builder()
+          .customScalarAdapters(customScalarAdaptersBuilder.build())
+          .interceptors(interceptors)
+          .requestedDispatcher(requestedDispatcher)
+          .executionContext(executionContext)
+          .httpMethod(httpMethod)
+          .httpHeaders(httpHeaders)
+          .sendApqExtensions(sendApqExtensions)
+          .sendDocument(sendDocument)
+          .enableAutoPersistedQueries(enableAutoPersistedQueries)
+          .canBeBatched(canBeBatched)
+      httpServerUrl?.let { builder.httpServerUrl(it) }
+      httpEngine?.let { builder.httpEngine(it) }
+      httpExposeErrorBody?.let { builder.httpExposeErrorBody(it) }
+      for (httpInterceptor in httpInterceptors) {
+        builder.addHttpInterceptor(httpInterceptor)
+      }
+      webSocketServerUrl?.let { builder.webSocketServerUrl(it) }
+      webSocketEngine?.let { builder.webSocketEngine(it) }
+      webSocketReconnectWhen?.let { builder.webSocketReconnectWhen(it) }
+      webSocketIdleTimeoutMillis?.let { builder.webSocketIdleTimeoutMillis(it) }
+      wsProtocolFactory?.let { builder.wsProtocol(it) }
+      return builder
+    }
   }
 
   fun newBuilder(): Builder {
-    return builder
+    return builder.copy()
   }
 
   companion object {

--- a/apollo-runtime/src/jvmTest/kotlin/com/apollographql/apollo3/ApolloClientBuilderTest.kt
+++ b/apollo-runtime/src/jvmTest/kotlin/com/apollographql/apollo3/ApolloClientBuilderTest.kt
@@ -1,0 +1,21 @@
+package com.apollographql.apollo3
+
+import com.apollographql.apollo3.network.okHttpClient
+import okhttp3.OkHttpClient
+import kotlin.test.Test
+
+class ApolloClientBuilderTest {
+  @Test
+  fun allowSettingOkHttpClientOnNewBuilder() {
+    val apolloClient1 = ApolloClient.Builder()
+        .serverUrl("http://localhost:8080")
+        .okHttpClient(OkHttpClient())
+        .build()
+
+    @Suppress("UNUSED_VARIABLE")
+    val apolloClient2 = apolloClient1.newBuilder()
+        .okHttpClient(OkHttpClient())
+        .build()
+  }
+}
+


### PR DESCRIPTION
Related to #3759.

In the [first commit](https://github.com/apollographql/apollo-kotlin/pull/3771/commits/ef8638cdef75e7616d7c1a9306cb24d8fafe1934) I kept builder "shortcuts" references in `ApolloClient` in order to use them in `newBuilder`. That's a bit "boilerplate-y" but then I realized if we're going to do this, why not simply keep the builder itself, which encapsulates all these references? Which I did in [second commit](https://github.com/apollographql/apollo-kotlin/pull/3771/commits/23223b17385df21d01a138a3860bf0d86507b26f). This almost seems too easy so not sure if I overlooked something 😅? Let me know what you think.