### PR TITLE
Fix custom scalars doc

### DIFF
--- a/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/LongAdapter.kt
+++ b/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/LongAdapter.kt
@@ -1,7 +1,0 @@
-package com.apollographql.apollo3.adapter
-
-import com.apollographql.apollo3.api.Adapter
-import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.json.JsonReader
-import com.apollographql.apollo3.api.json.JsonWriter
-

--- a/docs/source/essentials/custom-scalars.mdx
+++ b/docs/source/essentials/custom-scalars.mdx
@@ -119,13 +119,16 @@ This method takes a type-safe generated class from `Types`, along with its corre
 
 The `com.apollographql.apollo3:apollo-adapters` artifact provides built-in adapters for the following common custom scalar types.
 
-| Adapter | Description |
-|---------|-------------|
-| `com.apollographql.apollo3.adapter.InstantAdapter` | For `kotlinx.datetime.Instant` ISO8601 dates |
-| `com.apollographql.apollo3.adapter.LocalDateAdapter` | For `kotlinx.datetime.LocalDate` ISO8601 dates |
-| `com.apollographql.apollo3.adapter.DateAdapter` | For `java.util.Date` ISO8601 dates |
-| `com.apollographql.apollo3.adapter.LongAdapter` | For `java.lang.Long` |
-| `com.apollographql.apollo3.adapter.BigDecimalAdapter` | For a MPP `com.apollographql.apollo3.BigDecimal` class holding big decimal values |
+| Adapter                                                         | Description                                                                                         |
+|-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `com.apollographql.apollo3.adapter.KotlinxInstantAdapter`       | For `kotlinx.datetime.Instant` ISO8601 dates                                                        |
+| `com.apollographql.apollo3.adapter.JavaInstantAdapter`          | For `java.time.Instant` ISO8601 dates                                                               |
+| `com.apollographql.apollo3.adapter.KotlinxLocalDateAdapter`     | For `kotlinx.datetime.LocalDate` ISO8601 dates                                                      |
+| `com.apollographql.apollo3.adapter.JavaLocalDateAdapter`        | For `java.time.LocalDate` ISO8601 dates                                                             |
+| `com.apollographql.apollo3.adapter.KotlinxLocalDateTimeAdapter` | For `kotlinx.datetime.LocalDateTime` ISO8601 dates                                                  |
+| `com.apollographql.apollo3.adapter.JavaLocalDateTimeAdapter`    | For `java.time.LocalDateTime` ISO8601 dates                                                         |
+| `com.apollographql.apollo3.adapter.DateAdapter`                 | For `java.util.Date` ISO8601 dates                                                                  |
+| `com.apollographql.apollo3.adapter.BigDecimalAdapter`           | For a Multiplatform `com.apollographql.apollo3.adapter.BigDecimal` class holding big decimal values |
 
 For example, to use `DateAdapter`, configure your Gradle scripts like so:
 
@@ -135,6 +138,6 @@ dependencies {
 }
 
 apollo {
-  mapScalar("Date", "java.util.Date", "com.apollographql.apollo3.adapter.DateAdapter()")
+  mapScalar("Date", "java.util.Date", "com.apollographql.apollo3.adapter.DateAdapter")
 }
 ```

--- a/docs/source/essentials/custom-scalars.mdx
+++ b/docs/source/essentials/custom-scalars.mdx
@@ -114,10 +114,16 @@ This method takes a type-safe generated class from `Types`, along with its corre
 
 > If you can't find `Types`, build your project to trigger codegen.
 
-
 ## Apollo-provided adapters
 
-The `com.apollographql.apollo3:apollo-adapters` artifact provides built-in adapters for the following common custom scalar types.
+The following built-in adapters can be used with common custom scalar types:
+
+| Adapter                                      | Description                                       |
+|----------------------------------------------|---------------------------------------------------|
+| `com.apollographql.apollo3.api.FloatAdapter` | Converts from/to `kotlin.Float`/`java.lang.Float` |
+| `com.apollographql.apollo3.api.LongAdapter`  | Converts from/to `kotlin.Long`/`java.lang.Long`   |
+
+In addition, the `com.apollographql.apollo3:apollo-adapters` artifact provides these adapters:
 
 | Adapter                                                         | Description                                                                                         |
 |-----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
The list of provided adapters in `apollo-adapters` wasn't up to date.