### PR TITLE
Correct reference to addCustomScalarAdapter in 3.0 migration doc

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -44,7 +44,7 @@ val client = ApolloClient.builder()
   .addCustomTypeAdapter(CustomType.YOURTYPE, ...)
 
   // With:
-  .addCustomTypeAdapter(YourType.type, ...)
+  .addCustomScalarAdapter(YourType.type, ...)
 
   .build()
 


### PR DESCRIPTION
Correct reference to `addCustomScalarAdapter` for replacing `addCustomTypeAdapter` in "The quick route"