### PR TITLE
chore fixes link to change log

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 **Last updated: April 2022**
 
-For up to date release notes, refer to the project [Change Log](CHANGELOG.mdCHANGELOG.md).
+For up to date release notes, refer to the project [Change Log](https://github.com/apollographql/apollo-kotlin/blob/main/CHANGELOG.md).
 
 > **Please note:** This is an approximation of **larger effort** work planned for the next 6 - 12 months. It does not cover all new functionality that will be added, and nothing here is set in stone. Also note that each of these releases, and several patch releases in-between, will include bug fixes (based on issue triaging) and community submitted PR's.
 


### PR DESCRIPTION
this link reference was wrong, and instead of linking it to the file itself,  I switched it to always point to main's change link via a direct link.