### PR TITLE
defer: Add graphql-helix in js test

### DIFF
--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -28,6 +28,13 @@ kotlin {
         implementation(groovy.util.Eval.x(project, "x.dep.kotlinJunit"))
       }
     }
+
+    val jsTest by getting {
+      dependencies {
+        implementation(npm("graphql", "16.0.0-experimental-stream-defer.5"))
+        implementation(npm("graphql-helix", "1.12.0"))
+      }
+    }
   }
 }
 

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 
     val jsTest by getting {
       dependencies {
-        implementation(npm("graphql", "16.0.0-experimental-stream-defer.5"))
+        implementation(npm("graphql", "canary-pr-2839"))
         implementation(npm("graphql-helix", "1.12.0"))
       }
     }
@@ -42,11 +42,13 @@ apollo {
   service("kotlin") {
     packageName.set("defer")
     generateKotlinModels.set(true)
+    generateTestBuilders.set(true)
     configureConnection(true)
   }
   service("java") {
     packageName.set("defer")
     generateKotlinModels.set(false)
+    generateTestBuilders.set(true)
     configureConnection(false)
   }
 }

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -44,13 +44,11 @@ apollo {
   service("kotlin") {
     packageName.set("defer")
     generateKotlinModels.set(true)
-    generateTestBuilders.set(true)
     configureConnection(true)
   }
   service("java") {
     packageName.set("defer")
     generateKotlinModels.set(false)
-    generateTestBuilders.set(true)
     configureConnection(false)
   }
 }

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -31,8 +31,10 @@ kotlin {
 
     val jsTest by getting {
       dependencies {
-        implementation(npm("graphql", "canary-pr-2839"))
         implementation(npm("graphql-helix", "1.12.0"))
+        // Depend on a more recent 'canary' version of graphql-js (version graphql-helix depends on by default is older).
+        // This corresponds to this PR: https://github.com/graphql/graphql-js/pull/2839/
+        implementation(npm("graphql", "canary-pr-2839"))
       }
     }
   }

--- a/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
@@ -1,0 +1,10 @@
+package graphql
+
+import util.jsObject
+
+fun GraphQLSchemaConfig(query: GraphQLObjectType) = jsObject<GraphQLSchemaConfig> { this.query = query }
+
+fun GraphQLObjectTypeConfig(
+    name: String,
+    fields: () -> dynamic,
+) = jsObject<GraphQLObjectTypeConfig> { this.name = name; this.fields = fields }

--- a/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
@@ -2,9 +2,24 @@ package graphql
 
 import util.dynamicObject
 
-fun GraphQLSchemaConfig(query: GraphQLObjectType) = dynamicObject<GraphQLSchemaConfig> { this.query = query }
+fun GraphQLSchemaConfig(
+    query: GraphQLObjectType,
+    directives: Array<GraphQLDirective>? = null,
+) = dynamicObject<GraphQLSchemaConfig> {
+  this.query = query
+  directives?.let { this.directives = specifiedDirectives + it }
+}
 
 fun GraphQLObjectTypeConfig(
     name: String,
-    fields: () -> dynamic,
+    fields: dynamic,
 ) = dynamicObject<GraphQLObjectTypeConfig> { this.name = name; this.fields = fields }
+
+fun GraphQLField(type: GraphQLType, args: (() -> dynamic)? = null, resolve: ((dynamic, dynamic) -> dynamic)? = null): dynamic {
+  val field = dynamicObject {
+    this.type = type
+  }
+  if (args != null) field.args = args
+  if (resolve != null) field.resolve = resolve
+  return field
+}

--- a/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
@@ -1,10 +1,10 @@
 package graphql
 
-import util.jsObject
+import util.dynamicObject
 
-fun GraphQLSchemaConfig(query: GraphQLObjectType) = jsObject<GraphQLSchemaConfig> { this.query = query }
+fun GraphQLSchemaConfig(query: GraphQLObjectType) = dynamicObject<GraphQLSchemaConfig> { this.query = query }
 
 fun GraphQLObjectTypeConfig(
     name: String,
     fields: () -> dynamic,
-) = jsObject<GraphQLObjectTypeConfig> { this.name = name; this.fields = fields }
+) = dynamicObject<GraphQLObjectTypeConfig> { this.name = name; this.fields = fields }

