### PR TITLE
defer: Merge payloads in subscriptions

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/AdapterContext.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/AdapterContext.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloInternal
+
 class AdapterContext private constructor(
     private val variables: Executable.Variables?,
     private val mergedDeferredFragmentIds: Set<DeferredFragmentIdentifier>?,
@@ -43,3 +45,12 @@ class AdapterContext private constructor(
     }
   }
 }
+
+@ApolloInternal
+fun CustomScalarAdapters.withDeferredFragmentIds(deferredFragmentIds: Set<DeferredFragmentIdentifier>) = newBuilder()
+    .adapterContext(
+        adapterContext.newBuilder()
+            .mergedDeferredFragmentIds(deferredFragmentIds)
+            .build()
+    )
+    .build()

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
@@ -30,20 +30,24 @@ class DeferredJsonMerger {
 
   fun merge(payload: BufferedSource): Map<String, Any?> {
     val payloadMap = jsonToMap(payload)
+    return merge(payloadMap)
+  }
+
+  fun merge(payload: Map<String, Any?>): Map<String, Any?> {
     if (merged.isEmpty()) {
       // Initial payload, no merging needed
-      _merged += payloadMap
+      _merged += payload
       return merged
     }
 
-    mergeData(payloadMap)
-    if (payloadMap.containsKey("errors")) {
-      _merged["errors"] = payloadMap["errors"]
+    mergeData(payload)
+    if (payload.containsKey("errors")) {
+      _merged["errors"] = payload["errors"]
     } else {
       _merged.remove("errors")
     }
-    if (payloadMap.containsKey("extensions")) {
-      _merged["extensions"] = payloadMap["extensions"]
+    if (payload.containsKey("extensions")) {
+      _merged["extensions"] = payload["extensions"]
     } else {
       _merged.remove("extensions")
     }
@@ -103,4 +107,8 @@ class DeferredJsonMerger {
     }
     return node
   }
+}
+
+internal fun Map<String, Any?>.isDeferred(): Boolean {
+  return keys.contains("hasNext")
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.DeferredFragmentIdentifier
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpHeader
@@ -13,6 +12,7 @@ import com.apollographql.apollo3.api.http.HttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.withDeferredFragmentIds
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloParseException
@@ -156,14 +156,6 @@ private constructor(
               statusCode = httpResponse.statusCode,
               headers = httpResponse.headers
           )
-      )
-      .build()
-
-  private fun CustomScalarAdapters.withDeferredFragmentIds(deferredFragmentIds: Set<DeferredFragmentIdentifier>) = newBuilder()
-      .adapterContext(
-          adapterContext.newBuilder()
-              .mergedDeferredFragmentIds(deferredFragmentIds)
-              .build()
       )
       .build()
 

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3.network.ws
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_1
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -9,8 +10,11 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.withDeferredFragmentIds
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.internal.BackgroundDispatcher
+import com.apollographql.apollo3.internal.DeferredJsonMerger
+import com.apollographql.apollo3.internal.isDeferred
 import com.apollographql.apollo3.internal.transformWhile
 import com.apollographql.apollo3.network.NetworkTransport
 import com.apollographql.apollo3.network.ws.internal.Command
@@ -238,9 +242,12 @@ private constructor(
     }
   }
 
+  @OptIn(ApolloInternal::class)
   override fun <D : Operation.Data> execute(
       request: ApolloRequest<D>,
   ): Flow<ApolloResponse<D>> {
+    val deferredJsonMergers = mutableMapOf<String, DeferredJsonMerger>()
+
     return events.onSubscription {
       messages.send(StartOperation(request))
     }.filter {
@@ -266,18 +273,34 @@ private constructor(
           true
         }
       }
-    }.map {
-      when (it) {
-        is OperationResponse -> request.operation
-            .parseJsonResponse(it.payload.jsonReader(), request.executionContext[CustomScalarAdapters]!!)
-            .newBuilder()
-            .requestUuid(request.requestUuid)
-            .build()
-        is OperationError -> throw ApolloNetworkException("Operation error ${request.operation.name()}: ${it.payload}")
-        is NetworkError -> throw ApolloNetworkException("Network error while executing ${request.operation.name()}", it.cause)
+    }.map { response ->
+      when (response) {
+        is OperationResponse -> {
+          val responsePayload = response.payload
+          val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters]!!
+          val (payload, customScalarAdapters) = if (responsePayload.isDeferred()) {
+            val responseId = response.id ?: ""
+            val deferredJsonMerger = deferredJsonMergers.getOrPut(responseId) { DeferredJsonMerger() }
+            deferredJsonMerger.merge(responsePayload)
+            if (responsePayload["hasNext"] == false) {
+              // Last deferred payload: discard the deferredJsonMerger
+              deferredJsonMergers.remove(responseId)
+            }
+            deferredJsonMerger.merged to requestCustomScalarAdapters.withDeferredFragmentIds(deferredJsonMerger.mergedFragmentIds)
+          } else {
+            responsePayload to requestCustomScalarAdapters
+          }
+          request.operation
+              .parseJsonResponse(payload.jsonReader(), customScalarAdapters)
+              .newBuilder()
+              .requestUuid(request.requestUuid)
+              .build()
+        }
+        is OperationError -> throw ApolloNetworkException("Operation error ${request.operation.name()}: ${response.payload}")
+        is NetworkError -> throw ApolloNetworkException("Network error while executing ${request.operation.name()}", response.cause)
 
         // Cannot happen as these events are filtered out upstream
-        is OperationComplete, is GeneralError -> error("Unexpected event $it")
+        is OperationComplete, is GeneralError -> error("Unexpected event $response")
       }
     }.onCompletion {
       messages.send(StopOperation(request))

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -13,6 +13,17 @@ kotlin {
     withJava()
   }
 
+  js {
+    nodejs {
+      testTask {
+        useMocha {
+          // Override default timeout (needed for subscriptions tests)
+          timeout = "120s"
+        }
+      }
+    }
+  }
+
   sourceSets {
     val commonMain by getting {
       dependencies {

--- a/tests/defer/src/commonMain/graphql/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/operation.graphql
@@ -42,3 +42,23 @@ mutation WithFragmentSpreadsMutation {
     ...ComputerFields @defer(label: "c")
   }
 }
+
+subscription WithInlineFragmentsSubscription {
+  count(to: 3) {
+    value
+    ... on Counter @defer {
+      valueTimesTwo
+    }
+  }
+}
+
+subscription WithFragmentSpreadsSubscription {
+  count(to: 3) {
+    value
+    ...CounterFields @defer(label: "d")
+  }
+}
+
+fragment CounterFields on Counter{
+  valueTimesTwo
+}

--- a/tests/defer/src/commonMain/graphql/schema.graphqls
+++ b/tests/defer/src/commonMain/graphql/schema.graphqls
@@ -6,6 +6,15 @@ type Mutation {
   computers: [Computer!]!
 }
 
+type Subscription {
+  count(to: Int!): Counter!
+}
+
+type Counter {
+  value: Int!
+  valueTimesTwo: Int!
+}
+
 type Computer {
   id: ID!
   cpu: String!

--- a/tests/defer/src/commonTest/kotlin/test/DeferSubscriptionsTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferSubscriptionsTest.kt
@@ -1,0 +1,79 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.network.ws.GraphQLWsProtocol
+import com.apollographql.apollo3.testing.runTest
+import defer.WithFragmentSpreadsSubscription
+import defer.WithInlineFragmentsSubscription
+import defer.fragment.CounterFields
+import kotlinx.coroutines.flow.toList
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * This test is ignored on the CI because it requires a specific server to run.
+ *
+ * It can be manually tested by running the server from https://github.com/BoD/DeferDemo/tree/master/helix
+ */
+@Ignore
+@OptIn(ApolloExperimental::class)
+class DeferSubscriptionsTest {
+  private lateinit var apolloClient: ApolloClient
+
+  private fun setUp() {
+    apolloClient = ApolloClient.Builder()
+        .serverUrl("http://localhost:4000/graphql")
+        .webSocketServerUrl("ws://localhost:4000/graphql")
+        .wsProtocol(GraphQLWsProtocol.Factory())
+        .build()
+  }
+
+  private fun tearDown() {
+    apolloClient.dispose()
+  }
+
+  @Test
+  fun subscriptionWithInlineFragment() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val expectedDataList = listOf(
+        // Emission 0, deferred payload 0
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 1, null)),
+        // Emission 0, deferred payload 1
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 1, WithInlineFragmentsSubscription.OnCounter(2))),
+        // Emission 1, deferred payload 0
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 2, null)),
+        // Emission 1, deferred payload 1
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 2, WithInlineFragmentsSubscription.OnCounter(4))),
+        // Emission 2, deferred payload 0
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 3, null)),
+        // Emission 2, deferred payload 1
+        WithInlineFragmentsSubscription.Data(WithInlineFragmentsSubscription.Count("Counter", 3, WithInlineFragmentsSubscription.OnCounter(6))),
+    )
+
+    val actualDataList = apolloClient.subscription(WithInlineFragmentsSubscription()).toFlow().toList().map { it.dataAssertNoErrors }
+    assertEquals(expectedDataList, actualDataList)
+  }
+
+  @Test
+  fun subscriptionWithFragmentSpreads() = runTest(before = { setUp() }, after = { tearDown() }) {
+    val expectedDataList = listOf(
+        // Emission 0, deferred payload 0
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 1, null)),
+        // Emission 0, deferred payload 1
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 1, CounterFields(2))),
+        // Emission 1, deferred payload 0
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 2, null)),
+        // Emission 1, deferred payload 1
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 2, CounterFields(4))),
+        // Emission 2, deferred payload 0
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 3, null)),
+        // Emission 2, deferred payload 1
+        WithFragmentSpreadsSubscription.Data(WithFragmentSpreadsSubscription.Count("Counter", 3, CounterFields(6))),
+    )
+
+    val actualDataList = apolloClient.subscription(WithFragmentSpreadsSubscription()).toFlow().toList().map { it.dataAssertNoErrors }
+    assertEquals(expectedDataList, actualDataList)
+  }
+
+}


### PR DESCRIPTION
This adds support for `@defer` in subscriptions.

Alas! I couldn't make a working unit test using the embedded Helix at this point, so the tests rely on running an external Helix instance manually.

Related to #3884