### PR TITLE
Add Operation.Data.toJsonString() convenience function for the jvm

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -752,7 +752,6 @@ public abstract interface class com/apollographql/apollo3/api/Upload {
 public final class com/apollographql/apollo3/api/_DataKt {
 	public static final fun toJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
 	public static synthetic fun toJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)V
-	public static final fun toJsonString (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
 	public static synthetic fun toJsonString$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 }
 

--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -752,6 +752,8 @@ public abstract interface class com/apollographql/apollo3/api/Upload {
 public final class com/apollographql/apollo3/api/_DataKt {
 	public static final fun toJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
 	public static synthetic fun toJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)V
+	public static final fun toJsonString (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;)Ljava/lang/String;
+	public static synthetic fun toJsonString$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/http/ByteStringHttpBody : com/apollographql/apollo3/api/http/HttpBody {

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
@@ -1,6 +1,8 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.json.JsonWriter
+import com.apollographql.apollo3.api.json.buildJsonString
 
 private fun Operation.Data.adapter(): Adapter<Operation.Data> {
   val name = this::class.java.name
@@ -25,6 +27,9 @@ fun Operation.Data.toJson(jsonWriter: JsonWriter, customScalarAdapters: CustomSc
   adapter().toJson(jsonWriter, customScalarAdapters, this)
 }
 
+@ApolloExperimental
 fun Operation.Data.toJsonString(customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty, indent: String? = null): String {
-  return adapter().toJsonString(this, customScalarAdapters, indent)
+  return buildJsonString(indent) {
+    toJson(this, customScalarAdapters)
+  }
 }

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-Data.kt
@@ -25,3 +25,6 @@ fun Operation.Data.toJson(jsonWriter: JsonWriter, customScalarAdapters: CustomSc
   adapter().toJson(jsonWriter, customScalarAdapters, this)
 }
 
+fun Operation.Data.toJsonString(customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty, indent: String? = null): String {
+  return adapter().toJsonString(this, customScalarAdapters, indent)
+}


### PR DESCRIPTION
Allows a more convenient way to simply get the Json representation from `Operation.Data` without having to manually deal with Buffers etc in client code which the current `toJson` function requires.

This could be imitated on the clients by instead calling the existing `toJson` function like this:
```kotlin
fun Operation.Data.toJsonString(
    scalarTypeAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
    indent: String? = null,
): String {
    val buffer = Buffer()
    val jsonWriter = BufferedSinkJsonWriter(buffer, indent)
    toJson(jsonWriter, scalarTypeAdapters)
    return buffer.readUtf8()
}
```
Which should be functionally equivalent to what the introduced function does (if we inlined `buildJsonString` which `toJsonString` uses internally)

If you believe that the API doesn't need this addition that would be totally understandable, and you can feel free to simply close this PR 🙌