### PR TITLE
Make it possible to compile with `apollo-gradle-plugin` and Kotlin 1.5

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -43,6 +43,18 @@ if (relocateJar) {
       exclude("META-INF/versions/9/module-info\\.class")
       exclude("META-INF/kotlin-stdlib.*\\.kotlin_module")
 
+      // Remove the following error:
+      // /Users/mbonnin/.m2/repository/com/apollographql/apollo3/apollo-gradle-plugin/3.3.3-SNAPSHOT/apollo-gradle-plugin-3.3.3-SNAPSHOT.jar!/META-INF/kotlinpoet.kotlin_module:
+      // Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1,
+      // expected version is 1.5.1.
+      exclude("META-INF/kotlinpoet.kotlin_module")
+
+      //Remove the following error:
+      // /Users/mbonnin/git/test-gradle-7-4/src/main/kotlin/Main.kt: (2, 5): Class 'kotlin.Unit' was compiled
+      // with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1, expected version
+      // is 1.5.1.
+      exclude("kotlin/Unit.class")
+
       // Remove proguard rules from dependencies, we'll manage them ourselves
       exclude("META-INF/proguard/.*")
     }


### PR DESCRIPTION
Bumping KotlinPoet pulled `kotlin-stdlib:1.7` as a dependency and the Kotlin 1.5 compiler fails with these warnings:

```
> Task :compileKotlin FAILED
'compileJava' task (current target is 17) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
e: Incompatible classes were found in dependencies. Remove them from the classpath or use '-Xskip-metadata-version-check' to suppress errors
e: /Users/mbonnin/.gradle/caches/modules-2/files-2.1/com.apollographql.apollo3/apollo-gradle-plugin/3.3.2/fcf5eff2ad1c8e0cd36be9e5457cf0257b4c3b01/apollo-gradle-plugin-3.3.2.jar!/META-INF/kotlinpoet.kotlin_module: Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1, expected version is 1.5.1.
e: /Users/mbonnin/git/test-gradle-7-4/src/main/kotlin/Main.kt: (2, 5): Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.7.1, expected version is 1.5.1.
The class is loaded from /Users/mbonnin/.gradle/caches/modules-2/files-2.1/com.apollographql.apollo3/apollo-gradle-plugin/3.3.2/fcf5eff2ad1c8e0cd36be9e5457cf0257b4c3b01/apollo-gradle-plugin-3.3.2.jar!/kotlin/Unit.class
```

KotlinPoet is not part of the `apollo-gradle-plugin` public API. It should be safe to remove its `.module` file (this is where the compiler is looking for things like top-level declarations).

`kotlin.Unit` is provided by Gradle in the first place so there should be no need to include it in the relocated jar. 