### PR TITLE
JS Websocket properly handle remote close

### DIFF
--- a/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
+++ b/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
@@ -41,6 +41,9 @@ actual class DefaultWebSocketEngine : WebSocketEngine {
         }
       }
     }
+    socket.onclose = {
+      messageChannel.close()
+    }
     return object : WebSocketConnection {
       override suspend fun receive(): String {
         return messageChannel.receive()


### PR DESCRIPTION
In the addition of support for JS Websockets (PR 3913), I forgot to add a listener for the close events, without this, if the remote closes the connection, the client doesn't get notified. This should resolve that.