### PR TITLE
Keep the 'interfaces' field on the JSON introspection

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/introspection/IntrospectionSchema.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/introspection/IntrospectionSchema.kt
@@ -49,6 +49,7 @@ data class IntrospectionSchema(
           override val name: String,
           override val description: String?,
           val fields: List<Field>?,
+          val interfaces: List<Interface>?,
       ) : Type()
 
       @TypeLabel("INTERFACE")
@@ -56,6 +57,7 @@ data class IntrospectionSchema(
       data class Interface(
           override val name: String,
           override val description: String?,
+          val kind: String,
           val fields: List<Field>?,
           val possibleTypes: List<TypeRef>?,
       ) : Type()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/introspection/schema_to_introspection.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/introspection/schema_to_introspection.kt
@@ -57,7 +57,8 @@ private class IntrospectionSchemaBuilder(private val schema: Schema) {
     return IntrospectionSchema.Schema.Type.Object(
         name = name,
         description = description,
-        fields = fields.map { it.toSchemaField() }
+        fields = fields.map { it.toSchemaField() },
+        interfaces = implementsInterfaces.map { IntrospectionSchema.Schema.Type.Interface(kind = "INTERFACE", name = it, description = null, fields = null, possibleTypes = null) }.ifEmpty { null },
     )
   }
 
@@ -108,6 +109,7 @@ private class IntrospectionSchemaBuilder(private val schema: Schema) {
 
   private fun GQLInterfaceTypeDefinition.toSchemaType(): IntrospectionSchema.Schema.Type.Interface {
     return IntrospectionSchema.Schema.Type.Interface(
+        kind = "INTERFACE",
         name = name,
         description = description,
         fields = fields.map { it.toSchemaField() },

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaDownloader.kt
@@ -39,15 +39,17 @@ object SchemaDownloader {
       insecure: Boolean = false,
       headers: Map<String, String> = emptyMap()
   ) {
+    var introspectionSchemaJson: String? = null
     var introspectionSchema: IntrospectionSchema? = null
     var gqlSchema: GQLDocument? = null
     when {
       endpoint != null -> {
-        introspectionSchema = downloadIntrospection(
+        introspectionSchemaJson = downloadIntrospection(
             endpoint = endpoint,
             headers = headers,
             insecure = insecure,
-        ).toIntrospectionSchema()
+        )
+        introspectionSchema = introspectionSchemaJson.toIntrospectionSchema()
       }
       else -> {
         check(key != null) {
@@ -79,8 +81,10 @@ object SchemaDownloader {
     if (schema.extension.lowercase() == "json") {
       if (introspectionSchema == null) {
         introspectionSchema = gqlSchema!!.validateAsSchema().valueAssertNoErrors().toIntrospectionSchema()
+        schema.writeText(introspectionSchema.toJson(indent = "  "))
+      } else {
+        schema.writeText(introspectionSchemaJson!!)
       }
-      schema.writeText(introspectionSchema.toJson(indent = "  "))
     } else {
       if (gqlSchema == null) {
         gqlSchema = introspectionSchema!!.toGQLDocument()

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
@@ -15,19 +15,6 @@ import java.io.File
 class DownloadSchemaTests {
   private val mockServer = MockWebServer()
   private val schemaString1 = """
-        {
-          "__schema": {
-            "queryType": {
-              "name": "foo"
-            },
-            "types": []
-          }
-        }
-      """.trimIndent()
-
-  private val schemaString2 = schemaString1.replace("foo", "bar")
-
-  private val schemaStringWithInterfaces = """
   {
     "__schema": {
       "queryType": {
@@ -104,6 +91,8 @@ class DownloadSchemaTests {
     }
   }
   """.trimIndent()
+
+  private val schemaString2 = schemaString1.replace("foo", "bar")
 
   private val apolloConfiguration = """
       apollo {
@@ -196,30 +185,6 @@ class DownloadSchemaTests {
           "--endpoint=${mockServer.url("/")}")
 
       assertEquals(schemaString1, schema.readText())
-    }
-  }
-
-  @Test
-  fun `manually downloading a schema keeps the interfaces field`() {
-    withSimpleProject(apolloConfiguration = "") { dir ->
-      val mockResponse = MockResponse().setBody(schemaStringWithInterfaces)
-      mockServer.enqueue(mockResponse)
-      val schema = File("build/testProject/schema.json")
-
-      TestUtils.executeGradle(dir, "downloadApolloSchema",
-          "--schema=${schema.absolutePath}",
-          "--endpoint=${mockServer.url("/")}")
-
-      // We can't compare 'verbatim' the original schema text to the created one because it is re-written
-      // but check if interfaces are present
-      assert(schema.readText().contains("""
-        |        "interfaces": [
-        |          {
-        |            "name": "MyInterface",
-        |            "kind": "INTERFACE"
-        |          }
-        |        ]
-        """.trimMargin()))
     }
   }
 


### PR DESCRIPTION
Related to #4126.

I'm wondering if we should save the introspection JSON as-is instead of parsing it and then serializing it, in `SchemaDownloader`? 🤔