### PR TITLE
⬇️  add SchemaDownloader.download()

### DIFF
--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -64,7 +64,7 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
 
   @get:Optional
   @get:Input
-  @get:Option(option = "insecure", description = "if set to true, certificates will not be checked during introspection")
+  @get:Option(option = "insecure", description = "if set to true, TLS/SSL certificates will not be checked when downloading")
   abstract val insecure: Property<Boolean>
 
   init {

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloDownloadSchemaTask.kt
@@ -59,7 +59,7 @@ abstract class ApolloDownloadSchemaTask : DefaultTask() {
 
   @get:Optional
   @get:Input
-  @set:Option(option = "header", description = "headers in the form 'Name: Value'")
+  @set:Option(option = "header", description = "HTTP headers in the form 'Name: Value'")
   var header = emptyList<String>() // cannot be abstract for @Option to work
 
   @get:Optional

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
@@ -1,8 +1,95 @@
 package com.apollographql.apollo3.gradle.internal
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.ast.GQLDocument
+import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.toUtf8
+import com.apollographql.apollo3.ast.validateAsSchema
 import com.apollographql.apollo3.compiler.fromJson
+import com.apollographql.apollo3.compiler.introspection.IntrospectionSchema
+import com.apollographql.apollo3.compiler.introspection.toGQLDocument
+import com.apollographql.apollo3.compiler.introspection.toIntrospectionSchema
+import com.apollographql.apollo3.compiler.toJson
+import okio.Buffer
+import java.io.File
 
 object SchemaDownloader {
+  /**
+   * Main entry point for downloading a schema either from introspection or from the Studio registry
+   *
+   * One of [endpoint] (for introspection) or [key] (for registry) is required.
+   *
+   * @param endpoint url of the GraphQL endpoint for introspection
+   * @param graph [Apollo Studio users only] The identifier of the Apollo graph used to download the schema.
+   * @param key [Apollo Studio users only] The Apollo API key. See https://www.apollographql.com/docs/studio/api-keys/ for more information on how to get your API key.
+   * @param graphVariant [Apollo Studio users only] The variant of the Apollo graph used to download the schema.
+   * @param registryUrl [Apollo Studio users only] The registry url of the registry instance used to download the schema.
+   * Defaults to "https://graphql.api.apollographql.com/api/graphql"
+   * @param schema the file where to store the schema. If the file extension is ".json" it will be stored in introspection format.
+   * Else it will use SDL. Prefer SDL if you can as it is more compact and carries more information.
+   * @param insecure if set to true, certificates will not be checked during introspection.
+   * @param headers extra HTTP headers to send during introspection.
+   */
+  @OptIn(ApolloExperimental::class)
+  fun download(
+      endpoint: String? = null,
+      graph: String? = null,
+      key: String? = null,
+      graphVariant: String = "current",
+      registryUrl: String = "https://graphql.api.apollographql.com/api/graphql",
+      schema: File,
+      insecure: Boolean = false,
+      headers: Map<String, String> = emptyMap()
+  ) {
+    var introspectionSchema: IntrospectionSchema? = null
+    var gqlSchema: GQLDocument? = null
+    when {
+      endpoint != null -> {
+        introspectionSchema = downloadIntrospection(
+            endpoint = endpoint,
+            headers = headers,
+            insecure = insecure,
+        ).toIntrospectionSchema()
+      }
+      else -> {
+        check(key != null) {
+          "Apollo: either endpoint (for introspection) or key (for registry) is required"
+        }
+        var graph2 = graph
+        if (graph2 == null && key.startsWith("service:")) {
+          // Fallback to reading the graph from the key
+          // This will not work with user keys
+          graph2 = key.split(":")[1]
+        }
+        check (graph2 != null) {
+          "Apollo: graph is required to download from the registry"
+        }
+
+        gqlSchema = downloadRegistry(
+            graph = graph2,
+            key = key,
+            variant = graphVariant,
+            endpoint = registryUrl,
+            insecure = insecure,
+        ).let { Buffer().writeUtf8(it) }.parseAsGQLDocument().valueAssertNoErrors()
+      }
+    }
+
+    schema.parentFile?.mkdirs()
+
+    if (schema.extension.lowercase() == "json") {
+      if (introspectionSchema == null) {
+        introspectionSchema = gqlSchema!!.validateAsSchema().valueAssertNoErrors().toIntrospectionSchema()
+      }
+      schema.writeText(introspectionSchema.toJson(indent = "  "))
+    } else {
+      if (gqlSchema == null) {
+        gqlSchema = introspectionSchema!!.toGQLDocument()
+      }
+      schema.writeText(gqlSchema.toUtf8(indent = "  "))
+    }
+  }
+
   fun downloadIntrospection(
       endpoint: String,
       headers: Map<String, String>,

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
@@ -15,7 +15,7 @@ import java.io.File
 
 object SchemaDownloader {
   /**
-   * Main entry point for downloading a schema either from introspection or from the Studio registry
+   * Main entry point for downloading a schema either from introspection or from the Apollo Studio registry
    *
    * One of [endpoint] (for introspection) or [key] (for registry) is required.
    *

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
@@ -27,7 +27,7 @@ object SchemaDownloader {
    * Defaults to "https://graphql.api.apollographql.com/api/graphql"
    * @param schema the file where to store the schema. If the file extension is ".json" it will be stored in introspection format.
    * Else it will use SDL. Prefer SDL if you can as it is more compact and carries more information.
-   * @param insecure if set to true, certificates will not be checked during introspection.
+   * @param insecure if set to true, TLS/SSL certificates will not be checked when downloading.
    * @param headers extra HTTP headers to send during introspection.
    */
   @OptIn(ApolloExperimental::class)

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
@@ -70,6 +70,7 @@ object SchemaDownloader {
             key = key,
             variant = graphVariant,
             endpoint = registryUrl,
+            headers = headers,
             insecure = insecure,
         ).let { Buffer().writeUtf8(it) }.parseAsGQLDocument().valueAssertNoErrors()
       }
@@ -112,6 +113,7 @@ object SchemaDownloader {
       graph: String,
       variant: String,
       endpoint: String = "https://graphql.api.apollographql.com/api/graphql",
+      headers: Map<String, String>,
       insecure: Boolean,
   ): String {
     val query = """
@@ -129,7 +131,7 @@ object SchemaDownloader {
   """.trimIndent()
     val variables = mapOf("graphID" to graph, "variant" to variant)
 
-    val response = SchemaHelper.executeQuery(query, variables, endpoint, mapOf("x-api-key" to key), insecure)
+    val response = SchemaHelper.executeQuery(query, variables, endpoint, headers + mapOf("x-api-key" to key), insecure)
 
     val responseString = response.body.use { it?.string() }
 


### PR DESCRIPTION
Minor refactoring to expose a generic `SchemaDownloader.download` that does most of the heavy lifting behing the `downloadApolloSchema` task. Planning to use it for some nice automation coming up :)