### PR TITLE
Pagination: arguments and metadata on Record and MetadataGenerator

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
@@ -1,0 +1,21 @@
+package com.apollographql.apollo3.cache.normalized.api
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.Executable
+
+@ApolloExperimental
+interface MetadataGenerator {
+  fun metadataForObject(obj: Map<String, Any?>, context: MetadataGeneratorContext): Map<String, Any?>
+}
+
+@ApolloExperimental
+class MetadataGeneratorContext(
+    val field: CompiledField,
+    val variables: Executable.Variables,
+)
+
+@ApolloExperimental
+object EmptyMetadataGenerator : MetadataGenerator {
+  override fun metadataForObject(obj: Map<String, Any?>, context: MetadataGeneratorContext): Map<String, Any?> = emptyMap()
+}

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -38,7 +38,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
   return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator)
-      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType().name)
+      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType())
 }
 
 @ApolloExperimental

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.cache.normalized.api
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.Fragment
@@ -15,7 +16,16 @@ fun <D : Operation.Data> Operation<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
     cacheKeyGenerator: CacheKeyGenerator,
-) = normalize(data, customScalarAdapters, cacheKeyGenerator, CacheKey.rootKey().key)
+) = normalize(data, customScalarAdapters, cacheKeyGenerator, EmptyMetadataGenerator, CacheKey.rootKey().key)
+
+@ApolloExperimental
+fun <D : Operation.Data> Operation<D>.normalize(
+    data: D,
+    customScalarAdapters: CustomScalarAdapters,
+    cacheKeyGenerator: CacheKeyGenerator,
+    metadataGenerator: MetadataGenerator,
+) = normalize(data, customScalarAdapters, cacheKeyGenerator, metadataGenerator, CacheKey.rootKey().key)
+
 
 @Suppress("UNCHECKED_CAST")
 fun <D : Executable.Data> Executable<D>.normalize(
@@ -27,9 +37,26 @@ fun <D : Executable.Data> Executable<D>.normalize(
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
-  return Normalizer(variables, rootKey, cacheKeyGenerator)
+  return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator)
+      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType().name)
+}
+
+@ApolloExperimental
+@Suppress("UNCHECKED_CAST")
+fun <D : Executable.Data> Executable<D>.normalize(
+    data: D,
+    customScalarAdapters: CustomScalarAdapters,
+    cacheKeyGenerator: CacheKeyGenerator,
+    metadataGenerator: MetadataGenerator,
+    rootKey: String,
+): Map<String, Record> {
+  val writer = MapJsonWriter()
+  adapter().toJson(writer, customScalarAdapters, data)
+  val variables = variables(customScalarAdapters)
+  return Normalizer(variables, rootKey, cacheKeyGenerator, metadataGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType())
 }
+
 
 fun <D : Executable.Data> Executable<D>.readDataFromCache(
     customScalarAdapters: CustomScalarAdapters,

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/Record.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/Record.kt
@@ -31,14 +31,32 @@ class Record(
   var date: Map<String, Long?>? = null
     private set
 
+  /**
+   * The arguments of the field this Record represents in its parent.
+   */
+  @ApolloExperimental
+  var arguments: Map<String, Any?> = emptyMap()
+    private set
+
+  /**
+   * Arbitrary metadata that can be attached to a Record.
+   */
+  @ApolloExperimental
+  var metadata: Map<String, Any?> = emptyMap()
+    private set
+
   @ApolloInternal
   constructor(
       key: String,
       fields: Map<String, Any?>,
       mutationId: Uuid?,
       date: Map<String, Long?>,
+      arguments: Map<String, Any?>,
+      metadata: Map<String, Any?>,
   ) : this(key, fields, mutationId) {
     this.date = date
+    this.arguments = arguments
+    this.metadata = metadata
   }
 
   val sizeInBytes: Int

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
@@ -31,7 +31,9 @@ object DefaultRecordMerger : RecordMerger {
         key = existing.key,
         fields = mergedFields,
         mutationId = incoming.mutationId,
-        date = date
+        date = date,
+        arguments = existing.arguments,
+        metadata = existing.metadata + incoming.metadata,
     ) to changedKeys
   }
 }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/BlobRecordSerializer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/BlobRecordSerializer.kt
