### PR TITLE
 Updated Batching Exception Handling

### DIFF
--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -208,8 +208,11 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
           AnyAdapter.toJson(this, CustomScalarAdapters.Empty, it)
         })
       }
-    } catch (e: ApolloException) {
-      exception = e
+    } catch (e: Exception) {
+      exception = when (e) {
+        is ApolloException -> e
+        else -> ApolloException("batched query failed with exception", e)
+      }
       null
     }
 


### PR DESCRIPTION
Updating exception handling for the batching interceptor to catch all exceptions and wrap any non ApolloException in one to ensure that they're propagated for handling.

IDK if the when here or a separate catch is preferred so feel free to suggest which way to go there. Happy to go either way.

Closes #3903 