### PR TITLE
Sort the type names in the list so the code gen is deterministic.

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
@@ -40,7 +40,7 @@ class SchemaBuilder(
 
   private fun typesFieldSpec(): FieldSpec {
     val allTypenames = interfaces.map { it.name } + objects.map { it.name } + unions.map { it.name }
-    val initilizer = allTypenames.map {
+    val initilizer = allTypenames.sortedBy { it }.map {
       CodeBlock.of("$T.type", context.resolver.resolveSchemaType(it))
     }.toListInitializerCodeblock(withNewLines = true)
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
@@ -42,7 +42,7 @@ class SchemaBuilder(
     builder.add("listOf(\n")
     builder.indent()
     builder.add(
-        allTypenames.map {
+        allTypenames.sortedBy { it }.map {
           CodeBlock.of("%T.type", context.resolver.resolveSchemaType(it))
         }.joinToString(", ")
     )

--- a/apollo-compiler/src/test/graphql/com/example/__schema/java/operationBased/__schema/type/__Schema.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/__schema/java/operationBased/__schema/type/__Schema.java.expected
@@ -18,10 +18,10 @@ import java.util.List;
 public class __Schema {
   public static List<CompiledType> types = Arrays.asList(
     Bar.type,
-    Character.type,
-    Foo.type,
     BarObject.type,
+    Character.type,
     Droid.type,
+    Foo.type,
     FooBar.type,
     FooObject.type,
     FriendsConnection.type,
@@ -31,10 +31,10 @@ public class __Schema {
     PageInfo.type,
     Query.type,
     Review.type,
+    SearchResult.type,
     Starship.type,
     Tree.type,
-    TypeWithGraphQLKeywords.type,
-    SearchResult.type
+    TypeWithGraphQLKeywords.type
   );
 
   public static List<ObjectType> possibleTypes(CompiledNamedType type) {

--- a/apollo-compiler/src/test/graphql/com/example/__schema/kotlin/responseBased/__schema/type/__Schema.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/__schema/kotlin/responseBased/__schema/type/__Schema.kt.expected
@@ -15,17 +15,17 @@ import kotlin.collections.List
  */
 public object __Schema {
   public val all: List<CompiledType> = listOf(
-        com.example.__schema.type.Bar.type, com.example.__schema.type.Character.type,
-            com.example.__schema.type.Foo.type, com.example.__schema.type.BarObject.type,
-            com.example.__schema.type.Droid.type, com.example.__schema.type.FooBar.type,
+        com.example.__schema.type.Bar.type, com.example.__schema.type.BarObject.type,
+            com.example.__schema.type.Character.type, com.example.__schema.type.Droid.type,
+            com.example.__schema.type.Foo.type, com.example.__schema.type.FooBar.type,
             com.example.__schema.type.FooObject.type,
             com.example.__schema.type.FriendsConnection.type,
             com.example.__schema.type.FriendsEdge.type, com.example.__schema.type.Human.type,
             com.example.__schema.type.Mutation.type, com.example.__schema.type.PageInfo.type,
             com.example.__schema.type.Query.type, com.example.__schema.type.Review.type,
-            com.example.__schema.type.Starship.type, com.example.__schema.type.Tree.type,
-            com.example.__schema.type.TypeWithGraphQLKeywords.type,
-            com.example.__schema.type.SearchResult.type)
+            com.example.__schema.type.SearchResult.type, com.example.__schema.type.Starship.type,
+            com.example.__schema.type.Tree.type,
+            com.example.__schema.type.TypeWithGraphQLKeywords.type)
 
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =

--- a/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,8 +2,8 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  189197
-aggregate-kotlin-responseBased                                                                  48615
+aggregate-all                                                                                  189514
+aggregate-kotlin-responseBased                                                                  48932
 aggregate-kotlin-operationBased                                                                 34136
 aggregate-kotlin-compat                                                                         35553
 aggregate-java-operationBased                                                                   70893
@@ -240,6 +240,7 @@ kotlin-responseBased-subscriptions                                              
 kotlin-responseBased-enums_as_sealed                                                              340
 kotlin-responseBased-operation_id_generator                                                       325
 kotlin-responseBased-merged_include                                                               323
+kotlin-responseBased-big_query                                                                    317
 kotlin-responseBased-enum_field                                                                   316
 kotlin-responseBased-case_sensitive_enum                                                          315
 kotlin-responseBased-nonnull                                                                      309


### PR DESCRIPTION
Fix for #4137