### PR TITLE
Make guessNumber read the next value only once

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReaders.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReaders.kt
@@ -51,18 +51,17 @@ fun JsonReader.readAny(): Any? {
 }
 
 private fun JsonReader.guessNumber(): Any {
-  val jsonNumber = nextNumber()
   try {
-    return jsonNumber.value.toInt()
+    return nextInt()
   } catch (_: Exception) {
   }
   try {
-    return jsonNumber.value.toLong()
+    return nextLong()
   } catch (_: Exception) {
   }
   try {
-    return jsonNumber.value.toDouble()
+    return nextDouble()
   } catch (_: Exception) {
   }
-  return jsonNumber
+  return nextNumber()
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReaders.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReaders.kt
@@ -1,4 +1,5 @@
 @file:JvmName("-JsonReaders")
+
 package com.apollographql.apollo3.api.json
 
 import com.apollographql.apollo3.annotations.ApolloInternal
@@ -22,7 +23,7 @@ fun Map<String, Any?>.jsonReader(): JsonReader {
  */
 @ApolloInternal
 fun JsonReader.readAny(): Any? {
-  return when(val token = peek()) {
+  return when (val token = peek()) {
     JsonReader.Token.NULL -> nextNull()
     JsonReader.Token.BOOLEAN -> nextBoolean()
     JsonReader.Token.LONG, JsonReader.Token.NUMBER -> guessNumber()
@@ -30,7 +31,7 @@ fun JsonReader.readAny(): Any? {
     JsonReader.Token.BEGIN_OBJECT -> {
       beginObject()
       val result = mutableMapOf<String, Any?>()
-      while(hasNext()) {
+      while (hasNext()) {
         result.put(nextName(), readAny())
       }
       endObject()
@@ -39,7 +40,7 @@ fun JsonReader.readAny(): Any? {
     JsonReader.Token.BEGIN_ARRAY -> {
       beginArray()
       val result = mutableListOf<Any?>()
-      while(hasNext()) {
+      while (hasNext()) {
         result.add(readAny())
       }
       endArray()
@@ -50,17 +51,18 @@ fun JsonReader.readAny(): Any? {
 }
 
 private fun JsonReader.guessNumber(): Any {
+  val jsonNumber = nextNumber()
   try {
-    return nextInt()
-  } catch (e: Exception) {
+    return jsonNumber.value.toInt()
+  } catch (_: Exception) {
   }
   try {
-    return nextLong()
-  } catch (e: Exception) {
+    return jsonNumber.value.toLong()
+  } catch (_: Exception) {
   }
   try {
-    return nextDouble()
-  } catch (e: Exception) {
+    return jsonNumber.value.toDouble()
+  } catch (_: Exception) {
   }
-  return nextNumber()
+  return jsonNumber
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
@@ -247,7 +247,6 @@ class MapJsonReader(val root: Map<String, Any?>) : JsonReader {
   }
 
   override fun skipValue() {
-    nextValue()
     consumeValue()
   }
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -3,6 +3,7 @@ package test
 import assertEquals2
 import com.apollographql.apollo3.adapter.KotlinxLocalDateAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.api.toJsonString
@@ -245,6 +246,16 @@ class ParseResponseBodyTest {
     )
   }
 
+  @Test
+  fun parseFloats() {
+    val dataMap = mapOf("a" to 1.1)
+    val data = GetJsonScalarQuery.Data(dataMap)
+    val query = GetJsonScalarQuery()
+    assertEquals(
+        data,
+        query.adapter().fromJson(MapJsonReader(mapOf("json" to dataMap)), CustomScalarAdapters.Empty)
+    )
+  }
 
   @Test
   fun forgettingToAddARuntimeAdapterForAScalarRegisteredInThePluginFails() {


### PR DESCRIPTION
Related to #3836

When using `AnyAdapter` (e.g. a custom scalar with no specified mapping), `JsonReader.readAny()` is used, which calls `guessNumber()`. This was calling `MapJsonReader.nextValue()` multiple times if the value could not be parsed as an `Int`, which isn't supported.

With this fix, we instead read the value once as a `JsonNumber` and try the different cases here.

