### PR TITLE
make it possible to reuse a File Upload

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -438,6 +438,7 @@ public final class com/apollographql/apollo3/api/DefaultUpload : com/apollograph
 	public fun getContentLength ()J
 	public fun getContentType ()Ljava/lang/String;
 	public fun getFileName ()Ljava/lang/String;
+	public final fun newBuilder ()Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public fun writeTo (Lokio/BufferedSink;)V
 }
 
@@ -445,12 +446,18 @@ public final class com/apollographql/apollo3/api/DefaultUpload$Builder {
 	public fun <init> ()V
 	public final fun build ()Lcom/apollographql/apollo3/api/DefaultUpload;
 	public final fun content (Ljava/lang/String;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
+	public final fun content (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun content (Lokio/BufferedSource;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun content (Lokio/ByteString;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun content ([B)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun contentLength (J)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun contentType (Ljava/lang/String;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public final fun fileName (Ljava/lang/String;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
+}
+
+public final class com/apollographql/apollo3/api/DefaultUploadKt {
+	public static final fun toUpload (Lokio/Path;Ljava/lang/String;Lokio/FileSystem;)Lcom/apollographql/apollo3/api/Upload;
+	public static synthetic fun toUpload$default (Lokio/Path;Ljava/lang/String;Lokio/FileSystem;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Upload;
 }
 
 public final class com/apollographql/apollo3/api/DeferredFragmentIdentifier {
@@ -559,6 +566,7 @@ public final class com/apollographql/apollo3/api/ExecutionOptions$Companion {
 public final class com/apollographql/apollo3/api/FileUpload {
 	public static final fun content (Lcom/apollographql/apollo3/api/DefaultUpload$Builder;Ljava/io/File;)Lcom/apollographql/apollo3/api/DefaultUpload$Builder;
 	public static final fun create (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/Upload;
+	public static final fun toUpload (Ljava/io/File;Ljava/lang/String;)Lcom/apollographql/apollo3/api/DefaultUpload;
 }
 
 public abstract interface class com/apollographql/apollo3/api/Fragment : com/apollographql/apollo3/api/Executable {

--- a/apollo-api/src/appleMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
+++ b/apollo-api/src/appleMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.api
+
+import okio.FileSystem
+
+internal actual val systemFileSystem: FileSystem
+  get() = FileSystem.SYSTEM

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/-FileSystem.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/-FileSystem.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.api
+
+import okio.FileSystem
+
+internal expect val systemFileSystem: FileSystem

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/DefaultUpload.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/DefaultUpload.kt
@@ -1,70 +1,87 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import okio.BufferedSink
 import okio.BufferedSource
 import okio.ByteString
-import okio.ByteString.Companion.encodeUtf8
-import okio.ByteString.Companion.toByteString
+import okio.FileSystem
+import okio.Path
+import okio.buffer
 import okio.use
+import okio.utf8Size
 
 /**
- * An [Upload] that writes data from the provided content
- *
- * If the content is a [bufferedSource], the [DefaultUpload] will close it once uploaded
- * If the content is a [byteString], the [DefaultUpload] can be reused
+ * A default [Upload] that can upload from a wide variety of content
  */
 class DefaultUpload internal constructor(
-    private val bufferedSource: BufferedSource?,
-    private val byteString: ByteString?,
+    private val writeTo: (BufferedSink) -> Unit,
     override val contentType: String,
     override val contentLength: Long,
     override val fileName: String?,
 ) : Upload {
-  private var bufferedSourceConsumed = false
-
   override fun writeTo(sink: BufferedSink) {
-    if (bufferedSource != null) {
-      check(!bufferedSourceConsumed) { "Apollo: DefaultUpload body can only be read once. If you want to read it several times for logging or other purposes, either buffer it in memory or use your own `Upload` implementation." }
-      bufferedSource.use {
-        sink.writeAll(it)
-      }
-      bufferedSourceConsumed = true
-    } else if (byteString != null) {
-      sink.write(byteString)
-    } else {
-      error("No upload content found")
+    writeTo.invoke(sink)
+  }
+
+  fun newBuilder(): Builder {
+    val builder = Builder()
+        .content(writeTo)
+        .contentType(contentType)
+        .contentLength(contentLength)
+
+    if (fileName != null) {
+      builder.fileName(fileName)
     }
+    return builder
   }
 
   class Builder {
-    private var bufferedSource: BufferedSource? = null
-    private var byteString: ByteString? = null
+    private var writeTo: ((BufferedSink) -> Unit)? = null
     private var contentType: String? = null
     private var contentLength: Long = -1
     private var fileName: String? = null
-    private val hasContent: Boolean
-      get() = bufferedSource != null || byteString != null
 
+    @Deprecated("This API is dangerous because the resulting upload can only be used once and can also lead to resource leaks.",
+        ReplaceWith("content {sink ->\nval source = openSource()\nsource.use {sink.writeAll(it)}\n}"))
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_3_3)
     fun content(content: BufferedSource): Builder = apply {
-      check(!hasContent) { "content() can only be called once" }
-      this.bufferedSource = content
+      check(writeTo == null) { "content() can only be called once" }
+      var consumed = false
+      this.writeTo = { sink ->
+        check(!consumed) { "Apollo: DefaultUpload body can only be read once. If you want to read it several times for logging or other purposes, either buffer it in memory or use your own `Upload` implementation." }
+        content.use {
+          sink.writeAll(it)
+        }
+        consumed = true
+      }
+    }
+
+    fun content(writeTo: (BufferedSink) -> Unit): Builder = apply {
+      check(this.writeTo == null) { "content() can only be called once" }
+      this.writeTo = writeTo
     }
 
     fun content(content: String): Builder = apply {
-      check(!hasContent) { "content() can only be called once" }
-      this.byteString = content.encodeUtf8()
-      this.contentLength = content.length.toLong()
+      check(writeTo == null) { "content() can only be called once" }
+      this.writeTo = { sink ->
+        sink.writeUtf8(content)
+      }
+      contentLength = content.utf8Size()
     }
 
     fun content(byteString: ByteString): Builder = apply {
-      check(!hasContent) { "content() can only be called once" }
-      this.byteString = byteString
+      check(writeTo == null) { "content() can only be called once" }
+      this.writeTo = { sink ->
+        sink.write(byteString)
+      }
       this.contentLength = byteString.size.toLong()
     }
 
     fun content(byteArray: ByteArray): Builder = apply {
-      check(!hasContent) { "content() can only be called once" }
-      this.byteString = byteArray.toByteString()
+      check(writeTo == null) { "content() can only be called once" }
+      this.writeTo = { sink ->
+        sink.write(byteArray)
+      }
       this.contentLength = byteArray.size.toLong()
     }
 
@@ -82,12 +99,23 @@ class DefaultUpload internal constructor(
 
     fun build(): DefaultUpload {
       return DefaultUpload(
-          bufferedSource,
-          byteString,
+          writeTo ?: error("DefaultUpload content is missing"),
           contentType ?: "application/octet-stream",
           contentLength,
           fileName
       )
     }
   }
+}
+
+fun Path.toUpload(contentType: String, fileSystem: FileSystem = systemFileSystem): Upload {
+  return DefaultUpload.Builder()
+      .content { sink ->
+        fileSystem.openReadOnly(this).use {
+          sink.writeAll(it.source().buffer())
+        }
+      }
+      .contentType(contentType)
+      .contentLength(fileSystem.metadata(this).size ?: -1L)
+      .build()
 }

--- a/apollo-api/src/jsMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
+++ b/apollo-api/src/jsMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.api
+
+import okio.FileSystem
+
+internal actual val systemFileSystem: FileSystem
+  get() = throw IllegalStateException("There is no SYSTEM filesystem on JS")

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-systemFileSystem.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/-systemFileSystem.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.api
+
+import okio.FileSystem
+
+internal actual val systemFileSystem: FileSystem
+  get() = FileSystem.SYSTEM

--- a/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
+++ b/apollo-api/src/jvmMain/kotlin/com/apollographql/apollo3/api/FileUpload.kt
@@ -4,26 +4,39 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_3_3
 import okio.buffer
 import okio.source
 import java.io.File
 
+@Deprecated("Use File.toUpload() instead")
+@ApolloDeprecatedSince(v3_3_3)
 fun DefaultUpload.Builder.content(file: File): DefaultUpload.Builder {
-  return content(file.source().buffer()).contentLength(file.length())
+  file.source().buffer()
+  return content { sink ->
+    file.source().buffer().use { sink.writeAll(it) }
+  }.contentLength(file.length())
+}
+
+fun File.toUpload(contentType: String): DefaultUpload {
+  return DefaultUpload.Builder()
+      .content { sink ->
+        source().buffer().use { sink.writeAll(it) }
+      }
+      .contentLength(length())
+      .contentType(contentType)
+      .fileName(name)
+      .build()
 }
 
 @Deprecated(
-  "This is a helper function to help migrating to 3.x and will be removed in a future version",
-  ReplaceWith(
-    "DefaultUpload.Builder().content(filePath).contentType(mimetype).build()",
-    imports = ["com.apollographql.apollo3.api.DefaultUpload"]
-  )
+    "This is a helper function to help migrating to 3.x and will be removed in a future version",
+    ReplaceWith(
+        "File(filePath).toUpload(mimetype)",
+        imports = ["java.io.File"]
+    )
 )
 @ApolloDeprecatedSince(v3_0_0)
 fun create(mimetype: String, filePath: String): Upload {
-  val file = File(filePath)
-  return DefaultUpload.Builder()
-      .content(file)
-      .contentType(mimetype)
-      .build()
+  return File(filePath).toUpload(mimetype)
 }

--- a/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
+++ b/apollo-api/src/linuxMain/kotlin/com/apollographql/apollo3/api/systemFileSystem.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.api
+
+import okio.FileSystem
+
+internal actual val systemFileSystem: FileSystem
+  get() = FileSystem.SYSTEM

--- a/tests/integration-tests/src/jvmTest/kotlin/test/JvmFileUploadTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/JvmFileUploadTest.kt
@@ -1,9 +1,8 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.DefaultUpload
 import com.apollographql.apollo3.api.Upload
-import com.apollographql.apollo3.api.content
+import com.apollographql.apollo3.api.toUpload
 import com.apollographql.apollo3.integration.upload.SingleUploadTwiceMutation
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -18,16 +17,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class JvmFileUploadTest {
-  private val upload0: Upload = DefaultUpload.Builder()
-      .content(File("src/jvmTest/resources/file0.txt"))
-      .fileName("file0.txt")
-      .contentType("plain/txt")
-      .build()
-  private val upload1: Upload = DefaultUpload.Builder()
-      .content(File("src/jvmTest/resources/file1.jpg"))
-      .fileName("file1.jpg")
-      .contentType("image/jpeg")
-      .build()
+  private val upload0: Upload = File("src/jvmTest/resources/file0.txt").toUpload("plain/txt")
+
+  private val upload1: Upload = File("src/jvmTest/resources/file1.jpg").toUpload("image/jpeg")
 
   private val mutationTwice = SingleUploadTwiceMutation(upload0, upload1)
 


### PR DESCRIPTION
See #4054

In addition to making the File Upload reusable, this adds:

```
fun File.toUpload(contentType: String): Upload
fun Path.toUpload(contentType: String, fileSystem: FileSystem = systemFileSystem): Upload
```

