### PR TITLE
✅ update binary compat validation

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -752,7 +752,6 @@ public abstract interface class com/apollographql/apollo3/api/Upload {
 public final class com/apollographql/apollo3/api/_DataKt {
 	public static final fun toJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
 	public static synthetic fun toJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/json/JsonWriter;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)V
-	public static synthetic fun toJsonString$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/http/ByteStringHttpBody : com/apollographql/apollo3/api/http/HttpBody {
@@ -1080,8 +1079,6 @@ public class com/apollographql/apollo3/exception/ApolloException : java/lang/Run
 }
 
 public final class com/apollographql/apollo3/exception/ApolloExceptionHandlerKt {
-	public static final fun getApolloExceptionHandler ()Lkotlin/jvm/functions/Function1;
-	public static final fun setApolloExceptionHandler (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class com/apollographql/apollo3/exception/ApolloGenericException : com/apollographql/apollo3/exception/ApolloException {
@@ -1125,10 +1122,8 @@ public final class com/apollographql/apollo3/exception/AutoPersistedQueriesNotSu
 public final class com/apollographql/apollo3/exception/CacheMissException : com/apollographql/apollo3/exception/ApolloException {
 	public static final field Companion Lcom/apollographql/apollo3/exception/CacheMissException$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getFieldName ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
-	public final fun getStale ()Z
 }
 
 public final class com/apollographql/apollo3/exception/CacheMissException$Companion {

--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1,9 +1,4 @@
 public final class com/apollographql/apollo3/ast/ApolloParser {
-	public static synthetic fun parseAsGQLDocument$default (Lokio/BufferedSource;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLSelections$default (Lokio/BufferedSource;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLValue$default (Lokio/BufferedSource;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun toExecutableDefinitions$default (Lokio/BufferedSource;Lcom/apollographql/apollo3/ast/Schema;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
-	public static synthetic fun toSchema$default (Lokio/BufferedSource;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/Schema;
 }
 
 public final class com/apollographql/apollo3/ast/Check_key_fieldsKt {
@@ -1033,7 +1028,6 @@ public final class com/apollographql/apollo3/ast/GqltypedefinitionKt {
 	public static final fun implementsAbstractType (Lcom/apollographql/apollo3/ast/GQLTypeDefinition;Lcom/apollographql/apollo3/ast/Schema;)Z
 	public static final fun isAbstract (Lcom/apollographql/apollo3/ast/GQLTypeDefinition;)Z
 	public static final fun isFieldNonNull (Lcom/apollographql/apollo3/ast/GQLTypeDefinition;Ljava/lang/String;)Z
-	public static synthetic fun isFieldNonNull$default (Lcom/apollographql/apollo3/ast/GQLTypeDefinition;Ljava/lang/String;Lcom/apollographql/apollo3/ast/Schema;ILjava/lang/Object;)Z
 	public static final fun possibleTypes (Lcom/apollographql/apollo3/ast/GQLTypeDefinition;Lcom/apollographql/apollo3/ast/Schema;)Ljava/util/Set;
 }
 
@@ -1654,7 +1648,6 @@ public final class com/apollographql/apollo3/ast/introspection/IntrospectionSche
 }
 
 public final class com/apollographql/apollo3/ast/introspection/Introspection_to_schemaKt {
-	public static synthetic fun toGQLDocument$default (Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLDocument;
 }
 
 public final class com/apollographql/apollo3/ast/introspection/Schema_to_introspectionKt {

--- a/apollo-compiler/api/apollo-compiler.api
+++ b/apollo-compiler/api/apollo-compiler.api
@@ -1419,7 +1419,6 @@ public final class com/apollographql/apollo3/compiler/introspection/Introspectio
 }
 
 public final class com/apollographql/apollo3/compiler/introspection/Introspection_to_schemaKt {
-	public static synthetic fun toGQLDocument$default (Lcom/apollographql/apollo3/compiler/introspection/IntrospectionSchema;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLDocument;
 }
 
 public final class com/apollographql/apollo3/compiler/introspection/Schema_to_introspectionKt {

--- a/apollo-mockserver/api/apollo-mockserver.api
+++ b/apollo-mockserver/api/apollo-mockserver.api
@@ -1,8 +1,4 @@
 public final class com/apollographql/apollo3/mockserver/-MockServers {
-	public static synthetic fun createMultipartMixedChunkedResponse$default (Ljava/util/List;ILjava/lang/String;Ljava/util/Map;JJLjava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockResponse;
-	public static synthetic fun createMultipartMixedPart$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZILjava/lang/Object;)Ljava/lang/String;
-	public static synthetic fun enqueue$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JIILjava/lang/Object;)V
-	public static synthetic fun enqueueMultipart$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/util/List;ILjava/lang/String;Ljava/util/Map;JJLjava/lang/String;ILjava/lang/Object;)V
 }
 
 public final class com/apollographql/apollo3/mockserver/MockRequest {

--- a/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
+++ b/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
@@ -1,5 +1,4 @@
 public final class com/apollographql/apollo3/cache/normalized/api/ApolloCacheHeaders {
-	public static final field DATE Ljava/lang/String;
 	public static final field DO_NOT_STORE Ljava/lang/String;
 	public static final field EVICT_AFTER_READ Ljava/lang/String;
 	public static final field INSTANCE Lcom/apollographql/apollo3/cache/normalized/api/ApolloCacheHeaders;
@@ -163,7 +162,6 @@ public final class com/apollographql/apollo3/cache/normalized/api/Record : java/
 	public final fun fieldKeys ()Ljava/util/Set;
 	public final fun get (Ljava/lang/Object;)Ljava/lang/Object;
 	public fun get (Ljava/lang/String;)Ljava/lang/Object;
-	public final fun getDate ()Ljava/util/Map;
 	public fun getEntries ()Ljava/util/Set;
 	public final fun getFields ()Ljava/util/Map;
 	public final fun getKey ()Ljava/lang/String;

--- a/apollo-testing-support/api/apollo-testing-support.api
+++ b/apollo-testing-support/api/apollo-testing-support.api
@@ -5,7 +5,6 @@ public final class com/apollographql/apollo3/testing/-FileSystemCommon {
 }
 
 public final class com/apollographql/apollo3/testing/ChannelsKt {
-	public static synthetic fun receiveOrTimeout$default (Lkotlinx/coroutines/channels/Channel;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/testing/MockserverKt {
@@ -25,7 +24,5 @@ public final class com/apollographql/apollo3/testing/RunWithMainLoopJvmKt {
 }
 
 public final class com/apollographql/apollo3/testing/TestNetworkTransportKt {
-	public static synthetic fun enqueueTestResponse$default (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;ILjava/lang/Object;)V
-	public static synthetic fun registerTestResponse$default (Lcom/apollographql/apollo3/ApolloClient;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;ILjava/lang/Object;)V
 }
 

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -45,7 +45,7 @@ ext.dep = [
     assertj: "org.assertj:assertj-core:3.21.0",
     atomicfu: "org.jetbrains.kotlinx:atomicfu:0.17.0",
     benManesVersions: "com.github.ben-manes:gradle-versions-plugin:0.33.0",
-    binaryCompatibilityValidator: "org.jetbrains.kotlinx:binary-compatibility-validator:0.9.0",
+    binaryCompatibilityValidator: "org.jetbrains.kotlinx:binary-compatibility-validator:0.10.1",
     clikt: "com.github.ajalt.clikt:clikt:3.4.0",
     dokka: "org.jetbrains.dokka:dokka-gradle-plugin:1.5.0",
     gr8: "com.gradleup:gr8-plugin:0.4",


### PR DESCRIPTION
This version removes `@ApolloExperimental` and `@ApolloInternal` symbols from the public API dumps

See https://github.com/Kotlin/binary-compatibility-validator/issues/58