### PR TITLE
CacheAndNetwork FetchPolicy

### DIFF
--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -77,6 +77,7 @@ public final class com/apollographql/apollo3/cache/normalized/CacheMissLoggingIn
 }
 
 public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java/lang/Enum {
+	public static final field CacheAndNetwork Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field CacheFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field CacheOnly Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
 	public static final field NetworkFirst Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;
@@ -86,6 +87,7 @@ public final class com/apollographql/apollo3/cache/normalized/FetchPolicy : java
 }
 
 public final class com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors {
+	public static final fun getCacheAndNetworkInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getCacheFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getCacheOnlyInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
 	public static final fun getNetworkFirstInterceptor ()Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;
@@ -123,10 +125,6 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun watch (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Query$Data;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun watch$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;Z)Lkotlinx/coroutines/flow/Flow;
-	public static final fun watchCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;ZZ)Lkotlinx/coroutines/flow/Flow;
-	public static synthetic fun watchCacheAndNetwork$default (Lcom/apollographql/apollo3/ApolloCall;ZZILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun writeToCacheAsynchronously (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 }
 

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -31,32 +31,36 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
 
 enum class FetchPolicy {
   /**
-   * Try cache first, then network
+   * Try the cache, if that failed, try the network
    *
    * This is the default behaviour
    */
   CacheFirst,
 
   /**
-   * Only try cache
+   * Only try the cache
    */
   CacheOnly,
 
   /**
-   * Try network first, then cache
+   * Try the network, if that failed, try the cache
    */
   NetworkFirst,
 
   /**
-   * Only try network
+   * Only try the network
    */
   NetworkOnly,
+
+  /**
+   * Try the cache, then also try the network
+   */
+  CacheAndNetwork,
 }
 
 /**
@@ -128,28 +132,6 @@ fun <D : Query.Data> ApolloCall<D>.watch(
                   !refetchThrows
                 }
         )
-      }
-}
-
-/**
- * Gets the result from the cache, then the network, then observes the cache for any changes.
- * [fetchPolicy] has no effect, while [refetchPolicy] will control the subsequent fetches.
- * Network and cache exceptions are ignored by default, this can be changed by setting [fetchThrows] for the initial cache and network
- * fetches and [refetchThrows] for subsequent fetches (non Apollo exceptions like `OutOfMemoryError` are always propagated).
- *
- * @param fetchThrows whether to throw if an [ApolloException] happens during the initial cache and network fetches. Default: false
- * @param refetchThrows whether to throw if an [ApolloException] happens during a refetch. Default: false
- */
-@JvmOverloads
-fun <D : Query.Data> ApolloCall<D>.watchCacheAndNetwork(
-    fetchThrows: Boolean = false,
-    refetchThrows: Boolean = false,
-): Flow<ApolloResponse<D>> {
-  return copy().fetchPolicy(FetchPolicy.NetworkOnly).watch(fetchThrows, refetchThrows)
-      .onStart {
-        emitAll(copy().fetchPolicy(FetchPolicy.CacheOnly).toFlow().catch {
-          if (it !is ApolloException || fetchThrows) throw it
-        })
       }
 }
 
@@ -249,6 +231,7 @@ private fun interceptorFor(fetchPolicy: FetchPolicy) = when (fetchPolicy) {
   FetchPolicy.NetworkOnly -> NetworkOnlyInterceptor
   FetchPolicy.CacheFirst -> CacheFirstInterceptor
   FetchPolicy.NetworkFirst -> NetworkFirstInterceptor
+  FetchPolicy.CacheAndNetwork -> CacheAndNetworkInterceptor
 }
 
 /**

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -36,29 +36,41 @@ import kotlin.jvm.JvmOverloads
 
 enum class FetchPolicy {
   /**
-   * Try the cache, if that failed, try the network
+   * Try the cache, if that failed, try the network.
    *
-   * This is the default behaviour
+   * An [ApolloCompositeException] is thrown if the data is not in the cache and the network call failed, otherwise 1 value is emitted.
+   *
+   * This is the default behaviour.
    */
   CacheFirst,
 
   /**
-   * Only try the cache
+   * Only try the cache.
+   *
+   * A [CacheMissException] is thrown if the data is not in the cache, otherwise 1 value is emitted.
    */
   CacheOnly,
 
   /**
-   * Try the network, if that failed, try the cache
+   * Try the network, if that failed, try the cache.
+   *
+   * An [ApolloCompositeException] is thrown if the network call failed and the data is not in the cache, otherwise 1 value is emitted.
    */
   NetworkFirst,
 
   /**
-   * Only try the network
+   * Only try the network.
+   *
+   * An [ApolloException] is thrown if the network call failed, otherwise 1 value is emitted.
    */
   NetworkOnly,
 
   /**
-   * Try the cache, then also try the network
+   * Try the cache, then also try the network.
+   *
+   * If the data is in the cache, it is emitted, if not, no exception is thrown at that point. Then the network call is made, and if
+   * successful, the value is emitted, if not, either an [ApolloCompositeException] (both cache miss and network failed) or an
+   * [ApolloException] (only network failed) is thrown.
    */
   CacheAndNetwork,
 }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -152,6 +152,66 @@ val NetworkFirstInterceptor = object : ApolloInterceptor {
   }
 }
 
