### PR TITLE
Fix null pointer exception in LruCache

### DIFF
--- a/apollo-normalized-cache-api/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
+++ b/apollo-normalized-cache-api/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
@@ -1,5 +1,5 @@
 package com.apollographql.apollo3.cache.normalized.api.internal
 
-actual class CacheLock actual constructor() {
+internal actual class CacheLock actual constructor() {
   actual fun <T> lock(block: () -> T): T = block()
 }

--- a/apollo-normalized-cache-api/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
+++ b/apollo-normalized-cache-api/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.cache.normalized.api.internal
+
+actual class CacheLock actual constructor() {
+  actual fun <T> lock(block: () -> T): T = block()
+}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
@@ -1,5 +1,5 @@
 package com.apollographql.apollo3.cache.normalized.api.internal
 
-expect class CacheLock() {
+internal expect class CacheLock() {
   fun <T> lock(block: () -> T): T
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.cache.normalized.api.internal
+
+expect class CacheLock() {
+  fun <T> lock(block: () -> T): T
+}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/LruCache.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/LruCache.kt
@@ -119,9 +119,14 @@ internal class LruCache<Key, Value>(
     }
 
     node.prev?.next = node.next
-    node.next?.prev = node.prev
 
-    node.next = headNode?.next
+    if (node.next == null) {
+      tailNode = node.prev
+    } else {
+      node.next?.prev = node.prev
+    }
+
+    node.next = headNode
     node.prev = null
 
     headNode?.prev = node

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/LruCache.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/LruCache.kt
@@ -22,14 +22,11 @@ internal class LruCache<Key, Value>(
   private var headNode: Node<Key, Value>? = null
   private var tailNode: Node<Key, Value>? = null
   private var size: Int = 0
-  private val lock = CacheLock()
 
   operator fun get(key: Key): Value? {
     val node = cache[key]
     if (node != null) {
-      lock.lock {
-        moveNodeToHead(node)
-      }
+      moveNodeToHead(node)
     }
     return node?.value
   }

--- a/apollo-normalized-cache-api/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
+++ b/apollo-normalized-cache-api/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
@@ -1,5 +1,5 @@
 package com.apollographql.apollo3.cache.normalized.api.internal
 
-actual class CacheLock actual constructor() {
+internal actual class CacheLock actual constructor() {
   actual fun <T> lock(block: () -> T): T = block()
 }

--- a/apollo-normalized-cache-api/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
+++ b/apollo-normalized-cache-api/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.cache.normalized.api.internal
+
+actual class CacheLock actual constructor() {
+  actual fun <T> lock(block: () -> T): T = block()
+}

--- a/apollo-normalized-cache-api/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
+++ b/apollo-normalized-cache-api/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
@@ -1,8 +1,6 @@
 package com.apollographql.apollo3.cache.normalized.api.internal
 
-import java.util.concurrent.atomic.AtomicInteger
-
-actual class CacheLock actual constructor() {
+internal actual class CacheLock actual constructor() {
   actual fun <T> lock(block: () -> T): T {
     return synchronized(this) {
       block()

--- a/apollo-normalized-cache-api/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
+++ b/apollo-normalized-cache-api/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
@@ -1,0 +1,11 @@
+package com.apollographql.apollo3.cache.normalized.api.internal
+
+import java.util.concurrent.atomic.AtomicInteger
+
+actual class CacheLock actual constructor() {
+  actual fun <T> lock(block: () -> T): T {
+    return synchronized(this) {
+      block()
+    }
+  }
+}

--- a/tests/integration-tests/src/jvmTest/kotlin/test/CacheConcurrencyTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/CacheConcurrencyTest.kt
@@ -1,0 +1,37 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.store
+import com.apollographql.apollo3.integration.normalizer.CharacterNameByIdQuery
+import com.apollographql.apollo3.testing.QueueTestNetworkTransport
+import com.apollographql.apollo3.testing.enqueueTestResponse
+import com.apollographql.apollo3.testing.runTest
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlin.test.Test
+
+@OptIn(ApolloExperimental::class)
+class CacheConcurrencyTest {
+
+  @Test
+  fun storeConcurrently() = runTest {
+    val store = ApolloStore(MemoryCacheFactory(maxSizeBytes = 1000))
+    val apolloClient = ApolloClient.Builder().networkTransport(QueueTestNetworkTransport()).store(store).build()
+
+    val concurrency = 100
+
+    0.until(concurrency).map {
+      launch {
+        val query = CharacterNameByIdQuery((it / 2).toString())
+        apolloClient.enqueueTestResponse(query, CharacterNameByIdQuery.Data(CharacterNameByIdQuery.Character(name = it.toString())))
+        apolloClient.query(query).execute()
+      }
+    }.joinAll()
+
+    println(store.dump().values.toList()[1].map { (k, v) -> "$k -> ${v.fields}" }.joinToString("\n"))
+  }
+}

--- a/tests/integration-tests/src/jvmTest/kotlin/test/CacheConcurrencyTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/CacheConcurrencyTest.kt
@@ -10,8 +10,10 @@ import com.apollographql.apollo3.testing.QueueTestNetworkTransport
 import com.apollographql.apollo3.testing.enqueueTestResponse
 import com.apollographql.apollo3.testing.runTest
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
+import java.util.concurrent.Executors
 import kotlin.test.Test
 
 @OptIn(ApolloExperimental::class)
@@ -20,18 +22,26 @@ class CacheConcurrencyTest {
   @Test
   fun storeConcurrently() = runTest {
     val store = ApolloStore(MemoryCacheFactory(maxSizeBytes = 1000))
-    val apolloClient = ApolloClient.Builder().networkTransport(QueueTestNetworkTransport()).store(store).build()
+    val executor = Executors.newFixedThreadPool(10)
+    val dispatcher = executor.asCoroutineDispatcher()
+
+    val apolloClient = ApolloClient.Builder()
+        .networkTransport(QueueTestNetworkTransport())
+        .store(store)
+        .requestedDispatcher(dispatcher)
+        .build()
 
     val concurrency = 100
 
     0.until(concurrency).map {
-      launch {
+      launch(dispatcher) {
         val query = CharacterNameByIdQuery((it / 2).toString())
         apolloClient.enqueueTestResponse(query, CharacterNameByIdQuery.Data(CharacterNameByIdQuery.Character(name = it.toString())))
         apolloClient.query(query).execute()
       }
     }.joinAll()
 
+    executor.shutdown()
     println(store.dump().values.toList()[1].map { (k, v) -> "$k -> ${v.fields}" }.joinToString("\n"))
   }
 }


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-kotlin/issues/3818

It turns out there were two issues:

* LruCache cannot use a read lock only because accesses actually write data structures
* The `moveNodeToHead` function wasn't updating the tail pointer