### PR TITLE
🧽  reorganize dependencies.gradle

### DIFF
--- a/apollo-ast/build.gradle.kts
+++ b/apollo-ast/build.gradle.kts
@@ -7,16 +7,16 @@ plugins {
 }
 
 dependencies {
-  antlr(groovy.util.Eval.x(project, "x.dep.antlr.antlr"))
-  implementation(groovy.util.Eval.x(project, "x.dep.antlr.runtime"))
+  antlr(groovy.util.Eval.x(project, "x.dep.antlrAntlr"))
+  implementation(groovy.util.Eval.x(project, "x.dep.antlrRuntime"))
   api(okio())
   api(projects.apolloAnnotations)
 
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.sealedRuntime"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiSealedRuntime"))
 
-  ksp(groovy.util.Eval.x(project, "x.dep.moshi.sealedCodegen"))
-  ksp(groovy.util.Eval.x(project, "x.dep.moshi.ksp"))
+  ksp(groovy.util.Eval.x(project, "x.dep.moshiSealedCodegen"))
+  ksp(groovy.util.Eval.x(project, "x.dep.moshiKsp"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-compiler/build.gradle.kts
+++ b/apollo-compiler/build.gradle.kts
@@ -10,17 +10,17 @@ dependencies {
   implementation(projects.apolloApi) {
     because("For BooleanExpression")
   }
-  implementation(groovy.util.Eval.x(project, "x.dep.poet.kotlin").toString()) {
+  implementation(groovy.util.Eval.x(project, "x.dep.poetKotlin").toString()) {
     // We don't use any of the KotlinPoet kotlin-reflect features
     exclude(module = "kotlin-reflect")
   }
-  implementation(groovy.util.Eval.x(project, "x.dep.poet.java"))
+  implementation(groovy.util.Eval.x(project, "x.dep.poetJava"))
 
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.sealedRuntime"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiSealedRuntime"))
 
-  ksp(groovy.util.Eval.x(project, "x.dep.moshi.sealedCodegen"))
-  ksp(groovy.util.Eval.x(project, "x.dep.moshi.ksp"))
+  ksp(groovy.util.Eval.x(project, "x.dep.moshiSealedCodegen"))
+  ksp(groovy.util.Eval.x(project, "x.dep.moshiKsp"))
 
   testImplementation(groovy.util.Eval.x(project, "x.dep.kotlinCompileTesting"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.javaCompileTesting"))

--- a/apollo-gradle-plugin-external/build.gradle.kts
+++ b/apollo-gradle-plugin-external/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   compileOnly(groovy.util.Eval.x(project, "x.dep.minGradleApi"))
   compileOnly(groovy.util.Eval.x(project, "x.dep.kotlinPluginMin"))
-  compileOnly(groovy.util.Eval.x(project, "x.dep.android.minPlugin"))
+  compileOnly(groovy.util.Eval.x(project, "x.dep.androidMinPlugin"))
   
   api(projects.apolloCompiler)
   implementation(projects.apolloTooling)

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -28,8 +28,8 @@ dependencies {
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.truth"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.assertj"))
-  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttp.mockWebServer"))
-  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttp.tls"))
+  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttpMockWebServer"))
+  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttpTls"))
 }
 
 if (relocateJar) {

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.kts.template
@@ -4,14 +4,7 @@ buildscript {
   apply("../../../gradle/dependencies.gradle")
 
   val classpathDep = {artifact: String ->
-    val c = artifact.split(".")
-
-    var ret = (extra["dep"] as Map<String, *>)[c[0]]!!
-
-    if (c.size > 1) {
-      ret = (ret as Map<String, *>)[c[1]]!!
-    }
-    ret
+    (extra["dep"] as Map<String, *>)[artifact]!!
   }
 
   repositories {
@@ -27,14 +20,7 @@ buildscript {
 }
 
 fun kotlinDep(artifact: String): Any {
-  val c = artifact.split(".")
-
-  var ret = (extra["dep"] as Map<String, *>)[c[0]]!!
-
-  if (c.size > 1) {
-    ret = (ret as Map<String, *>)[c[1]]!!
-  }
-  return ret
+  return (extra["dep"] as Map<String, *>)[artifact]!!
 }
 
 // ADD PLUGINS HERE
@@ -52,7 +38,7 @@ repositories {
 dependencies {
   // ADD DEPENDENCIES HERE
   add("implementation", kotlinDep("jetbrainsAnnotations"))
-  add("implementation", kotlinDep("apollo.api"))
+  add("implementation", kotlinDep("apolloApi"))
 }
 
 // ADD ANDROID CONFIGURATION HERE

--- a/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
+++ b/apollo-gradle-plugin/src/test/files/gradle/build.gradle.template
@@ -30,7 +30,7 @@ repositories {
 dependencies {
   // ADD DEPENDENCIES HERE
   implementation dep.jetbrainsAnnotations
-  implementation dep.apollo.api
+  implementation dep.apolloApi
 }
 
 // ADD ANDROID CONFIGURATION HERE

--- a/apollo-gradle-plugin/src/test/files/gradle/settings.gradle.kts
+++ b/apollo-gradle-plugin/src/test/files/gradle/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
   resolutionStrategy {
     eachPlugin {
       if (requested.id.id == "com.apollographql.apollo3") {
-        useModule(groovy.util.Eval.x(extra, "x.dep.apollo.plugin"))
+        useModule(groovy.util.Eval.x(extra, "x.dep.apolloPlugin"))
       }
     }
   }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
@@ -209,7 +209,7 @@ class ServiceTests {
   @Test
   fun `versions are enforced`() {
     withSimpleProject { dir ->
-      File(dir, "build.gradle").replaceInText("dep.apollo.api", "\"com.apollographql.apollo3:apollo-api:1.2.0\"")
+      File(dir, "build.gradle").replaceInText("dep.apolloApi", "\"com.apollographql.apollo3:apollo-api:1.2.0\"")
 
       var exception: Exception? = null
       try {
@@ -231,7 +231,7 @@ class ServiceTests {
       val result = TestUtils.executeTask("checkApolloVersions", dir)
       assert(result.task(":checkApolloVersions")?.outcome == TaskOutcome.UP_TO_DATE)
 
-      File(dir, "build.gradle").replaceInText("dep.apollo.api", "\"com.apollographql.apollo3:apollo-api:1.2.0\"")
+      File(dir, "build.gradle").replaceInText("dep.apolloApi", "\"com.apollographql.apollo3:apollo-api:1.2.0\"")
 
       var exception: Exception? = null
       try {

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -13,11 +13,11 @@ import java.io.File
 object TestUtils {
   class Plugin(val artifact: String?, val id: String)
 
-  val androidApplicationPlugin = Plugin(id = "com.android.application", artifact = "android.plugin")
-  val androidLibraryPlugin = Plugin(id = "com.android.library", artifact = "android.plugin")
+  val androidApplicationPlugin = Plugin(id = "com.android.application", artifact = "androidPlugin")
+  val androidLibraryPlugin = Plugin(id = "com.android.library", artifact = "androidPlugin")
   val kotlinJvmPlugin = Plugin(id = "org.jetbrains.kotlin.jvm", artifact = "kotlinPlugin")
   val kotlinAndroidPlugin = Plugin(id = "org.jetbrains.kotlin.android", artifact = "kotlinPlugin")
-  val apolloPlugin = Plugin(id = "com.apollographql.apollo3", artifact = "apollo.plugin")
+  val apolloPlugin = Plugin(id = "com.apollographql.apollo3", artifact = "apolloPlugin")
 
   fun withDirectory(block: (File) -> Unit) {
     val dest = File(File(System.getProperty("user.dir")), "build/testProject")

--- a/apollo-gradle-plugin/testProjects/android-java/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/android-java/build.gradle.kts
@@ -9,7 +9,7 @@ apply(plugin = "com.android.application")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<BaseExtension> {

--- a/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/androidTestVariants/build.gradle.kts
@@ -10,7 +10,7 @@ apply(plugin = "org.jetbrains.kotlin.android")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<BaseExtension> {

--- a/apollo-gradle-plugin/testProjects/androidVariants/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/androidVariants/build.gradle.kts
@@ -10,7 +10,7 @@ apply(plugin = "org.jetbrains.kotlin.android")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<BaseExtension> {

--- a/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
@@ -17,7 +17,7 @@ project.buildscript.repositories {
 project.buildscript.dependencies.apply {
   add("classpath", groovy.util.Eval.x(project, "x.dep.kotlinPlugin"))
   add("classpath", groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
-  add("classpath", groovy.util.Eval.x(project, "x.dep.android.plugin"))
+  add("classpath", groovy.util.Eval.x(project, "x.dep.androidPlugin"))
 }
 
 allprojects {

--- a/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/buildscript.gradle.kts
@@ -16,7 +16,7 @@ project.buildscript.repositories {
 
 project.buildscript.dependencies.apply {
   add("classpath", groovy.util.Eval.x(project, "x.dep.kotlinPlugin"))
-  add("classpath", groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
+  add("classpath", groovy.util.Eval.x(project, "x.dep.apolloPlugin"))
   add("classpath", groovy.util.Eval.x(project, "x.dep.androidPlugin"))
 }
 

--- a/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/gradle-min-version/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.apolloPlugin"))
     // This project is run with Gradle 5.4 and Kotlin 1.5 doesn't support that so stick with 1.4.32
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
   }
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-gradle-plugin/testProjects/groovy/settings.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/groovy/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
   resolutionStrategy {
     eachPlugin {
       when (requested.id.id) {
-        "com.apollographql.apollo3" -> useModule(groovy.util.Eval.x(settings, "x.dep.apollo.plugin"))
+        "com.apollographql.apollo3" -> useModule(groovy.util.Eval.x(settings, "x.dep.apolloPlugin"))
         "org.jetbrains.kotlin.jvm" -> useModule(groovy.util.Eval.x(settings, "x.dep.kotlinPlugin"))
       }
     }

--- a/apollo-gradle-plugin/testProjects/kotlin-plugin-version/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/kotlin-plugin-version/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.apollo.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.apolloPlugin"))
     // This project is run with Gradle 5.4 and Kotlin 1.5 doesn't support that so stick with 1.4.32
     classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:KOTLIN_VERSION")
   }
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/kotlinJvmSourceSets/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/leaf/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   implementation(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/root/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/leaf/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   implementation(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/root/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/leaf/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   implementation(kotlin("stdlib"))
   testImplementation(kotlin("test-junit"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   implementation(project(":node1"))
   implementation(project(":node2"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/node1/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/node1/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   api(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/node2/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/node2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   api(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-diamond/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-diamond/root/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   implementation(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   implementation(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-publishing/consumer/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-publishing/consumer/build.gradle.kts
@@ -9,7 +9,7 @@ apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
   add("implementation", "com.jvm:jvm-producer:1.0.0")
   add("apolloMetadata", "com.jvm:jvm-producer-apollo:1.0.0")
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules-publishing/jvm-producer/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-publishing/jvm-producer/build.gradle.kts
@@ -13,7 +13,7 @@ group = "com.jvm"
 version = "1.0.0"
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   implementation(kotlin("stdlib"))
   testImplementation(kotlin("test-junit"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   api(project(":root"))
   apolloMetadata(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
   testImplementation(kotlin("test-junit"))
 
   implementation(project(":root"))

--- a/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(kotlin("stdlib"))
-  implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
 
   testImplementation(kotlin("test-junit"))
 }

--- a/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/multiplatform/build.gradle.kts
@@ -26,7 +26,7 @@ configure<KotlinMultiplatformExtension> {
     sourceSets {
         get("commonMain").apply {
             dependencies {
-                implementation(groovy.util.Eval.x(project, "x.dep.apollo.api"))
+                implementation(groovy.util.Eval.x(project, "x.dep.apolloApi"))
             }
         }
     }

--- a/apollo-gradle-plugin/testProjects/register-operations/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/register-operations/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("implementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
+++ b/apollo-gradle-plugin/testProjects/testSourceSet/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "org.jetbrains.kotlin.jvm")
 apply(plugin = "com.apollographql.apollo3")
 
 dependencies {
-  add("testImplementation", groovy.util.Eval.x(project, "x.dep.apollo.api"))
+  add("testImplementation", groovy.util.Eval.x(project, "x.dep.apolloApi"))
 }
 
 configure<ApolloExtension> {

--- a/apollo-http-cache/build.gradle.kts
+++ b/apollo-http-cache/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-  api(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+  api(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
   api(projects.apolloApi)
   api(projects.apolloRuntime)
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
   implementation(groovy.util.Eval.x(project, "x.dep.kotlinxdatetime"))
 
   testImplementation(projects.apolloMockserver)

--- a/apollo-idling-resource/build.gradle.kts
+++ b/apollo-idling-resource/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-  implementation(groovy.util.Eval.x(project, "x.dep.androidx.espressoIdlingResource"))
+  implementation(groovy.util.Eval.x(project, "x.dep.androidxEspressoIdlingResource"))
   api(projects.apolloRuntime)
 }
 

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -13,13 +13,13 @@ kotlin {
         implementation(groovy.util.Eval.x(project, "x.dep.atomicfu").toString()) {
           because("We need locks for native (we don't use the gradle plugin rewrite)")
         }
-        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlinCoroutines"))
       }
     }
 
     val jsMain by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.nodejs"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlinNodejs"))
       }
     }
 

--- a/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -39,13 +39,13 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
     val jvmMain by getting {
       dependsOn(commonMain)
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.jvm"))
+        implementation(groovy.util.Eval.x(project, "x.dep.sqldelightJvm"))
       }
     }
 
     val appleMain by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.native"))
+        implementation(groovy.util.Eval.x(project, "x.dep.sqldelightNative"))
       }
     }
 
@@ -59,10 +59,10 @@ configure<org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension> {
       val androidMain by getting {
         dependsOn(commonMain)
         dependencies {
-          api(groovy.util.Eval.x(project, "x.dep.androidx.sqlite"))
-          implementation(groovy.util.Eval.x(project, "x.dep.sqldelight.android"))
-          implementation(groovy.util.Eval.x(project, "x.dep.androidx.sqliteFramework"))
-          implementation(groovy.util.Eval.x(project, "x.dep.androidx.startupRuntime"))
+          api(groovy.util.Eval.x(project, "x.dep.androidxSqlite"))
+          implementation(groovy.util.Eval.x(project, "x.dep.sqldelightAndroid"))
+          implementation(groovy.util.Eval.x(project, "x.dep.androidxSqliteFramework"))
+          implementation(groovy.util.Eval.x(project, "x.dep.androidxStartupRuntime"))
         }
       }
       val androidTest by getting {

--- a/apollo-normalized-cache/build.gradle.kts
+++ b/apollo-normalized-cache/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
       dependencies {
         api(projects.apolloRuntime)
         api(projects.apolloNormalizedCacheApi)
-        api(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
+        api(groovy.util.Eval.x(project, "x.dep.kotlinCoroutines"))
       }
     }
   }

--- a/apollo-runtime/build.gradle.kts
+++ b/apollo-runtime/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
         api(projects.apolloMppUtils)
         api(okio())
         api(groovy.util.Eval.x(project, "x.dep.uuid"))
-        api(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
+        api(groovy.util.Eval.x(project, "x.dep.kotlinCoroutines"))
       }
     }
 
@@ -25,13 +25,13 @@ kotlin {
 
     val jvmMain by getting {
       dependencies {
-        api(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+        api(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
       }
     }
 
     val jsMain by getting {
       dependencies {
-        api(groovy.util.Eval.x(project, "x.dep.ktor.clientJs"))
+        api(groovy.util.Eval.x(project, "x.dep.ktorClientJs"))
       }
     }
 
@@ -44,7 +44,7 @@ kotlin {
       dependencies {
         implementation(kotlin("test-junit"))
         implementation(groovy.util.Eval.x(project, "x.dep.truth"))
-        implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+        implementation(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
       }
     }
   }

--- a/apollo-rx2-support/build.gradle.kts
+++ b/apollo-rx2-support/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
   implementation(projects.apolloApi)
   api(groovy.util.Eval.x(project, "x.dep.rx2"))
-  api(groovy.util.Eval.x(project, "x.dep.kotlin.coroutinesRx2"))
+  api(groovy.util.Eval.x(project, "x.dep.kotlinCoroutinesRx2"))
 
   api(projects.apolloRuntime)
   api(projects.apolloNormalizedCache)

--- a/apollo-rx3-support/build.gradle.kts
+++ b/apollo-rx3-support/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 dependencies {
   implementation(projects.apolloApi)
   api(groovy.util.Eval.x(project, "x.dep.rx3"))
-  api(groovy.util.Eval.x(project, "x.dep.kotlin.coroutinesRx3"))
+  api(groovy.util.Eval.x(project, "x.dep.kotlinCoroutinesRx3"))
 
   api(projects.apolloRuntime)
   api(projects.apolloNormalizedCache)

--- a/apollo-testing-support/build.gradle.kts
+++ b/apollo-testing-support/build.gradle.kts
@@ -12,7 +12,7 @@ kotlin {
         api(projects.apolloNormalizedCacheApi)
         api(projects.apolloRuntime)
         api(projects.apolloMockserver)
-        api(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
+        api(groovy.util.Eval.x(project, "x.dep.kotlinCoroutines"))
         implementation(groovy.util.Eval.x(project, "x.dep.atomicfu").toString()) {
           because("We need locks in TestNetworkTransportHandler (we don't use the gradle plugin rewrite)")
         }
@@ -27,7 +27,7 @@ kotlin {
 
     val jsMain by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.nodejs"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlinNodejs"))
         implementation(kotlin("test-js"))
         api(okioNodeJs())
       }

--- a/apollo-tooling/build.gradle.kts
+++ b/apollo-tooling/build.gradle.kts
@@ -8,11 +8,11 @@ dependencies {
   implementation(projects.apolloAnnotations)
   implementation(projects.apolloAst)
   api(projects.apolloCompiler)
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.sealedRuntime"))
-  implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiSealedRuntime"))
+  implementation(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
 
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.truth"))
 }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -40,8 +40,8 @@ dependencies {
   add("implementation", "com.apollographql.apollo3:apollo-normalized-cache-sqlite:${properties.get("apolloVersion")}")
   add("implementation", "com.apollographql.apollo3:apollo-normalized-cache:${properties.get("apolloVersion")}")
 
-  add("implementation", groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
-  add("ksp", groovy.util.Eval.x(project, "x.dep.moshi.ksp"))
+  add("implementation", groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
+  add("ksp", groovy.util.Eval.x(project, "x.dep.moshiKsp"))
 
   add("androidTestImplementation", "androidx.benchmark:benchmark-junit4:1.0.0")
 }

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath(groovy.util.Eval.x(project, "x.dep.android.plugin"))
+    classpath(groovy.util.Eval.x(project, "x.dep.androidPlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kotlinPlugin"))
     classpath(groovy.util.Eval.x(project, "x.dep.kspGradlePlugin"))
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -15,8 +15,8 @@ group = "com.apollographql.apollo3"
 dependencies {
   compileOnly(groovy.util.Eval.x(project, "x.dep.gradleApi"))
 
-  implementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
-  implementation(groovy.util.Eval.x(project, "x.dep.moshi.moshi"))
+  implementation(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
+  implementation(groovy.util.Eval.x(project, "x.dep.moshiMoshi"))
   implementation(groovy.util.Eval.x(project, "x.dep.dokka"))
 
   // We add all the plugins to the classpath here so that they are loaded with proper conflict resolution
@@ -36,14 +36,14 @@ dependencies {
     runtimeOnly(groovy.util.Eval.x(project, "x.dep.kspGradlePluginDuringIdeaSync"))
   }
 
-  runtimeOnly(groovy.util.Eval.x(project, "x.dep.sqldelight.plugin"))
+  runtimeOnly(groovy.util.Eval.x(project, "x.dep.sqldelightPlugin"))
   runtimeOnly(groovy.util.Eval.x(project, "x.dep.gradlePublishPlugin"))
   runtimeOnly(groovy.util.Eval.x(project, "x.dep.benManesVersions"))
   runtimeOnly(groovy.util.Eval.x(project, "x.dep.gr8"))
   runtimeOnly(groovy.util.Eval.x(project, "x.dep.binaryCompatibilityValidator"))
   // XXX: This is only needed for tests. We could have different build logic for different
   // builds but this seems just overkill for now
-  runtimeOnly(groovy.util.Eval.x(project, "x.dep.kotlin.allOpen"))
+  runtimeOnly(groovy.util.Eval.x(project, "x.dep.kotlinAllOpen"))
 }
 
 // This shuts down a warning in Kotlin 1.5.30:

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -21,7 +21,7 @@ dependencies {
 
   // We add all the plugins to the classpath here so that they are loaded with proper conflict resolution
   // See https://github.com/gradle/gradle/issues/4741
-  implementation(groovy.util.Eval.x(project, "x.dep.android.plugin"))
+  implementation(groovy.util.Eval.x(project, "x.dep.androidPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.gradleJapiCmpPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.gradleMetalavaPlugin"))
   implementation(groovy.util.Eval.x(project, "x.dep.vespene"))

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -27,114 +27,94 @@ def versions = [
 ext.versions = versions
 
 ext.dep = [
-    android                      : [
-        plugin   : "com.android.tools.build:gradle:$versions.androidPlugin",
-        minPlugin: "com.android.tools.build:gradle:$versions.minAndroidPlugin",
-    ],
-    androidx                     : [
-        appcompat             : "androidx.appcompat:appcompat:1.1.0",
-        espressoIdlingResource: "androidx.test.espresso:espresso-idling-resource:3.4.0",
-        recyclerView          : "androidx.recyclerview:recyclerview:1.1.0",
-        sqlite                : "androidx.sqlite:sqlite:${versions.androidxSqlite}",
-        sqliteFramework       : "androidx.sqlite:sqlite-framework:${versions.androidxSqlite}",
-        startupRuntime        : "androidx.startup:startup-runtime:1.1.1",
-    ],
-    antlr                        : [
-        antlr  : "org.antlr:antlr4:$versions.antlr4",
-        runtime: "org.antlr:antlr4-runtime:$versions.antlr4",
-    ],
-    apollo                       : [
-        plugin : "com.apollographql.apollo3:apollo-gradle-plugin:$versions.apollo",
-        runtime: "com.apollographql.apollo3:apollo-runtime:$versions.apollo",
-        api    : "com.apollographql.apollo3:apollo-api:$versions.apollo",
-    ],
-    kotlinCompileTesting         : "com.github.tschuchortdev:kotlin-compile-testing:1.4.6",
-    javaCompileTesting           : "com.google.testing.compile:compile-testing:0.19",
-    gradleJapiCmpPlugin          : "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
-    gradleMetalavaPlugin         : "me.tylerbwong.gradle:metalava-gradle:0.1.5",
-    vespene                      : "net.mbonnin.vespene:vespene-lib:0.5",
-    gradlePublishPlugin          : "com.gradle.publish:plugin-publish-plugin:0.12.0",
-    guavaJre                     : "com.google.guava:guava:$versions.guava",
-    jetbrainsAnnotations         : "org.jetbrains:annotations:$versions.jetbrainsAnnotations",
-    junit                        : "junit:junit:$versions.junit",
-    kotlinJunit                  : "org.jetbrains.kotlin:kotlin-test", // the Kotlin plugin resolves the version
-    kotlin                       : [
-        coroutines       : "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.kotlinCoroutines",
-        coroutinesRx2    : "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$versions.kotlinCoroutines",
-        coroutinesRx3    : "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:$versions.kotlinCoroutines",
-        coroutinesReactor: "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$versions.kotlinCoroutines",
-        reflect          : "org.jetbrains.kotlin:kotlin-reflect", // the Kotlin plugin resolves the version
-        nodejs           : "org.jetbrains.kotlinx:kotlinx-nodejs:0.0.7",
-        allOpen          : "org.jetbrains.kotlin:kotlin-allopen", // the Kotlin plugin resolves the version
-    ],
-    moshi                        : [
-        ksp          : "dev.zacsweers.moshix:moshi-ksp:$versions.moshix",
-        sealedCodegen: "dev.zacsweers.moshix:moshi-sealed-codegen:$versions.moshix",
-        sealedRuntime: "dev.zacsweers.moshix:moshi-sealed-runtime:$versions.moshix",
-        moshi        : "com.squareup.moshi:moshi:$versions.moshi",
-    ],
-    okHttp                       : [
-        mockWebServer: "com.squareup.okhttp3:mockwebserver:$versions.okHttp",
-        okHttp       : "com.squareup.okhttp3:okhttp:$versions.okHttp",
-        logging      : "com.squareup.okhttp3:logging-interceptor:$versions.okHttp",
-        tls          : "com.squareup.okhttp3:okhttp-tls:$versions.okHttp",
-    ],
-    okio                         : "com.squareup.okio:okio", // Version resolved depending on whether HMPP is enabled or not
-    okioNodeJs                   : "com.squareup.okio:okio-nodefilesystem", // Version resolved depending on whether HMPP is enabled or not
-    poet                         : [
-        java  : "com.squareup:javapoet:$versions.javaPoet",
-        kotlin: "com.squareup:kotlinpoet:1.11.0",
-    ],
-    rx2                          : "io.reactivex.rxjava2:rxjava:$versions.rxjava",
-    rx3                          : "io.reactivex.rxjava3:rxjava:$versions.rxjava3",
-    sqldelight                   : [
-        android: "com.squareup.sqldelight:android-driver:$versions.sqldelight",
-        jvm    : "com.squareup.sqldelight:sqlite-driver:$versions.sqldelight",
-        native : "com.squareup.sqldelight:native-driver:$versions.sqldelight",
-        plugin : "com.squareup.sqldelight:gradle-plugin:$versions.sqldelight"
-    ],
-    truth                        : "com.google.truth:truth:$versions.truth",
-    assertj                      : "org.assertj:assertj-core:3.21.0",
-    uuid                         : "com.benasher44:uuid:0.3.1",
-    benManesVersions             : "com.github.ben-manes:gradle-versions-plugin:0.33.0",
-    gr8                          : "com.gradleup:gr8-plugin:0.4",
-    kspGradlePlugin              : "com.google.devtools.ksp:symbol-processing-gradle-plugin:$versions.kspGradlePlugin",
-    kspGradlePluginDuringIdeaSync: "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2",
-    kotlinxdatetime              : "org.jetbrains.kotlinx:kotlinx-datetime:$versions.kotlinxdatetime",
-    kotlinxserializationjson     : "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2",
-    atomicfu                     : "org.jetbrains.kotlinx:atomicfu:0.17.0",
-    ktor                         : [
-        clientJs: "io.ktor:ktor-client-js:$versions.ktor"
-    ],
-    dokka                        : "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0",
-    androidSupportAnnotations    : "com.android.support:support-annotations:28.0.0",
-    androidTestRunner            : "com.android.support.test:runner:1.0.2",
+    androidMinPlugin: "com.android.tools.build:gradle:$versions.minAndroidPlugin",
+    androidPlugin: "com.android.tools.build:gradle:$versions.androidPlugin",
+    androidSupportAnnotations: "com.android.support:support-annotations:28.0.0",
+    androidTestRunner: "com.android.support.test:runner:1.0.2",
+    androidxAppcompat: "androidx.appcompat:appcompat:1.1.0",
+    androidxEspressoIdlingResource: "androidx.test.espresso:espresso-idling-resource:3.4.0",
+    androidxRecyclerView: "androidx.recyclerview:recyclerview:1.1.0",
+    androidxSqlite: "androidx.sqlite:sqlite:${versions.androidxSqlite}",
+    androidxSqliteFramework: "androidx.sqlite:sqlite-framework:${versions.androidxSqlite}",
+    androidxStartupRuntime: "androidx.startup:startup-runtime:1.1.1",
+    antlrAntlr: "org.antlr:antlr4:$versions.antlr4",
+    antlrRuntime: "org.antlr:antlr4-runtime:$versions.antlr4",
+    apolloApi: "com.apollographql.apollo3:apollo-api:$versions.apollo",
+    apolloPlugin: "com.apollographql.apollo3:apollo-gradle-plugin:$versions.apollo",
+    apolloRuntime: "com.apollographql.apollo3:apollo-runtime:$versions.apollo",
+    assertj: "org.assertj:assertj-core:3.21.0",
+    atomicfu: "org.jetbrains.kotlinx:atomicfu:0.17.0",
+    benManesVersions: "com.github.ben-manes:gradle-versions-plugin:0.33.0",
+    binaryCompatibilityValidator: "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0",
+    clikt: "com.github.ajalt.clikt:clikt:3.4.0",
+    dokka: "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0",
+    gr8: "com.gradleup:gr8-plugin:0.4",
     /**
-     * We use the Nokee [redistributed artifacts](https://docs.nokee.dev/manual/gradle-plugin-development.html#sec:gradle-dev-redistributed-gradle-api)
-     * to avoid leaking the Kotlin stdlib on the classpath
      * See https://github.com/gradle/gradle/issues/1835
+     * We use the Nokee[redistributed artifacts](https://docs.nokee.dev/manual/gradle-plugin-development.html#sec:gradle-dev-redistributed-gradle-api)
+     * to avoid leaking the Kotlin stdlib on the classpath
      */
     // Keep in sync with gradle-wrapper.properties
-    gradleApi                    : "dev.gradleplugins:gradle-api:7.2",
-    // Keep in sync with MIN_GRADLE_VERSION
-    minGradleApi                 : "dev.gradleplugins:gradle-api:5.6",
-    graphqlKotlin                : "com.expediagroup:graphql-kotlin-spring-server:5.3.0",
-    testParameterInjector        : "com.google.testparameterinjector:test-parameter-injector:1.4",
-    binaryCompatibilityValidator : "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0",
-    // For Gradle integration tests to make sure we stay compatible with 1.5.0
-    kotlinPluginMin              : "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0",
-    // See https://youtrack.jetbrains.com/issue/KTIJ-21583/HMPP:-1.6.20-breaks-autocomplete-in-multiplatform-composite-buil#focus=Comments-27-6022244.0-0
-    kotlinPluginDuringIdeaSync   : "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10",
+    gradleApi: "dev.gradleplugins:gradle-api:7.2",
+    gradleJapiCmpPlugin: "me.champeau.gradle:japicmp-gradle-plugin:0.2.8",
+    gradleMetalavaPlugin: "me.tylerbwong.gradle:metalava-gradle:0.1.5",
+    gradlePublishPlugin: "com.gradle.publish:plugin-publish-plugin:0.12.0",
+    graphqlKotlin: "com.expediagroup:graphql-kotlin-spring-server:5.3.0",
+    guavaJre: "com.google.guava:guava:$versions.guava",
+    javaCompileTesting: "com.google.testing.compile:compile-testing:0.19",
+    jetbrainsAnnotations: "org.jetbrains:annotations:$versions.jetbrainsAnnotations",
+    junit: "junit:junit:$versions.junit",
+    kotlinAllOpen: "org.jetbrains.kotlin:kotlin-allopen", // the Kotlin plugin resolves the version
+    kotlinCompileTesting: "com.github.tschuchortdev:kotlin-compile-testing:1.4.6",
+    kotlinCoroutines: "org.jetbrains.kotlinx:kotlinx-coroutines-core:$versions.kotlinCoroutines",
+    kotlinCoroutinesReactor: "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$versions.kotlinCoroutines",
+    kotlinCoroutinesRx2: "org.jetbrains.kotlinx:kotlinx-coroutines-rx2:$versions.kotlinCoroutines",
+    kotlinCoroutinesRx3: "org.jetbrains.kotlinx:kotlinx-coroutines-rx3:$versions.kotlinCoroutines",
+    kotlinJunit: "org.jetbrains.kotlin:kotlin-test", // the Kotlin plugin resolves the version
+    kotlinNodejs: "org.jetbrains.kotlinx:kotlinx-nodejs:0.0.7",
     // The main kotlin version for build-logic and Gradle tests
-    kotlinPlugin                 : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinPlugin",
+    kotlinPlugin: "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinPlugin",
+    // See https://youtrack.jetbrains.com/issue/KTIJ-21583/HMPP:-1.6.20-breaks-autocomplete-in-multiplatform-composite-buil#focus=Comments-27-6022244.0-0
+    kotlinPluginDuringIdeaSync: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10",
+    // For Gradle integration tests to make sure we stay compatible with 1.5.0
+    kotlinPluginMin: "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.0",
     // Used by the Apollo Gradle plugin because the Kotlin plugin is in the buildscript classpath already so there's no need to
     // specify the version
-    kotlinPluginWithoutVersion   : "org.jetbrains.kotlin:kotlin-gradle-plugin",
-    turbine                      : "app.cash.turbine:turbine:0.7.0",
-    clikt                      : "com.github.ajalt.clikt:clikt:3.4.0",
-]
-ext.androidConfig = [
-    compileSdkVersion: 30,
-    minSdkVersion    : 15,
-    targetSdkVersion : 30
-]
+    kotlinPluginWithoutVersion: "org.jetbrains.kotlin:kotlin-gradle-plugin",
+    kotlinReflect: "org.jetbrains.kotlin:kotlin-reflect", // the Kotlin plugin resolves the version
+    kotlinxdatetime: "org.jetbrains.kotlinx:kotlinx-datetime:$versions.kotlinxdatetime",
+    kotlinxserializationjson: "org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2",
+    kspGradlePlugin: "com.google.devtools.ksp:symbol-processing-gradle-plugin:$versions.kspGradlePlugin",
+    kspGradlePluginDuringIdeaSync: "com.google.devtools.ksp:symbol-processing-gradle-plugin:1.6.10-1.0.2",
+    ktorClientJs: "io.ktor:ktor-client-js:$versions.ktor",
+    // Keep in sync with MIN_GRADLE_VERSION
+    minGradleApi: "dev.gradleplugins:gradle-api:5.6",
+    moshiKsp: "dev.zacsweers.moshix:moshi-ksp:$versions.moshix",
+    moshiMoshi: "com.squareup.moshi:moshi:$versions.moshi",
+    moshiSealedCodegen: "dev.zacsweers.moshix:moshi-sealed-codegen:$versions.moshix",
+    moshiSealedRuntime: "dev.zacsweers.moshix:moshi-sealed-runtime:$versions.moshix",
+    okHttpLogging: "com.squareup.okhttp3:logging-interceptor:$versions.okHttp",
+    okHttpMockWebServer: "com.squareup.okhttp3:mockwebserver:$versions.okHttp",
+    okHttpPkHttp: "com.squareup.okhttp3:okhttp:$versions.okHttp",
+    okHttpTls: "com.squareup.okhttp3:okhttp-tls:$versions.okHttp",
+    okio: "com.squareup.okio:okio", // Version resolved depending on whether HMPP is enabled or not
+    okioNodeJs: "com.squareup.okio:okio-nodefilesystem", // Version resolved depending on whether HMPP is enabled or not
+    poetJava: "com.squareup:javapoet:$versions.javaPoet",
+    poetKotlin: "com.squareup:kotlinpoet:1.11.0",
+    rx2: "io.reactivex.rxjava2:rxjava:$versions.rxjava",
+    rx3: "io.reactivex.rxjava3:rxjava:$versions.rxjava3",
+    sqldelightAndroid: "com.squareup.sqldelight:android-driver:$versions.sqldelight",
+    sqldelightJvm: "com.squareup.sqldelight:sqlite-driver:$versions.sqldelight",
+    sqldelightNative: "com.squareup.sqldelight:native-driver:$versions.sqldelight",
+    sqldelightPlugin: "com.squareup.sqldelight:gradle-plugin:$versions.sqldelight",
+    testParameterInjector: "com.google.testparameterinjector:test-parameter-injector:1.4",
+    truth: "com.google.truth:truth:$versions.truth",
+    turbine: "app.cash.turbine:turbine:0.7.0",
+    uuid: "com.benasher44:uuid:0.3.1",
+    vespene: "net.mbonnin.vespene:vespene-lib:0.5",
+    ]
+    ext.androidConfig = [
+        compileSdkVersion: 30,
+        minSdkVersion    : 15,
+        targetSdkVersion : 30
+    ]

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,27 +1,27 @@
 def versions = [
-    minAndroidPlugin    : '3.4.2',
     androidPlugin       : '4.2.2',
     androidxSqlite      : '2.1.0',
-    apollo              : '3.3.1-SNAPSHOT', // This is used by the gradle integration tests to get the artifacts locally
     antlr4              : '4.9.3',
+    apollo              : '3.3.1-SNAPSHOT', // This is used by the gradle integration tests to get the artifacts locally
     cache               : '2.0.2',
     guava               : '28.0-jre',
     javaPoet            : '1.13.0',
     jetbrainsAnnotations: '13.0',
     junit               : '4.13.2',
     kotlinCoroutines    : '1.6.1',
+    kotlinPlugin        : System.env.COM_APOLLOGRAPHQL_VERSION_KOTLIN_PLUGIN ?: "1.6.21",
+    kotlinxdatetime     : System.env.COM_APOLLOGRAPHQL_VERSION_KOTLINXDATETIME ?: "0.3.1",
+    kspGradlePlugin     : System.env.COM_APOLLOGRAPHQL_VERSION_KSP_GRADLE_PLUGIN ?: "1.6.21-1.0.5",
+    ktor                : '1.6.7',
+    minAndroidPlugin    : '3.4.2',
     moshi               : '1.12.0',
     moshix              : '0.14.1',
     okHttp              : '4.9.3',
+    rxandroid           : '2.0.1',
     rxjava              : '2.2.21',
     rxjava3             : '3.1.3',
-    rxandroid           : '2.0.1',
     sqldelight          : '1.5.3',
     truth               : '1.1.3',
-    ktor                : '1.6.7',
-    kotlinPlugin        : System.env.COM_APOLLOGRAPHQL_VERSION_KOTLIN_PLUGIN ?: "1.6.21",
-    kspGradlePlugin     : System.env.COM_APOLLOGRAPHQL_VERSION_KSP_GRADLE_PLUGIN ?: "1.6.21-1.0.5",
-    kotlinxdatetime     : System.env.COM_APOLLOGRAPHQL_VERSION_KOTLINXDATETIME ?: "0.3.1",
 ]
 
 ext.versions = versions
@@ -95,7 +95,7 @@ ext.dep = [
     moshiSealedRuntime: "dev.zacsweers.moshix:moshi-sealed-runtime:$versions.moshix",
     okHttpLogging: "com.squareup.okhttp3:logging-interceptor:$versions.okHttp",
     okHttpMockWebServer: "com.squareup.okhttp3:mockwebserver:$versions.okHttp",
-    okHttpPkHttp: "com.squareup.okhttp3:okhttp:$versions.okHttp",
+    okHttpOkHttp: "com.squareup.okhttp3:okhttp:$versions.okHttp",
     okHttpTls: "com.squareup.okhttp3:okhttp-tls:$versions.okHttp",
     okio: "com.squareup.okio:okio", // Version resolved depending on whether HMPP is enabled or not
     okioNodeJs: "com.squareup.okio:okio-nodefilesystem", // Version resolved depending on whether HMPP is enabled or not
@@ -113,8 +113,9 @@ ext.dep = [
     uuid: "com.benasher44:uuid:0.3.1",
     vespene: "net.mbonnin.vespene:vespene-lib:0.5",
     ]
-    ext.androidConfig = [
-        compileSdkVersion: 30,
-        minSdkVersion    : 15,
-        targetSdkVersion : 30
-    ]
+
+ext.androidConfig = [
+    compileSdkVersion: 30,
+    minSdkVersion    : 15,
+    targetSdkVersion : 30
+]

--- a/tests/idling-resource/build.gradle.kts
+++ b/tests/idling-resource/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  implementation(groovy.util.Eval.x(project, "x.dep.androidx.espressoIdlingResource"))
+  implementation(groovy.util.Eval.x(project, "x.dep.androidxEspressoIdlingResource"))
   implementation("com.apollographql.apollo3:apollo-idling-resource")
   testImplementation("com.apollographql.apollo3:apollo-mockserver")
   testImplementation(groovy.util.Eval.x(project, "x.dep.androidSupportAnnotations"))

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 
     val commonTest by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutines"))
+        implementation(groovy.util.Eval.x(project, "x.dep.kotlinCoroutines"))
         implementation(groovy.util.Eval.x(project, "x.dep.kotlinxserializationjson").toString()) {
           because("OperationOutputTest uses it to check the json and we can't use moshi since it's mpp code")
         }
@@ -43,7 +43,7 @@ kotlin {
 
     val jvmTest by getting {
       dependencies {
-        implementation(groovy.util.Eval.x(project, "x.dep.okHttp.logging"))
+        implementation(groovy.util.Eval.x(project, "x.dep.okHttpLogging"))
       }
     }
   }

--- a/tests/no-runtime/build.gradle.kts
+++ b/tests/no-runtime/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   implementation("com.apollographql.apollo3:apollo-testing-support")
   testImplementation(groovy.util.Eval.x(project, "x.dep.kotlinJunit"))
   testImplementation(groovy.util.Eval.x(project, "x.dep.junit"))
-  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttp.okHttp"))
+  testImplementation(groovy.util.Eval.x(project, "x.dep.okHttpOkHttp"))
 }
 
 apollo {

--- a/tests/sample-server/build.gradle.kts
+++ b/tests/sample-server/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
 
 dependencies {
   api(groovy.util.Eval.x(project, "x.dep.graphqlKotlin"))
-  api(groovy.util.Eval.x(project, "x.dep.kotlin.reflect").toString()) {
+  api(groovy.util.Eval.x(project, "x.dep.kotlinReflect").toString()) {
     because("graphqlKotlin pull kotlin-reflect and that triggers a warning like" +
         "Runtime JAR files in the classpath should have the same version.")
   }
-  implementation(groovy.util.Eval.x(project, "x.dep.kotlin.coroutinesReactor").toString()) {
+  implementation(groovy.util.Eval.x(project, "x.dep.kotlinCoroutinesReactor").toString()) {
     because("reactor must have the same version as the coroutines version")
   }
 }


### PR DESCRIPTION
Something I've been wanting to do for a while: flatten the dependencies and order them alphabetically so that it's easier to find them. No functional change