### PR TITLE
🔄  JS Websocket follow up

### DIFF
--- a/tests/websockets/build.gradle.kts
+++ b/tests/websockets/build.gradle.kts
@@ -6,6 +6,17 @@ plugins {
 configureMppTestsDefaults()
 
 kotlin {
+  js {
+    nodejs {
+      testTask {
+        useMocha {
+          // Override default timeout (needed for tests like FullStackTest that require interacting with the backend manually)
+          timeout = "120s"
+        }
+      }
+    }
+  }
+
   sourceSets {
     val commonMain by getting {
       dependencies {

--- a/tests/websockets/src/commonTest/kotlin/FullStackTest.kt
+++ b/tests/websockets/src/commonTest/kotlin/FullStackTest.kt
@@ -21,5 +21,7 @@ class FullStackTest {
         .collect {
           println("trips booked: ${it.data?.tripsBooked}")
         }
+
+    apolloClient.dispose()
   }
 }


### PR DESCRIPTION
Small follow up from https://github.com/apollographql/apollo-kotlin/pull/3913:

Give more time to JS tests and dispose the apolloClient 

