### PR TITLE
Fix wrong LocalDate and LocalDateTime formats in JavaTimeAdapters

### DIFF
--- a/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/JavaTimeAdapters.kt
+++ b/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/JavaTimeAdapters.kt
@@ -28,33 +28,33 @@ object JavaInstantAdapter : Adapter<Instant> {
 }
 
 /**
- * An [Adapter] that converts an ISO 8601 String like "2010-06-01T22:19:44.475Z" to/from
+ * An [Adapter] that converts an ISO 8601 String like "2010-06-01" to/from
  * a [java.time.LocalDate]
  *
  * It requires Android Gradle plugin 4.0 or newer and [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
  */
 object JavaLocalDateAdapter : Adapter<LocalDate> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): LocalDate {
-    return formatter.parse(reader.nextString()!!, LocalDate::from)
+    return LocalDate.parse(reader.nextString()!!)
   }
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: LocalDate) {
-    writer.value(formatter.format(value))
+    writer.value(value.toString())
   }
 }
 
 /**
- * An [Adapter] that converts an ISO 8601 String like "2010-06-01T22:19:44.475Z" to/from
+ * An [Adapter] that converts an ISO 8601 String without time zone information like "2010-06-01T22:19:44.475" to/from
  * a [java.time.LocalDateTime]
  *
  * It requires Android Gradle plugin 4.0 or newer and [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
  */
 object JavaLocalDateTimeAdapter : Adapter<LocalDateTime> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): LocalDateTime {
-    return formatter.parse(reader.nextString()!!, LocalDateTime::from)
+    return LocalDateTime.parse(reader.nextString()!!)
   }
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: LocalDateTime) {
-    writer.value(formatter.format(value))
+    writer.value(value.toString())
   }
 }


### PR DESCRIPTION
The current code does not always interpret correctly.

I think it would be correct to interpret date strings like KotlinxLocalDateAdapter and KotlinxLocalDateTimeAdapter.

Playground
https://pl.kotl.in/S-iy9PlKg