### PR TITLE
SDLWriter: join implemented interfaces with & instead of space

### DIFF
--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
@@ -266,7 +266,7 @@ data class GQLInterfaceTypeDefinition(
       write("interface $name")
       if (implementsInterfaces.isNotEmpty()) {
         write(" implements ")
-        write(implementsInterfaces.joinToString(" "))
+        write(implementsInterfaces.joinToString(" & "))
       }
       if (directives.isNotEmpty()) {
         write(" ")
@@ -308,7 +308,7 @@ data class GQLObjectTypeDefinition(
       write("type $name")
       if (implementsInterfaces.isNotEmpty()) {
         write(" implements ")
-        write(implementsInterfaces.joinToString(" "))
+        write(implementsInterfaces.joinToString(" & "))
       }
       if (directives.isNotEmpty()) {
         write(" ")

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
@@ -1,0 +1,51 @@
+package com.apollographql.apollo3.graphql.ast.test
+
+import com.apollographql.apollo3.ast.SDLWriter
+import com.apollographql.apollo3.ast.Schema
+import com.apollographql.apollo3.ast.internal.buffer
+import com.apollographql.apollo3.ast.toSchema
+import okio.Buffer
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class SDLWriterTest {
+  @Test
+  fun schemaMayContainBuiltinDirectives() {
+    val schemaString = """
+      schema {
+          query: Query
+      }
+      
+      type Query {
+          foo: Int
+      }
+      
+      interface A {
+          a: String
+      }
+      
+      interface B {
+          b: String
+      }
+      
+      type C implements A & B {
+          a: String
+      
+          b: String
+      }
+      
+      interface D implements A & B {
+          a: String
+      
+          b: String
+      }
+
+    """.trimIndent()
+
+    val schema: Schema = schemaString.buffer().toSchema()
+    val writerBuffer = Buffer()
+    val sdlWriter = SDLWriter(writerBuffer, "    ")
+    sdlWriter.write(schema.toGQLDocument())
+    assertEquals(writerBuffer.readUtf8(), schemaString)
+  }
+}


### PR DESCRIPTION
Fix for #4149