### PR TITLE
Don't check git status on Kotlin 1.7 branch

### DIFF
--- a/.github/workflows/kotlin-1-7.yml
+++ b/.github/workflows/kotlin-1-7.yml
@@ -30,6 +30,7 @@ jobs:
           COM_APOLLOGRAPHQL_VERSION_KOTLIN_PLUGIN: '1.7.0'
           COM_APOLLOGRAPHQL_VERSION_KSP_GRADLE_PLUGIN: '1.7.0-1.0.6'
           COM_APOLLOGRAPHQL_VERSION_KOTLINXDATETIME: '0.3.3'
+          COM_APOLLOGRAPHQL_CHECK_GIT_STATUS: 'false'
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts

--- a/build-logic/src/main/kotlin/GitStatus.kt
+++ b/build-logic/src/main/kotlin/GitStatus.kt
@@ -1,5 +1,7 @@
 
 fun checkGitStatus() {
+  val checkGitStatus = (System.getenv("COM_APOLLOGRAPHQL_CHECK_GIT_STATUS") ?: "true") == "true"
+  if (!checkGitStatus) return
   val modifiedFiles = runCommand("git", "status", "--porcelain")
   if (modifiedFiles.isNotEmpty()) {
     error("The CI modified local files. This is certainly an indication that they should have been included in the PR. Modified files:\n$modifiedFiles")


### PR DESCRIPTION
On the Kotlin 1.7 branch, this check fails because of differences in yarn.lock. Adds a way to ignore it with a flag.