### PR TITLE
📖  Incorporate feedbacks about the migration guide

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -374,13 +374,13 @@ val apolloClient = apolloClientBuilder.addCustomScalarAdapter(Date.type, dateAda
 
 This method takes a type-safe generated class from `Types`, along with its corresponding adapter.
 
-### Caching
-
-#### Normalized cache
+### Normalized Cache
 
 The Apollo Android 2.x runtime has a dependency on the normalized cache APIs, and it's possible to call cache methods even if no cache implementation is in the classpath.
 
 The Apollo Kotlin 3.x runtime is more modular and doesn't know anything about normalized cache by default. To add normalized cache support, add the dependencies to your gradle file:
+
+#### Configuration
 
 ```kotlin
 dependencies {
@@ -429,48 +429,18 @@ val response = apolloClient.query(request)
                       .execute()
 ```
 
-#### HTTP cache
+#### Watchers
 
-To add http cache support, add the dependency to your gradle file:
-
-```kotlin
-dependencies {
-  // Add
-  implementation("com.apollographql.apollo3:apollo-http-cache:$version") // Gives access to `httpCache` and `httpFetchPolicy`
-}
-```
-
-Similarly, the HTTP cache is configurable through extension functions:
+Watchers now default to a `CacheOnly` refetchPolicy instead `CACHE_FIRST`. To keep behaviour unchanged, set a `refetchPolicy` on your watchers:
 
 ```kotlin
-// Replace
-val cacheStore = DiskLruHttpCacheStore()
-val apolloClient = ApolloClient.builder()
-    .serverUrl("/")
-    .httpCache(ApolloHttpCache(cacheStore))
-    .build()
+val response = apolloClient.subscribe(subscription)
+                      .toFlow()
 
 // With
-val apolloClient = ApolloClient.Builder()
-    .serverUrl("https://...")
-    .httpCache(File(cacheDir, "apolloCache"), 1024 * 1024)
-    .build()
-```
-
-Configuring the HTTP fetch policy is now made on an `ApolloCall` instance:
-
-```kotlin
-// Replace
-val response = apolloClient.query(query)
-                      .toBuilder()
-                      .httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
-                      .build()
-                      .await()
-
-// With
-val response = apolloClient.query(request)
-                      .httpFetchPolicy(CacheFirst)
-                      .execute()
+val response = apolloClient.subscription(subscription)
+                      .refetchPolicy(CacheFirst)
+                      .toFlow()
 ```
 
 #### `CacheKeyResolver`
@@ -544,6 +514,50 @@ try {
 } catch (e: ApolloException) {
   // handle error
 }
+```
+
+### HTTP cache
+
+To add http cache support, add the dependency to your gradle file:
+
+```kotlin
+dependencies {
+  // Add
+  implementation("com.apollographql.apollo3:apollo-http-cache:$version") // Gives access to `httpCache` and `httpFetchPolicy`
+}
+```
+
+Similarly, the HTTP cache is configurable through extension functions:
+
+```kotlin
+// Replace
+val cacheStore = DiskLruHttpCacheStore()
+val apolloClient = ApolloClient.builder()
+    .serverUrl("/")
+    .httpCache(ApolloHttpCache(cacheStore))
+    .build()
+
+// With
+val apolloClient = ApolloClient.Builder()
+    .serverUrl("https://...")
+    .httpCache(File(cacheDir, "apolloCache"), 1024 * 1024)
+    .build()
+```
+
+Configuring the HTTP fetch policy is now made on an `ApolloCall` instance:
+
+```kotlin
+// Replace
+val response = apolloClient.query(query)
+                      .toBuilder()
+                      .httpCachePolicy(HttpCachePolicy.CACHE_FIRST)
+                      .build()
+                      .await()
+
+// With
+val response = apolloClient.query(request)
+                      .httpFetchPolicy(CacheFirst)
+                      .execute()
 ```
 
 ### Optional values

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -699,3 +699,16 @@ For cache misses, you can use the convenience `ApolloClient.Builder.logCacheMiss
         .normalizedCache(MemoryCacheFactory())
         .build()
 ```
+
+### Subscriptions
+
+Apollo Android 2.x had a `SubscriptionManager` class. This class exposed a lot of methods and data about the Websocket state management. While very flexible, it was hard to maintain and evolve.
+
+Apollo Android 3.x instead uses `WebsocketNetworkTransport` to expose a simplified API:
+
+- `protocolFactory` allows using `graphql-ws` or AppSync (or your custom one) as a lowlevel protocol instead of the default.
+- `reopenWhen` allows to automatically re-subscribe in case of a network error or another error.
+
+If you were previously using `apolloClient.subscriptionManager.reconnect()` to force a Websocket reconnect (for an example to send new authentication parameters), you should now create a new `ApolloClient`.
+
+If you feel some API is missing from `SubscriptionManager`, please [reach out](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=%3Asparkles%3A+Type%3A+Feature&template=feature_request.md&title=) so we can discuss the best way to add them.


### PR DESCRIPTION
Incorporate 2 missing behaviour changes in the migration guide:

- watchers now have a `CacheOnly` refetch policy (instead of `CACHE_FIRST`) (thanks @demoritas !)
- `subscriptionManager` is not there any more and should use either `websocketNetworkTransport` or re-create the client (thanks @StylianosGakis !).
