### PR TITLE
Fix @skip with if=true/false not being inverted

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -608,10 +608,10 @@ internal fun GQLDirective.toBooleanExpression(): BooleanExpression<BVariable>? {
     is GQLBooleanValue -> {
       if (value.value) BooleanExpression.True else BooleanExpression.False
     }
-    is GQLVariableValue -> BooleanExpression.Element(BVariable(name = value.name)).let {
-      if (name == "skip") not(it) else it
-    }
+    is GQLVariableValue -> BooleanExpression.Element(BVariable(name = value.name))
     else -> throw IllegalStateException("Apollo: cannot pass ${value.toUtf8()} to '$name' directive")
+  }.let {
+    if (name == "skip") not(it) else it
   }
 }
 

--- a/tests/include-skip-operation-based/src/main/graphql/operations.graphql
+++ b/tests/include-skip-operation-based/src/main/graphql/operations.graphql
@@ -1,4 +1,4 @@
-query GetCat($withCat: Boolean!) {
+query GetCatIncludeVariable($withCat: Boolean!) {
   animal {
     ... on Cat @include(if: $withCat) {
       meow
@@ -6,9 +6,38 @@ query GetCat($withCat: Boolean!) {
   }
 }
 
-query GetDog($withoutDog: Boolean!) {
+query GetCatIncludeFalse {
+  animal {
+    ... on Cat @include(if: false) {
+      meow
+    }
+  }
+}
+
+query GetCatIncludeTrue {
+  animal {
+    ... on Cat @include(if: true) {
+      meow
+    }
+  }
+}
+
+
+query GetDogSkipVariable($withoutDog: Boolean!) {
   animal {
     ...dogFragment @skip(if: $withoutDog)
+  }
+}
+
+query GetDogSkipTrue {
+  animal {
+    ...dogFragment @skip(if: true)
+  }
+}
+
+query GetDogSkipFalse {
+  animal {
+    ...dogFragment @skip(if: false)
   }
 }
 

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,19 +1,27 @@
 import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
-import com.example.GetCatQuery
-import com.example.GetDogQuery
-import com.example.test.GetCatQuery_TestBuilder
-import com.example.test.GetDogQuery_TestBuilder
+import com.example.GetCatIncludeFalseQuery
+import com.example.GetCatIncludeTrueQuery
+import com.example.GetCatIncludeVariableQuery
+import com.example.GetDogSkipFalseQuery
+import com.example.GetDogSkipTrueQuery
+import com.example.GetDogSkipVariableQuery
+import com.example.test.GetCatIncludeFalseQuery_TestBuilder
+import com.example.test.GetCatIncludeTrueQuery_TestBuilder
+import com.example.test.GetCatIncludeVariableQuery_TestBuilder
+import com.example.test.GetDogSkipFalseQuery_TestBuilder
+import com.example.test.GetDogSkipTrueQuery_TestBuilder
+import com.example.test.GetDogSkipVariableQuery_TestBuilder
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class IncludeTest {
   @Test
-  fun includeTrue() = runBlocking {
-    val operation = GetCatQuery(withCat = true)
+  fun includeVariableTrue() = runBlocking {
+    val operation = GetCatIncludeVariableQuery(withCat = true)
 
-    val dataMap = GetCatQuery_TestBuilder.DataBuilder().apply {
+    val dataMap = GetCatIncludeVariableQuery_TestBuilder.DataBuilder().apply {
       animal = catAnimal {
         meow = "meeoooowwwww"
       }
@@ -29,10 +37,10 @@ class IncludeTest {
   }
 
   @Test
-  fun includeFalse() = runBlocking {
-    val operation = GetCatQuery(withCat = false)
+  fun includeVariableFalse() = runBlocking {
+    val operation = GetCatIncludeVariableQuery(withCat = false)
 
-    val dataMap = GetCatQuery_TestBuilder.DataBuilder().apply {
+    val dataMap = GetCatIncludeVariableQuery_TestBuilder.DataBuilder().apply {
       animal = catAnimal {
         meow = "meeoooowwwww"
       }
@@ -48,10 +56,48 @@ class IncludeTest {
   }
 
   @Test
-  fun skipTrue() = runBlocking {
-    val operation = GetDogQuery(withoutDog = true)
+  fun includeHardcodedTrue() = runBlocking {
+    val operation = GetCatIncludeTrueQuery()
 
-    val dataMap = GetDogQuery_TestBuilder.DataBuilder().apply {
+    val dataMap = GetCatIncludeTrueQuery_TestBuilder.DataBuilder().apply {
+      animal = catAnimal {
+        meow = "meeoooowwwww"
+      }
+    }.build()
+
+    val response = operation.parseJsonResponse(
+        MapJsonReader(
+            mapOf("data" to dataMap)
+        )
+    )
+
+    assertEquals("meeoooowwwww", response.dataAssertNoErrors.animal!!.onCat!!.meow)
+  }
+
+  @Test
+  fun includeHardcodedFalse() = runBlocking {
+    val operation = GetCatIncludeFalseQuery()
+
+    val dataMap = GetCatIncludeFalseQuery_TestBuilder.DataBuilder().apply {
+      animal = catAnimal {
+        meow = "meeoooowwwww"
+      }
+    }.build()
+
+    val response = operation.parseJsonResponse(
+        MapJsonReader(
+            mapOf("data" to dataMap)
+        )
+    )
+
+    assertEquals(null, response.dataAssertNoErrors.animal!!.onCat)
+  }
+
+  @Test
+  fun skipVariableTrue() = runBlocking {
+    val operation = GetDogSkipVariableQuery(withoutDog = true)
+
+    val dataMap = GetDogSkipVariableQuery_TestBuilder.DataBuilder().apply {
       animal = dogAnimal {
         barf = "ouaf"
       }
@@ -67,10 +113,48 @@ class IncludeTest {
   }
 
   @Test
-  fun skipFalse() = runBlocking {
-    val operation = GetDogQuery(withoutDog = false)
+  fun skipVariableFalse() = runBlocking {
+    val operation = GetDogSkipVariableQuery(withoutDog = false)
 
-    val dataMap = GetDogQuery_TestBuilder.DataBuilder().apply {
+    val dataMap = GetDogSkipVariableQuery_TestBuilder.DataBuilder().apply {
+      animal = dogAnimal {
+        barf = "ouaf"
+      }
+    }.build()
+
+    val response = operation.parseJsonResponse(
+        MapJsonReader(
+            mapOf("data" to dataMap)
+        )
+    )
+
+    assertEquals("ouaf", response.dataAssertNoErrors.animal!!.dogFragment!!.barf)
+  }
+
+  @Test
+  fun skipHardcodedTrue() = runBlocking {
+    val operation = GetDogSkipTrueQuery()
+
+    val dataMap = GetDogSkipTrueQuery_TestBuilder.DataBuilder().apply {
+      animal = dogAnimal {
+        barf = "ouaf"
+      }
+    }.build()
+
+    val response = operation.parseJsonResponse(
+        MapJsonReader(
+            mapOf("data" to dataMap)
+        )
+    )
+
+    assertEquals(null, response.dataAssertNoErrors.animal!!.dogFragment)
+  }
+
+  @Test
+  fun skipHardcodedFalse() = runBlocking {
+    val operation = GetDogSkipFalseQuery()
+
+    val dataMap = GetDogSkipFalseQuery_TestBuilder.DataBuilder().apply {
       animal = dogAnimal {
         barf = "ouaf"
       }


### PR DESCRIPTION
A follow-up of #3813

Skip is the opposite of include so `toBooleanExpression` should return the opposite of what its `if` is set to (if that makes sense!), which was correctly done for a variable, but not for a hardcoded `true`/`false`.