### PR TITLE
Pagination: FieldRecordMerger

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
@@ -36,3 +36,57 @@ object DefaultRecordMerger : RecordMerger {
     ) to changedKeys
   }
 }
+
+@ApolloExperimental
+class FieldRecordMerger(private val fieldMerger: FieldMerger) : RecordMerger {
+  @ApolloExperimental
+  interface FieldMerger {
+    fun mergeFields(existing: FieldInfo, incoming: FieldInfo): FieldInfo
+  }
+
+  @ApolloExperimental
+  data class FieldInfo(
+      val value: Any?,
+      val metadata: Map<String, Any?>,
+  )
+
+  override fun merge(existing: Record, incoming: Record, newDate: Long?): Pair<Record, Set<String>> {
+    val changedKeys = mutableSetOf<String>()
+    val mergedFields = existing.fields.toMutableMap()
+    val mergedMetadata = existing.metadata.toMutableMap()
+    val date = existing.date?.toMutableMap() ?: mutableMapOf()
+
+    for ((fieldKey, incomingFieldValue) in incoming.fields) {
+      val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
+      val existingFieldValue = existing.fields[fieldKey]
+      if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
+        val existingFieldInfo = FieldInfo(
+            value = existingFieldValue,
+            metadata = existing.metadata[fieldKey]!!,
+        )
+        val incomingFieldInfo = FieldInfo(
+            value = incomingFieldValue,
+            metadata = incoming.metadata[fieldKey]!!,
+        )
+
+        val mergeResult = fieldMerger.mergeFields(existing = existingFieldInfo, incoming = incomingFieldInfo)
+        mergedFields[fieldKey] = mergeResult.value
+        mergedMetadata[fieldKey] = mergeResult.metadata
+
+        changedKeys.add("${existing.key}.$fieldKey")
+      }
+      // Even if the value did not change update date
+      if (newDate != null) {
+        date[fieldKey] = newDate
+      }
+    }
+
+    return Record(
+        key = existing.key,
+        fields = mergedFields,
+        mutationId = incoming.mutationId,
+        date = date,
+        metadata = mergedMetadata,
+    ) to changedKeys
+  }
+}

--- a/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
@@ -3,12 +3,11 @@ package pagination
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo3.cache.normalized.api.Record
-import com.apollographql.apollo3.cache.normalized.api.RecordMerger
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.testing.runTest
@@ -38,7 +37,7 @@ class CursorBasedPaginationTest {
         cacheKeyGenerator = TypePolicyCacheKeyGenerator,
         metadataGenerator = CursorPaginationMetadataGenerator(),
         apolloResolver = FieldPolicyApolloResolver,
-        recordMerger = CursorPaginationRecordMerger()
+        recordMerger = FieldRecordMerger(CursorPaginationFieldMerger())
     )
     apolloStore.clearAll()
 
