### PR TITLE
Handle SqlNormalizedCache merge APIs Exceptions with ApolloExceptionHandler

### DIFF
--- a/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheTest.kt
+++ b/apollo-normalized-cache-sqlite/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheTest.kt
@@ -216,8 +216,23 @@ class SqlNormalizedCacheTest {
     apolloExceptionHandler = {
       throwable = it
     }
+
     badCache.loadRecord(STANDARD_KEY, CacheHeaders.NONE)
     assertEquals("Unable to read a record from the database", throwable!!.message)
+    assertEquals("bad cache", throwable!!.cause!!.message)
+
+    throwable = null
+    badCache.merge(
+        record = Record(
+            key = STANDARD_KEY,
+            fields = mapOf(
+                "fieldKey" to "valueUpdated",
+                "newFieldKey" to true,
+            ),
+        ),
+        cacheHeaders = CacheHeaders.NONE,
+    )
+    assertEquals("Unable to merge a record from the database", throwable!!.message)
     assertEquals("bad cache", throwable!!.cause!!.message)
   }
 


### PR DESCRIPTION
Handle merge exceptions that could happen as described in #4001, so it doesn't crash the application andwe can use the exception handler to still investigate these issues.