### PR TITLE
Allow configuration of frame types used in SubscriptionWsProtocol and default to Text

### DIFF
--- a/apollo-runtime/api/apollo-runtime.api
+++ b/apollo-runtime/api/apollo-runtime.api
@@ -396,8 +396,11 @@ public final class com/apollographql/apollo3/network/ws/GraphQLWsProtocol$Factor
 }
 
 public final class com/apollographql/apollo3/network/ws/SubscriptionWsProtocol : com/apollographql/apollo3/network/ws/WsProtocol {
+	public fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;)V
+	public fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;J)V
 	public fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;JLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;JLkotlin/jvm/functions/Function1;Lcom/apollographql/apollo3/network/ws/WsFrameType;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;JLkotlin/jvm/functions/Function1;Lcom/apollographql/apollo3/network/ws/WsFrameType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun connectionInit (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun handleServerMessage (Ljava/util/Map;)V
 	public fun startOperation (Lcom/apollographql/apollo3/api/ApolloRequest;)V
@@ -406,8 +409,10 @@ public final class com/apollographql/apollo3/network/ws/SubscriptionWsProtocol :
 
 public final class com/apollographql/apollo3/network/ws/SubscriptionWsProtocol$Factory : com/apollographql/apollo3/network/ws/WsProtocol$Factory {
 	public fun <init> ()V
+	public fun <init> (J)V
 	public fun <init> (JLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (JLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLkotlin/jvm/functions/Function1;Lcom/apollographql/apollo3/network/ws/WsFrameType;)V
+	public synthetic fun <init> (JLkotlin/jvm/functions/Function1;Lcom/apollographql/apollo3/network/ws/WsFrameType;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Lcom/apollographql/apollo3/network/ws/WebSocketConnection;Lcom/apollographql/apollo3/network/ws/WsProtocol$Listener;Lkotlinx/coroutines/CoroutineScope;)Lcom/apollographql/apollo3/network/ws/WsProtocol;
 	public fun getName ()Ljava/lang/String;
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/GraphQLWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/GraphQLWsProtocol.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.withTimeout
 /**
  * An [WsProtocol] that uses https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md
  * It can carry queries in addition to subscriptions over the websocket
- *
- * @param connectionPayload a map of additional parameters to send in the "connection_init" message
  */
 class GraphQLWsProtocol(
     private val connectionPayload: Map<String, Any?>? = null,
@@ -108,12 +106,15 @@ class GraphQLWsProtocol(
   }
 
   /**
-   * A factory that for [WsProtocol]
+   * A factory for [GraphQLWsProtocol].
    *
+   * @param connectionPayload a map of additional parameters to send in the "connection_init" message
    * @param pingIntervalMillis the interval between two client-initiated pings or -1 to not send any ping.
    * Default value: -1
    * @param pingPayload the ping payload to send in "ping" messages or null to not send a payload
    * @param pongPayload the pong payload to send in "pong" messages or null to not send a payload
+   * @param connectionAcknowledgeTimeoutMs the timeout for receiving the "connection_ack" message, in milliseconds
+   * @param frameType the type of the websocket frames to use. Default value: [WsFrameType.Text]
    */
   class Factory(
       private val connectionPayload: Map<String, Any?>? = null,

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
@@ -9,12 +9,15 @@ import kotlinx.coroutines.withTimeout
 
 /**
  * A [WsProtocol] for https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
+ *
+ * Note: This protocol is no longer actively maintained, and [GraphQLWsProtocol] should be favored instead.
  */
 class SubscriptionWsProtocol(
     webSocketConnection: WebSocketConnection,
     listener: Listener,
     private val connectionAcknowledgeTimeoutMs: Long = 10_000,
     private val connectionPayload: suspend () -> Map<String, Any?>? = { null },
+    private val frameType: WsFrameType = WsFrameType.Text,
 ) : WsProtocol(webSocketConnection, listener) {
 
   override suspend fun connectionInit() {
@@ -27,7 +30,7 @@ class SubscriptionWsProtocol(
       message.put("payload", payload)
     }
 
-    sendMessageMapBinary(message)
+    sendMessageMap(message, frameType)
 
     withTimeout(connectionAcknowledgeTimeoutMs) {
       val map = receiveMessageMap()
@@ -57,27 +60,37 @@ class SubscriptionWsProtocol(
   }
 
   override fun <D : Operation.Data> startOperation(request: ApolloRequest<D>) {
-    sendMessageMapBinary(
+    sendMessageMap(
         mapOf(
             "type" to "start",
             "id" to request.requestUuid.toString(),
             "payload" to DefaultHttpRequestComposer.composePayload(request)
-        )
+        ),
+        frameType
     )
   }
 
   override fun <D : Operation.Data> stopOperation(request: ApolloRequest<D>) {
-    sendMessageMapBinary(
+    sendMessageMap(
         mapOf(
             "type" to "stop",
             "id" to request.requestUuid.toString(),
-        )
+        ),
+        frameType
     )
   }
 
+  /**
+   * A factory for [SubscriptionWsProtocol].
+   *
+   * @param connectionAcknowledgeTimeoutMs the timeout for receiving the "connection_ack" message, in milliseconds
+   * @param connectionPayload a map of additional parameters to send in the "connection_init" message
+   * @param frameType the type of the websocket frames to use. Default value: [WsFrameType.Text]
+   */
   class Factory(
       private val connectionAcknowledgeTimeoutMs: Long = 10_000,
       private val connectionPayload: suspend () -> Map<String, Any?>? = { null },
+      private val frameType: WsFrameType = WsFrameType.Text,
   ) : WsProtocol.Factory {
     override val name: String
       get() = "graphql-ws"
@@ -85,13 +98,14 @@ class SubscriptionWsProtocol(
     override fun create(
         webSocketConnection: WebSocketConnection,
         listener: Listener,
-        scope: CoroutineScope
+        scope: CoroutineScope,
     ): WsProtocol {
       return SubscriptionWsProtocol(
           connectionPayload = connectionPayload,
           connectionAcknowledgeTimeoutMs = connectionAcknowledgeTimeoutMs,
           webSocketConnection = webSocketConnection,
           listener = listener,
+          frameType = frameType,
       )
     }
   }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/SubscriptionWsProtocol.kt
@@ -6,13 +6,16 @@ import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withTimeout
+import kotlin.jvm.JvmOverloads
 
 /**
  * A [WsProtocol] for https://github.com/apollographql/subscriptions-transport-ws/blob/master/PROTOCOL.md
  *
  * Note: This protocol is no longer actively maintained, and [GraphQLWsProtocol] should be favored instead.
  */
-class SubscriptionWsProtocol(
+class SubscriptionWsProtocol
+@JvmOverloads
+constructor(
     webSocketConnection: WebSocketConnection,
     listener: Listener,
     private val connectionAcknowledgeTimeoutMs: Long = 10_000,
@@ -87,7 +90,9 @@ class SubscriptionWsProtocol(
    * @param connectionPayload a map of additional parameters to send in the "connection_init" message
    * @param frameType the type of the websocket frames to use. Default value: [WsFrameType.Text]
    */
-  class Factory(
+  class Factory
+  @JvmOverloads
+  constructor(
       private val connectionAcknowledgeTimeoutMs: Long = 10_000,
       private val connectionPayload: suspend () -> Map<String, Any?>? = { null },
       private val frameType: WsFrameType = WsFrameType.Text,


### PR DESCRIPTION
Add a  `frameType` parameter to `SubscriptionWsProtocol.Builder` to specify the frame type, and default to Text.

Should resolve #3990 and #3991.