### PR TITLE
add DslMarker for test builders

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -1051,6 +1051,9 @@ public final class com/apollographql/apollo3/api/json/MapJsonWriter : com/apollo
 	public fun value (Z)Lcom/apollographql/apollo3/api/json/MapJsonWriter;
 }
 
+public abstract interface annotation class com/apollographql/apollo3/api/test/ApolloTestBuilderMarker : java/lang/annotation/Annotation {
+}
+
 public final class com/apollographql/apollo3/api/test/TestResolverKt {
 }
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/test/MapBuilder.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/test/MapBuilder.kt
@@ -4,9 +4,13 @@ import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.CompiledType
 import kotlin.reflect.KProperty
 
+@DslMarker
+annotation class ApolloTestBuilderMarker
+
 /**
  * Base class for test builders that define a DSL to build type safe operation data
  */
+@ApolloTestBuilderMarker
 @ApolloExperimental
 abstract class MapBuilder {
   /**


### PR DESCRIPTION
Introduce a custom DslMarker for MapBuilder. This way nesting builders
won't see their parent implicit receiver and users cannot define
parent receiver's properties without an explicit receiver reference.