### PR TITLE
🏖️  Relax MapJsonReader endObject, fixes reading inline + named fragments with compat models

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
@@ -156,9 +156,11 @@ constructor(
   }
 
   override fun endObject() = apply {
-    if (peek() != JsonReader.Token.END_OBJECT) {
-      throw JsonDataException("Expected END_OBJECT but was ${peek()} at path ${getPathAsString()}")
-    }
+    // Do not fail if there are trailing names in buffered readers.
+    // See https://github.com/apollographql/apollo-kotlin/issues/4212
+//    if (peek() != JsonReader.Token.END_OBJECT) {
+//      throw JsonDataException("Expected END_OBJECT but was ${peek()} at path ${getPathAsString()}")
+//    }
     stackSize--
     iteratorStack[stackSize] = null // allow garbage collection
     path[stackSize] = null // allow garbage collection

--- a/tests/models-compat/src/commonTest/kotlin/test/InlineAndNamedFragments.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/InlineAndNamedFragments.kt
@@ -1,0 +1,26 @@
+package test
+
+import codegen.models.InlineAndNamedFragmentQuery
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.testing.runTest
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class InlineAndNamedFragments {
+  @Test
+  fun canReadInlineAndNamedFragments() = runTest {
+    val dataString = """
+      {
+        "hero": {
+          "__typename": "Droid",
+          "primaryFunction": "translation"
+        }
+      }
+    """.trimIndent()
+
+    val data = InlineAndNamedFragmentQuery().adapter().fromJson(Buffer().apply { writeUtf8(dataString) }.jsonReader(), CustomScalarAdapters.Empty)
+    assertTrue(data.hero?.asDroid?.primaryFunction == "translation")
+  }
+}

--- a/tests/models-fixtures/graphql/operations.graphql
+++ b/tests/models-fixtures/graphql/operations.graphql
@@ -138,3 +138,16 @@ query Starship($id: ID!) {
         id
     }
 }
+
+
+fragment NamedFragment on Human {
+  name
+}
+query InlineAndNamedFragment {
+    hero {
+        ...NamedFragment
+        ... on Droid {
+          primaryFunction
+        }
+    }
+}

--- a/tests/models-operation-based/src/commonTest/kotlin/test/InlineAndNamedFragments.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/test/InlineAndNamedFragments.kt
@@ -1,0 +1,26 @@
+package test
+
+import codegen.models.InlineAndNamedFragmentQuery
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.testing.runTest
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class InlineAndNamedFragments {
+  @Test
+  fun canReadInlineAndNamedFragments() = runTest {
+    val dataString = """
+      {
+        "hero": {
+          "__typename": "Droid",
+          "primaryFunction": "translation"
+        }
+      }
+    """.trimIndent()
+
+    val data = InlineAndNamedFragmentQuery().adapter().fromJson(Buffer().apply { writeUtf8(dataString) }.jsonReader(), CustomScalarAdapters.Empty)
+    assertTrue(data.hero?.onDroid?.primaryFunction == "translation")
+  }
+}


### PR DESCRIPTION
Because the synthetic `Fragments` field was rewinding the stream, it caused leftover fields at the end of objects. 

Closes #4212

This is a simple, minimal fix. 

In order to support https://github.com/apollographql/apollo-kotlin/issues/3344, we'll need something more involved. Especially, because we know which models are buffered and which are not, I think we could generate code that doesn't use the `JsonReader` API for buffered adapters. That should be faster because there's no need to iterate all the keys for each fragments, the adapters could do a hashmap lookup instead. Because that's a bigger change, I've added it to the 4.0 list at https://github.com/apollographql/apollo-kotlin/issues/4171