### PR TITLE
Add watchCacheAndNetwork()

### DIFF
--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -123,6 +123,10 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;Z)Lkotlinx/coroutines/flow/Flow;
+	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun watchCacheAndNetwork$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 }
 

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -77,6 +77,7 @@ public final class com/apollographql/apollo3/cache/normalized/CacheMissLoggingIn
 }
 
 public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java/lang/Enum {
+	public static final field CacheAndNetwork Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field CacheFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field CacheOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field NetworkFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
@@ -86,6 +87,7 @@ public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java
 }
 
 public final class com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors {
+	public static final fun getCacheAndNetworkInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getCacheFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getCacheOnlyInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getNetworkFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
@@ -123,10 +125,6 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;Z)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun watchCacheAndNetwork$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -152,6 +152,66 @@ val NetworkFirstInterceptor = object : ApolloInterceptor {
   }
 }
 
+/**
+ * An interceptor that goes to cache first and then to the network.
+ * An exception is not thrown if the cache fails, whereas an exception will be thrown upon network failure.
+ */
+val CacheAndNetworkInterceptor = object : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return flow {
+      var cacheException: ApolloException? = null
+      var networkException: ApolloException? = null
+
+      val cacheResponse = chain.proceed(
+          request = request
+              .newBuilder()
+              .fetchFromCache(true)
+              .build()
+      ).catch { throwable ->
+        if (throwable is ApolloException) {
+          cacheException = throwable
+        } else {
+          throw throwable
+        }
+      }.singleOrNull()
+
+      if (cacheResponse != null) {
+        emit(cacheResponse)
+      }
+
+      val networkResponse = chain.proceed(request)
+          .catch {
+            if (it is ApolloException) {
+              networkException = it
+            } else {
+              throw it
+            }
+          }.singleOrNull()
+
+      if (networkResponse != null) {
+        emit(
+            networkResponse.newBuilder()
+                .cacheInfo(
+                    networkResponse.cacheInfo!!
+                        .newBuilder()
+                        .cacheMissException(cacheException as? CacheMissException)
+                        .build()
+                )
+                .build()
+        )
+        return@flow
+      }
+      if (cacheException != null) {
+        throw ApolloCompositeException(
+            cacheException,
+            networkException
+        )
+      }
+      throw networkException!!
+    }
+  }
+}
+
 internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -12,7 +12,6 @@ import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.refetchPolicy
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
-import com.apollographql.apollo3.cache.normalized.watchCacheAndNetwork
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameWithIdQuery
@@ -446,7 +445,7 @@ class WatcherTest {
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -479,7 +478,7 @@ class WatcherTest {
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -513,7 +512,7 @@ class WatcherTest {
     apolloClient.enqueueTestNetworkError()
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -544,7 +543,7 @@ class WatcherTest {
     apolloClient.enqueueTestNetworkError()
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.refetchPolicy
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
+import com.apollographql.apollo3.cache.normalized.watchCacheAndNetwork
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameWithIdQuery
@@ -19,6 +20,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithI
 import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.testing.QueueTestNetworkTransport
+import com.apollographql.apollo3.testing.enqueueTestNetworkError
 import com.apollographql.apollo3.testing.enqueueTestResponse
 import com.apollographql.apollo3.testing.receiveOrTimeout
 import com.apollographql.apollo3.testing.runTest
@@ -374,8 +376,11 @@ class WatcherTest {
     job.cancel()
   }
 
+  /**
+   * Demonstrates how watch(Data?) can be used in advanced scenarios.
+   */
   @Test
-  fun watchCacheAndNetwork() = runTest(before = { setUp() }) {
+  fun watchCacheAndNetworkManual() = runTest(before = { setUp() }) {
     val channel = Channel<EpisodeHeroNameQuery.Data?>(capacity = Channel.UNLIMITED)
     val query = EpisodeHeroNameQuery(Episode.EMPIRE)
 
@@ -424,6 +429,140 @@ class WatcherTest {
 
     job.cancel()
   }
+
+  /**
+   * watchCacheAndNetwork() with cached value and no network error
+   */
+  @Test
+  fun watchCacheAndNetwork() = runTest(before = { setUp() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>(capacity = Channel.UNLIMITED)
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // Set up the cache with a "R2-D2" name
+    apolloClient.enqueueTestResponse(query, episodeHeroNameData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // Prepare next call to get "Artoo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
+
+    val job = launch {
+      apolloClient.query(query).watchCacheAndNetwork()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    // 1. Value from the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "R2-D2")
+
+    // 2. Value from the network
+    assertEquals(channel.receiveOrTimeout(5000)?.hero?.name, "Artoo")
+
+    // Another newer call updates the cache with "ArTwo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // 3. Value from watching the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "ArTwo")
+
+    job.cancel()
+  }
+
+  /**
+   * watchCacheAndNetwork() with a cache miss
+   */
+  @Test
+  fun watchCacheAndNetworkWithCacheMiss() = runTest(before = { setUp() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>(capacity = Channel.UNLIMITED)
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // Prepare next call to get "Artoo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
+
+    val job = launch {
+      apolloClient.query(query).watchCacheAndNetwork()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    // 1. Value from the network
+    assertEquals(channel.receiveOrTimeout(5000)?.hero?.name, "Artoo")
+
+    // Another newer call updates the cache with "ArTwo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // 2. Value from watching the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "ArTwo")
+
+    job.cancel()
+  }
+
+  /**
+   * watchCacheAndNetwork() with a network error on the initial call
+   */
+  @Test
+  fun watchCacheAndNetworkWithNetworkError() = runTest(before = { setUp() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>(capacity = Channel.UNLIMITED)
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // Set up the cache with a "R2-D2" name
+    apolloClient.enqueueTestResponse(query, episodeHeroNameData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // Prepare next call to be a network error
+    apolloClient.enqueueTestNetworkError()
+
+    val job = launch {
+      apolloClient.query(query).watchCacheAndNetwork()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+    // 1. Value from the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "R2-D2")
+    channel.assertEmpty()
+
+    // Another newer call updates the cache with "ArTwo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // 2. Value from watching the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "ArTwo")
+
+    job.cancel()
+  }
+
+  /**
+   * watchCacheAndNetwork() with a cache error AND a network error on the initial call
+   */
+  @Test
+  fun watchCacheAndNetworkWithCacheAndNetworkError() = runTest(before = { setUp() }) {
+    val channel = Channel<EpisodeHeroNameQuery.Data?>(capacity = Channel.UNLIMITED)
+    val query = EpisodeHeroNameQuery(Episode.EMPIRE)
+
+    // Prepare next call to be a network error
+    apolloClient.enqueueTestNetworkError()
+
+    val job = launch {
+      apolloClient.query(query).watchCacheAndNetwork()
+          .collect {
+            channel.send(it.data)
+          }
+    }
+
+    // We got nothing
+    channel.assertEmpty()
+
+    // Another newer call updates the cache with "ArTwo"
+    apolloClient.enqueueTestResponse(query, episodeHeroNameChangedTwoData)
+    apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+
+    // Value from watching the cache
+    assertEquals(channel.receiveOrTimeout()?.hero?.name, "ArTwo")
+
+    job.cancel()
+  }
+
 }
 
 suspend fun <D> Channel<D>.assertEmpty() {


### PR DESCRIPTION
Related to #3763.

This adds a `watchCacheAndNetwork()` extension.

Unrelated, this PR also adds `enqueueTestNetworkError` / `registerNetworkError` to `TestNetworkTransport`.

Another approach is in #3829, to compare.