--- a/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Extras.kt
@@ -15,6 +15,12 @@ fun GraphQLObjectTypeConfig(
     fields: dynamic,
 ) = dynamicObject<GraphQLObjectTypeConfig> { this.name = name; this.fields = fields }
 
+fun GraphQLObjectType(
+    name: String,
+    fields: dynamic,
+) = GraphQLObjectType(GraphQLObjectTypeConfig(name, fields))
+
+
 fun GraphQLField(type: GraphQLType, args: (() -> dynamic)? = null, resolve: ((dynamic, dynamic) -> dynamic)? = null): dynamic {
   val field = dynamicObject {
     this.type = type

--- a/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
@@ -1,0 +1,36 @@
+@file:JsModule("graphql")
+@file:JsNonModule
+
+package graphql
+
+external class GraphQLSchema(config: GraphQLSchemaConfig)
+
+external interface GraphQLSchemaConfig {
+    var query: GraphQLObjectType
+
+//    var mutation: GraphQLObjectType?
+//    var subscription: GraphQLObjectType?
+//    var types: Array<GraphQLNamedType>?
+//    var directives: Array<GraphQLDirective>?
+}
+
+external class GraphQLObjectType(config: GraphQLObjectTypeConfig)
+
+external interface GraphQLObjectTypeConfig {
+    var name: String
+    var fields: () -> dynamic
+}
+
+external class GraphQLField(config: GraphQLFieldConfig)
+
+external interface GraphQLFieldConfig {
+    val type: Any
+    val args: () -> Any
+    val resolve: (Any, Any) -> Any
+}
+
+external object GraphQLString
+external object GraphQLInt
+external object GraphQLFloat
+external object GraphQLBoolean
+external object GraphQLID

--- a/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
@@ -14,7 +14,9 @@ external interface GraphQLSchemaConfig {
 //    var directives: Array<GraphQLDirective>?
 }
 
-external class GraphQLObjectType(config: GraphQLObjectTypeConfig)
+external interface GraphQLType
+
+external class GraphQLObjectType(config: GraphQLObjectTypeConfig) : GraphQLType
 
 external interface GraphQLObjectTypeConfig {
     var name: String
@@ -29,8 +31,11 @@ external interface GraphQLFieldConfig {
     val resolve: (Any, Any) -> Any
 }
 
-external object GraphQLString
-external object GraphQLInt
-external object GraphQLFloat
-external object GraphQLBoolean
-external object GraphQLID
+external object GraphQLString : GraphQLType
+external object GraphQLInt : GraphQLType
+external object GraphQLFloat : GraphQLType
+external object GraphQLBoolean : GraphQLType
+external object GraphQLID : GraphQLType
+
+external class GraphQLList(ofType: GraphQLType) : GraphQLType
+external class GraphQLNonNull(ofType: GraphQLType) : GraphQLType

--- a/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
@@ -11,7 +11,7 @@ external interface GraphQLSchemaConfig {
 //    var mutation: GraphQLObjectType?
 //    var subscription: GraphQLObjectType?
 //    var types: Array<GraphQLNamedType>?
-//    var directives: Array<GraphQLDirective>?
+var directives: Array<GraphQLDirective>?
 }
 
 external interface GraphQLType
@@ -23,14 +23,6 @@ external interface GraphQLObjectTypeConfig {
     var fields: () -> dynamic
 }
 
-external class GraphQLField(config: GraphQLFieldConfig)
-
-external interface GraphQLFieldConfig {
-    val type: Any
-    val args: () -> Any
-    val resolve: (Any, Any) -> Any
-}
-
 external object GraphQLString : GraphQLType
 external object GraphQLInt : GraphQLType
 external object GraphQLFloat : GraphQLType
@@ -39,3 +31,11 @@ external object GraphQLID : GraphQLType
 
 external class GraphQLList(ofType: GraphQLType) : GraphQLType
 external class GraphQLNonNull(ofType: GraphQLType) : GraphQLType
+
+external interface GraphQLDirective
+
+external object GraphQLDeferDirective : GraphQLDirective
+external object GraphQLStreamDirective : GraphQLDirective
+
+external val specifiedDirectives: Array<GraphQLDirective>
+

--- a/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
+++ b/tests/defer/src/jsTest/kotlin/graphql/Imports.kt
@@ -7,7 +7,7 @@ external class GraphQLSchema(config: GraphQLSchemaConfig)
 
 external interface GraphQLSchemaConfig {
     var query: GraphQLObjectType
-
+// Unused for now
 //    var mutation: GraphQLObjectType?
 //    var subscription: GraphQLObjectType?
 //    var types: Array<GraphQLNamedType>?

--- a/tests/defer/src/jsTest/kotlin/helix/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/Extras.kt
@@ -1,0 +1,25 @@
+package helix
+
+import graphql.GraphQLSchema
+import util.jsObject
+
+fun Request(body: dynamic, headers: dynamic, method: String, query: dynamic) = jsObject<Request> {
+  this.body = body
+  this.headers = headers
+  this.method = method
+  this.query = query
+}
+
+fun ProcessRequestOptions(
+    operationName: String?,
+    query: String?,
+    variables: dynamic,
+    request: Request,
+    schema: GraphQLSchema,
+) = jsObject<ProcessRequestOptions> {
+  this.operationName = operationName
+  this.query = query
+  this.variables = variables
+  this.request = request
+  this.schema = schema
+}

--- a/tests/defer/src/jsTest/kotlin/helix/Extras.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/Extras.kt
@@ -1,9 +1,9 @@
 package helix
 
 import graphql.GraphQLSchema
-import util.jsObject
+import util.dynamicObject
 
-fun Request(body: dynamic, headers: dynamic, method: String, query: dynamic) = jsObject<Request> {
+fun Request(body: dynamic, headers: dynamic, method: String, query: dynamic) = dynamicObject<Request> {
   this.body = body
   this.headers = headers
   this.method = method
@@ -16,7 +16,7 @@ fun ProcessRequestOptions(
     variables: dynamic,
     request: Request,
     schema: GraphQLSchema,
-) = jsObject<ProcessRequestOptions> {
+) = dynamicObject<ProcessRequestOptions> {
   this.operationName = operationName
   this.query = query
   this.variables = variables

--- a/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
@@ -1,0 +1,85 @@
+package helix
+
+import Buffer
+import NodeJS.get
+import graphql.GraphQLSchema
+import http.createServer
+import net.AddressInfo
+import url.URL
+import util.OutgoingHttpHeaders
+import util.objectFromEntries
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+class HelixServer
+(
+    private val schema: GraphQLSchema,
+    port: Long? = null,
+) {
+  private var url: String? = null
+
+  private val server = createServer { req, res ->
+    val url = URL(req.url, "http://${req.headers["Host"]}")
+
+    if (url.pathname != "/graphql") {
+      res.writeHead(404)
+      res.end("Not found")
+      return@createServer
+    }
+
+    val payload = StringBuilder()
+
+    req.on("data") { chunk ->
+      when (chunk) {
+        is String -> payload.append(chunk)
+        is Buffer -> payload.append(chunk.toString("utf8"))
+      }
+    }
+
+    req.on("end") { _ ->
+      val request = Request(
+          body = JSON.parse<Any>(payload.toString().ifBlank { "{}" }),
+          headers = req.headers,
+          method = req.method,
+          query = objectFromEntries(url.searchParams),
+      )
+
+      if (shouldRenderGraphiQL(request)) {
+        res.writeHead(200, OutgoingHttpHeaders("content-type" to "text/html"))
+        res.end(renderGraphiQL())
+      } else {
+        val graphQLParams = getGraphQLParameters(request)
+        processRequest(
+            ProcessRequestOptions(
+                operationName = graphQLParams.operationName,
+                query = graphQLParams.query,
+                variables = graphQLParams.variables,
+                request = request,
+                schema = schema,
+            )
+        ).then { result ->
+          sendResult(result, res)
+        }
+      }
+    }
+  }.apply {
+    if (port != null) {
+      listen(port)
+    } else {
+      listen()
+    }
+  }
+
+  suspend fun url() = url ?: suspendCoroutine { cont ->
+    url = "http://localhost:${server.address().unsafeCast<AddressInfo>().port}/graphql"
+    server.on("listening") { _ ->
+      cont.resume(url!!)
+    }
+  }
+
+  suspend fun stop() = suspendCoroutine<Unit> { cont ->
+    server.close {
+      cont.resume(Unit)
+    }
+  }
+}

--- a/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
@@ -18,6 +18,7 @@ class HelixServer
 ) {
   private var url: String? = null
 
+  // Based on https://github.com/contra/graphql-helix/blob/main/examples/http/server.ts
   private val server = createServer { req, res ->
     val url = URL(req.url, "http://${req.headers["Host"]}")
 

--- a/tests/defer/src/jsTest/kotlin/helix/Imports.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/Imports.kt
@@ -1,0 +1,40 @@
+@file:JsModule("graphql-helix")
+@file:JsNonModule
+
+package helix
+
+import graphql.GraphQLSchema
+import kotlin.js.Promise
+
+external interface Request {
+  var body: dynamic
+  var headers: dynamic
+  var method: String
+  var query: dynamic
+}
+
+external fun shouldRenderGraphiQL(request: Request): Boolean
+
+external fun renderGraphiQL(): String
+
+external interface GraphQLParams {
+  val operationName: String?
+  val query: String?
+  val variables: dynamic
+}
+
+external fun getGraphQLParameters(request: Request): GraphQLParams
+
+external interface ProcessRequestOptions {
+  var operationName: String?
+  var query: String?
+  var variables: dynamic
+  var request: Request
+  var schema: GraphQLSchema
+}
+
+external interface ProcessRequestResult
+
+external fun processRequest(options: ProcessRequestOptions): Promise<ProcessRequestResult>
+
+external fun sendResult(result: ProcessRequestResult, rawResponse: http.ServerResponse): Promise<Unit>

--- a/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
@@ -61,26 +61,28 @@ class DeferWithHelixTest {
                     resolve = { _: dynamic, _: dynamic ->
                       JSON.parse<Any>(
                           //language=JSON
-                          """[
-                                  {
-                                    "id": "Computer1",
-                                    "cpu": "386",
-                                    "year": 1993,
-                                    "screen": {
-                                      "resolution": "640x480",
-                                      "isColor": false
-                                    }
-                                  },
-                                  {
-                                    "id": "Computer2",
-                                    "cpu": "486",
-                                    "year": 1996,
-                                    "screen": {
-                                      "resolution": "800x600",
-                                      "isColor": true
-                                    }
-                                  }
-                                ]""".trimIndent()
+                          """
+                          [
+                            {
+                              "id": "Computer1",
+                              "cpu": "386",
+                              "year": 1993,
+                              "screen": {
+                                "resolution": "640x480",
+                                "isColor": false
+                              }
+                            },
+                            {
+                              "id": "Computer2",
+                              "cpu": "486",
+                              "year": 1996,
+                              "screen": {
+                                "resolution": "800x600",
+                                "isColor": true
+                              }
+                            }
+                          ]
+                          """.trimIndent()
                       )
                     }
                 )

--- a/tests/defer/src/jsTest/kotlin/test/HelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/HelixTest.kt
@@ -1,0 +1,104 @@
+package test
+
+import Buffer
+import NodeJS.get
+import com.apollographql.apollo3.testing.runTest
+import graphql.GraphQLObjectType
+import graphql.GraphQLObjectTypeConfig
+import graphql.GraphQLSchema
+import graphql.GraphQLSchemaConfig
+import graphql.GraphQLString
+import helix.ProcessRequestOptions
+import helix.Request
+import helix.getGraphQLParameters
+import helix.processRequest
+import helix.renderGraphiQL
+import helix.sendResult
+import helix.shouldRenderGraphiQL
+import http.createServer
+import url.URL
+import util.OutgoingHttpHeaders
+import util.jsObject
+import util.objectFromEntries
+import kotlin.test.Test
+
+class HelixTest {
+  private suspend fun setUp() {
+  }
+
+  private suspend fun tearDown() {
+  }
+
+  private val schema = GraphQLSchema(
+      GraphQLSchemaConfig(
+          query = GraphQLObjectType(
+              GraphQLObjectTypeConfig(
+                  name = "Query",
+                  fields = {
+                    jsObject {
+                      hello = jsObject {
+                        type = GraphQLString
+                        resolve = { _: dynamic, _: dynamic -> "Hello, World!" }
+                      }
+                    }
+                  }
+              )
+          )
+      )
+  )
+
+  @Test
+  fun helixText() = runTest(before = { setUp() }, after = { tearDown() }) {
+    println("Hello, World!")
+
+    val server = createServer { req, res ->
+      val url = URL(req.url, "http://${req.headers["Host"]}")
+
+      if (url.pathname != "/graphql") {
+        res.writeHead(404)
+        res.end("Not found")
+        return@createServer
+      }
+
+      val payload = StringBuilder()
+
+      req.on("data") { chunk ->
+        when (chunk) {
+          is String -> payload.append(chunk)
+          is Buffer -> payload.append(chunk.toString("utf8"))
+        }
+      }
+
+      req.on("end") { _ ->
+        val request = Request(
+            body = JSON.parse<Any>(payload.toString().ifBlank { "{}" }),
+            headers = req.headers,
+            method = req.method,
+            query = objectFromEntries(url.searchParams),
+        )
+
+        if (shouldRenderGraphiQL(request)) {
+          res.writeHead(200, OutgoingHttpHeaders("content-type" to "text/html"))
+          res.end(renderGraphiQL())
+        } else {
+          val graphQLParams = getGraphQLParameters(request)
+          processRequest(
+              ProcessRequestOptions(
+                  operationName = graphQLParams.operationName,
+                  query = graphQLParams.query,
+                  variables = graphQLParams.variables,
+                  request = request,
+                  schema = this@HelixTest.schema,
+              )
+          ).then { result ->
+            sendResult(result, res)
+          }
+        }
+      }
+    }
+
+    server.listen(4000) {
+      println("Listening on http://localhost:4000")
+    }
+  }
+}

--- a/tests/defer/src/jsTest/kotlin/test/HelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/HelixTest.kt
@@ -3,6 +3,11 @@ package test
 import Buffer
 import NodeJS.get
 import com.apollographql.apollo3.testing.runTest
+import graphql.GraphQLBoolean
+import graphql.GraphQLID
+import graphql.GraphQLInt
+import graphql.GraphQLList
+import graphql.GraphQLNonNull
 import graphql.GraphQLObjectType
 import graphql.GraphQLObjectTypeConfig
 import graphql.GraphQLSchema
@@ -18,7 +23,7 @@ import helix.shouldRenderGraphiQL
 import http.createServer
 import url.URL
 import util.OutgoingHttpHeaders
-import util.jsObject
+import util.dynamicObject
 import util.objectFromEntries
 import kotlin.test.Test
 
@@ -35,10 +40,71 @@ class HelixTest {
               GraphQLObjectTypeConfig(
                   name = "Query",
                   fields = {
-                    jsObject {
-                      hello = jsObject {
-                        type = GraphQLString
+                    dynamicObject {
+                      hello = dynamicObject {
+                        type = GraphQLNonNull(GraphQLString)
                         resolve = { _: dynamic, _: dynamic -> "Hello, World!" }
+                      }
+
+                      computers = dynamicObject {
+                        type = GraphQLNonNull(GraphQLList(GraphQLNonNull(GraphQLObjectType(
+                            GraphQLObjectTypeConfig(
+                                name = "Computer",
+                                fields = {
+                                  dynamicObject {
+                                    id = dynamicObject {
+                                      type = GraphQLNonNull(GraphQLID)
+                                    }
+                                    cpu = dynamicObject {
+                                      type = GraphQLNonNull(GraphQLString)
+                                    }
+                                    year = dynamicObject {
+                                      type = GraphQLNonNull(GraphQLInt)
+                                    }
+                                    screen = dynamicObject {
+                                      type = GraphQLNonNull(GraphQLObjectType(GraphQLObjectTypeConfig(
+                                          name = "Screen",
+                                          fields = {
+                                            dynamicObject {
+                                              resolution = dynamicObject {
+                                                type = GraphQLNonNull(GraphQLString)
+                                              }
+                                              isColor = dynamicObject {
+                                                type = GraphQLNonNull(GraphQLBoolean)
+                                              }
+                                            }
+                                          }
+                                      )))
+                                    }
+                                  }
+                                }
+                            )
+                        ))))
+                        resolve = { _: dynamic, _: dynamic ->
+                          JSON.parse<Any>(
+                              //language=JSON
+                              """[
+                                  {
+                                    "id": "Computer1",
+                                    "cpu": "386",
+                                    "year": 1993,
+                                    "screen": {
+                                      "resolution": "640x480",
+                                      "isColor": false
+                                    }
+                                  },
+                                  {
+                                    "id": "Computer2",
+                                    "cpu": "486",
+                                    "year": 1996,
+                                    "screen": {
+                                      "resolution": "800x600",
+                                      "isColor": true
+                                    }
+                                  }
+                                ]""".trimIndent()
+                          )
+                        }
                       }
                     }
                   }

--- a/tests/defer/src/jsTest/kotlin/util/HttpUtil.kt
+++ b/tests/defer/src/jsTest/kotlin/util/HttpUtil.kt
@@ -1,0 +1,6 @@
+package util
+
+import http.OutgoingHttpHeaders
+import kotlin.js.json
+
+fun OutgoingHttpHeaders(vararg headers: Pair<String, Any?>) = json(*headers).unsafeCast<OutgoingHttpHeaders>()

--- a/tests/defer/src/jsTest/kotlin/util/JsUtil.kt
+++ b/tests/defer/src/jsTest/kotlin/util/JsUtil.kt
@@ -1,0 +1,14 @@
+package util
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun jsObject(noinline init: dynamic.() -> Unit): dynamic {
+  val js = js("{}")
+  init(js)
+  return js
+}
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun <T> jsObject(noinline init: T.() -> Unit): T = (js("{}") as T).apply(init)
+
+@Suppress("NOTHING_TO_INLINE")
+inline fun objectFromEntries(@Suppress("UNUSED_PARAMETER") entries: dynamic) = js("Object.fromEntries(entries)")

--- a/tests/defer/src/jsTest/kotlin/util/JsUtil.kt
+++ b/tests/defer/src/jsTest/kotlin/util/JsUtil.kt
@@ -1,14 +1,14 @@
 package util
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun jsObject(noinline init: dynamic.() -> Unit): dynamic {
+inline fun dynamicObject(noinline init: dynamic.() -> Unit): dynamic {
   val js = js("{}")
   init(js)
   return js
 }
 
 @Suppress("NOTHING_TO_INLINE")
-inline fun <T> jsObject(noinline init: T.() -> Unit): T = (js("{}") as T).apply(init)
+inline fun <T> dynamicObject(noinline init: T.() -> Unit): T = (js("{}") as T).apply(init)
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun objectFromEntries(@Suppress("UNUSED_PARAMETER") entries: dynamic) = js("Object.fromEntries(entries)")


### PR DESCRIPTION
Related to #3968

In this PR, the helix server is integrated in the `defer` test projects. If needed, this could be moved to its own module so it could be used by other tests.