### PR TITLE
📝  rename tests to apollo-tests

### DIFF
--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "tests"
+rootProject.name = "apollo-tests"
 
 // Include all tests
 rootProject.projectDir


### PR DESCRIPTION
A small cosmetic change so that it's easier to distinguish the apollo projects when opened in IDEA (IDEA takes the project name to use as a window name)