### PR TITLE
🗄️  fix the cache keys of fragments written programmatically 

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -71,7 +71,7 @@ internal class Normalizer(
 
           val fieldKey = mergedField.nameWithArguments(variables)
 
-          val base = if (key == rootKey) {
+          val base = if (key == CacheKey.rootKey().key) {
             // If we're at the root level, skip `QUERY_ROOT` altogether to save a few bytes
             null
           } else {

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -105,6 +105,11 @@ fun configureApollo(generateKotlinModels: Boolean) {
           service("${it.name}-$extra") {
             srcDir(it)
 
+            when (it.name) {
+              "fragment_normalizer" -> {
+                generateFragmentImplementations.set(true)
+              }
+            }
             generateSchema.set(it.name == "schema")
             this.generateKotlinModels.set(generateKotlinModels)
             codegenModels.set("operationBased")

--- a/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -246,6 +246,16 @@ class NormalizerTest {
     assertEquals(lukeRecord["height({\"unit\":\"FOOT\"})"], 5.905512)
   }
 
+  @Test
+  @Throws(Exception::class)
+  fun fragmentRootKeyIsKept() {
+    val records = records(HeroParentTypeDependentFieldQuery(Episode.EMPIRE), "HeroParentTypeDependentFieldHumanResponse.json")
+
+    val lukeRecord = records.get("$TEST_FIELD_KEY_EMPIRE.friends.0")
+    assertEquals(lukeRecord!!["name"], "Han Solo")
+    assertEquals(lukeRecord["height({\"unit\":\"FOOT\"})"], 5.905512)
+  }
+
   companion object {
     internal fun <D : Operation.Data> records(operation: Operation<D>, name: String): Map<String, Record> {
       val response = operation.parseJsonResponse(testFixtureToJsonReader(name))

--- a/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/NormalizerTest.kt
@@ -246,16 +246,6 @@ class NormalizerTest {
     assertEquals(lukeRecord["height({\"unit\":\"FOOT\"})"], 5.905512)
   }
 
-  @Test
-  @Throws(Exception::class)
-  fun fragmentRootKeyIsKept() {
-    val records = records(HeroParentTypeDependentFieldQuery(Episode.EMPIRE), "HeroParentTypeDependentFieldHumanResponse.json")
-
-    val lukeRecord = records.get("$TEST_FIELD_KEY_EMPIRE.friends.0")
-    assertEquals(lukeRecord!!["name"], "Han Solo")
-    assertEquals(lukeRecord["height({\"unit\":\"FOOT\"})"], 5.905512)
-  }
-
   companion object {
     internal fun <D : Operation.Data> records(operation: Operation<D>, name: String): Map<String, Record> {
       val response = operation.parseJsonResponse(testFixtureToJsonReader(name))

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
@@ -28,34 +28,51 @@ class FragmentNormalizerTest{
         .build()
 
     var fragment1 = ConversationFragment(
-        id = "1",
-        author = ConversationFragment.Author(
-            fullName = "John Doe",
+        "1",
+        ConversationFragment.Author(
+            "John Doe",
         ),
-        read = false
+        false
+    )
+
+    /**
+     * This is not using .copy() because this test also runs in Java and Java doesn't have copy()
+     */
+    var fragment1Read = ConversationFragment(
+        "1",
+        ConversationFragment.Author(
+            "John Doe",
+        ),
+        true
     )
     val fragment2 = ConversationFragment(
-        id = "2",
-        author = ConversationFragment.Author(
-            fullName = "Yayyy Pancakes!",
+        "2",
+        ConversationFragment.Author(
+            "Yayyy Pancakes!",
         ),
-        read = false
+        false
+    )
+    /**
+     * This is not using .copy() because this test also runs in Java and Java doesn't have copy()
+     */
+    val fragment2Read = ConversationFragment(
+        "2",
+        ConversationFragment.Author(
+            "Yayyy Pancakes!",
+        ),
+        true
     )
     apolloClient.apolloStore.writeFragment(
         ConversationFragmentImpl(),
         CacheKey(fragment1.id),
-        fragment1.copy(
-            read = true,
-        ),
+        fragment1Read,
         CustomScalarAdapters.Empty
     )
 
     apolloClient.apolloStore.writeFragment(
         ConversationFragmentImpl(),
         CacheKey(fragment2.id),
-        fragment2.copy(
-            read = true,
-        ),
+        fragment2Read,
         CustomScalarAdapters.Empty
     )
 
@@ -70,11 +87,11 @@ class FragmentNormalizerTest{
   @Test
   fun rootKeyIsNotSkipped() = runTest {
     val fragment = ConversationFragment(
-        id = "1",
-        author = ConversationFragment.Author(
-            fullName = "John Doe",
+        "1",
+        ConversationFragment.Author(
+            "John Doe",
         ),
-        read = false
+        false
     )
 
     val records = ConversationFragmentImpl().normalize(

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
@@ -1,16 +1,19 @@
 package test.fragment_normalizer
 
+import IdCacheKeyGenerator
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.testing.runTest
 import fragment_normalizer.fragment.ConversationFragment
 import fragment_normalizer.fragment.ConversationFragmentImpl
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 @OptIn(ApolloExperimental::class)
@@ -62,5 +65,25 @@ class FragmentNormalizerTest{
     )
 
     assertEquals("John Doe", fragment1.author.fullName)
+  }
+
+  @Test
+  fun rootKeyIsNotSkipped() = runTest {
+    val fragment = ConversationFragment(
+        id = "1",
+        author = ConversationFragment.Author(
+            fullName = "John Doe",
+        ),
+        read = false
+    )
+
+    val records = ConversationFragmentImpl().normalize(
+        fragment,
+        CustomScalarAdapters.Empty,
+        IdCacheKeyGenerator,
+        "1",
+    )
+
+    assertContains( records.keys, "1.author")
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
@@ -1,0 +1,66 @@
+package test.fragment_normalizer
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.cache.normalized.api.CacheKey
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.apolloStore
+import com.apollographql.apollo3.cache.normalized.normalizedCache
+import com.apollographql.apollo3.testing.runTest
+import fragment_normalizer.fragment.ConversationFragment
+import fragment_normalizer.fragment.ConversationFragmentImpl
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ApolloExperimental::class)
+class FragmentNormalizerTest{
+  @Test
+  fun testFoo() = runTest {
+    val cacheFactory = MemoryCacheFactory()
+
+    val apolloClient = ApolloClient.builder()
+        .serverUrl("https:/example.com")
+        .normalizedCache(cacheFactory)
+        .build()
+
+    var fragment1 = ConversationFragment(
+        id = "1",
+        author = ConversationFragment.Author(
+            fullName = "John Doe",
+        ),
+        read = false
+    )
+    val fragment2 = ConversationFragment(
+        id = "2",
+        author = ConversationFragment.Author(
+            fullName = "Yayyy Pancakes!",
+        ),
+        read = false
+    )
+    apolloClient.apolloStore.writeFragment(
+        ConversationFragmentImpl(),
+        CacheKey(fragment1.id),
+        fragment1.copy(
+            read = true,
+        ),
+        CustomScalarAdapters.Empty
+    )
+
+    apolloClient.apolloStore.writeFragment(
+        ConversationFragmentImpl(),
+        CacheKey(fragment2.id),
+        fragment2.copy(
+            read = true,
+        ),
+        CustomScalarAdapters.Empty
+    )
+
+    fragment1 = apolloClient.apolloStore.readFragment(
+        ConversationFragmentImpl(),
+        CacheKey(fragment1.id),
+    )
+
+    assertEquals("John Doe", fragment1.author.fullName)
+  }
+}

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/FragmentNormalizerTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 @OptIn(ApolloExperimental::class)
 class FragmentNormalizerTest{
   @Test
-  fun testFoo() = runTest {
+  fun test() = runTest {
     val cacheFactory = MemoryCacheFactory()
 
     val apolloClient = ApolloClient.builder()

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/graphql/operations.graphql
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/graphql/operations.graphql
@@ -1,0 +1,8 @@
+# From https://github.com/apollographql/apollo-kotlin/issues/3875
+fragment ConversationFragment on Conversation {
+  id
+  author {
+    fullName
+  }
+  read
+}

--- a/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/graphql/schema.graphqls
+++ b/tests/integration-tests/src/commonTest/kotlin/test/fragment_normalizer/graphql/schema.graphqls
@@ -1,0 +1,14 @@
+type Query {
+  conversation: Conversation
+}
+
+type Conversation {
+  id: ID!
+  author: Author!
+  read: Boolean!
+}
+
+type Author {
+  id: ID!
+  fullName: String!
+}


### PR DESCRIPTION
Do not strip the first cache key component if it's not QUERY_ROOT

Closes https://github.com/apollographql/apollo-kotlin/issues/3875