### PR TITLE
Fix NPE in checkCapitalizedFields

### DIFF
--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkCapitalizedFields.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkCapitalizedFields.kt
@@ -58,7 +58,7 @@ private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection
         }
       }
       is GQLInlineFragment -> checkCapitalizedFields(it.selectionSet.selections)
-      is GQLFragmentSpread -> checkCapitalizedFields(fragmentsByName[it.name]!!.selectionSet.selections)
+      is GQLFragmentSpread -> fragmentsByName[it.name]?.let { fragment -> checkCapitalizedFields(fragment.selectionSet.selections) }
     }
   }
 }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkCapitalizedFields.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkCapitalizedFields.kt
@@ -58,6 +58,8 @@ private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection
         }
       }
       is GQLInlineFragment -> checkCapitalizedFields(it.selectionSet.selections)
+      // it might be that the fragment is defined in an upstream module. In that case, it is validated
+      // already, no need to check it again
       is GQLFragmentSpread -> fragmentsByName[it.name]?.let { fragment -> checkCapitalizedFields(fragment.selectionSet.selections) }
     }
   }

--- a/tests/multi-module-child/build.gradle.kts
+++ b/tests/multi-module-child/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
 
 apollo {
   packageName.set("multimodule.child")
+  flattenModels.set(false)
 }

--- a/tests/multi-module-child/src/main/graphql/operations.graphql
+++ b/tests/multi-module-child/src/main/graphql/operations.graphql
@@ -1,4 +1,5 @@
 #
 query GetLong2 {
   long2: long
+  ... QueryDetails
 }

--- a/tests/multi-module-child/src/test/kotlin/test/TestScalar.kt
+++ b/tests/multi-module-child/src/test/kotlin/test/TestScalar.kt
@@ -1,13 +1,14 @@
 package test
 
 import multimodule.child.GetLong2Query
+import multimodule.root.fragment.QueryDetails
 import org.junit.Test
 import kotlin.test.assertIs
 
 class TestScalar {
   @Test
   fun testScalar() {
-    val data = GetLong2Query.Data(0)
+    val data = GetLong2Query.Data("", 0, QueryDetails(0))
     assertIs<Long>(data.long2)
   }
 }


### PR DESCRIPTION
Don't crash if a Fragment definition from upstream is not found when checking capitalized fields