### PR TITLE
Mention we require Kotlin 1.6 for native

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Some platforms have specific requirements:
 For building, it requires:
 
 * Gradle 5.6
-* Kotlin 1.4+
+* Kotlin 1.4+ (1.6+ for native)
 
 ## Contributing
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -144,7 +144,7 @@ Some platforms have specific requirements:
 For building, it requires:
 
 * Gradle 5.6
-* Kotlin 1.4+
+* Kotlin 1.4+ (1.6+ for native)
 
 ## Proguard / R8 configuration
 


### PR DESCRIPTION
Moving forward, we should be more conservative about updating the Kotlin version as consumers will require at least the same version as the one we're using for building the lib. See also https://youtrack.jetbrains.com/issue/KT-42293