### PR TITLE
📠 Fix some @DeprecatedSince annotations

### DIFF
--- a/apollo-annotations/api/apollo-annotations.api
+++ b/apollo-annotations/api/apollo-annotations.api
@@ -6,6 +6,7 @@ public final class com/apollographql/apollo3/annotations/ApolloDeprecatedSince$V
 	public static final field v3_0_0 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_0_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_1_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
+	public static final field v3_2_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun values ()[Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 }

--- a/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
+++ b/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
@@ -17,5 +17,6 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v3_0_0,
     v3_0_1,
     v3_1_1,
+    v3_2_1,
   }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
@@ -3,7 +3,7 @@
 package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
-import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_1_1
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_2_1
 import kotlin.jvm.JvmName
 import kotlin.reflect.KClass
 
@@ -114,7 +114,7 @@ fun <T : Any> BooleanExpression<T>.evaluate(block: (T) -> Boolean): Boolean {
 }
 
 @Deprecated("Kept for binary compatibility with generated code from older versions")
-@ApolloDeprecatedSince(v3_1_1)
+@ApolloDeprecatedSince(v3_2_1)
 @Suppress("DeprecatedCallableAddReplaceWith")
 fun BooleanExpression<BTerm>.evaluate(variables: Set<String>, typename: String?): Boolean {
   return evaluate {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CustomScalarAdapters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CustomScalarAdapters.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
-import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_1_1
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_2_1
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.internal.Version2CustomTypeAdapterToAdapter
 import kotlin.jvm.JvmField
@@ -59,7 +59,7 @@ class CustomScalarAdapters private constructor(
   }
 
   @Deprecated("Use adapterContext.variables() instead", ReplaceWith("adapterContext.variables()"))
-  @ApolloDeprecatedSince(v3_1_1)
+  @ApolloDeprecatedSince(v3_2_1)
   fun variables() = adapterContext.variables()
 
   override val key: ExecutionContext.Key<*>
@@ -113,7 +113,7 @@ class CustomScalarAdapters private constructor(
     }
 
     @Deprecated("Use AdapterContext.Builder.variables() instead")
-    @ApolloDeprecatedSince(v3_1_1)
+    @ApolloDeprecatedSince(v3_2_1)
     fun variables(variables: Executable.Variables): Builder = apply {
       adapterContext = adapterContext.newBuilder().variables(variables).build()
     }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.exception
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
-import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_2_1
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_1_1
 import com.apollographql.apollo3.api.http.HttpHeader
 import okio.BufferedSource
 
@@ -105,7 +105,7 @@ class HttpCacheMissException(message: String, cause: Exception? = null) : Apollo
 class ApolloCompositeException(first: Throwable?, second: Throwable?) : ApolloException(message = "multiple exceptions happened", second) {
 
   @get:Deprecated("Use suppressedExceptions instead", ReplaceWith("suppressedExceptions.first()"))
-  @ApolloDeprecatedSince(v3_2_1)
+  @ApolloDeprecatedSince(v3_1_1)
   val first: ApolloException
     get() {
       val firstException = suppressedExceptions.firstOrNull()
@@ -113,7 +113,7 @@ class ApolloCompositeException(first: Throwable?, second: Throwable?) : ApolloEx
     }
 
   @get:Deprecated("Use suppressedExceptions instead", ReplaceWith("suppressedExceptions.getOrNull(1)"))
-  @ApolloDeprecatedSince(v3_2_1)
+  @ApolloDeprecatedSince(v3_1_1)
   val second: ApolloException
     get() {
       val secondException = suppressedExceptions.getOrNull(1)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo3.exception
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_2_1
 import com.apollographql.apollo3.api.http.HttpHeader
 import okio.BufferedSource
 
@@ -104,6 +105,7 @@ class HttpCacheMissException(message: String, cause: Exception? = null) : Apollo
 class ApolloCompositeException(first: Throwable?, second: Throwable?) : ApolloException(message = "multiple exceptions happened", second) {
 
   @get:Deprecated("Use suppressedExceptions instead", ReplaceWith("suppressedExceptions.first()"))
+  @ApolloDeprecatedSince(v3_2_1)
   val first: ApolloException
     get() {
       val firstException = suppressedExceptions.firstOrNull()
@@ -111,6 +113,7 @@ class ApolloCompositeException(first: Throwable?, second: Throwable?) : ApolloEx
     }
 
   @get:Deprecated("Use suppressedExceptions instead", ReplaceWith("suppressedExceptions.getOrNull(1)"))
+  @ApolloDeprecatedSince(v3_2_1)
   val second: ApolloException
     get() {
       val secondException = suppressedExceptions.getOrNull(1)


### PR DESCRIPTION
A few `@DeprecatedSince` were added in the `defer` branch but a new release was published since then, so they were incorrect.

Also we forgot to add the annotation on `ApolloCompositeException.first` / `second`.