### PR TITLE
Add migration documentation for authenticated subscriptions

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -739,6 +739,10 @@ to send new authentication parameters), you can now
 call `apolloClient.subscriptionNetworkTransport.closeConnection(<your exception>)`: this will behave as if a network
 error occurred, and you can react to this by reconnecting with `reopenWhen`.
 
+If you were previously using `subscriptionConnectionParams` to authenticate your subscription, you can now use
+`wsProtocol` with a `connectionPayload` passed inside the `SubscriptionWsProtocol.Factory`. More information can be
+found in [Authenticating your WebSockets](../advanced/authentication.mdx#authenticating-your-websockets).
+
 If you feel some API is missing from `SubscriptionManager`,
 please [reach out](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=%3Asparkles%3A+Type%3A+Feature&template=feature_request.md&title=)
 so we can discuss the best way to add them.


### PR DESCRIPTION
Add a mention to `subscriptionConnectionParams` in the migration guide along with a link to the specific place in the docs that mention the new approach.