### PR TITLE
[3.1.0] Modifying a test to reproduce the double Watcher issue

### DIFF
--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -78,6 +78,7 @@ class WatcherTest {
 
     // The first query should get a "R2-D2" name
     apolloClient.enqueueTestResponse(query, episodeHeroNameData)
+    apolloClient.enqueueTestResponse(query, episodeHeroNameData)
     val job = launch {
       apolloClient.query(query).watch().collect {
         channel.send(it.data)


### PR DESCRIPTION
Just to reproduce the issue:
- Open two `watch` collectors (2 different channels)
- The first time, both channels gets updated (from network)
- The second time, only the first channel gets updated