### PR TITLE
Chunked Transfer-Encoding support in MockServer

### DIFF
--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -17,12 +17,6 @@ kotlin {
       }
     }
 
-    val jvmMain by getting {
-      dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
-      }
-    }
-
     val jsMain by getting {
       dependencies {
         implementation(groovy.util.Eval.x(project, "x.dep.kotlin.nodejs"))

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         implementation(groovy.util.Eval.x(project, "x.dep.atomicfu").toString()) {
           because("We need locks for native (we don't use the gradle plugin rewrite)")
         }
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
       }
     }
 

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -18,7 +18,7 @@ kotlin {
 
     val jvmMain by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.okHttp.mockWebServer"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
       }
     }
 

--- a/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
+++ b/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/Socket.kt
@@ -12,6 +12,7 @@ import kotlinx.cinterop.memScoped
 import kotlinx.cinterop.nativeHeap
 import kotlinx.cinterop.ptr
 import kotlinx.cinterop.value
+import kotlinx.coroutines.runBlocking
 import okio.IOException
 import okio.buffer
 import platform.Foundation.NSMutableArray
@@ -145,7 +146,7 @@ class Socket(
         }
 
         try {
-          writeResponse(sink, mockResponse, request.version)
+          runBlocking { writeResponse(sink, mockResponse, request.version) }
         } catch (e: IOException) {
           debug("'$connectionFd': writeResponse error")
           return

--- a/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerCommon.kt
+++ b/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerCommon.kt
@@ -29,11 +29,14 @@ suspend fun writeResponse(sink: BufferedSink, mockResponse: MockResponse, versio
   sink.writeUtf8("$version ${mockResponse.statusCode}\r\n")
   val isChunked = mockResponse.chunks.isNotEmpty()
 
-  val headers = mockResponse.headers + if (isChunked) {
-    mapOf("Transfer-Encoding" to "chunked")
-  } else {
-    mapOf("Content-Length" to mockResponse.body.size.toString())
-  }
+  val headers = mockResponse.headers +
+      if (isChunked) {
+        mapOf("Transfer-Encoding" to "chunked")
+      } else {
+        mapOf("Content-Length" to mockResponse.body.size.toString())
+      } +
+      // We don't support 'Connection: Keep-Alive', so indicate it to the client
+      mapOf("Connection" to "close")
 
   headers.forEach {
     sink.writeUtf8("${it.key}: ${it.value}\r\n")

--- a/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerExtensions.kt
+++ b/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerExtensions.kt
@@ -1,9 +1,12 @@
 @file:JvmName("-MockServers")
+
 package com.apollographql.apollo3.mockserver
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import okio.ByteString.Companion.encodeUtf8
 import kotlin.jvm.JvmName
 
+@ApolloExperimental
 fun MockServer.enqueue(string: String, delayMs: Long = 0) {
   val byteString = string.encodeUtf8()
   enqueue(MockResponse(
@@ -12,4 +15,57 @@ fun MockServer.enqueue(string: String, delayMs: Long = 0) {
       body = byteString,
       delayMillis = delayMs
   ))
+}
+
+@ApolloExperimental
+fun MockServer.enqueueMultipart(
+    parts: List<String>,
+    statusCode: Int = 200,
+    partsContentType: String = "application/json; charset=utf-8",
+    headers: Map<String, String> = emptyMap(),
+    responseDelayMillis: Long = 0,
+    chunksDelayMillis: Long = 0,
+    boundary: String = "-",
+) {
+  enqueue(createMultipartMixedChunkedResponse(
+      parts = parts,
+      statusCode = statusCode,
+      partsContentType = partsContentType,
+      headers = headers,
+      responseDelayMillis = responseDelayMillis,
+      chunksDelayMillis = chunksDelayMillis,
+      boundary = boundary
+  ))
+}
+
+@ApolloExperimental
+fun createMultipartMixedChunkedResponse(
+    parts: List<String>,
+    statusCode: Int = 200,
+    partsContentType: String = "application/json; charset=utf-8",
+    headers: Map<String, String> = emptyMap(),
+    responseDelayMillis: Long = 0,
+    chunksDelayMillis: Long = 0,
+    boundary: String = "-",
+): MockResponse {
+  return MockResponse(
+      statusCode = statusCode,
+      delayMillis = responseDelayMillis,
+      headers = headers + mapOf("Content-Type" to """multipart/mixed; boundary="$boundary""""),
+      chunks = parts.mapIndexed { index, part ->
+        val startBoundary = if (index == 0) "--$boundary\r\n" else ""
+        val contentLengthHeader = "Content-Length: ${part.length}"
+        val contentTypeHeader = "Content-Type: $partsContentType"
+        val endBoundary = if (index == parts.lastIndex) "--$boundary--" else "--$boundary"
+        MockChunk(
+            body = startBoundary +
+                "$contentLengthHeader\r\n" +
+                "$contentTypeHeader\r\n" +
+                "\r\n" +
+                "$part\r\n" +
+                "$endBoundary\r\n",
+            delayMillis = chunksDelayMillis
+        )
+      }
+  )
 }

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo3.mockserver.test
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.mockserver.MockChunk
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
@@ -33,6 +34,11 @@ class EnqueueTest {
             body = "Hello, World! 001",
             statusCode = 200,
             headers = mapOf("X-Test" to "true"),
+        ),
+        MockResponse(
+            chunks = listOf(MockChunk("First chunk\n"), MockChunk("Second chunk")),
+            statusCode = 200,
+            headers = mapOf("X-Test" to "false"),
         ),
     )
     for (mockResponse in mockResponses) {

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/ReadRequestTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/ReadRequestTest.kt
@@ -49,4 +49,28 @@ class ReadRequestTest {
     assertEquals("POST", recordedRequest.method)
     assertEquals("Hello world", recordedRequest.body.utf8())
   }
+
+  @Test
+  fun readChunkedPostRequest() {
+    val request = """
+      POST / HTTP/2
+      Transfer-Encoding: chunked
+      
+      a
+      This is 
+      
+      6
+      a test
+      0
+
+    """.trimIndent()
+        .split("\n")
+        .joinToString(separator = "\r\n", postfix = "")
+
+    val recordedRequest = readRequest(Buffer().apply { writeUtf8(request) })
+    assertNotNull(recordedRequest)
+    assertEquals("POST", recordedRequest.method)
+    assertEquals("This is \r\na test", recordedRequest.body.utf8())
+  }
+
 }

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.mockserver.test
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.mockserver.MockResponse
@@ -11,6 +12,7 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ApolloExperimental::class)
 class SocketTest {
   @Test
   fun writeMoreThan8kToTheSocket() = runTest {

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo3.mockserver.test
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.mockserver.MockChunk
 import com.apollographql.apollo3.mockserver.MockResponse
+import com.apollographql.apollo3.mockserver.createMultipartMixedChunkedResponse
 import com.apollographql.apollo3.mockserver.writeResponse
 import com.apollographql.apollo3.testing.runTest
 import okio.Buffer
@@ -57,4 +58,43 @@ class WriteResponseTest {
         buffer.readUtf8()
     )
   }
+
+  @Test
+  fun writeMultipartChunkedResponse() = runTest {
+    val mockResponse = createMultipartMixedChunkedResponse(listOf(
+        """{"data":{"song":{"firstVerse":"Now I know my ABC's."}},"hasNext":true}""",
+        """{"data":{"secondVerse":"Next time won't you sing with me?"},"path":["song"],"hasNext":false}"""
+    ))
+
+    val buffer = Buffer()
+    writeResponse(buffer, mockResponse, "1.1")
+    assertEquals(
+        listOf(
+            "1.1 200",
+            """Content-Type: multipart/mixed; boundary="-"""",
+            "Transfer-Encoding: chunked",
+            "Connection: close",
+            "",
+            "97",
+            "---",
+            "Content-Length: 70",
+            "Content-Type: application/json; charset=utf-8",
+            "",
+            """{"data":{"song":{"firstVerse":"Now I know my ABC's."}},"hasNext":true}""",
+            "---",
+            "",
+            "aa",
+            "Content-Length: 92",
+            "Content-Type: application/json; charset=utf-8",
+            "",
+            """{"data":{"secondVerse":"Next time won't you sing with me?"},"path":["song"],"hasNext":false}""",
+            "-----",
+            "",
+            "0",
+            "",
+        ).joinToString("\r\n", postfix = "\r\n"),
+        buffer.readUtf8()
+    )
+  }
+
 }

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
@@ -25,6 +25,7 @@ class WriteResponseTest {
         "1.1 404\r\n" +
             "X-Custom-Header: Custom-Value\r\n" +
             "Content-Length: 44\r\n" +
+            "Connection: close\r\n" +
             "\r\n" +
             "I will not buy this record, it is scratched.",
         buffer.readUtf8()
@@ -45,6 +46,7 @@ class WriteResponseTest {
         "1.1 404\r\n" +
             "X-Custom-Header: Custom-Value\r\n" +
             "Transfer-Encoding: chunked\r\n" +
+            "Connection: close\r\n" +
             "\r\n" +
             "1c\r\n" +
             "I will not buy this record, \r\n" +

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/WriteResponseTest.kt
@@ -1,0 +1,58 @@
+package com.apollographql.apollo3.mockserver.test
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.mockserver.MockChunk
+import com.apollographql.apollo3.mockserver.MockResponse
+import com.apollographql.apollo3.mockserver.writeResponse
+import com.apollographql.apollo3.testing.runTest
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ApolloExperimental::class)
+class WriteResponseTest {
+  @Test
+  fun writeResponse() = runTest {
+    val mockResponse = MockResponse(
+        statusCode = 404,
+        body = "I will not buy this record, it is scratched.",
+        headers = mapOf("X-Custom-Header" to "Custom-Value")
+    )
+
+    val buffer = Buffer()
+    writeResponse(buffer, mockResponse, "1.1")
+    assertEquals(
+        "1.1 404\r\n" +
+            "X-Custom-Header: Custom-Value\r\n" +
+            "Content-Length: 44\r\n" +
+            "\r\n" +
+            "I will not buy this record, it is scratched.",
+        buffer.readUtf8()
+    )
+  }
+
+  @Test
+  fun writeChunkedResponse() = runTest {
+    val mockResponse = MockResponse(
+        statusCode = 404,
+        chunks = listOf(MockChunk("I will not buy this record, "), MockChunk("it is scratched.")),
+        headers = mapOf("X-Custom-Header" to "Custom-Value")
+    )
+
+    val buffer = Buffer()
+    writeResponse(buffer, mockResponse, "1.1")
+    assertEquals(
+        "1.1 404\r\n" +
+            "X-Custom-Header: Custom-Value\r\n" +
+            "Transfer-Encoding: chunked\r\n" +
+            "\r\n" +
+            "1c\r\n" +
+            "I will not buy this record, \r\n" +
+            "10\r\n" +
+            "it is scratched.\r\n" +
+            "0\r\n" +
+            "\r\n",
+        buffer.readUtf8()
+    )
+  }
+}

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/assertMockResponse.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/assertMockResponse.kt
@@ -9,7 +9,12 @@ fun assertMockResponse(
     mockResponse: MockResponse,
     httpResponse: HttpResponse,
 ) {
-  assertEquals(mockResponse.body.utf8(), httpResponse.body!!.readUtf8())
+  if (mockResponse.chunks.isNotEmpty()) {
+    val body = mockResponse.chunks.joinToString("") { chunk -> chunk.body.utf8() }
+    assertEquals(body, httpResponse.body!!.readUtf8())
+  } else {
+    assertEquals(mockResponse.body.utf8(), httpResponse.body!!.readUtf8())
+  }
   assertEquals(mockResponse.statusCode, httpResponse.statusCode)
   // JS MockServer serves headers in lowercase, so convert before comparing
   val mockResponseHeaders = mockResponse.headers.map { it.key.lowercase() to it.value.lowercase() }

--- a/apollo-mockserver/src/jvmMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/apollo-mockserver/src/jvmMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -1,14 +1,63 @@
 package com.apollographql.apollo3.mockserver
 
-import okhttp3.Headers
-import okhttp3.mockwebserver.Dispatcher
-import okhttp3.mockwebserver.MockWebServer
-import okhttp3.mockwebserver.RecordedRequest
-import okio.Buffer
-import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import okio.buffer
+import okio.sink
+import okio.source
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.concurrent.Executors
 
-actual class MockServer actual constructor(override val mockServerHandler: MockServerHandler) : MockServerInterface {
-  private val mockWebServer = MockWebServer().apply { dispatcher = mockServerHandler.toOkHttpDispatcher() }
+@Suppress("BlockingMethodInNonBlockingContext")
+actual class MockServer actual constructor(
+    override val mockServerHandler: MockServerHandler,
+) : MockServerInterface {
+  private val serverSocket = ServerSocket(0)
+  private val mockRequests = mutableListOf<MockRequest>()
+
+  private val dispatcher = Executors.newFixedThreadPool(5).asCoroutineDispatcher()
+  private val coroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+
+  init {
+    coroutineScope.launch {
+      while (true) {
+        val clientSocket = try {
+          serverSocket.accept()
+        } catch (_: Exception) {
+          // An exception here means the server socket has been closed (stop() was called)
+          break
+        }
+        coroutineScope.launch { handleClient(clientSocket) }
+      }
+    }
+  }
+
+  private suspend fun handleClient(clientSocket: Socket) {
+    try {
+      val clientSource = clientSocket.getInputStream().source().buffer()
+      val clientSink = clientSocket.getOutputStream().sink().buffer()
+
+      val mockRequest = readRequest(clientSource)!!
+      mockRequests += mockRequest
+
+      val mockResponse = mockServerHandler.handle(mockRequest)
+      delay(mockResponse.delayMillis)
+      writeResponse(clientSink, mockResponse, mockRequest.version)
+    } catch (_: CancellationException) {
+      // Ignored: this is expected when the MockServer is closed
+    } catch (e: Exception) {
+      println("Apollo: error in MockServer while handling client - $e")
+      e.printStackTrace()
+    } finally {
+      runCatching { clientSocket.close() }
+    }
+  }
 
   override fun enqueue(mockResponse: MockResponse) {
     (mockServerHandler as? QueueMockServerHandler)?.enqueue(mockResponse)
@@ -16,50 +65,16 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
   }
 
   override fun takeRequest(): MockRequest {
-    return mockWebServer.takeRequest(10, TimeUnit.MILLISECONDS)?.toApolloMockRequest() ?: error("No recorded request")
+    return mockRequests.removeFirst()
   }
-
-  private fun RecordedRequest.toApolloMockRequest() = MockRequest(
-      method = method!!,
-      path = path!!,
-      version = parseRequestLine(requestLine).third,
-      headers = headers.toMap(),
-      body = body.peek().readByteString()
-  )
-
-  private fun MockResponse.toOkHttpMockResponse() = okhttp3.mockwebserver.MockResponse()
-      .setResponseCode(statusCode)
-      .apply {
-        this@toOkHttpMockResponse.headers.forEach {
-          addHeader(it.key, it.value)
-        }
-      }.setBody(Buffer().apply { write(body) })
-      .setHeadersDelay(delayMillis, TimeUnit.MILLISECONDS)
-
-  private fun MockServerHandler.toOkHttpDispatcher() = object : Dispatcher() {
-    override fun dispatch(request: RecordedRequest): okhttp3.mockwebserver.MockResponse {
-      val apolloMockRequest = request.toApolloMockRequest()
-      val mockResponse = try {
-        handle(apolloMockRequest)
-      } catch (e: Exception) {
-        throw Exception("MockServerHandler.handle() threw an exception: ${e.message}", e)
-      }
-      return mockResponse.toOkHttpMockResponse()
-    }
-
-    override fun shutdown() {}
-  }
-
-  private fun Headers.toMap(): Map<String, String> = (0.until(size)).map {
-    name(it) to get(name(it))!!
-  }.toMap()
 
   override suspend fun url(): String {
-    return mockWebServer.url("/").toString()
+    return "http://${serverSocket.inetAddress.hostAddress}:${serverSocket.localPort}/"
   }
 
   override suspend fun stop() {
-    mockWebServer.shutdown()
+    runCatching { serverSocket.close() }
+    coroutineScope.cancel()
+    dispatcher.close()
   }
 }
-

--- a/apollo-mockserver/src/jvmTest/kotlin/com/apollographql/apollo3/mockserver/test/MultipartTest.kt
+++ b/apollo-mockserver/src/jvmTest/kotlin/com/apollographql/apollo3/mockserver/test/MultipartTest.kt
@@ -1,0 +1,58 @@
+package com.apollographql.apollo3.mockserver.test
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.http.HttpMethod
+import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueMultipart
+import com.apollographql.apollo3.network.http.DefaultHttpEngine
+import com.apollographql.apollo3.testing.runTest
+import okhttp3.MultipartReader
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ApolloExperimental::class)
+class MultipartTest {
+  private lateinit var mockServer: MockServer
+
+  private fun setUp() {
+    mockServer = MockServer()
+  }
+
+  private suspend fun tearDown() {
+    mockServer.stop()
+  }
+
+  /**
+   * Check that the multipart encoded by MockServer can be decoded by OkHttp's MultipartReader.
+   */
+  @Test
+  fun receiveAndDecodeParts() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val part0 = """{"data":{"song":{"firstVerse":"Now I know my ABC's."}},"hasNext":true}"""
+    val part1 = """{"data":{"secondVerse":"Next time won't you sing with me?"},"path":["song"],"hasNext":false}"""
+    val boundary = "-"
+    mockServer.enqueueMultipart(listOf(part0, part1), boundary = boundary)
+
+    val httpResponse = DefaultHttpEngine().execute(HttpRequest.Builder(HttpMethod.Get, mockServer.url()).build())
+
+    val parts = mutableListOf<MultipartReader.Part>()
+    val partBodies = mutableListOf<String>()
+    // Taken from https://square.github.io/okhttp/4.x/okhttp/okhttp3/-multipart-reader/
+    val multipartReader = MultipartReader(httpResponse.body!!, boundary = boundary)
+    multipartReader.use {
+      while (true) {
+        val part = multipartReader.nextPart() ?: break
+        parts.add(part)
+        partBodies.add(part.body.readUtf8())
+      }
+    }
+
+    assertEquals("application/json; charset=utf-8", parts[0].headers["Content-Type"])
+    assertEquals(part0.length.toString(), parts[0].headers["Content-Length"])
+    assertEquals(part0, partBodies[0])
+
+    assertEquals("application/json; charset=utf-8", parts[1].headers["Content-Type"])
+    assertEquals(part1.length.toString(), parts[1].headers["Content-Length"])
+    assertEquals(part1, partBodies[1])
+  }
+}

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -156,7 +156,7 @@ class HttpCacheTest {
     val okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
 
     val mockServer = MockServer()
-
+    mockServer.enqueue(MockResponse())
     val apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
         .okHttpClient(okHttpClient)

--- a/tests/integration-tests/src/jvmTest/kotlin/test/OkHttpClientTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/OkHttpClientTest.kt
@@ -1,10 +1,9 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.cache.normalized.cacheInfo
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.network.http.HttpInfo
 import com.apollographql.apollo3.network.okHttpClient
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -23,6 +22,7 @@ class OkHttpClientTest {
 
     runBlocking {
       val mockServer = MockServer()
+      mockServer.enqueue(MockResponse())
 
       val apolloClient = ApolloClient.Builder()
           .serverUrl(mockServer.url())


### PR DESCRIPTION
This adds support for chunks in MockServer. To do this, first we update the JVM implementation of MockServer to use our own server instead of delegating to OkHttp's MockWebServer, and re-use the `readRequest`/`writeResponse` code that was already used in the Apple implementation.

Then we introduce `MockChunk` + a list of them in `MockResponse`, and handle them in the `readRequest`/`writeResponse` code.

Turns out chunked is supported in the Node HTTP API we use so updating the JS implementation was not hard.