### PR TITLE
Use rawValue instead of name for enums in test builders

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/test/TBuilderBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/test/TBuilderBuilder.kt
@@ -104,7 +104,7 @@ internal class TBuilderBuilder(
         .add("resolve(%S, %L", responseName, gqlType!!.codeBlock(context))
         .apply {
           if (enumName != null) {
-            add(", %M().map { it.name }", MemberName(context.resolver.resolveSchemaType(enumName).nestedClass("Companion"), "knownValues"))
+            add(", %M().map { it.rawValue }", MemberName(context.resolver.resolveSchemaType(enumName).nestedClass("Companion"), "knownValues"))
           } else {
             add(", emptyList()")
           }

--- a/tests/models-fixtures/graphql/operations.graphql
+++ b/tests/models-fixtures/graphql/operations.graphql
@@ -126,3 +126,11 @@ query HeroHumanOrDroid($episode: Episode) {
         }
     }
 }
+
+query Starship($id: ID!) {
+    starship(id: $id) {
+        id
+        name
+        starshipType
+    }
+}

--- a/tests/models-fixtures/graphql/schema.graphqls
+++ b/tests/models-fixtures/graphql/schema.graphqls
@@ -248,6 +248,14 @@ type Starship {
     length ( unit: LengthUnit = METER): Float
 
     coordinates: [[Float!]!]
+
+    starshipType: StarshipType
+}
+
+enum StarshipType {
+    BATTLE_CRUISER
+    COMBAT_CRUISER
+    STAR_CRUISER
 }
 
 """

--- a/tests/models-response-based/build.gradle.kts
+++ b/tests/models-response-based/build.gradle.kts
@@ -30,4 +30,5 @@ apollo {
   generateTestBuilders.set(true)
   customScalarsMapping.put("Date", "kotlin.Long")
   codegenModels.set("responseBased")
+  sealedClassesForEnumsMatching.set(setOf("StarshipType"))
 }

--- a/tests/models-response-based/src/commonTest/kotlin/test/TestBuildersTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/TestBuildersTest.kt
@@ -5,13 +5,16 @@ import codegen.models.BirthdateQuery
 import codegen.models.EpisodeQuery
 import codegen.models.HeroAndFriendsWithTypenameQuery
 import codegen.models.MergedFieldWithSameShapeQuery
+import codegen.models.StarshipQuery
 import codegen.models.test.AllPlanetsQuery_TestBuilder.Data
 import codegen.models.test.BirthdateQuery_TestBuilder.Data
 import codegen.models.test.EpisodeQuery_TestBuilder.Data
 import codegen.models.test.HeroAndFriendsWithTypenameQuery_TestBuilder.Data
 import codegen.models.test.MergedFieldWithSameShapeQuery_TestBuilder.Data
+import codegen.models.test.StarshipQuery_TestBuilder.Data
 import codegen.models.type.Date
 import codegen.models.type.Episode
+import codegen.models.type.StarshipType
 import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CompiledListType
 import com.apollographql.apollo3.api.CompiledNamedType
@@ -162,7 +165,12 @@ class TestBuildersTest {
     val defaultFloat = 7.0
 
     val myTestResolver = object : TestResolver {
-      override fun <T> resolve(responseName: String, compiledType: CompiledType, enumValues: List<String>, ctors: Array<out () -> Map<String, Any?>>?): T {
+      override fun <T> resolve(
+          responseName: String,
+          compiledType: CompiledType,
+          enumValues: List<String>,
+          ctors: Array<out () -> Map<String, Any?>>?,
+      ): T {
         return when (compiledType) {
           is CompiledNotNullType -> resolve(responseName, compiledType.ofType, enumValues, ctors)
           is CompiledListType -> listOf(resolve<Any>(responseName, compiledType.ofType, enumValues, ctors))
@@ -228,4 +236,24 @@ class TestBuildersTest {
       assertIs<Episode>(it)
     }
   }
+
+  @Test
+  fun enumAsSealedClass() {
+    val data = StarshipQuery.Data {
+      starship = starship {
+        starshipType = StarshipType.STAR_CRUISER.rawValue
+      }
+    }
+    assertEquals(StarshipType.STAR_CRUISER, data.starship?.starshipType)
+  }
+
+  @Test
+  fun enumAsSealedClassResolve() {
+    val data = StarshipQuery.Data {
+    }
+
+    val sealedClass = data.starship?.starshipType
+    assertIs<StarshipType>(sealedClass)
+  }
+
 }


### PR DESCRIPTION
`.name` only works with enums, not sealed classes.

I'm not 100% sure this is ok though?