### PR TITLE
🎓  experimental_targetName -> targetName

### DIFF
--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldirective.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldirective.kt
@@ -33,7 +33,7 @@ fun List<GQLDirective>.findExperimentalReason() = firstOrNull { it.name == "expe
     }
 
 @ApolloInternal
-fun List<GQLDirective>.findTargetName() = firstOrNull { it.name == "experimental_targetName" }
+fun List<GQLDirective>.findTargetName() = firstOrNull { it.name == "targetName" }
     ?.let {
       it.arguments
           ?.arguments

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -64,7 +64,7 @@ private fun GQLDocument.withoutDefinitions(definitions: List<GQLDefinition>): GQ
 /**
  * Adds [definitions] to the [GQLDocument]
  *
- * If a definition alreay exists, it is kept as is and a warning is logged
+ * If a definition already exists, it is kept as is and a warning is logged
  *
  * See https://spec.graphql.org/draft/#sel-FAHnBPLCAACCcooU
  */

--- a/apollo-ast/src/main/resources/apollo.graphqls
+++ b/apollo-ast/src/main/resources/apollo.graphqls
@@ -28,4 +28,4 @@ directive @experimental(
 # Use the specified name for the enum value in the generated code.
 # Use this for instance when the name would clash with a reserved keyword or field in the generated code.
 # This directive is experimental.
-directive @experimental_targetName(name: String!) on ENUM_VALUE
+directive @targetName(name: String!) on ENUM_VALUE

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkNoApolloReservedEnumValueNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkNoApolloReservedEnumValueNames.kt
@@ -21,7 +21,7 @@ fun findApolloReservedEnumValueNames(schema: Schema): List<Issue> {
         if (targetName == null) {
           issues.add(
               Issue.ReservedEnumValueName(
-                  message = "'${value.name}' is a reserved enum value name, please use the @experimental_targetName directive to specify a target name",
+                  message = "'${value.name}' is a reserved enum value name, please use the @targetName directive to specify a target name",
                   sourceLocation = value.sourceLocation
               )
           )

--- a/apollo-compiler/src/test/graphql/com/example/enum_field/schema.graphqls
+++ b/apollo-compiler/src/test/graphql/com/example/enum_field/schema.graphqls
@@ -13,5 +13,5 @@ enum Gravity {
   is
 
   # a name that clashes with the generated `type` constant
-  type @experimental_targetName(name: "type_")
+  type @targetName(name: "type_")
 }

--- a/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/schema.sdl
+++ b/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/schema.sdl
@@ -8,5 +8,5 @@ enum Enum {
     NORTH
     SOUTH
 
-    type @experimental_targetName(name: "type_")
+    type @targetName(name: "type_")
 }

--- a/apollo-compiler/src/test/validation/schema/reserved-enum-value-names.expected
+++ b/apollo-compiler/src/test/validation/schema/reserved-enum-value-names.expected
@@ -1,5 +1,5 @@
 ERROR: ReservedEnumValueName (6:2)
-'type' is a reserved enum value name, please use the @experimental_targetName directive to specify a target name
+'type' is a reserved enum value name, please use the @targetName directive to specify a target name
 ------------
 ERROR: ReservedEnumValueName (10:2)
 'type' is a reserved enum value name, please use a different name

--- a/apollo-compiler/src/test/validation/schema/reserved-enum-value-names.graphql
+++ b/apollo-compiler/src/test/validation/schema/reserved-enum-value-names.graphql
@@ -7,5 +7,5 @@ enum Enum {
 }
 
 enum Enum2 {
-  type @experimental_targetName(name: "type")
+  type @targetName(name: "type")
 }

--- a/tests/enums/src/main/graphql/extra.graphqls
+++ b/tests/enums/src/main/graphql/extra.graphqls
@@ -1,8 +1,8 @@
 extend enum Direction {
-  type @experimental_targetName(name: "type_")
+  type @targetName(name: "type_")
 }
 
 extend enum Gravity {
-  type @experimental_targetName(name: "type_")
+  type @targetName(name: "type_")
 }
 


### PR DESCRIPTION
As all the Apollo directives have the same level of maturity at the moment, no need to make a special case for `targetName`. We'll handle stability at the spec level. See also https://github.com/apollographql/specs/pull/23