### PR TITLE
Creating a copy() funtion for the ApolloRequest 

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -23,8 +23,12 @@ private constructor(
     override val canBeBatched: Boolean?,
 ) : ExecutionOptions {
 
-  fun newBuilder(): Builder<D> {
-    return Builder(operation)
+  fun newBuilder(): Builder<D> = duplicate(Builder(operation))
+
+  fun copy(operation: Operation<D>): ApolloRequest<D> = duplicate(Builder(operation)).build()
+
+  private fun duplicate(builder: Builder<D>): Builder<D> {
+    return builder
         .requestUuid(requestUuid)
         .executionContext(executionContext)
         .httpMethod(httpMethod)

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
@@ -23,12 +24,12 @@ private constructor(
     override val canBeBatched: Boolean?,
 ) : ExecutionOptions {
 
-  fun newBuilder(): Builder<D> = duplicate(Builder(operation))
+  @OptIn(ApolloExperimental::class)
+  fun newBuilder(): Builder<D> = newBuilder(operation)
 
-  fun copy(operation: Operation<D>): ApolloRequest<D> = duplicate(Builder(operation)).build()
-
-  private fun duplicate(builder: Builder<D>): Builder<D> {
-    return builder
+  @ApolloExperimental
+  fun <E: Operation.Data> newBuilder(operation: Operation<E>): Builder<E> {
+    return Builder(operation)
         .requestUuid(requestUuid)
         .executionContext(executionContext)
         .httpMethod(httpMethod)
@@ -37,6 +38,7 @@ private constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
+
   }
 
   class Builder<D : Operation.Data>(


### PR DESCRIPTION
**Purpose:** to allow setting a new `Operation` which consumes the exact same values as an existing request and returns the result. Useful for when we want to intercept and relay the `ApolloRequest` through various stages of the network request.

There are various points in the API where one may want to wrap or proxy calls in the chain and without access to the `Operation`, we cannot. This `copy` function would allow the consumer to be sure that all values (beside the UUID) would be copied over, both now and in the future.