### PR TITLE
Pagination: fixes in FieldRecordMerger and MemoryCache

### DIFF
--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MemoryCache.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MemoryCache.kt
@@ -120,7 +120,7 @@ class MemoryCache(
       changedKeys
     }
 
-    return changedKeys + nextCache?.merge(record, cacheHeaders).orEmpty()
+    return changedKeys + nextCache?.merge(record, cacheHeaders, recordMerger).orEmpty()
   }
 
   @ApolloExperimental

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/RecordMerger.kt
@@ -59,7 +59,11 @@ class FieldRecordMerger(private val fieldMerger: FieldMerger) : RecordMerger {
     for ((fieldKey, incomingFieldValue) in incoming.fields) {
       val hasExistingFieldValue = existing.fields.containsKey(fieldKey)
       val existingFieldValue = existing.fields[fieldKey]
-      if (!hasExistingFieldValue || existingFieldValue != incomingFieldValue) {
+      if (!hasExistingFieldValue) {
+        mergedFields[fieldKey] = incomingFieldValue
+        mergedMetadata[fieldKey] = incoming.metadata[fieldKey]!!
+        changedKeys.add("${existing.key}.$fieldKey")
+      } else if (existingFieldValue != incomingFieldValue) {
         val existingFieldInfo = FieldInfo(
             value = existingFieldValue,
             metadata = existing.metadata[fieldKey]!!,

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/internal/BlobRecordDatabase.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/internal/BlobRecordDatabase.kt
@@ -1,9 +1,8 @@
 package com.apollographql.apollo3.cache.normalized.sql.internal
 
-import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.cache.internal.blob.BlobQueries
 import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.api.internal.BlobRecordSerializer
-import com.apollographql.apollo3.cache.internal.blob.BlobQueries
 
 internal class BlobRecordDatabase(private val blobQueries: BlobQueries): RecordDatabase {
   override fun select(key: String): Record? {
@@ -52,6 +51,8 @@ internal class BlobRecordDatabase(private val blobQueries: BlobQueries): RecordD
   }
 
   override fun selectAll(): List<Record> {
-    TODO("Not yet implemented")
+    return blobQueries.selectRecords().executeAsList().map {
+      BlobRecordSerializer.deserialize(it.key, it.blob)
+    }
   }
 }

--- a/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/internal/JsonRecordDatabase.kt
+++ b/apollo-normalized-cache-sqlite/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/internal/JsonRecordDatabase.kt
@@ -1,11 +1,10 @@
 package com.apollographql.apollo3.cache.normalized.sql.internal
 
-import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.cache.internal.json.JsonQueries
 import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.api.internal.JsonRecordSerializer
-import com.apollographql.apollo3.cache.internal.json.JsonQueries
 
-internal class JsonRecordDatabase(private val jsonQueries: JsonQueries): RecordDatabase {
+internal class JsonRecordDatabase(private val jsonQueries: JsonQueries) : RecordDatabase {
   override fun select(key: String): Record? {
     return jsonQueries.recordForKey(key).executeAsList()
         .map {
@@ -52,6 +51,8 @@ internal class JsonRecordDatabase(private val jsonQueries: JsonQueries): RecordD
   }
 
   override fun selectAll(): List<Record> {
-    TODO("Not yet implemented")
+    return jsonQueries.selectRecords().executeAsList().map {
+      JsonRecordSerializer.deserialize(it.key, it.record)
+    }
   }
 }

--- a/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
@@ -31,6 +31,11 @@ class CursorBasedPaginationTest {
     cursorBased(SqlNormalizedCacheFactory(name = "json", withDates = false))
   }
 
+  @Test
+  fun cursorBasedChainedCache() {
+    cursorBased(MemoryCacheFactory().chain(SqlNormalizedCacheFactory(name = "json", withDates = false)))
+  }
+
   private fun cursorBased(cacheFactory: NormalizedCacheFactory) = runTest {
     val apolloStore = ApolloStore(
         normalizedCacheFactory = cacheFactory,
@@ -64,6 +69,7 @@ class CursorBasedPaginationTest {
     apolloStore.writeOperation(query1, data1)
     var dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data1, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page after
     val query2 = UsersCursorBasedQuery(first = Optional.Present(2), after = Optional.Present("xx43"))
@@ -118,6 +124,7 @@ class CursorBasedPaginationTest {
       }
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page after
     val query3 = UsersCursorBasedQuery(first = Optional.Present(2), after = Optional.Present("xx45"))
@@ -184,6 +191,7 @@ class CursorBasedPaginationTest {
       }
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page before
     val query4 = UsersCursorBasedQuery(last = Optional.Present(2), before = Optional.Present("xx42"))
@@ -262,6 +270,7 @@ class CursorBasedPaginationTest {
       }
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Non-contiguous page (should reset)
     val query5 = UsersCursorBasedQuery(first = Optional.Present(2), after = Optional.Present("xx50"))
@@ -286,6 +295,7 @@ class CursorBasedPaginationTest {
     apolloStore.writeOperation(query5, data5)
     dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
   }
 
   @Suppress("UNCHECKED_CAST")

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
@@ -33,6 +33,11 @@ class OffsetBasedWithArrayPaginationTest {
     offsetBasedWithArray(SqlNormalizedCacheFactory(name = "json", withDates = false))
   }
 
+  @Test
+  fun offsetBasedWithArrayChainedCache() {
+    offsetBasedWithArray(MemoryCacheFactory().chain(SqlNormalizedCacheFactory(name = "json", withDates = false)))
+  }
+
   private fun offsetBasedWithArray(cacheFactory: NormalizedCacheFactory) = runTest {
     val apolloStore = ApolloStore(
         normalizedCacheFactory = cacheFactory,
@@ -54,6 +59,7 @@ class OffsetBasedWithArrayPaginationTest {
     apolloStore.writeOperation(query1, data1)
     var dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data1, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page after
     val query2 = UsersOffsetBasedWithArrayQuery(offset = Optional.Present(44), limit = Optional.Present(2))
@@ -74,6 +80,7 @@ class OffsetBasedWithArrayPaginationTest {
       )
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page in the middle
     val query3 = UsersOffsetBasedWithArrayQuery(offset = Optional.Present(44), limit = Optional.Present(3))
@@ -96,6 +103,7 @@ class OffsetBasedWithArrayPaginationTest {
       )
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Page before
     val query4 = UsersOffsetBasedWithArrayQuery(offset = Optional.Present(40), limit = Optional.Present(2))
@@ -119,6 +127,7 @@ class OffsetBasedWithArrayPaginationTest {
       )
     }
     assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
 
     // Non-contiguous page (should reset)
     val query5 = UsersOffsetBasedWithArrayQuery(offset = Optional.Present(50), limit = Optional.Present(2))
@@ -131,6 +140,7 @@ class OffsetBasedWithArrayPaginationTest {
     apolloStore.writeOperation(query5, data5)
     dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
   }
 
   private class OffsetPaginationMetadataGenerator(private val fieldName: String) : MetadataGenerator {

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithArrayPaginationTest.kt
@@ -141,6 +141,16 @@ class OffsetBasedWithArrayPaginationTest {
     dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data5, dataFromStore)
     assertChainedCachesAreEqual(apolloStore)
+
+    // Empty page (should keep previous result)
+    val query6 = UsersOffsetBasedWithArrayQuery(offset = Optional.Present(52), limit = Optional.Present(2))
+    val data6 = UsersOffsetBasedWithArrayQuery.Data {
+      usersOffsetBasedWithArray = emptyList()
+    }
+    apolloStore.writeOperation(query6, data6)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
   }
 
   private class OffsetPaginationMetadataGenerator(private val fieldName: String) : MetadataGenerator {

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerato
 import com.apollographql.apollo3.cache.normalized.api.internal.OptimisticCache
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
 import com.apollographql.apollo3.testing.runTest
+import com.squareup.sqldelight.internal.AtomicBoolean
 import pagination.test.UsersOffsetBasedWithPageQuery_TestBuilder.Data
 import kotlin.math.max
 import kotlin.math.min
@@ -231,12 +232,12 @@ class OffsetBasedWithPagePaginationTest {
 }
 
 internal suspend fun assertChainedCachesAreEqual(apolloStore: ApolloStore) {
-  var hasNextCache = false
+  val hasNextCache = AtomicBoolean(false)
   apolloStore.accessCache { cache ->
     // First cache is always OptimisticCache
-    hasNextCache = cache.nextCache!!.nextCache != null
+    hasNextCache.set(cache.nextCache!!.nextCache != null)
   }
-  if (!hasNextCache) return
+  if (!hasNextCache.get()) return
   val dump = apolloStore.dump().filterKeys { it != OptimisticCache::class }
   val caches = dump.values.toList()
   val cache1: Map<String, Record> = caches[0]

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -160,6 +160,18 @@ class OffsetBasedWithPagePaginationTest {
     dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data5, dataFromStore)
     assertChainedCachesAreEqual(apolloStore)
+
+    // Empty page (should keep previous result)
+    val query6 = UsersOffsetBasedWithPageQuery(offset = Optional.Present(52), limit = Optional.Present(2))
+    val data6 = UsersOffsetBasedWithPageQuery.Data {
+      usersOffsetBasedWithPage = usersOffsetBasedWithPage {
+        users = emptyList()
+      }
+    }
+    apolloStore.writeOperation(query6, data6)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
   }
 
   private class OffsetPaginationMetadataGenerator(private val typeName: String) : MetadataGenerator {


### PR DESCRIPTION
- FieldRecordMerger: a field can be merged into a record that doesn't contain the field
- MemoryCache: pass the RecordMerger when using a chained cache

Also: take empty page cases in the tests.