### PR TITLE
Add macosArm64 or macosX64 target for tests depending on architecture

### DIFF
--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -1,6 +1,5 @@
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import java.io.ByteArrayOutputStream
 
 fun Project.configureMppDefaults(withJs: Boolean = true, withLinux: Boolean = true) {
   // See https://kotlinlang.org/docs/mpp-dsl-reference.html#targets

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -103,16 +103,23 @@ fun Project.configureMppTestsDefaults(withJs: Boolean = true) {
       }
     }
 
-    val appleMain = sourceSets.create("appleMain")
-    val appleTest = sourceSets.create("appleTest")
+    if (System.getProperty("idea.sync.active") == null) {
 
-    macosX64().apply {
-      compilations.getByName("main").source(appleMain)
-      compilations.getByName("test").source(appleTest)
-    }
-    macosArm64().apply {
-      compilations.getByName("main").source(appleMain)
-      compilations.getByName("test").source(appleTest)
+      val appleMain = sourceSets.create("appleMain")
+      val appleTest = sourceSets.create("appleTest")
+
+      macosX64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+      macosArm64().apply {
+        compilations.getByName("main").source(appleMain)
+        compilations.getByName("test").source(appleTest)
+      }
+    } else {
+      // We are in intelliJ
+      // Make intelliJ believe we have a single target with all the code in "apple" sourceSets
+      macosX64("apple")
     }
 
     addTestDependencies(withJs)

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -99,7 +99,7 @@ ext.dep = [
     gr8                      : "com.gradleup:gr8-plugin:0.2",
     kspGradlePlugin          : "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2",
     kotlinxdatetime          : "org.jetbrains.kotlinx:kotlinx-datetime:0.3.1",
-    kotlinxserializationjson : "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0",
+    kotlinxserializationjson : "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2",
     atomicfu                 : "org.jetbrains.kotlinx:atomicfu:0.17.0",
     ktor                     : [
         clientJs: "io.ktor:ktor-client-js:$versions.ktor"


### PR DESCRIPTION
This makes running `appleTest` on an ARM based Mac work. Note: GitHub workflows don't have ARM runners yet ([issue](https://github.com/actions/virtual-environments/issues/2187), [issue](https://github.com/actions/runner/issues/805)).

Not sure if there's a better/simpler way to do this!