### PR TITLE
Merge HTTP headers when batching

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -733,8 +733,15 @@ public abstract interface class com/apollographql/apollo3/api/http/HttpBody {
 
 public final class com/apollographql/apollo3/api/http/HttpHeader {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/http/HttpHeader;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/http/HttpHeader;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/http/HttpHeader;
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/http/HttpHeaders {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/Http.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/Http.kt
@@ -22,7 +22,7 @@ interface HttpBody {
 /**
  * a HTTP header
  */
-class HttpHeader(val name: String, val value: String)
+data class HttpHeader(val name: String, val value: String)
 
 /**
  * a HTTP request to be sent

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -50,6 +50,9 @@ import kotlin.jvm.JvmStatic
  *
  * [BatchingHttpInterceptor] only works with Post requests. Trying to batch a Get request is undefined.
  *
+ * HTTP headers will be merged from all requests in the batch by keeping the ones that have the same name and value in all requests. Any
+ * headers present in only some requests, or with different values in some requests will be dropped.
+ *
  * @param batchIntervalMillis the maximum time interval before a new batch is sent
  * @param maxBatchSize the maximum number of requests queued before a new batch is sent
  * @param exposeErrorBody configures whether to expose the error body in [ApolloHttpException].
@@ -138,6 +141,12 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     }
 
     val allBodies = pending.map { it.request.body ?: error("empty body while batching queries") }
+    // Only keep headers with the same value in all requests
+    val mergedHeaders = pending.map { it.request.headers }.reduce { acc, headers ->
+      acc.intersect(headers.toSet()).toList()
+    }
+        // Also do not send our internal use header
+        .filter { it.name != ExecutionOptions.CAN_BE_BATCHED }
 
     val body = object : HttpBody {
       override val contentType = "application/json"
@@ -159,9 +168,10 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     val request = HttpRequest.Builder(
         method = HttpMethod.Post,
         url = firstRequest.url,
-    ).body(
-        body = body,
-    ).build()
+    )
+        .body(body)
+        .headers(mergedHeaders)
+        .build()
 
     freeze(request)
 
@@ -198,8 +208,8 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         }
         @OptIn(ApolloInternal::class)
         (buildJsonByteString {
-      AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
-    })
+          AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
+        })
       }
     } catch (e: ApolloException) {
       exception = e

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -141,8 +141,8 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     }
 
     val allBodies = pending.map { it.request.body ?: error("empty body while batching queries") }
-    // Only keep headers with the same value in all requests
-    val mergedHeaders = pending.map { it.request.headers }.reduce { acc, headers ->
+    // Only keep headers with the same name and value in all requests
+    val commonHeaders = pending.map { it.request.headers }.reduce { acc, headers ->
       acc.intersect(headers.toSet()).toList()
     }
         // Also do not send our internal use header
@@ -170,7 +170,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         url = firstRequest.url,
     )
         .body(body)
-        .headers(mergedHeaders)
+        .headers(commonHeaders)
         .build()
 
     freeze(request)

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -192,7 +192,7 @@ class QueryBatchingTest {
   }
 
   @Test
-  fun httpHeadersOnClientAreMerged() = runTest(before = { setUp() }, after = { tearDown() }) {
+  fun httpHeadersOnClientAreKept() = runTest(before = { setUp() }, after = { tearDown() }) {
     val response = """
     [{"data":{"launch":{"id":"83"}}},{"data":{"launch":{"id":"84"}}}]
     """.trimIndent()
@@ -221,7 +221,7 @@ class QueryBatchingTest {
   }
 
   @Test
-  fun httpHeadersOnRequestsAreMerged() = runTest(before = { setUp() }, after = { tearDown() }) {
+  fun commonHttpHeadersOnRequestsAreKept() = runTest(before = { setUp() }, after = { tearDown() }) {
     val response = """
     [{"data":{"launch":{"id":"83"}}},{"data":{"launch":{"id":"84"}}}]
     """.trimIndent()


### PR DESCRIPTION
Fix for #3769.

Now headers present with the same value on all requests will be kept. 