### PR TITLE
Fix error reporting when there is a "schema.graphqls" but it doesn't contain any type definition

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
@@ -38,9 +38,12 @@ class IncomingOptions(
             || it.definitions.filterIsInstance<GQLTypeDefinition>().any { it.name == "Query" }
       }
 
-      check(mainSchemaDocuments.size == 1) {
-        "Multiple schemas found:\n${mainSchemaDocuments.map { it.filePath }.joinToString("\n")}\n" +
-            "Use different services for different schemas"
+      if(mainSchemaDocuments.size > 1) {
+        error("Multiple schemas found:\n${mainSchemaDocuments.map { it.filePath }.joinToString("\n")}\n" +
+            "Use different services for different schemas")
+      } else if (mainSchemaDocuments.isEmpty()) {
+        error("Schema(s) found:\n${schemaFiles.map { it.absolutePath }.joinToString("\n")}\n" +
+            "But none of them contain type definitions.")
       }
       val mainSchemaDocument = mainSchemaDocuments.single()
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
@@ -38,7 +38,7 @@ class IncomingOptions(
             || it.definitions.filterIsInstance<GQLTypeDefinition>().any { it.name == "Query" }
       }
 
-      if(mainSchemaDocuments.size > 1) {
+      if (mainSchemaDocuments.size > 1) {
         error("Multiple schemas found:\n${mainSchemaDocuments.map { it.filePath }.joinToString("\n")}\n" +
             "Use different services for different schemas")
       } else if (mainSchemaDocuments.isEmpty()) {

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
@@ -4,6 +4,8 @@ package com.apollographql.apollo3.gradle.test
 import com.apollographql.apollo3.gradle.util.TestUtils
 import com.apollographql.apollo3.gradle.util.TestUtils.withProject
 import com.apollographql.apollo3.gradle.util.generatedChild
+import com.google.common.truth.Truth
+import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.MatcherAssert
@@ -46,6 +48,22 @@ class MultiServicesTests {
             containsString("Multiple schemas found")
         )
       }
+    }
+  }
+
+  @Test
+  fun executableSchemaFails() {
+    TestUtils.withTestProject("executable-schema-file") { dir ->
+      try {
+        TestUtils.executeTask("generateApolloSources", dir)
+        fail("expected to fail")
+      } catch (e: UnexpectedBuildFailure) {
+        MatcherAssert.assertThat(
+            e.message,
+            containsString("But none of them contain type definitions.")
+        )
+      }
+
     }
   }
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiServicesTests.kt
@@ -63,7 +63,6 @@ class MultiServicesTests {
             containsString("But none of them contain type definitions.")
         )
       }
-
     }
   }
 

--- a/apollo-gradle-plugin/testProjects/executable-schema-file/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/executable-schema-file/build.gradle.kts
@@ -1,0 +1,14 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import com.apollographql.apollo3.gradle.api.ApolloExtension
+
+buildscript {
+    apply(from = "../../testProjects/buildscript.gradle.kts")
+}
+
+apply(plugin = "org.jetbrains.kotlin.jvm")
+apply(plugin = "com.apollographql.apollo3")
+
+configure<ApolloExtension> {
+    packageNamesFromFilePaths()
+}

--- a/apollo-gradle-plugin/testProjects/executable-schema-file/src/main/graphql/schema.graphqls
+++ b/apollo-gradle-plugin/testProjects/executable-schema-file/src/main/graphql/schema.graphqls
@@ -1,0 +1,5 @@
+# This file is named schema.graphqls but actually only contains executable
+# definitions
+query Hello {
+  hello
+}


### PR DESCRIPTION
If you have an empty `src/main/graphql/schema.graphqls` (or one containing executable definitions), the plugin fails with 

```
> Multiple schemas found:
  
  Use different services for different schemas
```

Which is completely misleading. Instead, output a better error:

```
Schema(s) found:
src/main/graphql/schema.graphqls

But none of them contain type definitions.
```

Many thanks to @pcarrier for catching this 💜