### PR TITLE
Make `reconnectWhen` suspend and pass attempt number

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -126,6 +126,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketIdleTimeoutMillis (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketReconnectWhen (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketReconnectWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun wsProtocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
@@ -440,7 +441,7 @@ public final class com/apollographql/apollo3/network/ws/WebSocketEngineKt {
 }
 
 public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport : com/apollographql/apollo3/network/NetworkTransport {
-	public synthetic fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/network/ws/WebSocketEngine;JLcom/apollographql/apollo3/network/ws/WsProtocol$Factory;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/network/ws/WebSocketEngine;JLcom/apollographql/apollo3/network/ws/WsProtocol$Factory;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;
 	public final fun getSubscriptionCount ()Lkotlinx/coroutines/flow/StateFlow;
@@ -452,6 +453,7 @@ public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTranspor
 	public final fun idleTimeoutMillis (J)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun protocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun reconnectWhen (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
+	public final fun reconnectWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun serverUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 }

--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -126,7 +126,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketIdleTimeoutMillis (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketReconnectWhen (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun webSocketReconnectWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketReopenWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun wsProtocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
@@ -453,7 +453,7 @@ public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTranspor
 	public final fun idleTimeoutMillis (J)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun protocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun reconnectWhen (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
-	public final fun reconnectWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
+	public final fun reopenWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun serverUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -323,7 +323,8 @@ private constructor(
       this.webSocketReconnectWhen = webSocketReconnectWhen
     }
 
-    fun webSocketReconnectWhen(reconnectWhen: (suspend (Throwable) -> Boolean)?) = apply {
+    @Deprecated("Use the overload where the lambda is suspend and has more args")
+    fun webSocketReconnectWhen(reconnectWhen: ((Throwable) -> Boolean)?) = apply {
       this.webSocketReconnectWhen = reconnectWhen?.let {
         val adaptedLambda: suspend (Throwable, Long) -> Boolean = { throwable, _ -> reconnectWhen(throwable) }
         adaptedLambda

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -581,7 +581,7 @@ private constructor(
       subscriptionNetworkTransport?.let { builder.subscriptionNetworkTransport(it) }
       webSocketServerUrl?.let { builder.webSocketServerUrl(it) }
       webSocketEngine?.let { builder.webSocketEngine(it) }
-      webSocketReconnectWhen?.let { builder.webSocketReconnectWhen(it) }
+      webSocketReopenWhen?.let { builder.webSocketReopenWhen(it) }
       webSocketIdleTimeoutMillis?.let { builder.webSocketIdleTimeoutMillis(it) }
       wsProtocolFactory?.let { builder.wsProtocol(it) }
       return builder

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -180,7 +180,7 @@ private constructor(
     private var wsProtocolFactory: WsProtocol.Factory? = null
     private var httpExposeErrorBody: Boolean? = null
     private var webSocketEngine: WebSocketEngine? = null
-    private var webSocketReconnectWhen: ((Throwable) -> Boolean)? = null
+    private var webSocketReconnectWhen: (suspend (Throwable) -> Boolean)? = null
 
     override var httpMethod: HttpMethod? = null
 
@@ -318,7 +318,7 @@ private constructor(
      *
      * See also [subscriptionNetworkTransport] for more customization
      */
-    fun webSocketReconnectWhen(webSocketReconnectWhen: ((Throwable) -> Boolean)) = apply {
+    fun webSocketReconnectWhen(webSocketReconnectWhen: (suspend (Throwable) -> Boolean)) = apply {
       this.webSocketReconnectWhen = webSocketReconnectWhen
     }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_1
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.ApolloRequest
@@ -323,7 +324,8 @@ private constructor(
       this.webSocketReconnectWhen = webSocketReconnectWhen
     }
 
-    @Deprecated("Use the overload where the lambda is suspend and has more args")
+    @Deprecated("Use webSocketReconnectWhen(webSocketReconnectWhen: (suspend (Throwable, attempt: Long) -> Boolean))")
+    @ApolloDeprecatedSince(v3_0_1)
     fun webSocketReconnectWhen(reconnectWhen: ((Throwable) -> Boolean)?) = apply {
       this.webSocketReconnectWhen = reconnectWhen?.let {
         val adaptedLambda: suspend (Throwable, Long) -> Boolean = { throwable, _ -> reconnectWhen(throwable) }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
-import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.internal.BackgroundDispatcher
 import com.apollographql.apollo3.internal.transformWhile
@@ -26,7 +25,6 @@ import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
@@ -55,7 +53,7 @@ private constructor(
     private val webSocketEngine: WebSocketEngine = DefaultWebSocketEngine(),
     private val idleTimeoutMillis: Long = 60_000,
     private val protocolFactory: WsProtocol.Factory = SubscriptionWsProtocol.Factory(),
-    private val reconnectWhen: ((Throwable) -> Boolean)?,
+    private val reconnectWhen: (suspend (Throwable) -> Boolean)?,
 ) : NetworkTransport {
 
   /**
@@ -283,7 +281,7 @@ private constructor(
     private var webSocketEngine: WebSocketEngine? = null
     private var idleTimeoutMillis: Long? = null
     private var protocolFactory: WsProtocol.Factory? = null
-    private var reconnectWhen: ((Throwable) -> Boolean)? = null
+    private var reconnectWhen: (suspend (Throwable) -> Boolean)? = null
 
     fun serverUrl(serverUrl: String) = apply {
       this.serverUrl = serverUrl
@@ -310,7 +308,7 @@ private constructor(
      * automatically or 'false' to forward the error to all listening [Flow]
      *
      */
-    fun reconnectWhen(reconnectWhen: ((Throwable) -> Boolean)?) = apply {
+    fun reconnectWhen(reconnectWhen: (suspend (Throwable) -> Boolean)?) = apply {
       this.reconnectWhen = reconnectWhen
     }
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.network.ws
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_1
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -317,7 +319,9 @@ private constructor(
       this.reconnectWhen = reconnectWhen
     }
 
-    @Deprecated("Use the overload where the lambda is suspend and has more args")
+
+    @Deprecated("Use reconnectWhen(reconnectWhen: (suspend (Throwable, attempt: Long) -> Boolean))")
+    @ApolloDeprecatedSince(v3_0_1)
     fun reconnectWhen(reconnectWhen: ((Throwable) -> Boolean)?) = apply {
       this.reconnectWhen = reconnectWhen?.let {
         val adaptedLambda: suspend (Throwable, Long) -> Boolean = { throwable, _ -> reconnectWhen(throwable) }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -317,7 +317,8 @@ private constructor(
       this.reconnectWhen = reconnectWhen
     }
 
-    fun reconnectWhen(reconnectWhen: (suspend (Throwable) -> Boolean)?) = apply {
+    @Deprecated("Use the overload where the lambda is suspend and has more args")
+    fun reconnectWhen(reconnectWhen: ((Throwable) -> Boolean)?) = apply {
       this.reconnectWhen = reconnectWhen?.let {
         val adaptedLambda: suspend (Throwable, Long) -> Boolean = { throwable, _ -> reconnectWhen(throwable) }
         adaptedLambda

--- a/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
@@ -232,7 +232,7 @@ class SampleServerTest {
     val apolloClient = ApolloClient.Builder()
         .serverUrl("http://localhost:8080/subscriptions")
         .wsProtocol(wsFactory)
-        .webSocketReconnectWhen {
+        .webSocketReopenWhen {
           it is AuthorizationException
         }
         .build()

--- a/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/SampleServerTest.kt
@@ -1,7 +1,6 @@
 import com.apollographql.apollo.sample.server.DefaultApplication
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.ApolloNetworkException
-import com.apollographql.apollo3.network.ws.SubscriptionWsProtocol
 import com.apollographql.apollo3.network.ws.SubscriptionWsProtocolAdapter
 import com.apollographql.apollo3.network.ws.WebSocketConnection
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
@@ -183,9 +182,12 @@ class SampleServerTest {
     }
   }
 
-  private object AuthorizationException: Exception()
+  private object AuthorizationException : Exception()
 
-  private class AuthorizationAwareWsProtocol(webSocketConnection: WebSocketConnection, listener: Listener) : SubscriptionWsProtocolAdapter(webSocketConnection, listener) {
+  private class AuthorizationAwareWsProtocol(
+      webSocketConnection: WebSocketConnection,
+      listener: Listener,
+  ) : SubscriptionWsProtocolAdapter(webSocketConnection, listener) {
     @Suppress("UNCHECKED_CAST")
     private fun Any?.asMap() = this as? Map<String, Any?>
 
@@ -217,7 +219,7 @@ class SampleServerTest {
     }
   }
 
-  class AuthorizationAwareWsProtocolFactory: WsProtocol.Factory {
+  class AuthorizationAwareWsProtocolFactory : WsProtocol.Factory {
     override val name: String
       get() = "graphql-ws"
 
@@ -232,8 +234,8 @@ class SampleServerTest {
     val apolloClient = ApolloClient.Builder()
         .serverUrl("http://localhost:8080/subscriptions")
         .wsProtocol(wsFactory)
-        .webSocketReopenWhen {
-          it is AuthorizationException
+        .webSocketReopenWhen { e, _ ->
+          e is AuthorizationException
         }
         .build()
 

--- a/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
@@ -91,7 +91,7 @@ class WebSocketErrorsTest {
   }
 
   @Test
-  fun socketReconnectsAfterAnError() = runBlocking {
+  fun socketReopensAfterAnError() = runBlocking {
     var connectionInitCount = 0
     var exception: Throwable? = null
 
@@ -106,7 +106,7 @@ class WebSocketErrorsTest {
                 }
             )
         )
-        .webSocketReconnectWhen {
+        .webSocketReopenWhen {
           exception = it
           // Only retry once
           connectionInitCount == 1

--- a/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
@@ -4,10 +4,8 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.ApolloWebSocketClosedException
 import com.apollographql.apollo3.network.ws.SubscriptionWsProtocol
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
@@ -19,10 +17,7 @@ import org.springframework.boot.runApplication
 import org.springframework.context.ConfigurableApplicationContext
 import sample.server.CloseSocketQuery
 import sample.server.CountSubscription
-import sample.server.OperationErrorSubscription
 import sample.server.TimeSubscription
-import java.util.concurrent.Executors
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -106,8 +101,8 @@ class WebSocketErrorsTest {
                 }
             )
         )
-        .webSocketReopenWhen {
-          exception = it
+        .webSocketReopenWhen { e, _ ->
+          exception = e
           // Only retry once
           connectionInitCount == 1
         }


### PR DESCRIPTION
### Reason

- Fixes #3766

### Changelist

- Accept `suspend` function as arg of `ApolloClient::webSocketReconnectWhen` and `WebSocketNetworkTransport::reconnectWhen`.
- Along with the `Throwable`, also pass the attempt number to the `reconnectWhen` predicate.