### PR TITLE
Defer: Fix false positive on duplicate labels validation

### DIFF
--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -58,7 +58,7 @@ internal class ExecutableValidationScope(
    */
   override val variableUsages = mutableListOf<VariableUsage>()
 
-  private val deferDirectiveLabels = mutableMapOf<String, SourceLocation>()
+  private val deferDirectiveLabels = mutableMapOf<String, GQLDirective>()
   private val deferDirectivePathAndLabels = mutableMapOf<String, SourceLocation>()
 
   fun validate(document: GQLDocument): List<Issue> {
@@ -392,15 +392,15 @@ internal class ExecutableValidationScope(
         )
       }
 
-      if (labelStringValue in deferDirectiveLabels) {
+      if (labelStringValue in deferDirectiveLabels && deferDirectiveLabels[labelStringValue] != this) {
         registerIssue(
             message = "@defer label '$labelStringValue' must be unique within all other @defer directives in the document. " +
-                "Same label found in ${deferDirectiveLabels[labelStringValue]!!.pretty()}",
+                "Same label found in ${deferDirectiveLabels[labelStringValue]!!.sourceLocation.pretty()}",
             sourceLocation = sourceLocation
         )
         return
       }
-      deferDirectiveLabels[labelStringValue] = sourceLocation
+      deferDirectiveLabels[labelStringValue] = this
     }
 
     val pathAndLabel = "$path/$labelStringValue"

--- a/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.expected
+++ b/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.expected
@@ -1,2 +1,2 @@
-ERROR: ValidationError (14:20)
-@defer label 'foobar' must be unique within all other @defer directives in the document. Same label found in duplicate_labels.graphql: (3, 16)
+ERROR: ValidationError (3:22)
+@defer label 'foobar' must be unique within all other @defer directives in the document. Same label found in duplicate_labels.graphql: (9, 21)

--- a/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.graphql
@@ -1,18 +1,15 @@
-query GetAnimal {
-  animal {
-    ... on Cat @defer(label: "foobar") {
-      meow
-    }
-    ... on Dog {
-      id
-    }
+query WithFragmentSpreads {
+  computers {
+    ...ComputerFields @defer(label: "foobar")
   }
 }
 
-query GetComputers {
-  computers {
-    ... on Computer @defer(label: "foobar") {
-      id
-    }
+fragment ComputerFields on Computer {
+  screen {
+    ...ScreenFields @defer(label: "foobar")
   }
+}
+
+fragment ScreenFields on Screen {
+  resolution
 }

--- a/apollo-compiler/src/test/validation/operation/defer/fragment_used_twice_not_duplicate_labels.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/fragment_used_twice_not_duplicate_labels.graphql
@@ -1,0 +1,28 @@
+query Query1 {
+  computers {
+    id
+    ...ComputerFields @defer
+  }
+}
+
+query Query2 {
+  computers {
+    id
+    ...ComputerFields @defer
+  }
+}
+
+fragment ComputerFields on Computer {
+  cpu
+  year
+  screen {
+    resolution
+    # This is traversed twice, but it's not a duplicate label
+    ...ScreenFields @defer(label: "a")
+  }
+}
+
+fragment ScreenFields on Screen {
+  isColor
+}
+


### PR DESCRIPTION
Fragments can be reused of course, so when finding a matching label, make sure it's not actually the same node we're looking at.