### PR TITLE
Add time API fallbacks for Android <26 without java.time.Instant

### DIFF
--- a/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/internal/InstantCompat.kt
+++ b/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/internal/InstantCompat.kt
@@ -1,0 +1,39 @@
+package com.apollographql.apollo3.cache.http.internal
+
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Helper functions to fallback on Java 7 APIs for older Android devices
+ */
+private fun dateFormat(): SimpleDateFormat {
+  return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.ROOT).apply {
+    timeZone = TimeZone.getTimeZone("UTC")
+  }
+}
+
+internal fun nowDateMillis(): Long {
+  return try {
+    Instant.now().toEpochMilli()
+  } catch (e: Exception) {
+    System.currentTimeMillis()
+  }
+}
+
+internal fun nowDateString(): String {
+  return try {
+    Instant.now().toString()
+  } catch (e: Exception) {
+    return dateFormat().format(System.currentTimeMillis())
+  }
+}
+
+internal fun parseDateString(dateString: String): Long {
+  return try {
+    Instant.parse(dateString).toEpochMilli()
+  } catch (e: Exception) {
+    dateFormat().parse(dateString.replace(Regex("\\.[0-9]*"), "")).time
+  }
+}


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/issues/3819

Since enabling [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) fixes this issue and since time is overall very complicated, I'd rather not merge this PR. I'm still opening it for reference in case this happens again.