### PR TITLE
update POM_URL and other maven information

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 GROUP=com.apollographql.apollo3
 VERSION_NAME=3.3.1-SNAPSHOT
 
-POM_URL=https://github.com/apollographql/apollo-android/
-POM_SCM_URL=https://github.com/apollographql/apollo-android/
-POM_SCM_CONNECTION=scm:git:git://github.com/apollographql/apollo-android.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/apollographql/apollo-android.git
+POM_URL=https://github.com/apollographql/apollo-kotlin/
+POM_SCM_URL=https://github.com/apollographql/apollo-kotlin/
+POM_SCM_CONNECTION=scm:git:git://github.com/apollographql/apollo-kotlin.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/apollographql/apollo-kotlin.git
 
 POM_LICENCE_NAME=MIT License
-POM_LICENCE_URL=https://raw.githubusercontent.com/apollographql/apollo-android/main/LICENSE
+POM_LICENCE_URL=https://raw.githubusercontent.com/apollographql/apollo-kotlin/main/LICENSE
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=apollographql


### PR DESCRIPTION
I was looking at search.maven.org and found out that POM_URL and others are pointing to older repository url.