### PR TITLE
Fix issue in Java codegen where selectors returned ImmutableMapBuilder instances instead of Map

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Collections.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Collections.kt
@@ -41,6 +41,7 @@ fun List<Pair<String, CodeBlock>>.toMapInitializerCodeblock(): CodeBlock {
         forEach {
           add(".put($S, $L)", it.first, it.second)
         }
+        add(".build()")
       }
       .build()
 }

--- a/apollo-compiler/src/test/graphql/com/example/hero_with_review/java/operationBased/hero_with_review/selections/TestQuerySelections.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/hero_with_review/java/operationBased/hero_with_review/selections/TestQuerySelections.java.expected
@@ -24,6 +24,6 @@ public class TestQuerySelections {
   );
 
   public static List<CompiledSelection> root = Arrays.asList(
-    new CompiledField.Builder("createReview", Review.type).arguments(Arrays.asList(new CompiledArgument("episode", new CompiledVariable("ep"), false), new CompiledArgument("review", new ImmutableMapBuilder().put("stars", 5).put("listOfEnums", Arrays.asList("JEDI", "EMPIRE", "NEWHOPE")).put("listOfStringNonOptional", Arrays.asList("1", "2", "3")).put("favoriteColor", new ImmutableMapBuilder().put("red", 1).put("blue", 1)), false))).selections(createReview).build()
+    new CompiledField.Builder("createReview", Review.type).arguments(Arrays.asList(new CompiledArgument("episode", new CompiledVariable("ep"), false), new CompiledArgument("review", new ImmutableMapBuilder().put("stars", 5).put("listOfEnums", Arrays.asList("JEDI", "EMPIRE", "NEWHOPE")).put("listOfStringNonOptional", Arrays.asList("1", "2", "3")).put("favoriteColor", new ImmutableMapBuilder().put("red", 1).put("blue", 1).build()).build(), false))).selections(createReview).build()
   );
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/java/operationBased/input_object_variable_and_argument/selections/TestQuerySelections.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/java/operationBased/input_object_variable_and_argument/selections/TestQuerySelections.java.expected
@@ -25,6 +25,6 @@ public class TestQuerySelections {
   );
 
   public static List<CompiledSelection> root = Arrays.asList(
-    new CompiledField.Builder("heroWithReview", Human.type).arguments(Arrays.asList(new CompiledArgument("episode", new CompiledVariable("episode"), false), new CompiledArgument("listOfInts", Arrays.asList(new CompiledVariable("stars"), new CompiledVariable("stars")), false), new CompiledArgument("review", new ImmutableMapBuilder().put("stars", new CompiledVariable("stars")).put("favoriteColor", new ImmutableMapBuilder().put("red", 0).put("green", new CompiledVariable("greenValue")).put("blue", 0)).put("booleanNonOptional", false).put("listOfStringNonOptional", Collections.emptyList()), false))).selections(heroWithReview).build()
+    new CompiledField.Builder("heroWithReview", Human.type).arguments(Arrays.asList(new CompiledArgument("episode", new CompiledVariable("episode"), false), new CompiledArgument("listOfInts", Arrays.asList(new CompiledVariable("stars"), new CompiledVariable("stars")), false), new CompiledArgument("review", new ImmutableMapBuilder().put("stars", new CompiledVariable("stars")).put("favoriteColor", new ImmutableMapBuilder().put("red", 0).put("green", new CompiledVariable("greenValue")).put("blue", 0).build()).put("booleanNonOptional", false).put("listOfStringNonOptional", Collections.emptyList()).build(), false))).selections(heroWithReview).build()
   );
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -185,7 +185,7 @@ class OtherCacheTest {
   }
 
   @Test
-  fun mutationWithoutVariable() = runTest(before = { setUp() }, after = { tearDown() }) {
+  fun mutationWithObjectValueArgument() = runTest(before = { setUp() }, after = { tearDown() }) {
     val mutation = UpdateReviewWithoutVariableMutation()
     val data = UpdateReviewWithoutVariableMutation.Data(
         UpdateReviewWithoutVariableMutation.UpdateReview(

--- a/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -17,6 +17,7 @@ import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsDirectivesQuery
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesWithIDsQuery
 import com.apollographql.apollo3.integration.normalizer.InstantQuery
+import com.apollographql.apollo3.integration.normalizer.UpdateReviewWithoutVariableMutation
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -181,5 +182,22 @@ class OtherCacheTest {
         .execute()
 
     assertEquals(instant, response.data!!.instant)
+  }
+
+  @Test
+  fun mutationWithoutVariable() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val mutation = UpdateReviewWithoutVariableMutation()
+    val data = UpdateReviewWithoutVariableMutation.Data(
+        UpdateReviewWithoutVariableMutation.UpdateReview(
+            "0",
+            5,
+            "Great"
+        )
+    )
+    mockServer.enqueue(mutation, data)
+    apolloClient.mutation(mutation).execute()
+
+    val storeData = store.readOperation(mutation)
+    assertEquals(data, storeData)
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -185,7 +185,7 @@ class OtherCacheTest {
   }
 
   @Test
-  fun mutationWithObjectValueArgument() = runTest(before = { setUp() }, after = { tearDown() }) {
+  fun cacheFieldWithObjectValueArgument() = runTest(before = { setUp() }, after = { tearDown() }) {
     val mutation = UpdateReviewWithoutVariableMutation()
     val data = UpdateReviewWithoutVariableMutation.Data(
         UpdateReviewWithoutVariableMutation.UpdateReview(

--- a/tests/integration-tests/src/main/graphql/com/apollographql/apollo3/integration/normalizer/UpdateReviewWithoutVariableMutation.graphql
+++ b/tests/integration-tests/src/main/graphql/com/apollographql/apollo3/integration/normalizer/UpdateReviewWithoutVariableMutation.graphql
@@ -1,0 +1,11 @@
+mutation UpdateReviewWithoutVariable {
+  updateReview(id: "0", review: {
+    stars: 5
+    commentary: "Great"
+    favoriteColor: {}
+  }) {
+    id
+    stars
+    commentary
+  }
+}


### PR DESCRIPTION
Added missing build statement to generated code. This issue caused JsonWriter.writeAny to fail as it doesnt handle the case where we pass in an ImmutableMapBuilder.