### PR TITLE
Add adapter for java.time.OffsetDateTime

### DIFF
--- a/apollo-adapters/README.md
+++ b/apollo-adapters/README.md
@@ -10,5 +10,6 @@ A few convenient adapters:
 | `com.apollographql.apollo3.adapter.JavaLocalDateAdapter`        | For `java.time.LocalDate` ISO8601 dates                                                             |
 | `com.apollographql.apollo3.adapter.KotlinxLocalDateTimeAdapter` | For `kotlinx.datetime.LocalDateTime` ISO8601 dates                                                  |
 | `com.apollographql.apollo3.adapter.JavaLocalDateTimeAdapter`    | For `java.time.LocalDateTime` ISO8601 dates                                                         |
+| `com.apollographql.apollo3.adapter.JavaOffsetDateTimeAdapter`   | For `java.time.OffsetDateTime` ISO8601 dates                                                        |
 | `com.apollographql.apollo3.adapter.DateAdapter`                 | For `java.util.Date` ISO8601 dates                                                                  |
 | `com.apollographql.apollo3.adapter.BigDecimalAdapter`           | For a Multiplatform `com.apollographql.apollo3.adapter.BigDecimal` class holding big decimal values |

--- a/apollo-adapters/api/apollo-adapters.api
+++ b/apollo-adapters/api/apollo-adapters.api
@@ -42,6 +42,14 @@ public final class com/apollographql/apollo3/adapter/JavaLocalDateTimeAdapter : 
 	public fun toJson (Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/time/LocalDateTime;)V
 }
 
+public final class com/apollographql/apollo3/adapter/JavaOffsetDateTimeAdapter : com/apollographql/apollo3/api/Adapter {
+	public static final field INSTANCE Lcom/apollographql/apollo3/adapter/JavaOffsetDateTimeAdapter;
+	public synthetic fun fromJson (Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/Object;
+	public fun fromJson (Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/time/OffsetDateTime;
+	public synthetic fun toJson (Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/Object;)V
+	public fun toJson (Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/time/OffsetDateTime;)V
+}
+
 public final class com/apollographql/apollo3/adapter/KotlinxInstantAdapter : com/apollographql/apollo3/api/Adapter {
 	public static final field INSTANCE Lcom/apollographql/apollo3/adapter/KotlinxInstantAdapter;
 	public synthetic fun fromJson (Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/Object;

--- a/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/JavaTimeAdapters.kt
+++ b/apollo-adapters/src/jvmMain/kotlin/com/apollographql/apollo3/adapter/JavaTimeAdapters.kt
@@ -8,6 +8,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
 
 
 /**
@@ -64,5 +65,23 @@ object JavaLocalDateTimeAdapter : Adapter<LocalDateTime> {
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: LocalDateTime) {
     writer.value(value.toString())
+  }
+}
+
+/**
+ * An [Adapter] that converts a date and time to/from [java.time.OffsetDateTime]
+ *
+ * Examples:
+ * - "2010-06-01T22:19:44.475+01:00"
+ *
+ * It requires Android Gradle plugin 4.0 or newer and [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
+ */
+object JavaOffsetDateTimeAdapter : Adapter<OffsetDateTime> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): OffsetDateTime {
+    return OffsetDateTime.parse(reader.nextString()!!)
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: OffsetDateTime) {
+    writer.value(value.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
   }
 }

--- a/apollo-adapters/src/jvmTest/kotlin/JavaTimeAdaptersTest.kt
+++ b/apollo-adapters/src/jvmTest/kotlin/JavaTimeAdaptersTest.kt
@@ -2,6 +2,7 @@ import com.apollographql.apollo3.adapter.DateAdapter
 import com.apollographql.apollo3.adapter.JavaInstantAdapter
 import com.apollographql.apollo3.adapter.JavaLocalDateAdapter
 import com.apollographql.apollo3.adapter.JavaLocalDateTimeAdapter
+import com.apollographql.apollo3.adapter.JavaOffsetDateTimeAdapter
 import com.apollographql.apollo3.adapter.KotlinxInstantAdapter
 import com.apollographql.apollo3.adapter.KotlinxLocalDateAdapter
 import com.apollographql.apollo3.adapter.KotlinxLocalDateTimeAdapter
@@ -42,6 +43,18 @@ class JavaTimeAdaptersTest {
     assertEquals(1275430784475, instant.toEpochMilli())
     // Time zone is lost
     assertEquals("2010-06-01T22:19:44.475Z", JavaInstantAdapter.toJson(instant))
+  }
+
+  @Test
+  fun offsetDateTime() {
+    var offsetDateTime = JavaOffsetDateTimeAdapter.fromJson("2010-06-01T23:19:44.475+01:00")
+    assertEquals(1275430784475, offsetDateTime.toInstant().toEpochMilli())
+    // Offset is retained
+    assertEquals("2010-06-01T23:19:44.475+01:00", JavaOffsetDateTimeAdapter.toJson(offsetDateTime))
+
+    offsetDateTime = JavaOffsetDateTimeAdapter.fromJson("2010-06-01T22:19:44.475Z")
+    assertEquals(1275430784475, offsetDateTime.toInstant().toEpochMilli())
+    assertEquals("2010-06-01T22:19:44.475Z", JavaOffsetDateTimeAdapter.toJson(offsetDateTime))
   }
 
   @Test


### PR DESCRIPTION
Close https://github.com/apollographql/apollo-kotlin/issues/4000

As discussed in the issue, I would like to retain the offset of ISO8601 date-time values from the server.

As detailed in the tests, `Instant` drops the offset information, thus I need to convert values to `OffsetDateTime` instead.


