### PR TITLE
⚙️  Fix fragments on the root query type in operationBased codegen

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/ExecutableCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/ExecutableCommon.kt
@@ -9,10 +9,12 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.toJson
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaResolver
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.java.adapter.singletonAdapterInitializer
+import com.apollographql.apollo3.compiler.ir.IrProperty
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.MethodSpec
@@ -22,7 +24,7 @@ import javax.lang.model.element.Modifier
 
 fun serializeVariablesMethodSpec(
     adapterClassName: TypeName?,
-    emptyMessage: String
+    emptyMessage: String,
 ): MethodSpec {
 
   val body = if (adapterClassName == null) {
@@ -41,20 +43,17 @@ fun serializeVariablesMethodSpec(
 }
 
 fun adapterMethodSpec(
-    adapterTypeName: TypeName,
-    adaptedTypeName: TypeName
+    resolver: JavaResolver,
+    property: IrProperty,
 ): MethodSpec {
+  val adaptedTypeName = resolver.resolveIrType(property.info.type)
   return MethodSpec.methodBuilder(Identifier.adapter)
       .addModifiers(Modifier.PUBLIC)
       .addAnnotation(JavaClassNames.Override)
       .returns(ParameterizedTypeName.get(JavaClassNames.Adapter, adaptedTypeName))
       .addCode(
           "return $L;\n",
-          singletonAdapterInitializer(
-              adapterTypeName,
-              adaptedTypeName,
-              false,
-          )
+          resolver.adapterInitializer(property.info.type, property.requiresBuffering)
       )
       .build()
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentBuilder.kt
@@ -68,7 +68,7 @@ class FragmentBuilder(
         .maybeAddDescription(description)
         .makeDataClassFromParameters(variables.map { it.toNamedType().toParameterSpec(context) })
         .addMethod(serializeVariablesMethodSpec())
-        .addMethod(adapterMethodSpec())
+        .addMethod(adapterMethodSpec(context.resolver, fragment.dataProperty))
         .addMethod(selectionsMethodSpec())
         // Fragments can have multiple data shapes
         .addTypes(dataTypeSpecs())
@@ -85,13 +85,6 @@ class FragmentBuilder(
       adapterClassName = context.resolver.resolveFragmentVariablesAdapter(name),
       emptyMessage = "This fragment doesn't have any variable",
   )
-
-  private fun IrNamedFragment.adapterMethodSpec(): MethodSpec {
-    return adapterMethodSpec(
-        adapterTypeName = context.resolver.resolveModelAdapter(dataModelGroup.baseModelId),
-        adaptedTypeName = context.resolver.resolveModel(dataModelGroup.baseModelId)
-    )
-  }
 
   private fun dataTypeSpecs(): List<TypeSpec> {
     return modelBuilders.map { it.build() }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
@@ -86,7 +86,7 @@ class OperationBuilder(
         .addMethod(queryDocumentMethodSpec(generateQueryDocument))
         .addMethod(nameMethodSpec())
         .addMethod(serializeVariablesMethodSpec())
-        .addMethod(adapterMethodSpec())
+        .addMethod(adapterMethodSpec(context.resolver, operation.dataProperty))
         .addMethod(rootFieldMethodSpec())
         .addTypes(dataTypeSpecs())
         .addField(
@@ -128,13 +128,6 @@ class OperationBuilder(
       adapterClassName = context.resolver.resolveOperationVariablesAdapter(operation.name),
       emptyMessage = "This operation doesn't have any variable"
   )
-
-  private fun adapterMethodSpec(): MethodSpec {
-    return adapterMethodSpec(
-        adapterTypeName = context.resolver.resolveModelAdapter(operation.dataModelGroup.baseModelId),
-        adaptedTypeName = context.resolver.resolveModel(operation.dataModelGroup.baseModelId)
-    )
-  }
 
   private fun dataTypeSpecs(): List<TypeSpec> {
     return modelBuilders.map {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ExecutableCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ExecutableCommon.kt
@@ -9,9 +9,11 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.serializeVariables
 import com.apollographql.apollo3.compiler.codegen.Identifier.toJson
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinResolver
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.obj
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.patchKotlinNativeOptionalArrayProperties
+import com.apollographql.apollo3.compiler.ir.IrProperty
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -44,13 +46,20 @@ fun serializeVariablesFunSpec(
 }
 
 fun adapterFunSpec(
-    adapterTypeName: TypeName,
-    adaptedTypeName: TypeName,
+    resolver: KotlinResolver,
+    property: IrProperty,
 ): FunSpec {
+  val type = property.info.type
+
   return FunSpec.builder("adapter")
       .addModifiers(KModifier.OVERRIDE)
-      .returns(KotlinSymbols.Adapter.parameterizedBy(adaptedTypeName))
-      .addCode(CodeBlock.of("return·%T", adapterTypeName).obj(false))
+      .returns(KotlinSymbols.Adapter.parameterizedBy(resolver.resolveIrType(type)))
+      .addCode(
+          CodeBlock.of(
+              "return·%L",
+              resolver.adapterInitializer(type, property.requiresBuffering)
+          )
+      )
       .build()
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
@@ -67,7 +67,7 @@ class FragmentBuilder(
         .maybeAddDescription(description)
         .makeDataClass(variables.map { it.toNamedType().toParameterSpec(context) }, addJvmOverloads)
         .addFunction(serializeVariablesFunSpec())
-        .addFunction(adapterFunSpec())
+        .addFunction(adapterFunSpec(context.resolver, dataProperty))
         .addFunction(rootFieldFunSpec())
         // Fragments can have multiple data shapes
         .addTypes(dataTypeSpecs())
@@ -85,13 +85,6 @@ class FragmentBuilder(
       adapterClassName = context.resolver.resolveFragmentVariablesAdapter(name),
       emptyMessage = "This fragment doesn't have any variable",
   )
-
-  private fun IrNamedFragment.adapterFunSpec(): FunSpec {
-    return adapterFunSpec(
-        adapterTypeName = context.resolver.resolveModelAdapter(dataModelGroup.baseModelId),
-        adaptedTypeName = context.resolver.resolveModel(dataModelGroup.baseModelId)
-    )
-  }
 
   private fun dataTypeSpecs(): List<TypeSpec> {
     return modelBuilders.map { it.build() }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
@@ -21,6 +21,7 @@ import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrOperationType
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
@@ -84,7 +85,7 @@ class OperationBuilder(
         .addFunction(queryDocumentFunSpec(generateQueryDocument))
         .addFunction(nameFunSpec())
         .addFunction(serializeVariablesFunSpec())
-        .addFunction(adapterFunSpec())
+        .addFunction(adapterFunSpec(context.resolver, operation.dataProperty))
         .addFunction(rootFieldFunSpec())
         .addTypes(dataTypeSpecs())
         .addType(companionTypeSpec())
@@ -96,13 +97,6 @@ class OperationBuilder(
       adapterClassName = context.resolver.resolveOperationVariablesAdapter(operation.name),
       emptyMessage = "This operation doesn't have any variable"
   )
-
-  private fun adapterFunSpec(): FunSpec {
-    return adapterFunSpec(
-        adapterTypeName = context.resolver.resolveModelAdapter(operation.dataModelGroup.baseModelId),
-        adaptedTypeName = context.resolver.resolveModel(operation.dataModelGroup.baseModelId)
-    )
-  }
 
   private fun dataTypeSpecs(): List<TypeSpec> {
     return modelBuilders.map {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
@@ -77,6 +77,7 @@ data class IrOperation(
     val sourceWithFragments: String,
     val filePath: String,
     val responseBasedDataModelGroup: IrModelGroup?,
+    val dataProperty: IrProperty,
     val dataModelGroup: IrModelGroup,
 )
 
@@ -92,6 +93,7 @@ data class IrNamedFragment(
     val typeCondition: String,
     val selections: List<GQLSelection>,
     val interfaceModelGroup: IrModelGroup?,
+    val dataProperty: IrProperty,
     val dataModelGroup: IrModelGroup,
 )
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -298,7 +298,7 @@ internal class IrBuilder(
       allFragmentDefinitions[fragmentName]!!.formatToString()
     }).trimEnd('\n')
 
-    val dataModelGroup = builder.buildOperationData(
+    val (dataProperty, dataModelGroup) = builder.buildOperationData(
         selections = selectionSet.selections,
         rawTypeName = typeDefinition.name,
         operationName = name!!
@@ -310,7 +310,7 @@ internal class IrBuilder(
           selections = selectionSet.selections,
           rawTypeName = typeDefinition.name,
           operationName = name!!
-      )
+      ).second
       else -> null
     }
 
@@ -323,6 +323,7 @@ internal class IrBuilder(
         selections = selectionSet.selections,
         sourceWithFragments = sourceWithFragments,
         filePath = sourceLocation.filePath!!,
+        dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
         responseBasedDataModelGroup = responseBasedModelGroup
     )
@@ -344,7 +345,7 @@ internal class IrBuilder(
         fragmentName = name
     )
 
-    val dataModelGroup = builder.buildFragmentData(
+    val (dataProperty, dataModelGroup) = builder.buildFragmentData(
         fragmentName = name
     )
 
@@ -356,6 +357,7 @@ internal class IrBuilder(
         variables = variableDefinitions.map { it.toIr() },
         selections = selectionSet.selections,
         interfaceModelGroup = interfaceModelGroup,
+        dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
     )
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ModelGroupBuilder.kt
@@ -1,14 +1,13 @@
 package com.apollographql.apollo3.compiler.ir
 
 import com.apollographql.apollo3.ast.GQLSelection
-import com.apollographql.apollo3.ast.Schema
 
 interface ModelGroupBuilder {
   fun buildOperationData(
       selections: List<GQLSelection>,
       rawTypeName: String,
       operationName: String
-  ): IrModelGroup
+  ): Pair<IrProperty, IrModelGroup>
 
   fun buildFragmentInterface(
       fragmentName: String
@@ -16,6 +15,6 @@ interface ModelGroupBuilder {
 
   fun buildFragmentData(
       fragmentName: String
-  ): IrModelGroup
+  ): Pair<IrProperty, IrModelGroup>
 
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
@@ -45,7 +45,7 @@ internal class OperationBasedModelGroupBuilder(
     return name
   }
 
-  override fun buildOperationData(selections: List<GQLSelection>, rawTypeName: String, operationName: String): IrModelGroup {
+  override fun buildOperationData(selections: List<GQLSelection>, rawTypeName: String, operationName: String): Pair<IrProperty, IrModelGroup> {
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
@@ -60,21 +60,23 @@ internal class OperationBasedModelGroupBuilder(
       selections
     }
     val usedNames = mutableSetOf<String>()
-    return buildField(
+    val field = buildField(
         path = "${MODEL_OPERATION_DATA}.$operationName",
         info = info,
         selections = mergedSelections.map { SelectionWithParent(it, rawTypeName) },
         condition = BooleanExpression.True,
         usedNames = usedNames,
         parentTypeConditions = listOf(rawTypeName),
-    ).toModelGroup()!!
+    )
+
+    return field.toProperty() to field.toModelGroup()!!
   }
 
   override fun buildFragmentInterface(fragmentName: String): IrModelGroup? {
     return null
   }
 
-  override fun buildFragmentData(fragmentName: String): IrModelGroup {
+  override fun buildFragmentData(fragmentName: String): Pair<IrProperty, IrModelGroup> {
     val fragmentDefinition = allFragmentDefinitions[fragmentName]!!
 
     /**
@@ -99,14 +101,16 @@ internal class OperationBasedModelGroupBuilder(
 
     val usedNames = mutableSetOf<String>()
 
-    return buildField(
+    val field = buildField(
         path = "${MODEL_FRAGMENT_DATA}.$fragmentName",
         info = info,
         selections = mergedSelections.map { SelectionWithParent(it, fragmentDefinition.typeCondition.name) },
         condition = BooleanExpression.True,
         usedNames = usedNames,
         parentTypeConditions = listOf(fragmentDefinition.typeCondition.name),
-    ).toModelGroup()!!
+    )
+
+    return field.toProperty() to field.toModelGroup()!!
   }
 
   /**

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -24,12 +24,13 @@ internal class ResponseBasedModelGroupBuilder(
       selections: List<GQLSelection>,
       rawTypeName: String,
       operationName: String,
-  ): IrModelGroup {
-    return fieldNodeBuilder.buildOperationData(
+  ): Pair<IrProperty, IrModelGroup> {
+    val field = fieldNodeBuilder.buildOperationData(
         selections,
         rawTypeName,
         operationName
-    ).toIrModelGroup()!!
+    )
+    return field.toIrProperty() to field.toIrModelGroup()!!
   }
 
   override fun buildFragmentInterface(
@@ -42,10 +43,11 @@ internal class ResponseBasedModelGroupBuilder(
 
   override fun buildFragmentData(
       fragmentName: String,
-  ): IrModelGroup {
-    return fieldNodeBuilder.buildFragmentData(
+  ): Pair<IrProperty, IrModelGroup> {
+    val field = fieldNodeBuilder.buildFragmentData(
         fragmentName
-    ).toIrModelGroup()!!
+    )
+    return field.toIrProperty() to field.toIrModelGroup()!!
   }
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -124,7 +124,7 @@ private class FieldNodeBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrModelType(MODEL_UNKNOWN),
+        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
         deprecationReason = null,
         gqlType = GQLNonNullType(type = GQLNamedType(name = rawTypeName)),
     )
@@ -171,7 +171,7 @@ private class FieldNodeBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrModelType(MODEL_UNKNOWN),
+        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
         deprecationReason = null,
         gqlType = GQLNonNullType(type = fragment.typeCondition),
     )

--- a/tests/models-compat/src/commonTest/kotlin/test/root_fragment/RootFragmentTest.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/root_fragment/RootFragmentTest.kt
@@ -1,0 +1,52 @@
+package test.root_fragment
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.testing.runTest
+import root_fragment.SearchSomethingQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * A test to make sure reading root fragments never rewinds
+ * See https://github.com/apollographql/apollo-kotlin/issues/3914
+ */
+@OptIn(ApolloExperimental::class)
+class RootFragmentTest {
+  private lateinit var mockServer: MockServer
+  private lateinit var apolloClient: ApolloClient
+
+  private fun setUp() {
+    mockServer = MockServer()
+  }
+
+  private suspend fun tearDown() {
+    mockServer.stop()
+    // This is important. JS will hang if the BatchingHttpInterceptor scope is not cancelled
+    apolloClient.dispose()
+  }
+
+  @Test
+  fun test() = runTest(before = { setUp() }, after = { tearDown() }) {
+    apolloClient = ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .build()
+
+    mockServer.enqueue("""
+      {
+        "data": {
+          "__typename": "Search",
+          "searchSomething": {
+            "name": "foo"
+          }
+        }
+      }
+    """.trimIndent())
+
+    val fragments = apolloClient.query(SearchSomethingQuery()).execute().data?.fragments
+    assertEquals("foo", fragments?.something?.searchSomething?.name)
+    assertEquals("foo", fragments?.something2?.searchSomething?.name)
+  }
+}

--- a/tests/models-compat/src/commonTest/kotlin/test/root_fragment/graphql/operations.graphql
+++ b/tests/models-compat/src/commonTest/kotlin/test/root_fragment/graphql/operations.graphql
@@ -1,0 +1,16 @@
+query SearchSomething {
+  ...Something
+  ...Something2
+}
+
+fragment Something on Query {
+  searchSomething {
+    name
+  }
+}
+
+fragment Something2 on Query {
+  searchSomething {
+    name
+  }
+}

--- a/tests/models-compat/src/commonTest/kotlin/test/root_fragment/graphql/schema.graphqls
+++ b/tests/models-compat/src/commonTest/kotlin/test/root_fragment/graphql/schema.graphqls
@@ -1,0 +1,7 @@
+type Query {
+  searchSomething: Search!
+}
+
+type Search {
+  name: String!
+}


### PR DESCRIPTION
Because the adapter was never buffered, we could never rewind.

Closes https://github.com/apollographql/apollo-kotlin/issues/3914