### PR TITLE
Bump gr8 version

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -96,7 +96,7 @@ ext.dep = [
     assertj                  : "org.assertj:assertj-core:3.21.0",
     uuid                     : "com.benasher44:uuid:0.3.1",
     benManesVersions         : "com.github.ben-manes:gradle-versions-plugin:0.33.0",
-    gr8                      : "com.gradleup:gr8-plugin:0.2",
+    gr8                      : "com.gradleup:gr8-plugin:0.4",
     kspGradlePlugin          : "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2",
     kotlinxdatetime          : "org.jetbrains.kotlinx:kotlinx-datetime:0.3.1",
     kotlinxserializationjson : "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0",


### PR DESCRIPTION
Fixes building with Java17

For the record, it failed because gr8 is passing the JAVA_HOME JDK on the classpath while calling into R8 (to resolve the JDK classes). So even if apollo-gradle-plugin is all Java8 bytecode, it was confusing the older version of R8