@@ -32,6 +32,8 @@ object BlobRecordSerializer {
   fun serialize(record: Record): ByteArray  {
     val buffer = Buffer()
 
+    buffer.writeAny(record.arguments)
+    buffer.writeAny(record.metadata)
     val keys = record.fields.keys
     buffer.writeInt(keys.size)
     for (key in keys) {
@@ -52,6 +54,9 @@ object BlobRecordSerializer {
   fun deserialize(key: String, bytes: ByteArray): Record {
     val buffer = Buffer().write(bytes)
 
+    val arguments = buffer.readAny() as Map<String, Any?>
+    val metadata = buffer.readAny() as Map<String, Any?>
+
     val fields = mutableMapOf<String, Any?>()
     val dates = mutableMapOf<String, Long?>()
     val size = buffer.readInt()
@@ -62,7 +67,7 @@ object BlobRecordSerializer {
       fields[name] = buffer.readAny()
     }
 
-    return Record(key, fields, null, dates)
+    return Record(key, fields, null, dates, arguments, metadata)
   }
 
   private fun Buffer.writeString(value: String) {

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -51,7 +51,7 @@ internal class Normalizer(
       typeInScope: String,
       embeddedFields: List<String>,
       field: CompiledField?,
-    ): Any {
+  ): Any {
 
     val typename = obj["__typename"] as? String
     val allFields = collectFields(selections, typeInScope, typename)
@@ -97,7 +97,11 @@ internal class Normalizer(
     return if (key != null) {
       val record = Record(
           key = key,
-          fields = fields
+          fields = fields,
+          mutationId = null,
+          date = emptyMap(),
+          arguments = field?.argumentsWithValue(variables) ?: emptyMap(),
+          metadata = field?.let { metadataGenerator.metadataForObject(obj, MetadataGeneratorContext(field = it, variables)) } ?: emptyMap(),
       )
 
       val existingRecord = records[key]
@@ -134,7 +138,7 @@ internal class Normalizer(
       field: CompiledField,
       type_: CompiledType,
       path: String,
-      embeddedFields: List<String>
+      embeddedFields: List<String>,
   ): Any? {
     /**
      * Remove the NotNull decoration if needed
@@ -168,7 +172,7 @@ internal class Normalizer(
         if (key == null && !embeddedFields.contains(field.name)) {
           key = path
         }
-        buildRecord(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields, , field)
+        buildRecord(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields, field)
       }
       else -> {
         // scalar

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -14,6 +14,8 @@ import com.apollographql.apollo3.api.isComposite
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGeneratorContext
+import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.Record
 
 /**
@@ -24,11 +26,12 @@ internal class Normalizer(
     private val variables: Executable.Variables,
     private val rootKey: String,
     private val cacheKeyGenerator: CacheKeyGenerator,
+    private val metadataGenerator: MetadataGenerator,
 ) {
   private val records = mutableMapOf<String, Record>()
 
   fun normalize(map: Map<String, Any?>, selections: List<CompiledSelection>, typeInScope: CompiledNamedType): Map<String, Record> {
-    buildRecord(map, rootKey, selections, typeInScope.name, typeInScope.embeddedFields, emptyMap())
+    buildRecord(map, rootKey, selections, typeInScope.name, typeInScope.embeddedFields, null)
 
     return records
   }
@@ -47,7 +50,7 @@ internal class Normalizer(
       selections: List<CompiledSelection>,
       typeInScope: String,
       embeddedFields: List<String>,
-      argumentsWithValue: Map<String, Any?>,
+      field: CompiledField?,
     ): Any {
 
     val typename = obj["__typename"] as? String
@@ -165,7 +168,7 @@ internal class Normalizer(
         if (key == null && !embeddedFields.contains(field.name)) {
           key = path
         }
-        buildRecord(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields, , field.argumentsWithValue(variables))
+        buildRecord(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields, , field)
       }
       else -> {
         // scalar

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -50,7 +50,6 @@ internal class Normalizer(
       selections: List<CompiledSelection>,
       typeInScope: String,
       embeddedFields: List<String>,
-      field: CompiledField?,
   ): Map<String, Any?> {
 
     val typename = obj["__typename"] as? String
@@ -96,6 +95,7 @@ internal class Normalizer(
 
     return fields
   }
+
   /**
    *
    *
@@ -110,30 +110,31 @@ internal class Normalizer(
       selections: List<CompiledSelection>,
       typeInScope: String,
       embeddedFields: List<String>,
+      field: CompiledField?,
   ): CacheKey {
     val fields = buildFields(obj, key, selections, typeInScope, embeddedFields)
-      val record = Record(
-          key = key,
-          fields = fields,
-          mutationId = null,
-          date = emptyMap(),
-          arguments = field?.argumentsWithValue(variables) ?: emptyMap(),
-          metadata = field?.let { metadataGenerator.metadataForObject(obj, MetadataGeneratorContext(field = it, variables)) } ?: emptyMap(),
-      )
+    val record = Record(
+        key = key,
+        fields = fields,
+        mutationId = null,
+        date = emptyMap(),
+        arguments = field?.argumentsWithValue(variables) ?: emptyMap(),
+        metadata = field?.let { metadataGenerator.metadataForObject(obj, MetadataGeneratorContext(field = it, variables)) } ?: emptyMap(),
+    )
 
-      val existingRecord = records[key]
+    val existingRecord = records[key]
 
-      val mergedRecord = if (existingRecord != null) {
-        /**
-         * A query might contain the same object twice, we don't want to lose some fields when that happens
-         */
-        existingRecord.mergeWith(record).first
-      } else {
-        record
-      }
-      records[key] = mergedRecord
+    val mergedRecord = if (existingRecord != null) {
+      /**
+       * A query might contain the same object twice, we don't want to lose some fields when that happens
+       */
+      existingRecord.mergeWith(record).first
+    } else {
+      record
+    }
+    records[key] = mergedRecord
 
-      return CacheKey(key)
+    return CacheKey(key)
   }
 
 

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCache.kt
@@ -175,10 +175,12 @@ class SqlNormalizedCache internal constructor(
       return this
     }
     return Record(
-        key,
-        fields,
-        mutationId,
-        fields.mapValues { date }
+        key = key,
+        fields = fields,
+        mutationId = mutationId,
+        date = fields.mapValues { date },
+        arguments = arguments,
+        metadata = metadata
     )
 
   }

--- a/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -10,7 +10,9 @@ import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
 import com.apollographql.apollo3.cache.normalized.api.DefaultRecordMerger
+import com.apollographql.apollo3.cache.normalized.api.EmptyMetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
+import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.Record
@@ -190,12 +192,25 @@ fun ApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
     cacheKeyGenerator: CacheKeyGenerator = TypePolicyCacheKeyGenerator,
     cacheResolver: CacheResolver = FieldPolicyCacheResolver,
-): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyGenerator, cacheResolver, DefaultRecordMerger)
+): ApolloStore = DefaultApolloStore(
+    normalizedCacheFactory = normalizedCacheFactory,
+    cacheKeyGenerator = cacheKeyGenerator,
+    metadataGenerator = EmptyMetadataGenerator,
+    cacheResolver = cacheResolver,
+    recordMerger = DefaultRecordMerger
+)
 
 @ApolloExperimental
 fun ApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
     cacheKeyGenerator: CacheKeyGenerator,
+    metadataGenerator: MetadataGenerator,
     apolloResolver: ApolloResolver,
     recordMerger: RecordMerger = DefaultRecordMerger,
-): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyGenerator, apolloResolver, recordMerger)
+): ApolloStore = DefaultApolloStore(
+    normalizedCacheFactory = normalizedCacheFactory,
+    cacheKeyGenerator = cacheKeyGenerator,
+    metadataGenerator = metadataGenerator,
+    cacheResolver = apolloResolver,
+    recordMerger = recordMerger
+)

