### PR TITLE
Make MockServer crash when querying with no enqueued response

### DIFF
--- a/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
+++ b/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
@@ -134,7 +134,7 @@ class Socket(
           try {
             mockServerHandler.handle(request)
           } catch (e: Exception) {
-            MockResponse("MockServerHandler.handle() threw an exception: ${e.message}", 500)
+            throw Exception("MockServerHandler.handle() threw an exception: ${e.message}", e)
           }
         }
 

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
@@ -8,8 +8,6 @@ import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.testing.runTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 @OptIn(ApolloExperimental::class)
 class EnqueueTest {
@@ -46,13 +44,5 @@ class EnqueueTest {
       val httpResponse = engine.execute(HttpRequest.Builder(HttpMethod.Get, mockServer.url()).build())
       assertMockResponse(mockResponse, httpResponse)
     }
-  }
-
-  @Test
-  fun status500WhenNothingWasEnqueued() = runTest(before = { setUp() }, after = { tearDown() }) {
-    val engine = DefaultHttpEngine()
-    val httpResponse = engine.execute(HttpRequest.Builder(HttpMethod.Get, mockServer.url()).build())
-    assertEquals(500, httpResponse.statusCode)
-    assertTrue(httpResponse.body!!.readUtf8().contains("No more responses in queue"))
   }
 }

--- a/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -34,7 +34,7 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
       val mockResponse = try {
         mockServerHandler.handle(request)
       } catch (e: Exception) {
-        MockResponse("MockServerHandler.handle() threw an exception: ${e.message}", 500)
+        throw Exception("MockServerHandler.handle() threw an exception: ${e.message}", e)
       }
       res.statusCode = mockResponse.statusCode
       mockResponse.headers.forEach {

--- a/apollo-mockserver/src/jvmMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/apollo-mockserver/src/jvmMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -42,7 +42,7 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
       val mockResponse = try {
         handle(apolloMockRequest)
       } catch (e: Exception) {
-        MockResponse("MockServerHandler.handle() threw an exception: ${e.message}", 500)
+        throw Exception("MockServerHandler.handle() threw an exception: ${e.message}", e)
       }
       return mockResponse.toOkHttpMockResponse()
     }


### PR DESCRIPTION
I looked at making MockServer crash when querying with no enqueued response, instead of it returning a `500` response, following [this discussion](https://github.com/apollographql/apollo-kotlin/pull/3817#discussion_r794396672).

When that happens inside a test:
- on JVM:
  - MockServer crashes its own thread and a log is printed
  - the test itself continues
  - (depending on the test) the test will crash also after 1 minute (read timeout)
  - the test is thus marked as failed
- on Apple:
  - same, except
  - the test crash was not propagated to the test runner, and we hung forever
  - ⬆️  This PR addresses this (see `runWithMainLoopApple.kt`), so now the test is marked as failed as well
- on JS:
  - MockServer crashes and a log is printed
  - the test is immediately marked as failed at this point (I guess any crash stops the runner)

The behavior is not 100% consistent (in fact I had to remove the `status500WhenNothingWasEnqueued` test), but I think it's still clear enough to make MockServer crash like it was previously.
