### PR TITLE
Allow to specify error handling for watch()

### DIFF
--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -117,9 +117,7 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun store (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -118,16 +118,18 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/cache/normalized/WatchErrorHandling : java/lang/Enum {
-	public static final field EMIT_CACHE_AND_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field EMIT_CACHE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field EMIT_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 	public static final field IGNORE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field THROW_CACHE_AND_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field THROW_CACHE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field THROW_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 }

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -126,10 +126,10 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 }
 
 public final class com/apollographql/apollo3/cache/normalized/WatchErrorHandling : java/lang/Enum {
-	public static final field IGNORE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field THROW_CACHE_AND_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field THROW_CACHE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field THROW_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field IgnoreErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field ThrowAll Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field ThrowCacheErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field ThrowNetworkErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 }

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -117,7 +117,9 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun store (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -118,19 +118,11 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;Lkotlin/jvm/functions/Function3;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Z)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/cache/normalized/WatchErrorHandling : java/lang/Enum {
-	public static final field IgnoreErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field ThrowAll Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field ThrowCacheErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static final field ThrowNetworkErrors Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
-	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 }
 

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -118,6 +118,17 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static synthetic fun store$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/ApolloStore;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun storePartialResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
+}
+
+public final class com/apollographql/apollo3/cache/normalized/WatchErrorHandling : java/lang/Enum {
+	public static final field EMIT_CACHE_AND_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field EMIT_CACHE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field EMIT_NETWORK_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static final field IGNORE_ERRORS Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
+	public static fun values ()[Lcom/apollographql/apollo3/cache/normalized/WatchErrorHandling;
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -105,11 +105,18 @@ enum class WatchErrorHandling {
 /***
  * Gets the result from the network, then observes the cache for any changes.
  * Overriding the [FetchPolicy] will change how the result is first queried.
- * Exception are ignored by default, this can be changed by setting [watchErrorHandling].
+ * Exception are ignored by default, this can be changed by setting [fetchErrorHandling] for the first fetch and [refetchErrorHandling]
+ * for subsequent fetches.
  */
 @JvmOverloads
-fun <D : Query.Data> ApolloCall<D>.watch(errorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS): Flow<ApolloResponse<D>> {
-  return copy().addExecutionContext(WatchContext(errorHandling)).toFlow()
+fun <D : Query.Data> ApolloCall<D>.watch(
+    fetchErrorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
+    refetchErrorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
+): Flow<ApolloResponse<D>> {
+  return copy().addExecutionContext(WatchContext(
+      fetchErrorHandling = fetchErrorHandling,
+      refetchErrorHandling = refetchErrorHandling,
+  )).toFlow()
 }
 
 /**
@@ -450,7 +457,10 @@ internal class OptimisticUpdatesContext<D : Mutation.Data>(val value: D) : Execu
   companion object Key : ExecutionContext.Key<OptimisticUpdatesContext<*>>
 }
 
-internal class WatchContext(val errorHandling: WatchErrorHandling) : ExecutionContext.Element {
+internal class WatchContext(
+    val fetchErrorHandling: WatchErrorHandling,
+    val refetchErrorHandling: WatchErrorHandling,
+) : ExecutionContext.Element {
   override val key: ExecutionContext.Key<*>
     get() = Key
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -101,7 +101,7 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
 
 /**
  * Use with [watch] to configure how errors are propagated.
- * Note that any non-Apollo exceptions (e.g. OutOfMemoryError) will still be thrown regardless of the policy.
+ * Note that any non-Apollo exceptions (e.g. `OutOfMemoryError`) will still be thrown regardless of the policy.
  */
 enum class WatchErrorHandling {
   ThrowCacheErrors,
@@ -113,7 +113,7 @@ enum class WatchErrorHandling {
 /***
  * Gets the result from the network, then observes the cache for any changes.
  * Overriding the [FetchPolicy] will change how the result is first queried.
- * Exception are ignored by default, this can be changed by setting [errorHandling] for the first fetch and [refetchErrorHandling]
+ * Exception are ignored by default, this can be changed by setting [fetchErrorHandling] for the first fetch and [refetchErrorHandling]
  * for subsequent fetches.
  */
 @JvmOverloads

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -104,6 +104,9 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
  * Overriding the [FetchPolicy] will change how the result is first queried.
  * Network and cache exceptions are ignored by default, this can be changed by setting [fetchThrows] for the first fetch and [refetchThrows]
  * for subsequent fetches (non Apollo exceptions like `OutOfMemoryError` are always propagated).
+ *
+ * @param fetchThrows whether to throw if an [ApolloException] happens during the initial fetch. Default: false
+ * @param refetchThrows whether to throw if an [ApolloException] happens during a refetch. Default: false
  */
 @JvmOverloads
 fun <D : Query.Data> ApolloCall<D>.watch(

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -112,6 +112,7 @@ enum class WatchErrorHandling {
  * Exception are ignored by default, this can be changed by setting [fetchErrorHandling] for the first fetch and [refetchErrorHandling]
  * for subsequent fetches.
  */
+@JvmOverloads
 fun <D : Query.Data> ApolloCall<D>.watch(
     fetchErrorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
     refetchErrorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -96,9 +96,9 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
 }
 
 enum class WatchErrorHandling {
-  EMIT_CACHE_ERRORS,
-  EMIT_NETWORK_ERRORS,
-  EMIT_CACHE_AND_NETWORK_ERRORS,
+  THROW_CACHE_ERRORS,
+  THROW_NETWORK_ERRORS,
+  THROW_CACHE_AND_NETWORK_ERRORS,
   IGNORE_ERRORS
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -114,8 +114,22 @@ fun <D : Query.Data> ApolloCall<D>.watch(
     refetchErrorHandling: WatchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
 ): Flow<ApolloResponse<D>> {
   return copy().addExecutionContext(WatchContext(
+      data = null,
       fetchErrorHandling = fetchErrorHandling,
       refetchErrorHandling = refetchErrorHandling,
+  )).toFlow()
+}
+
+/**
+ * Observes the cache for the given data. Unlike [watch], no initial request is executed on the network.
+ * The refetch policy set by [refetchPolicy] will be used.
+ * Cache and network exceptions are ignored.
+ */
+fun <D : Query.Data> ApolloCall<D>.watch(data: D): Flow<ApolloResponse<D>> {
+  return copy().addExecutionContext(WatchContext(
+      data = data,
+      fetchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
+      refetchErrorHandling = WatchErrorHandling.IGNORE_ERRORS,
   )).toFlow()
 }
 
@@ -458,6 +472,7 @@ internal class OptimisticUpdatesContext<D : Mutation.Data>(val value: D) : Execu
 }
 
 internal class WatchContext(
+    val data: Query.Data?,
     val fetchErrorHandling: WatchErrorHandling,
     val refetchErrorHandling: WatchErrorHandling,
 ) : ExecutionContext.Element {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -145,12 +145,12 @@ fun <D : Query.Data> ApolloCall<D>.watch(data: D?): Flow<ApolloResponse<D>> {
 
 private fun maybeThrow(throwable: Throwable, errorHandling: WatchErrorHandling) {
   // Only potentially swallow Apollo exceptions, the rest must be surfaced
-  if (throwable !is ApolloException) {
+  if (throwable !is ApolloException || errorHandling == WatchErrorHandling.ThrowAll) {
     throw throwable
   }
   if (errorHandling == WatchErrorHandling.IgnoreErrors) return
-  val throwCacheErrors = errorHandling == WatchErrorHandling.ThrowAll || errorHandling == WatchErrorHandling.ThrowCacheErrors
-  val throwNetworkErrors = errorHandling == WatchErrorHandling.ThrowAll || errorHandling == WatchErrorHandling.ThrowNetworkErrors
+  val throwCacheErrors = errorHandling == WatchErrorHandling.ThrowCacheErrors
+  val throwNetworkErrors = errorHandling == WatchErrorHandling.ThrowNetworkErrors
   when (throwable) {
     is ApolloCompositeException -> {
       if (errorHandling == WatchErrorHandling.ThrowAll) {

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -158,10 +158,6 @@ internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
       // Subscriptions and Mutations do not support fetchPolicies
       return chain.proceed(request)
     }
-    return if (!request.isRefetching) {
-      request.fetchPolicyInterceptor.intercept(request, chain)
-    } else {
-      request.refetchPolicyInterceptor.intercept(request, chain)
-    }
+    return request.fetchPolicyInterceptor.intercept(request, chain)
   }
 }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -6,25 +6,18 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
-import com.apollographql.apollo3.cache.normalized.WatchErrorHandling
 import com.apollographql.apollo3.cache.normalized.api.dependentKeys
 import com.apollographql.apollo3.cache.normalized.isRefetching
 import com.apollographql.apollo3.cache.normalized.watchContext
-import com.apollographql.apollo3.exception.ApolloCompositeException
-import com.apollographql.apollo3.exception.ApolloException
-import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 
 internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
@@ -36,70 +29,20 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
 
     val customScalarAdapters = request.executionContext[CustomScalarAdapters]!!
 
-    // We have 2 watch methods:
-    // - without a data: trigger an initial fetch, and then monitor for changes
-    // - with a data: no initial fetch, only monitor for changes
-    val withInitialFetch = watchContext.data == null
-
     @Suppress("UNCHECKED_CAST")
     var watchedKeys: Set<String>? = watchContext.data?.let { store.normalize(request.operation, it as D, customScalarAdapters).values.dependentKeys() }
-    var isRefetching = !withInitialFetch
 
     return store.changedKeys
-        .onStart {
-          // Trigger the initial fetch
-          if (withInitialFetch) emit(emptySet())
-        }
         .filter { changedKeys ->
           watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()
         }.map {
-          chain.proceed(request.newBuilder().isRefetching(isRefetching).build())
-              .catch {
-                if (it !is ApolloException) {
-                  // Re-throw cancellation exceptions
-                  throw it
-                }
-                // Else throw it or not according to error handling policy
-                maybeThrow(it, if (isRefetching) watchContext.refetchErrorHandling else watchContext.fetchErrorHandling)
-              }
+          chain.proceed(request.newBuilder().isRefetching(true).build())
               .onEach { response ->
                 if (response.data != null) {
                   watchedKeys = store.normalize(request.operation, response.data!!, customScalarAdapters).values.dependentKeys()
                 }
               }
-              .onCompletion {
-                isRefetching = true
-              }
         }.flattenConcatPolyfill()
-  }
-
-  private fun maybeThrow(exception: ApolloException, errorHandling: WatchErrorHandling) {
-    if (errorHandling == WatchErrorHandling.IGNORE_ERRORS) return
-    val throwCacheErrors = errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.THROW_CACHE_ERRORS
-    val throwNetworkErrors = errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.THROW_NETWORK_ERRORS
-    when (exception) {
-      is ApolloCompositeException -> {
-        if (errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS) {
-          throw exception
-        }
-        val cacheMissException = exception.first as? CacheMissException ?: exception.second as? CacheMissException
-        // If it's *not* a CacheMissException we consider it a network error (could be ApolloNetworkException, ApolloHttpException, ApolloParseException...)
-        val networkException = exception.first.takeIf { it !is CacheMissException } ?: exception.second.takeIf { it !is CacheMissException }
-        if (cacheMissException != null && throwCacheErrors) {
-          throw cacheMissException
-        }
-        if (networkException != null && throwNetworkErrors) {
-          throw networkException
-        }
-      }
-      is CacheMissException -> if (throwCacheErrors) {
-        throw exception
-      }
-      // Treat all other exceptions as network errors (could be ApolloNetworkException, ApolloHttpException, ApolloParseException...)
-      else -> if (throwNetworkErrors) {
-        throw exception
-      }
-    }
   }
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.dependentKeys
-import com.apollographql.apollo3.cache.normalized.isRefetching
 import com.apollographql.apollo3.cache.normalized.watchContext
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
@@ -36,7 +35,7 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
         .filter { changedKeys ->
           watchedKeys == null || changedKeys.intersect(watchedKeys!!).isNotEmpty()
         }.map {
-          chain.proceed(request.newBuilder().isRefetching(true).build())
+          chain.proceed(request.newBuilder().build())
               .onEach { response ->
                 if (response.data != null) {
                   watchedKeys = store.normalize(request.operation, response.data!!, customScalarAdapters).values.dependentKeys()

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -69,25 +69,25 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
 
   private fun maybeThrow(exception: ApolloException, errorHandling: WatchErrorHandling) {
     if (errorHandling == WatchErrorHandling.IGNORE_ERRORS) return
-    val emitCacheErrors = errorHandling == WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.EMIT_CACHE_ERRORS
-    val emitNetworkErrors = errorHandling == WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.EMIT_NETWORK_ERRORS
+    val throwCacheErrors = errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.THROW_CACHE_ERRORS
+    val throwNetworkErrors = errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS || errorHandling == WatchErrorHandling.THROW_NETWORK_ERRORS
     when (exception) {
-      is CacheMissException -> if (emitCacheErrors) {
+      is CacheMissException -> if (throwCacheErrors) {
         throw exception
       }
-      is ApolloNetworkException -> if (emitNetworkErrors) {
+      is ApolloNetworkException -> if (throwNetworkErrors) {
         throw exception
       }
       is ApolloCompositeException -> {
-        if (errorHandling == WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS) {
+        if (errorHandling == WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS) {
           throw exception
         }
         val cacheMissException = exception.first as? CacheMissException ?: exception.second as? CacheMissException
         val networkException = exception.first as? ApolloNetworkException ?: exception.second as? ApolloNetworkException
-        if (cacheMissException != null && emitCacheErrors) {
+        if (cacheMissException != null && throwCacheErrors) {
           throw cacheMissException
         }
-        if (networkException != null && emitNetworkErrors) {
+        if (networkException != null && throwNetworkErrors) {
           throw networkException
         }
       }

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -131,7 +131,7 @@ class WatcherErrorHandlingTest {
   @Test
   fun fetchThrowCacheErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
     mockServer.enqueue(MockResponse(500))
-    assertFailsWith(CacheMissException::class) {
+    assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
           .watch(WatchErrorHandling.ThrowCacheErrors)
@@ -146,7 +146,7 @@ class WatcherErrorHandlingTest {
     }
 
     mockServer.enqueue(MockResponse(500))
-    assertFailsWith(CacheMissException::class) {
+    assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
           .watch(WatchErrorHandling.ThrowCacheErrors)
@@ -157,7 +157,7 @@ class WatcherErrorHandlingTest {
   @Test
   fun fetchThrowNetworkErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
     mockServer.enqueue(MockResponse(500))
-    assertFailsWith(ApolloHttpException::class) {
+    assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
           .watch(WatchErrorHandling.ThrowNetworkErrors)
@@ -173,7 +173,7 @@ class WatcherErrorHandlingTest {
     }
 
     mockServer.enqueue(MockResponse(500))
-    assertFailsWith(ApolloHttpException::class) {
+    assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
           .watch(WatchErrorHandling.ThrowNetworkErrors)

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -1,0 +1,274 @@
+package test
+
+import IdCacheKeyGenerator
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.WatchErrorHandling
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.refetchPolicy
+import com.apollographql.apollo3.cache.normalized.store
+import com.apollographql.apollo3.cache.normalized.watch
+import com.apollographql.apollo3.exception.ApolloCompositeException
+import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.exception.CacheMissException
+import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
+import com.apollographql.apollo3.integration.normalizer.type.Episode
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.testing.receiveOrTimeout
+import com.apollographql.apollo3.testing.runTest
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import testFixtureToUtf8
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+@OptIn(ApolloExperimental::class)
+class WatcherErrorHandlingTest {
+  private lateinit var mockServer: MockServer
+  private lateinit var apolloClient: ApolloClient
+  private lateinit var store: ApolloStore
+
+  private suspend fun setUp() {
+    store = ApolloStore(MemoryCacheFactory(), cacheKeyGenerator = IdCacheKeyGenerator)
+    mockServer = MockServer()
+    apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).store(store).build()
+  }
+
+  private suspend fun tearDown() {
+    mockServer.stop()
+  }
+
+  @Test
+  fun fetchIgnoreAllErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>()
+    val jobs = mutableListOf<Job>()
+
+    jobs += launch {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheFirst)
+          .watch()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+
+    jobs += launch {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheOnly)
+          .watch()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+
+    jobs += launch {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkFirst)
+          .watch()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+
+    jobs += launch {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .watch()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+
+    channel.assertEmpty()
+    jobs.forEach { it.cancel() }
+  }
+
+  @Test
+  fun refetchIgnoreAllErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>()
+
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // The first query should get a "R2-D2" name
+    val job = launch {
+      mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseWithId.json"))
+      apolloClient.query(query)
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .refetchPolicy(FetchPolicy.NetworkOnly)
+          .watch()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "R2-D2")
+
+    // Another newer call gets updated information with "Artoo"
+    // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
+    // we didn't enqueue anything in the mockServer so a network exception is thrown, and ignored by default
+    mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    channel.assertEmpty()
+    job.cancel()
+  }
+
+
+  @Test
+  fun fetchThrowCacheErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    assertFailsWith(CacheMissException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheFirst)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(CacheMissException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheOnly)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(CacheMissException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkFirst)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .first()
+    }
+  }
+
+  @Test
+  fun fetchThrowNetworkErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    assertFailsWith(ApolloHttpException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkFirst)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(ApolloHttpException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(ApolloHttpException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheFirst)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .first()
+    }
+  }
+
+  @Test
+  fun refetchThrowNetworkErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>()
+
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    var throwable: Throwable? = null
+
+    // The first query should get a "R2-D2" name
+    val job = launch {
+      mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseWithId.json"))
+      apolloClient.query(query)
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .refetchPolicy(FetchPolicy.NetworkOnly)
+          .watch(refetchErrorHandling = WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .catch { throwable = it }
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "R2-D2")
+
+    // Another newer call gets updated information with "Artoo"
+    // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
+    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to THROW_NETWORK_ERRORS
+    mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    channel.assertEmpty()
+
+    assertIs<ApolloHttpException>(throwable)
+
+    job.cancel()
+  }
+
+  @Test
+  fun fetchThrowCacheAndNetworkErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    assertFailsWith(CacheMissException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheOnly)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(ApolloHttpException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(ApolloCompositeException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.NetworkFirst)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .first()
+    }
+
+    assertFailsWith(ApolloCompositeException::class) {
+      apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
+          .fetchPolicy(FetchPolicy.CacheFirst)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .first()
+    }
+  }
+
+  @Test
+  fun refetchThrowCacheAndNetworkErrors() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>()
+
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    var throwable: Throwable? = null
+
+    // The first query should get a "R2-D2" name
+    val job = launch {
+      mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseWithId.json"))
+      apolloClient.query(query)
+          .fetchPolicy(FetchPolicy.NetworkOnly)
+          .refetchPolicy(FetchPolicy.NetworkOnly)
+          .watch(refetchErrorHandling = WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .catch { throwable = it }
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "R2-D2")
+
+    // Another newer call gets updated information with "Artoo"
+    // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
+    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to THROW_CACHE_AND_NETWORK_ERRORS
+    mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    channel.assertEmpty()
+
+    assertIs<ApolloHttpException>(throwable)
+
+    job.cancel()
+  }
+}

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -7,9 +7,7 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.WatchErrorHandling
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.errorHandling
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
-import com.apollographql.apollo3.cache.normalized.refetchErrorHandling
 import com.apollographql.apollo3.cache.normalized.refetchPolicy
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
@@ -130,24 +128,21 @@ class WatcherErrorHandlingTest {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowCacheErrors)
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowCacheErrors)
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowCacheErrors)
           .first()
     }
   }
@@ -157,24 +152,21 @@ class WatcherErrorHandlingTest {
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowNetworkErrors)
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowNetworkErrors)
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
-          .watch()
+          .watch(WatchErrorHandling.ThrowNetworkErrors)
           .first()
     }
   }
@@ -193,8 +185,7 @@ class WatcherErrorHandlingTest {
       apolloClient.query(query)
           .fetchPolicy(FetchPolicy.NetworkOnly)
           .refetchPolicy(FetchPolicy.NetworkOnly)
-          .refetchErrorHandling(WatchErrorHandling.ThrowNetworkErrors)
-          .watch()
+          .watch(refetchErrorHandling = WatchErrorHandling.ThrowNetworkErrors)
           .catch { throwable = it }
           .collect {
             channel.send(it.data)
@@ -220,32 +211,28 @@ class WatcherErrorHandlingTest {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .errorHandling(WatchErrorHandling.ThrowAll)
-          .watch()
+          .watch(WatchErrorHandling.ThrowAll)
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .errorHandling(WatchErrorHandling.ThrowAll)
-          .watch()
+          .watch(WatchErrorHandling.ThrowAll)
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .errorHandling(WatchErrorHandling.ThrowAll)
-          .watch()
+          .watch(WatchErrorHandling.ThrowAll)
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .errorHandling(WatchErrorHandling.ThrowAll)
-          .watch()
+          .watch(WatchErrorHandling.ThrowAll)
           .first()
     }
   }
@@ -264,8 +251,7 @@ class WatcherErrorHandlingTest {
       apolloClient.query(query)
           .fetchPolicy(FetchPolicy.NetworkOnly)
           .refetchPolicy(FetchPolicy.NetworkOnly)
-          .refetchErrorHandling(WatchErrorHandling.ThrowAll)
-          .watch()
+          .watch(refetchErrorHandling = WatchErrorHandling.ThrowAll)
           .catch { throwable = it }
           .collect {
             channel.send(it.data)

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -7,7 +7,9 @@ import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.WatchErrorHandling
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.errorHandling
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.refetchErrorHandling
 import com.apollographql.apollo3.cache.normalized.refetchPolicy
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
@@ -128,21 +130,24 @@ class WatcherErrorHandlingTest {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
+          .watch()
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
+          .watch()
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowCacheErrors)
+          .watch()
           .first()
     }
   }
@@ -152,21 +157,24 @@ class WatcherErrorHandlingTest {
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
+          .watch()
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
+          .watch()
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowNetworkErrors)
+          .watch()
           .first()
     }
   }
@@ -185,7 +193,8 @@ class WatcherErrorHandlingTest {
       apolloClient.query(query)
           .fetchPolicy(FetchPolicy.NetworkOnly)
           .refetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(refetchErrorHandling = WatchErrorHandling.THROW_NETWORK_ERRORS)
+          .refetchErrorHandling(WatchErrorHandling.ThrowNetworkErrors)
+          .watch()
           .catch { throwable = it }
           .collect {
             channel.send(it.data)
@@ -195,7 +204,7 @@ class WatcherErrorHandlingTest {
 
     // Another newer call gets updated information with "Artoo"
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
-    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to THROW_NETWORK_ERRORS
+    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to ThrowNetworkErrors
     mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
@@ -211,28 +220,32 @@ class WatcherErrorHandlingTest {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowAll)
+          .watch()
           .first()
     }
 
     assertFailsWith(ApolloHttpException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowAll)
+          .watch()
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowAll)
+          .watch()
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .errorHandling(WatchErrorHandling.ThrowAll)
+          .watch()
           .first()
     }
   }
@@ -251,7 +264,8 @@ class WatcherErrorHandlingTest {
       apolloClient.query(query)
           .fetchPolicy(FetchPolicy.NetworkOnly)
           .refetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(refetchErrorHandling = WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
+          .refetchErrorHandling(WatchErrorHandling.ThrowAll)
+          .watch()
           .catch { throwable = it }
           .collect {
             channel.send(it.data)
@@ -261,7 +275,7 @@ class WatcherErrorHandlingTest {
 
     // Another newer call gets updated information with "Artoo"
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
-    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to THROW_CACHE_AND_NETWORK_ERRORS
+    // we didn't enqueue anything in mockServer so a network exception is thrown, and surfaced due to ThrowAll
     mockServer.enqueue(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -400,81 +400,81 @@ class WatcherTest {
   }
 
   @Test
-  fun emitCacheErrors() = runTest(before = { setUpForNetworkException() }) {
+  fun throwCacheErrors() = runTest(before = { setUpForNetworkException() }) {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.EMIT_CACHE_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .watch(WatchErrorHandling.EMIT_CACHE_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
           .first()
     }
 
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.EMIT_CACHE_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_ERRORS)
           .first()
     }
   }
 
   @Test
-  fun emitNetworkErrors() = runTest(before = { setUpForNetworkException() }) {
+  fun throwNetworkErrors() = runTest(before = { setUpForNetworkException() }) {
     assertFailsWith(ApolloNetworkException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.EMIT_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
           .first()
     }
 
     assertFailsWith(ApolloNetworkException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(WatchErrorHandling.EMIT_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
           .first()
     }
 
     assertFailsWith(ApolloNetworkException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.EMIT_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_NETWORK_ERRORS)
           .first()
     }
   }
 
 
   @Test
-  fun emitCacheAndNetworkErrors() = runTest(before = { setUpForNetworkException() }) {
+  fun throwCacheAndNetworkErrors() = runTest(before = { setUpForNetworkException() }) {
     assertFailsWith(CacheMissException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheOnly)
-          .watch(WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
           .first()
     }
 
     assertFailsWith(ApolloNetworkException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
-          .watch(WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
-          .watch(WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
           .first()
     }
 
     assertFailsWith(ApolloCompositeException::class) {
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
-          .watch(WatchErrorHandling.EMIT_CACHE_AND_NETWORK_ERRORS)
+          .watch(WatchErrorHandling.THROW_CACHE_AND_NETWORK_ERRORS)
           .first()
     }
   }

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -405,10 +405,6 @@ class WatcherTest {
           .onCompletion {
             emitAll(apolloClient.query(query).watch(data))
           }
-          .catch {
-            // Swallow cache and network errors
-            if (it !is ApolloException) throw it
-          }
           .collect {
             channel.send(it.data)
           }


### PR DESCRIPTION
Related to #3786.

Introduce `WatchErrorHandling` enum and use it in `WatcherInterceptor`.