@@ -300,76 +299,56 @@ class CursorBasedPaginationTest {
         return mapOf(
             "startCursor" to startCursor,
             "endCursor" to endCursor,
-            "arguments" to context.allArgumentValues()
+            "before" to context.argumentValue("before"),
+            "after" to context.argumentValue("after"),
         )
       }
       return emptyMap()
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
-  private class CursorPaginationRecordMerger : RecordMerger {
-    override fun merge(existing: Record, incoming: Record, newDate: Long?): Pair<Record, Set<String>> {
-      val changedKeys = mutableSetOf<String>()
-      val mergedFields = existing.fields.toMutableMap()
-      val mergedMetadata = existing.metadata.toMutableMap()
-      val date = existing.date?.toMutableMap() ?: mutableMapOf()
+  private class CursorPaginationFieldMerger : FieldRecordMerger.FieldMerger {
+    @Suppress("UNCHECKED_CAST")
+    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
+      val existingStartCursor = existing.metadata["startCursor"] as? String
+      val existingEndCursor = existing.metadata["endCursor"] as? String
+      val incomingBeforeArgument = incoming.metadata["before"] as? String
+      val incomingAfterArgument = incoming.metadata["after"] as? String
 
-      for ((fieldKey, incomingFieldValue) in incoming.fields) {
-        val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
-        val existingFieldValue = existing.fields[fieldKey]
-        if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
-          val existingStartCursor = existing.metadata[fieldKey]!!["startCursor"] as? String
-          val existingEndCursor = existing.metadata[fieldKey]!!["endCursor"] as? String
-          val incomingBeforeArgument = (incoming.metadata[fieldKey]!!["arguments"] as? Map<*, *>)?.get("before") as? String
-          val incomingAfterArgument = (incoming.metadata[fieldKey]!!["arguments"] as? Map<*, *>)?.get("after") as? String
+      return if (existingStartCursor == null || existingEndCursor == null || incomingBeforeArgument == null && incomingAfterArgument == null) {
+        incoming
+      } else {
+        val existingValue = existing.value as Map<String, Any?>
+        val existingList = existingValue["edges"] as List<*>
+        val incomingList = (incoming.value as Map<String, Any?>)["edges"] as List<*>
 
-          if (existingStartCursor == null || existingEndCursor == null || incomingBeforeArgument == null && incomingAfterArgument == null) {
-            mergedFields[fieldKey] = incomingFieldValue
-            mergedMetadata[fieldKey] = incoming.metadata[fieldKey] as Map<String, Any?>
-          } else {
-            val existingList = (existing[fieldKey] as Map<*, *>)["edges"] as List<*>
-            val incomingList = (incomingFieldValue as Map<*, *>)["edges"] as List<*>
-
-            val mergedList: List<*>
-            val newStartCursor: String
-            val newEndCursor: String
-            if (incomingAfterArgument == existingEndCursor) {
-              mergedList = existingList + incomingList
-              newStartCursor = existingStartCursor
-              newEndCursor = incoming.metadata[fieldKey]!!["endCursor"] as String
-            } else if (incomingBeforeArgument == existingStartCursor) {
-              mergedList = incomingList + existingList
-              newStartCursor = incoming.metadata[fieldKey]!!["startCursor"] as String
-              newEndCursor = existingEndCursor
-            } else {
-              // We received a list which is neither the previous nor the next page.
-              // Handle this case by resetting the cache with this page
-              mergedList = incomingList
-              newStartCursor = incoming.metadata[fieldKey]!!["startCursor"] as String
-              newEndCursor = incoming.metadata[fieldKey]!!["endCursor"] as String
-            }
-
-            val mergedFieldValue = incomingFieldValue.toMutableMap()
-            mergedFieldValue["edges"] = mergedList
-            mergedFields[fieldKey] = mergedFieldValue
-            mergedMetadata[fieldKey] = mapOf("startCursor" to newStartCursor, "endCursor" to newEndCursor)
-          }
-          changedKeys.add("${existing.key}.$fieldKey")
+        val mergedList: List<*>
+        val newStartCursor: String
+        val newEndCursor: String
+        if (incomingAfterArgument == existingEndCursor) {
+          mergedList = existingList + incomingList
+          newStartCursor = existingStartCursor
+          newEndCursor = incoming.metadata["endCursor"] as String
+        } else if (incomingBeforeArgument == existingStartCursor) {
+          mergedList = incomingList + existingList
+          newStartCursor = incoming.metadata["startCursor"] as String
+          newEndCursor = existingEndCursor
+        } else {
+          // We received a list which is neither the previous nor the next page.
+          // Handle this case by resetting the cache with this page
+          mergedList = incomingList
+          newStartCursor = incoming.metadata["startCursor"] as String
+          newEndCursor = incoming.metadata["endCursor"] as String
         }
-        // Even if the value did not change update date
-        if (newDate != null) {
-          date[fieldKey] = newDate
-        }
+
+        val mergedFieldValue = existingValue.toMutableMap()
+        mergedFieldValue["edges"] = mergedList
+        FieldRecordMerger.FieldInfo(
+            value = mergedFieldValue,
+            metadata = mapOf("startCursor" to newStartCursor, "endCursor" to newEndCursor)
+        )
       }
-
-      return Record(
-          key = existing.key,
-          fields = mergedFields,
-          mutationId = incoming.mutationId,
-          date = date,
-          metadata = mergedMetadata,
-      ) to changedKeys
     }
   }
 }
+

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
@@ -3,12 +3,11 @@ package pagination
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo3.cache.normalized.api.Record
-import com.apollographql.apollo3.cache.normalized.api.RecordMerger
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.testing.runTest
@@ -40,7 +39,7 @@ class OffsetBasedWithArrayPaginationTest {
         cacheKeyGenerator = TypePolicyCacheKeyGenerator,
         metadataGenerator = OffsetPaginationMetadataGenerator("usersOffsetBasedWithArray"),
         apolloResolver = FieldPolicyApolloResolver,
-        recordMerger = OffsetPaginationRecordMerger()
+        recordMerger = FieldRecordMerger(OffsetPaginationFieldMerger())
     )
     apolloStore.clearAll()
 
@@ -134,7 +133,6 @@ class OffsetBasedWithArrayPaginationTest {
     assertEquals(data5, dataFromStore)
   }
 
-  @Suppress("UNCHECKED_CAST")
   private class OffsetPaginationMetadataGenerator(private val fieldName: String) : MetadataGenerator {
     override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
       if (context.field.name == fieldName) {
@@ -144,45 +142,22 @@ class OffsetBasedWithArrayPaginationTest {
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
-  private class OffsetPaginationRecordMerger : RecordMerger {
-    override fun merge(existing: Record, incoming: Record, newDate: Long?): Pair<Record, Set<String>> {
-      val changedKeys = mutableSetOf<String>()
-      val mergedFields = existing.fields.toMutableMap()
-      val mergedMetadata = existing.metadata.toMutableMap()
-      val date = existing.date?.toMutableMap() ?: mutableMapOf()
-
-      for ((fieldKey, incomingFieldValue) in incoming.fields) {
-        val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
-        val existingFieldValue = existing.fields[fieldKey]
-        if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
-          val existingOffset = existing.metadata[fieldKey]!!["offset"] as? Int
-          val incomingOffset = incoming.metadata[fieldKey]!!["offset"] as? Int
-          if (existingOffset == null || incomingOffset == null) {
-            mergedFields[fieldKey] = incomingFieldValue
-            mergedMetadata[fieldKey] = incoming.metadata[fieldKey] as Map<String, Any?>
-          } else {
-            val existingList = existing[fieldKey] as List<*>
-            val incomingList = incomingFieldValue as List<*>
-            val (mergedList, mergedOffset) = mergeLists(existingList, incomingList, existingOffset, incomingOffset)
-            mergedFields[fieldKey] = mergedList
-            mergedMetadata[fieldKey] = mapOf("offset" to mergedOffset)
-          }
-          changedKeys.add("${existing.key}.$fieldKey")
-        }
-        // Even if the value did not change update date
-        if (newDate != null) {
-          date[fieldKey] = newDate
-        }
+  private class OffsetPaginationFieldMerger : FieldRecordMerger.FieldMerger {
+    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
+      val existingOffset = existing.metadata["offset"] as? Int
+      val incomingOffset = incoming.metadata["offset"] as? Int
+      return if (existingOffset == null || incomingOffset == null) {
+        incoming
+      } else {
+        val existingList = existing.value as List<*>
+        val incomingList = incoming.value as List<*>
+        val (mergedList, mergedOffset) = mergeLists(existingList, incomingList, existingOffset, incomingOffset)
+        val mergedMetadata = mapOf("offset" to mergedOffset)
+        FieldRecordMerger.FieldInfo(
+            value = mergedList,
+            metadata = mergedMetadata
+        )
       }
-
-      return Record(
-          key = existing.key,
-          fields = mergedFields,
-          mutationId = incoming.mutationId,
-          date = date,
-          metadata = mergedMetadata,
-      ) to changedKeys
     }
 
     private fun <T> mergeLists(existing: List<T>, incoming: List<T>, existingOffset: Int, incomingOffset: Int): Pair<List<T>, Int> {

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -40,7 +40,7 @@ class OffsetBasedWithPagePaginationTest {
         cacheKeyGenerator = TypePolicyCacheKeyGenerator,
         metadataGenerator = OffsetPaginationMetadataGenerator("UserPage"),
         apolloResolver = FieldPolicyApolloResolver,
-        recordMerger = FieldRecordMerger(OffsetPaginationRecordMerger())
+        recordMerger = FieldRecordMerger(OffsetPaginationFieldMerger())
     )
     apolloStore.clearAll()
 
@@ -159,7 +159,7 @@ class OffsetBasedWithPagePaginationTest {
     }
   }
 
-  private class OffsetPaginationRecordMerger : FieldRecordMerger.FieldMerger {
+  private class OffsetPaginationFieldMerger : FieldRecordMerger.FieldMerger {
     override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
       val existingOffset = existing.metadata["offset"] as? Int
       val incomingOffset = incoming.metadata["offset"] as? Int

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -3,12 +3,11 @@ package pagination
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
-import com.apollographql.apollo3.cache.normalized.api.Record
-import com.apollographql.apollo3.cache.normalized.api.RecordMerger
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.testing.runTest
@@ -41,7 +40,7 @@ class OffsetBasedWithPagePaginationTest {
         cacheKeyGenerator = TypePolicyCacheKeyGenerator,
         metadataGenerator = OffsetPaginationMetadataGenerator("UserPage"),
         apolloResolver = FieldPolicyApolloResolver,
-        recordMerger = OffsetPaginationRecordMerger()
+        recordMerger = FieldRecordMerger(OffsetPaginationRecordMerger())
     )
     apolloStore.clearAll()
 
@@ -151,7 +150,6 @@ class OffsetBasedWithPagePaginationTest {
     assertEquals(data5, dataFromStore)
   }
 
-  @Suppress("UNCHECKED_CAST")
   private class OffsetPaginationMetadataGenerator(private val typeName: String) : MetadataGenerator {
     override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
       if (context.field.type.leafType().name == typeName) {
@@ -161,47 +159,24 @@ class OffsetBasedWithPagePaginationTest {
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
-  private class OffsetPaginationRecordMerger : RecordMerger {
-    override fun merge(existing: Record, incoming: Record, newDate: Long?): Pair<Record, Set<String>> {
-      val changedKeys = mutableSetOf<String>()
-      val mergedFields = existing.fields.toMutableMap()
-      val mergedMetadata = existing.metadata.toMutableMap()
-      val date = existing.date?.toMutableMap() ?: mutableMapOf()
-
-      for ((fieldKey, incomingFieldValue) in incoming.fields) {
-        val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
-        val existingFieldValue = existing.fields[fieldKey]
-        if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
-          val existingOffset = existing.metadata[fieldKey]!!["offset"] as? Int
-          val incomingOffset = incoming.metadata[fieldKey]!!["offset"] as? Int
-          if (existingOffset == null || incomingOffset == null) {
-            mergedFields[fieldKey] = incomingFieldValue
-            mergedMetadata[fieldKey] = incoming.metadata[fieldKey] as Map<String, Any?>
-          } else {
-            val existingList = (existing[fieldKey] as Map<*, *>)["users"] as List<*>
-            val incomingList = (incomingFieldValue as Map<*, *>)["users"] as List<*>
-            val (mergedList, mergedOffset) = mergeLists(existingList, incomingList, existingOffset, incomingOffset)
-            val mergedFieldValue = incomingFieldValue.toMutableMap()
-            mergedFieldValue["users"] = mergedList
-            mergedFields[fieldKey] = mergedFieldValue
-            mergedMetadata[fieldKey] = mapOf("offset" to mergedOffset)
-          }
-          changedKeys.add("${existing.key}.$fieldKey")
-        }
-        // Even if the value did not change update date
-        if (newDate != null) {
-          date[fieldKey] = newDate
-        }
+  private class OffsetPaginationRecordMerger : FieldRecordMerger.FieldMerger {
+    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
+      val existingOffset = existing.metadata["offset"] as? Int
+      val incomingOffset = incoming.metadata["offset"] as? Int
+      return if (existingOffset == null || incomingOffset == null) {
+        incoming
+      } else {
+        val existingValue = existing.value as Map<*, *>
+        val existingList = existingValue["users"] as List<*>
+        val incomingList = (incoming.value as Map<*, *>)["users"] as List<*>
+        val (mergedList, mergedOffset) = mergeLists(existingList, incomingList, existingOffset, incomingOffset)
+        val mergedFieldValue = existingValue.toMutableMap()
+        mergedFieldValue["users"] = mergedList
+        FieldRecordMerger.FieldInfo(
+            value = mergedFieldValue,
+            metadata = mapOf("offset" to mergedOffset)
+        )
       }
-
-      return Record(
-          key = existing.key,
-          fields = mergedFields,
-          mutationId = incoming.mutationId,
-          date = date,
-          metadata = mergedMetadata,
-      ) to changedKeys
     }
 
     private fun <T> mergeLists(existing: List<T>, incoming: List<T>, existingOffset: Int, incomingOffset: Int): Pair<List<T>, Int> {


### PR DESCRIPTION
This is a tentative simplified API for the merging part. When merging Records it looks like the logic will be the same in most cases: iterate over the fields and merge them, handle `changedKeys` and `date`. With this, implementers can focus on the field merging part only. 

This still keeps the lower level `RecordMerger` API, even though at this point I'm not 100% sure if it's useful.