### PR TITLE
⚙️  Add support for triple quotes escapes

### DIFF
--- a/apollo-ast/src/main/antlr/com/apollographql/apollo3/generated/antlr/GraphQL.g4
+++ b/apollo-ast/src/main/antlr/com/apollographql/apollo3/generated/antlr/GraphQL.g4
@@ -374,7 +374,7 @@ name
 STRING
   : '"' ( ESC | ~ ["\\] )* '"'
   ;
-BLOCK_STRING:   '"""' .*? '"""';
+BLOCK_STRING:   '"""' ('\\"""' | .)*? '"""';
 BOOLEAN
   : 'true' | 'false'
   ;

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/AntlrParseTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/AntlrParseTest.kt
@@ -1,9 +1,12 @@
 package com.apollographql.apollo3.graphql.ast.test
 
 import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.ast.GQLStringValue
 import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.parseAsGQLValue
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.fail
 
 @OptIn(ApolloExperimental::class)
@@ -35,5 +38,24 @@ class AntlrParseTest {
           .buffer()
           .parseAsGQLDocument()
           .valueAssertNoErrors()
+  }
+
+  @Test
+  fun blockString() {
+    val value = "\"\"\" \\\"\"\" \"\"\"".buffer().parseAsGQLValue().valueAssertNoErrors()
+
+    assertEquals(" \"\"\" ", (value as GQLStringValue).value)
+  }
+
+  @Test
+  fun blockStringIndentationIsRemoved() {
+    val value = ("\"\"\"\n" +
+        "  first line\n" +
+        "   \n" +
+        "  second line\n" +
+        "   \n" +
+        "\"\"\"").buffer().parseAsGQLValue().valueAssertNoErrors()
+
+    assertEquals("first line\n \nsecond line", (value as GQLStringValue).value)
   }
 }


### PR DESCRIPTION
Add support for `\"""`:

```graphql
"""
It is valid to have \""" here
"""
```

Also improve the indendation trimming to match better with https://spec.graphql.org/draft/#BlockStringValue(). Previously, it would strip indents on the first line too.