+/**
+ * An interceptor that goes to cache first and then to the network.
+ * An exception is not thrown if the cache fails, whereas an exception will be thrown upon network failure.
+ */
+val CacheAndNetworkInterceptor = object : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    return flow {
+      var cacheException: ApolloException? = null
+      var networkException: ApolloException? = null
+
+      val cacheResponse = chain.proceed(
+          request = request
+              .newBuilder()
+              .fetchFromCache(true)
+              .build()
+      ).catch { throwable ->
+        if (throwable is ApolloException) {
+          cacheException = throwable
+        } else {
+          throw throwable
+        }
+      }.singleOrNull()
+
+      if (cacheResponse != null) {
+        emit(cacheResponse)
+      }
+
+      val networkResponse = chain.proceed(request)
+          .catch {
+            if (it is ApolloException) {
+              networkException = it
+            } else {
+              throw it
+            }
+          }.singleOrNull()
+
+      if (networkResponse != null) {
+        emit(
+            networkResponse.newBuilder()
+                .cacheInfo(
+                    networkResponse.cacheInfo!!
+                        .newBuilder()
+                        .cacheMissException(cacheException as? CacheMissException)
+                        .build()
+                )
+                .build()
+        )
+        return@flow
+      }
+      if (cacheException != null) {
+        throw ApolloCompositeException(
+            cacheException,
+            networkException
+        )
+      }
+      throw networkException!!
+    }
+  }
+}
+
 internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -12,7 +12,6 @@ import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.refetchPolicy
 import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.cache.normalized.watch
-import com.apollographql.apollo3.cache.normalized.watchCacheAndNetwork
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameWithIdQuery
@@ -446,7 +445,7 @@ class WatcherTest {
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -479,7 +478,7 @@ class WatcherTest {
     apolloClient.enqueueTestResponse(query, episodeHeroNameChangedData)
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -513,7 +512,7 @@ class WatcherTest {
     apolloClient.enqueueTestNetworkError()
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }
@@ -544,7 +543,7 @@ class WatcherTest {
     apolloClient.enqueueTestNetworkError()
 
     val job = launch {
-      apolloClient.query(query).watchCacheAndNetwork()
+      apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).watch()
           .collect {
             channel.send(it.data)
           }


### PR DESCRIPTION
This is another approach to #3763, to compare and choose the best one :).

Instead of having a specific `watchCacheAndNetwork()` method, a new `FetchPolicy.CacheAndNetwork` can be used with `watch()`.

(This one targets the branch of the first approach)

Thoughts: I thought I could replace the implementation of `executeCacheAndNetwork` with a call with the new policy, but the exception handling is different (current `executeCacheAndNetwork` throws only if both cache and network failed).