--- a/tests/integration-tests/src/commonTest/kotlin/test/embed/EmbedTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/embed/EmbedTest.kt
@@ -16,7 +16,7 @@ import kotlin.test.assertEquals
 
 class EmbedTest {
   @Test
-  fun test() {
+  fun normalize() {
     val query = GetHeroQuery()
 
     val records = query.normalize(
@@ -33,12 +33,11 @@ class EmbedTest {
         }
     )
 
-    // Should be 3?
-    assertEquals(2, records.size)
+    assertEquals(3, records.size)
   }
 
   @Test
-  fun readFromCache() = runTest {
+  fun denormalize() = runTest {
     val client = ApolloClient.Builder()
         .normalizedCache(normalizedCacheFactory = MemoryCacheFactory())
         .serverUrl("unused")

--- a/tests/integration-tests/src/commonTest/kotlin/test/embed/graphql/operations.graphql
+++ b/tests/integration-tests/src/commonTest/kotlin/test/embed/graphql/operations.graphql
@@ -2,6 +2,9 @@ query GetHero {
   hero {
     friends {
       name
+      pet {
+        name
+      }
     }
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/embed/graphql/schema.graphqls
+++ b/tests/integration-tests/src/commonTest/kotlin/test/embed/graphql/schema.graphqls
@@ -8,4 +8,9 @@ type Hero {
 
 type Friend {
   name: String!
+  pet: Animal!
+}
+
+type Animal {
+  name: String
 }

--- a/tests/pagination/src/commonMain/graphql/operations.graphql
+++ b/tests/pagination/src/commonMain/graphql/operations.graphql
@@ -1,7 +1,12 @@
-query UserList {
-  users {
-    id
-    name
-    email
+query UserList($after: String, $first: Int) {
+  users(after: $after, first: $first) {
+    edges {
+      cursor
+      node {
+        id
+        name
+        email
+      }
+    }
   }
 }

--- a/tests/pagination/src/commonMain/graphql/operations.graphql
+++ b/tests/pagination/src/commonMain/graphql/operations.graphql
@@ -1,5 +1,5 @@
-query UserList($after: String, $first: Int) {
-  users(after: $after, first: $first) {
+query UserList($first: Int, $after: String, $last: Int, $before: String) {
+  users(first: $first, after: $after, last: $last, before: $before) {
     edges {
       cursor
       node {

--- a/tests/pagination/src/commonMain/graphql/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/schema.graphqls
@@ -1,5 +1,20 @@
 type Query {
-  users: [User!]!
+  users(after: String = null, first: Int! = 10): UserConnection!
+}
+
+type UserConnection {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+}
+
+type PageInfo {
+  startCursor: String!
+  endCursor: String!
+}
+
+type UserEdge {
+  cursor: String!
+  node: User!
 }
 
 type User @typePolicy(keyFields: "id"){

--- a/tests/pagination/src/commonMain/graphql/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/schema.graphqls
@@ -2,7 +2,7 @@ type Query {
   users(after: String = null, first: Int! = 10): UserConnection!
 }
 
-type UserConnection {
+type UserConnection @typePolicy(embeddedFields: "pageInfo, edges") {
   pageInfo: PageInfo!
   edges: [UserEdge!]!
 }
@@ -17,7 +17,7 @@ type UserEdge {
   node: User!
 }
 
-type User @typePolicy(keyFields: "id"){
+type User @typePolicy(keyFields: "id") {
   id: ID!
   name: String!
   email: String!

--- a/tests/pagination/src/commonMain/graphql/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/schema.graphqls
@@ -1,5 +1,5 @@
 type Query {
-  users(after: String = null, first: Int! = 10): UserConnection!
+  users(first: Int = 10, after: String = null, last: Int = null, before: String = null): UserConnection!
 }
 
 type UserConnection @typePolicy(embeddedFields: "pageInfo, edges") {

--- a/tests/sqlite/src/commonTest/kotlin/ExpirationTest.kt
+++ b/tests/sqlite/src/commonTest/kotlin/ExpirationTest.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.DefaultRecordMerger
+import com.apollographql.apollo3.cache.normalized.api.EmptyMetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.ExpireDateCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.ReceiveDateApolloResolver
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
@@ -38,7 +39,8 @@ class ExpirationTest {
             normalizedCacheFactory = SqlNormalizedCacheFactory(name = null, withDates = true),
             cacheKeyGenerator = TypePolicyCacheKeyGenerator,
             apolloResolver = ReceiveDateApolloResolver(maxAge),
-            recordMerger = DefaultRecordMerger
+            recordMerger = DefaultRecordMerger,
+            metadataGenerator = EmptyMetadataGenerator,
         )
         .storeReceiveDate(true)
         .serverUrl("unused")


### PR DESCRIPTION
Add `arguments` and `metadata` on `Record`. Arguments are set in Normalizer. Metadata are also set in Normaliizer but by implementing a new interface: `MetadataGenerator`.

(Also includes the fix for the embedded fields from the `embed-test` branch)