### PR TITLE
Fix incorrect content-length in MockServer

### DIFF
--- a/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerCommon.kt
+++ b/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServerCommon.kt
@@ -102,10 +102,7 @@ constructor(
       contentLength = body.size
     }
 
-    fun body(body: String) = apply {
-      this.body = flowOf(body.encodeUtf8())
-      contentLength = body.length
-    }
+    fun body(body: String) = body(body.encodeUtf8())
 
     fun headers(headers: Map<String, String>) = apply {
       this.headers.clear()

--- a/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
+++ b/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
@@ -36,6 +36,9 @@ class EnqueueTest {
             .addHeader("X-Test", "true")
             .build(),
         MockResponse.Builder()
+            .body("ä".trimIndent())
+            .build(),
+        MockResponse.Builder()
             .body(flowOf("First chunk\n".encodeUtf8(), "Second chunk".encodeUtf8()).asChunked())
             .statusCode(200)
             .addHeader("X-Test", "false")


### PR DESCRIPTION
When a string contains non 8 bit characters, its Java length is not equal to its utf-8 encoded length. This caused receiving truncated responses from MockServer.

Thanks @StylianosGakis for finding this! 🙏 