### PR TITLE
Issue-3909: add ApolloResponse cache headers

### DIFF
--- a/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
+++ b/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
@@ -11,6 +11,7 @@ public final class com/apollographql/apollo3/cache/normalized/api/CacheHeaders {
 	public static final fun builder ()Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders$Builder;
 	public final fun hasHeader (Ljava/lang/String;)Z
 	public final fun headerValue (Ljava/lang/String;)Ljava/lang/String;
+	public final fun plus (Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;
 	public final fun toBuilder ()Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders$Builder;
 }
 

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheHeaders.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheHeaders.kt
@@ -41,5 +41,7 @@ class CacheHeaders internal constructor(private val headerMap: Map<String, Strin
     @JvmField
     val NONE = CacheHeaders(emptyMap())
   }
-
+  operator fun plus(cacheHeaders: CacheHeaders): CacheHeaders {
+    return toBuilder().addHeaders(cacheHeaders.headerMap).build()
+  }
 }

--- a/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -98,6 +98,7 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun -logCacheMisses (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun -logCacheMisses$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun apolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
+	public static final fun cacheHeaders (Lcom/apollographql/apollo3/api/ApolloResponse$Builder;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public static final fun cacheHeaders (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Ljava/lang/Object;
 	public static final fun clearNormalizedCache (Lcom/apollographql/apollo3/ApolloClient;)Z
 	public static final fun configureApolloClientBuilder (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -111,6 +112,7 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static final fun fetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
 	public static final fun fetchPolicyInterceptor (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Ljava/lang/Object;
 	public static final fun getApolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;
+	public static final fun getCacheHeaders (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;
 	public static final fun getCacheInfo (Lcom/apollographql/apollo3/api/ApolloResponse;)Lcom/apollographql/apollo3/cache/normalized/CacheInfo;
 	public static final fun isFromCache (Lcom/apollographql/apollo3/api/ApolloResponse;)Z
 	public static final fun optimisticUpdates (Lcom/apollographql/apollo3/ApolloCall;Lcom/apollographql/apollo3/api/Mutation$Data;)Lcom/apollographql/apollo3/ApolloCall;

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -576,3 +576,9 @@ internal fun <D : Operation.Data> ApolloRequest.Builder<D>.fetchFromCache(fetchF
 
 internal val <D : Operation.Data> ApolloRequest<D>.fetchFromCache
   get() = executionContext[FetchFromCacheContext]?.value ?: false
+
+fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: CacheHeaders) =
+    addExecutionContext( CacheHeadersContext(cacheHeaders))
+
+val <D: Operation.Data> ApolloResponse<D>.cacheHeaders
+    get() = executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -78,7 +78,7 @@ internal class ApolloCacheInterceptor(
 
     maybeAsync(request) {
       val cacheKeys = if (response.data != null) {
-        store.writeOperation(request.operation, response.data!!, customScalarAdapters, request.cacheHeaders, publish = false)
+        store.writeOperation(request.operation, response.data!!, customScalarAdapters, request.cacheHeaders + response.cacheHeaders, publish = false)
       } else {
         emptySet()
       }

--- a/tests/integration-tests/src/commonTest/kotlin/test/CacheFlagsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/CacheFlagsTest.kt
@@ -24,6 +24,7 @@ import com.apollographql.apollo3.testing.QueueTestNetworkTransport
 import com.apollographql.apollo3.testing.enqueueTestResponse
 import com.apollographql.apollo3.testing.runTest
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -115,7 +116,7 @@ class CacheFlagsTest {
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
     apolloClient = apolloClient.newBuilder().addInterceptor(object: ApolloInterceptor{
       override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
-        return chain.proceed(request).onEach { response ->
+        return chain.proceed(request).map { response ->
           response.newBuilder().cacheHeaders(CacheHeaders.Builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "").build()).build()
         }
       }

--- a/tests/integration-tests/src/commonTest/kotlin/test/CacheFlagsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/CacheFlagsTest.kt
@@ -116,8 +116,7 @@ class CacheFlagsTest {
     apolloClient = apolloClient.newBuilder().addInterceptor(object: ApolloInterceptor{
       override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
         return chain.proceed(request).onEach { response ->
-          val x = response.newBuilder().cacheHeaders(CacheHeaders.Builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "").build()).build()
-          x
+          response.newBuilder().cacheHeaders(CacheHeaders.Builder().addHeader(ApolloCacheHeaders.DO_NOT_STORE, "").build()).build()
         }
       }
     }).build()


### PR DESCRIPTION
see #[3909](https://github.com/apollographql/apollo-kotlin/issues/3909)

Suggestion Required.
Merging the `CacheHeaders` of `ApolloRequest` & `ApolloResponse`, does pose the risk of indeed overwriting the header values that have the same key. I am wondering if the team is okay with that?