### PR TITLE
Pagination: add connectionFields argument to @typePolicy

### DIFF
--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -982,6 +982,7 @@ public final class com/apollographql/apollo3/ast/GqldirectiveKt {
 
 public final class com/apollographql/apollo3/ast/GqldocumentKt {
 	public static final fun apolloDefinitions ()Ljava/util/List;
+	public static final fun apolloDefinitions (Ljava/lang/String;)Ljava/util/List;
 	public static final fun builtinDefinitions ()Ljava/util/List;
 	public static final fun linkDefinitions ()Ljava/util/List;
 	public static final fun withApolloDefinitions (Lcom/apollographql/apollo3/ast/GQLDocument;)Lcom/apollographql/apollo3/ast/GQLDocument;

--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1121,6 +1121,7 @@ public final class com/apollographql/apollo3/ast/Schema {
 	public static final field REQUIRES_OPT_IN Ljava/lang/String;
 	public static final field TYPE_POLICY Ljava/lang/String;
 	public fun <init> (Ljava/util/List;)V
+	public final fun getConnectionTypes ()Ljava/util/Set;
 	public final fun getDirectiveDefinitions ()Ljava/util/Map;
 	public final fun getForeignNames ()Ljava/util/Map;
 	public final fun getMutationTypeDefinition ()Lcom/apollographql/apollo3/ast/GQLTypeDefinition;

--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1121,7 +1121,6 @@ public final class com/apollographql/apollo3/ast/Schema {
 	public static final field REQUIRES_OPT_IN Ljava/lang/String;
 	public static final field TYPE_POLICY Ljava/lang/String;
 	public fun <init> (Ljava/util/List;)V
-	public final fun getConnectionTypes ()Ljava/util/Set;
 	public final fun getDirectiveDefinitions ()Ljava/util/Map;
 	public final fun getForeignNames ()Ljava/util/Map;
 	public final fun getMutationTypeDefinition ()Lcom/apollographql/apollo3/ast/GQLTypeDefinition;

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -29,6 +29,7 @@ class Schema internal constructor(
     private val keyFields: Map<String, Set<String>>,
     val foreignNames: Map<String, String>,
     private val directivesToStrip: List<String>,
+    @ApolloInternal
     val connectionTypes: Set<String>,
 ) {
   /**

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -29,6 +29,7 @@ class Schema internal constructor(
     private val keyFields: Map<String, Set<String>>,
     val foreignNames: Map<String, String>,
     private val directivesToStrip: List<String>,
+    val connectionTypes: Set<String>,
 ) {
   /**
    * Creates a new Schema from a list of definition.
@@ -42,7 +43,8 @@ class Schema internal constructor(
       definitions,
       emptyMap(),
       emptyMap(),
-      emptyList()
+      emptyList(),
+      emptySet(),
   )
 
   val typeDefinitions: Map<String, GQLTypeDefinition> = definitions
@@ -137,7 +139,8 @@ class Schema internal constructor(
         "sdl" to GQLDocument(definitions, null).toUtf8(),
         "keyFields" to keyFields,
         "foreignNames" to foreignNames,
-        "directivesToStrip" to directivesToStrip
+        "directivesToStrip" to directivesToStrip,
+        "connectionTypes" to connectionTypes,
     )
   }
 
@@ -213,6 +216,7 @@ class Schema internal constructor(
           keyFields = (map["keyFields"]!! as Map<String, Collection<String>>).mapValues { it.value.toSet() },
           foreignNames = map["foreignNames"]!! as Map<String, String>,
           directivesToStrip = map["directivesToStrip"]!! as List<String>,
+          connectionTypes = (map["connectionTypes"]!! as List<String>).toSet(),
       )
     }
   }

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -28,7 +28,7 @@ fun GQLDocument.withoutBuiltinDirectives(): GQLDocument {
 @Deprecated("This method is deprecated and will be removed in a future version")
 fun GQLDocument.withApolloDefinitions(): GQLDocument {
   @Suppress("DEPRECATION")
-  return withDefinitions(apolloDefinitions("v0.1"))
+  return withDefinitions(apolloDefinitions())
 }
 
 /**
@@ -46,7 +46,8 @@ fun linkDefinitions() = definitionsFromResources("link.graphqls")
 /**
  * Extra apollo specific definitions from https://specs.apollo.dev/kotlin_labs/<[version]>
  */
-fun apolloDefinitions(version: String) = definitionsFromResources("apollo-$version.graphqls")
+fun apolloDefinitions() = apolloDefinitions("v0.1")
+internal fun apolloDefinitions(version: String) = definitionsFromResources("apollo-$version.graphqls")
 
 private fun definitionsFromResources(name: String): List<GQLDefinition> {
   return GQLDocument::class.java.getResourceAsStream("/$name")!!

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -43,11 +43,13 @@ fun builtinDefinitions() = definitionsFromResources("builtins.graphqls")
  */
 fun linkDefinitions() = definitionsFromResources("link.graphqls")
 
+@Deprecated("Use apolloDefinitions(version) instead", ReplaceWith("apolloDefinitions(\"v0.1\")"))
+fun apolloDefinitions() = apolloDefinitions("v0.1")
+
 /**
  * Extra apollo specific definitions from https://specs.apollo.dev/kotlin_labs/<[version]>
  */
-fun apolloDefinitions() = apolloDefinitions("v0.1")
-internal fun apolloDefinitions(version: String) = definitionsFromResources("apollo-$version.graphqls")
+fun apolloDefinitions(version: String) = definitionsFromResources("apollo-$version.graphqls")
 
 private fun definitionsFromResources(name: String): List<GQLDefinition> {
   return GQLDocument::class.java.getResourceAsStream("/$name")!!

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -28,7 +28,7 @@ fun GQLDocument.withoutBuiltinDirectives(): GQLDocument {
 @Deprecated("This method is deprecated and will be removed in a future version")
 fun GQLDocument.withApolloDefinitions(): GQLDocument {
   @Suppress("DEPRECATION")
-  return withDefinitions(apolloDefinitions())
+  return withDefinitions(apolloDefinitions("v0.1"))
 }
 
 /**
@@ -44,9 +44,9 @@ fun builtinDefinitions() = definitionsFromResources("builtins.graphqls")
 fun linkDefinitions() = definitionsFromResources("link.graphqls")
 
 /**
- * Extra apollo specific definitions from https://specs.apollo.dev/kotlin_labs/v0.1
+ * Extra apollo specific definitions from https://specs.apollo.dev/kotlin_labs/<[version]>
  */
-fun apolloDefinitions() = definitionsFromResources("apollo.graphqls")
+fun apolloDefinitions(version: String) = definitionsFromResources("apollo-$version.graphqls")
 
 private fun definitionsFromResources(name: String): List<GQLDefinition> {
   return GQLDocument::class.java.getResourceAsStream("/$name")!!

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -29,7 +29,6 @@ import com.apollographql.apollo3.ast.GQLTypeSystemExtension
 import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
-import com.apollographql.apollo3.ast.Schema.Companion.REQUIRES_OPT_IN
 import com.apollographql.apollo3.ast.Schema.Companion.TYPE_POLICY
 import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.apolloDefinitions
@@ -170,8 +169,6 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
 
   val keyFields = mergedScope.validateAndComputeKeyFields()
   val connectionTypes = mergedScope.computeConnectionTypes()
-
-  mergedScope.validateRequiresOptInOnDirectiveArguments()
 
   return if (issues.containsError()) {
     /**
@@ -528,7 +525,7 @@ internal fun ValidationScope.validateAndComputeKeyFields(): Map<String, Set<Stri
 
 internal fun ValidationScope.computeConnectionTypes(): Set<String> {
   val connectionTypes = mutableSetOf<String>()
-  for (typeDefinition in typeDefinitions.values.filter { it is GQLObjectTypeDefinition || it is GQLInterfaceTypeDefinition }) {
+  for (typeDefinition in typeDefinitions.values) {
     val connectionFields = typeDefinition.directives.filter { originalDirectiveName(it.name) == TYPE_POLICY }.toConnectionFields()
     for (fieldName in connectionFields) {
       val field = typeDefinition.fields.firstOrNull { it.name == fieldName } ?: continue
@@ -538,40 +535,11 @@ internal fun ValidationScope.computeConnectionTypes(): Set<String> {
   return connectionTypes
 }
 
-internal fun ValidationScope.validateRequiresOptInOnDirectiveArguments() {
-  val directiveArgumentsRequiringOptIn = mutableMapOf<Pair<String, String>, String>() // Directive+Argument -> Feature
-  for (directiveDefinition in directiveDefinitions.values) {
-    for (argument in directiveDefinition.arguments) {
-      val requiresOptInFeature = argument.directives.firstOrNull { originalDirectiveName(it.name) == REQUIRES_OPT_IN }?.arguments?.arguments?.firstOrNull {
-        it.name == "feature"
-      }?.value as? GQLStringValue ?: continue
-      directiveArgumentsRequiringOptIn[directiveDefinition.name to argument.name] = requiresOptInFeature.value
-    }
-  }
-
-  for (typeDefinition in typeDefinitions.values) {
-    for (directive in typeDefinition.directives) {
-      val arguments = directive.arguments?.arguments ?: emptyList()
-      for (argument in arguments) {
-        val requiredFeatureForArgument = directiveArgumentsRequiringOptIn[directive.name to argument.name] ?: continue
-        registerIssue(
-            message = "'${directive.name}' directive argument '${argument.name}' requires opt-in feature '$requiredFeatureForArgument'",
-            sourceLocation = directive.sourceLocation,
-            severity = Issue.Severity.WARNING,
-        )
-      }
-    }
-  }
-}
-
 private val GQLTypeDefinition.directives
   get() = when (this) {
     is GQLObjectTypeDefinition -> directives
     is GQLInterfaceTypeDefinition -> directives
-    is GQLEnumTypeDefinition -> directives
-    is GQLInputObjectTypeDefinition -> directives
-    is GQLScalarTypeDefinition -> directives
-    is GQLUnionTypeDefinition -> directives
+    else -> emptyList()
   }
 
 private val GQLTypeDefinition.fields

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -54,7 +54,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
 
   var directivesToStrip = foreignSchemas.flatMap { it.directivesToStrip }
 
-  val apolloDefinitions = apolloDefinitions()
+  val apolloDefinitions = apolloDefinitions("v0.1")
 
   if (requiresApolloDefinitions && foreignSchemas.none { it.name == "kotlin_labs" }) {
     /**

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -54,7 +54,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
 
   var directivesToStrip = foreignSchemas.flatMap { it.directivesToStrip }
 
-  val apolloDefinitions = apolloDefinitions()
+  val apolloDefinitions = apolloDefinitions("v0.1")
 
   if (requiresApolloDefinitions && foreignSchemas.none { it.name == "kotlin_labs" }) {
     /**
@@ -283,6 +283,7 @@ private fun List<GQLSchemaExtension>.getForeignSchemas(
         }
 
         val foreignName = components[components.size - 2]
+        val version = components[components.size - 1]
 
         if (prefix == null) {
           prefix = foreignName
@@ -320,7 +321,7 @@ private fun List<GQLSchemaExtension>.getForeignSchemas(
 
 
         if (foreignName == "kotlin_labs") {
-          val (definitions, renames) = apolloDefinitions().rename(mappings, prefix)
+          val (definitions, renames) = apolloDefinitions(version).rename(mappings, prefix)
           foreignSchemas.add(
               ForeignSchema(
                   name = foreignName,

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -54,7 +54,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
 
   var directivesToStrip = foreignSchemas.flatMap { it.directivesToStrip }
 
-  val apolloDefinitions = apolloDefinitions("v0.1")
+  val apolloDefinitions = apolloDefinitions()
 
   if (requiresApolloDefinitions && foreignSchemas.none { it.name == "kotlin_labs" }) {
     /**

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -1,9 +1,44 @@
 package com.apollographql.apollo3.ast.internal
 
 import com.apollographql.apollo3.annotations.ApolloInternal
-import com.apollographql.apollo3.ast.*
+import com.apollographql.apollo3.ast.ConflictResolution
+import com.apollographql.apollo3.ast.GQLDefinition
+import com.apollographql.apollo3.ast.GQLDirective
+import com.apollographql.apollo3.ast.GQLDirectiveDefinition
+import com.apollographql.apollo3.ast.GQLEnumTypeDefinition
+import com.apollographql.apollo3.ast.GQLField
+import com.apollographql.apollo3.ast.GQLInputObjectTypeDefinition
+import com.apollographql.apollo3.ast.GQLInterfaceTypeDefinition
+import com.apollographql.apollo3.ast.GQLListType
+import com.apollographql.apollo3.ast.GQLListValue
+import com.apollographql.apollo3.ast.GQLNamed
+import com.apollographql.apollo3.ast.GQLNamedType
+import com.apollographql.apollo3.ast.GQLNonNullType
+import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
+import com.apollographql.apollo3.ast.GQLObjectValue
+import com.apollographql.apollo3.ast.GQLOperationTypeDefinition
+import com.apollographql.apollo3.ast.GQLResult
+import com.apollographql.apollo3.ast.GQLScalarTypeDefinition
+import com.apollographql.apollo3.ast.GQLSchemaDefinition
+import com.apollographql.apollo3.ast.GQLSchemaExtension
+import com.apollographql.apollo3.ast.GQLStringValue
+import com.apollographql.apollo3.ast.GQLType
+import com.apollographql.apollo3.ast.GQLTypeDefinition
 import com.apollographql.apollo3.ast.GQLTypeDefinition.Companion.builtInTypes
+import com.apollographql.apollo3.ast.GQLTypeSystemExtension
+import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
+import com.apollographql.apollo3.ast.Issue
+import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.Schema.Companion.TYPE_POLICY
+import com.apollographql.apollo3.ast.SourceLocation
+import com.apollographql.apollo3.ast.apolloDefinitions
+import com.apollographql.apollo3.ast.builtinDefinitions
+import com.apollographql.apollo3.ast.canHaveKeyFields
+import com.apollographql.apollo3.ast.combineDefinitions
+import com.apollographql.apollo3.ast.containsError
+import com.apollographql.apollo3.ast.linkDefinitions
+import com.apollographql.apollo3.ast.parseAsGQLSelections
+import com.apollographql.apollo3.ast.transform2
 
 internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefinitions: Boolean = false): GQLResult<Schema> {
   val issues = mutableListOf<Issue>()
@@ -133,6 +168,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
   mergedScope.validateObjects()
 
   val keyFields = mergedScope.validateAndComputeKeyFields()
+  val connectionTypes = mergedScope.computeConnectionTypes()
 
   return if (issues.containsError()) {
     /**
@@ -142,10 +178,11 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
   } else {
     GQLResult(
         Schema(
-            mergedDefinitions,
-            keyFields,
-            foreignNames,
-            directivesToStrip
+            definitions = mergedDefinitions,
+            keyFields = keyFields,
+            foreignNames = foreignNames,
+            directivesToStrip = directivesToStrip,
+            connectionTypes = connectionTypes,
         ),
         issues
     )
@@ -452,6 +489,9 @@ private fun List<GQLDirective>.toKeyFields(): Set<String> = extractFields("keyFi
 @ApolloInternal
 fun List<GQLDirective>.toEmbeddedFields(): Set<String> = extractFields("embeddedFields")
 
+@ApolloInternal
+fun List<GQLDirective>.toConnectionFields(): Set<String> = extractFields("connectionFields")
+
 private fun List<GQLDirective>.extractFields(argumentName: String): Set<String> {
   if (isEmpty()) {
     return emptySet()
@@ -482,3 +522,36 @@ internal fun ValidationScope.validateAndComputeKeyFields(): Map<String, Set<Stri
   }
   return keyFieldsCache
 }
+
+internal fun ValidationScope.computeConnectionTypes(): Set<String> {
+  val connectionTypes = mutableSetOf<String>()
+  for (typeDefinition in typeDefinitions.values) {
+    val connectionFields = typeDefinition.directives.filter { originalDirectiveName(it.name) == TYPE_POLICY }.toConnectionFields()
+    for (fieldName in connectionFields) {
+      val field = typeDefinition.fields.firstOrNull { it.name == fieldName } ?: continue
+      connectionTypes.add(field.type.name)
+    }
+  }
+  return connectionTypes
+}
+
+private val GQLTypeDefinition.directives
+  get() = when (this) {
+    is GQLObjectTypeDefinition -> directives
+    is GQLInterfaceTypeDefinition -> directives
+    else -> emptyList()
+  }
+
+private val GQLTypeDefinition.fields
+  get() = when (this) {
+    is GQLObjectTypeDefinition -> fields
+    is GQLInterfaceTypeDefinition -> fields
+    else -> emptyList()
+  }
+
+private val GQLType.name: String
+  get() = when (this) {
+    is GQLNonNullType -> type.name
+    is GQLListType -> type.name
+    is GQLNamedType -> name
+  }

--- a/apollo-ast/src/main/resources/README.md
+++ b/apollo-ast/src/main/resources/README.md
@@ -1,0 +1,6 @@
+This folder contains several groups of GraphQL definitions we use during codegen:
+
+* builtins.graphqls: the official built-in defintions such as [built-in scalars](https://spec.graphql.org/draft/#sec-Scalars.Built-in-Scalars), [built-in directives](https://spec.graphql.org/draft/#sec-Type-System.Directives.Built-in-Directives) or [introspection definitions](https://spec.graphql.org/draft/#sec-Schema-Introspection.Schema-Introspection-Schema).
+* link.graphqls: the [core schemas](https://specs.apollo.dev/link/v1.0/) definitions.
+* apollo-${version}.graphqls: the client directives supported by Apollo Kotlin. Changes are versioned at https://github.com/apollographql/specs. Changing them requires a new version and a PR.
+

--- a/apollo-ast/src/main/resources/apollo-v0.1.graphqls
+++ b/apollo-ast/src/main/resources/apollo-v0.1.graphqls
@@ -1,10 +1,3 @@
-# The kotlin_labs v0.1 directives
-# You can import them with:
-#
-# extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", import: ["@optional", "@nonnull", "@typePolicy", "@fieldPolicy", "requiresOptIn", "targetName"])
-#
-# They are included unconditionally for historical reasons but this will change in a future version
-
 # Marks a field or variable definition as optional or required
 # By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
 # but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value

--- a/apollo-ast/src/main/resources/apollo-v0.1.graphqls
+++ b/apollo-ast/src/main/resources/apollo-v0.1.graphqls
@@ -1,7 +1,7 @@
-# The kotlin_labs directives
-# You can import them with
+# The kotlin_labs v0.1 directives
+# You can import them with:
 #
-# extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", import: ["@optional", "@nonnull", "@typePolicy", "@fieldPolicy"])
+# extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", import: ["@optional", "@nonnull", "@typePolicy", "@fieldPolicy", "requiresOptIn", "targetName"])
 #
 # They are included unconditionally for historical reasons but this will change in a future version
 
@@ -22,8 +22,7 @@ directive @nonnull(fields: String! = "") on OBJECT | FIELD
 # `keyFields`: a selection set containing fields used to compute the cache key of an object. Order is important.
 # `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
 # embedded in their parent instead. Order is unimportant.
-# `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
-directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
+directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "") on OBJECT | INTERFACE | UNION
 
 # Attach extra information to a given field
 # `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 
@@ -48,9 +47,4 @@ on FIELD_DEFINITION
 # This directive is experimental.
 directive @targetName(name: String!)
 on OBJECT
-    | INTERFACE
-    | ENUM
     | ENUM_VALUE
-    | UNION
-    | SCALAR
-    | INPUT_OBJECT

--- a/apollo-ast/src/main/resources/apollo-v0.2.graphqls
+++ b/apollo-ast/src/main/resources/apollo-v0.2.graphqls
@@ -1,0 +1,56 @@
+# The kotlin_labs v0.2 directives
+# You can import them with:
+#
+# extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@optional", "@nonnull", "@typePolicy", "@fieldPolicy", "requiresOptIn", "targetName"])
+#
+# They are included unconditionally for historical reasons but this will change in a future version
+
+# Marks a field or variable definition as optional or required
+# By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
+# but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value
+directive @optional(if: Boolean = true) on FIELD | VARIABLE_DEFINITION
+
+# Marks a field as non-null. The corresponding Kotlin property will be made non-nullable even if the GraphQL type is nullable.
+# When used on an object definition in a schema document, `fields` must be non-empty and contain a selection set of fields that should be non-null
+# When used on a field from an executable document, `fields` must always be empty
+#
+# Setting the directive at the schema level is usually easier as there is little reason that a field would be non-null in one place
+# and null in the other
+directive @nonnull(fields: String! = "") on OBJECT | FIELD
+
+# Attach extra information to a given type
+# `keyFields`: a selection set containing fields used to compute the cache key of an object. Order is important.
+# `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
+# embedded in their parent instead. Order is unimportant.
+# `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
+directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
+
+# Attach extra information to a given field
+# `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 
+# The list is parsed as a selection set: both spaces and comas are valid separators.
+# `paginationArgs` (experimental): a list of arguments that vary when requesting different pages. 
+# These arguments are omitted when computing the cache key of this field.
+# The list is parsed as a selection set: both spaces and comas are valid separators.
+directive @fieldPolicy(forField: String!, keyArgs: String! = "", paginationArgs: String! = "") repeatable on OBJECT
+
+"""
+Indicates that the given field, argument, input field or enum value requires
+giving explicit consent before being used.
+"""
+directive @requiresOptIn(feature: String!) repeatable
+on FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | INPUT_FIELD_DEFINITION
+    | ENUM_VALUE
+
+# Use the specified name in the generated code instead of the GraphQL name.
+# Use this for instance when the name would clash with a reserved keyword or field in the generated code.
+# This directive is experimental.
+directive @targetName(name: String!)
+on OBJECT
+    | INTERFACE
+    | ENUM
+    | ENUM_VALUE
+    | UNION
+    | SCALAR
+    | INPUT_OBJECT

--- a/apollo-ast/src/main/resources/apollo-v0.2.graphqls
+++ b/apollo-ast/src/main/resources/apollo-v0.2.graphqls
@@ -1,41 +1,67 @@
-# The kotlin_labs v0.2 directives
-# You can import them with:
-#
-# extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@optional", "@nonnull", "@typePolicy", "@fieldPolicy", "requiresOptIn", "targetName"])
-#
-# They are included unconditionally for historical reasons but this will change in a future version
-
-# Marks a field or variable definition as optional or required
-# By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
-# but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value
+"""
+Marks a field or variable definition as optional or required
+By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
+but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value
+Since: 3.0.0
+"""
 directive @optional(if: Boolean = true) on FIELD | VARIABLE_DEFINITION
 
-# Marks a field as non-null. The corresponding Kotlin property will be made non-nullable even if the GraphQL type is nullable.
-# When used on an object definition in a schema document, `fields` must be non-empty and contain a selection set of fields that should be non-null
-# When used on a field from an executable document, `fields` must always be empty
-#
-# Setting the directive at the schema level is usually easier as there is little reason that a field would be non-null in one place
-# and null in the other
+"""
+Marks a field as non-null. The corresponding Kotlin property will be made non-nullable even if the GraphQL type is nullable.
+When used on an object definition in a schema document, `fields` must be non-empty and contain a selection set of fields that should be non-null
+When used on a field from an executable document, `fields` must always be empty
+
+Setting the directive at the schema level is usually easier as there is little reason that a field would be non-null in one place
+and null in the other
+Since: 3.0.0
+"""
 directive @nonnull(fields: String! = "") on OBJECT | FIELD
 
-# Attach extra information to a given type
-# `keyFields`: a selection set containing fields used to compute the cache key of an object. Order is important.
-# `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
-# embedded in their parent instead. Order is unimportant.
-# `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
-directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
+"""
+Attach extra information to a given type
+Since: 3.0.0
+"""
+directive @typePolicy(
+  """
+  a selection set containing fields used to compute the cache key of an object. Order is important.
+  """
+  keyFields: String! = "",
+  """
+  a selection set containing fields that shouldn't create a new cache Record and should be
+  embedded in their parent instead. Order is unimportant.
+  """
+  embeddedFields: String! = "",
+  """
+  a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
+  Since: 3.4.1
+  """
+  connectionFields: String! = ""
+) on OBJECT | INTERFACE | UNION
 
-# Attach extra information to a given field
-# `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 
-# The list is parsed as a selection set: both spaces and comas are valid separators.
-# `paginationArgs` (experimental): a list of arguments that vary when requesting different pages. 
-# These arguments are omitted when computing the cache key of this field.
-# The list is parsed as a selection set: both spaces and comas are valid separators.
-directive @fieldPolicy(forField: String!, keyArgs: String! = "", paginationArgs: String! = "") repeatable on OBJECT
+"""
+Attach extra information to a given field
+Since: 3.3.0
+"""
+directive @fieldPolicy(
+  forField: String!,
+  """
+  a list of arguments used to compute the cache key of the object this field is pointing to.
+  The list is parsed as a selection set: both spaces and comas are valid separators.
+  """
+  keyArgs: String! = "",
+  """
+  (experimental) a list of arguments that vary when requesting different pages.
+  These arguments are omitted when computing the cache key of this field.
+  The list is parsed as a selection set: both spaces and comas are valid separators.
+  Since: 3.4.1
+  """
+  paginationArgs: String! = ""
+) repeatable on OBJECT
 
 """
 Indicates that the given field, argument, input field or enum value requires
 giving explicit consent before being used.
+Since: 3.3.1
 """
 directive @requiresOptIn(feature: String!) repeatable
 on FIELD_DEFINITION
@@ -43,9 +69,12 @@ on FIELD_DEFINITION
     | INPUT_FIELD_DEFINITION
     | ENUM_VALUE
 
-# Use the specified name in the generated code instead of the GraphQL name.
-# Use this for instance when the name would clash with a reserved keyword or field in the generated code.
-# This directive is experimental.
+"""
+Use the specified name in the generated code instead of the GraphQL name.
+Use this for instance when the name would clash with a reserved keyword or field in the generated code.
+This directive is experimental.
+Since: 3.3.1
+"""
 directive @targetName(name: String!)
 on OBJECT
     | INTERFACE

--- a/apollo-ast/src/main/resources/apollo.graphqls
+++ b/apollo-ast/src/main/resources/apollo.graphqls
@@ -22,7 +22,8 @@ directive @nonnull(fields: String! = "") on OBJECT | FIELD
 # `keyFields`: a selection set containing fields used to compute the cache key of an object. Order is important.
 # `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
 # embedded in their parent instead. Order is unimportant.
-directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "") on OBJECT | INTERFACE | UNION
+# `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
+directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
 
 # Attach extra information to a given field
 # `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 

--- a/apollo-ast/src/main/resources/apollo.graphqls
+++ b/apollo-ast/src/main/resources/apollo.graphqls
@@ -23,7 +23,11 @@ directive @nonnull(fields: String! = "") on OBJECT | FIELD
 # `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
 # embedded in their parent instead. Order is unimportant.
 # `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
-directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
+directive @typePolicy(
+    keyFields: String! = "",
+    embeddedFields: String! = "",
+    connectionFields: String! = "" @requiresOptIn(feature: "connectionFields"),
+) on OBJECT | INTERFACE | UNION
 
 # Attach extra information to a given field
 # `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 

--- a/apollo-ast/src/main/resources/apollo.graphqls
+++ b/apollo-ast/src/main/resources/apollo.graphqls
@@ -23,11 +23,7 @@ directive @nonnull(fields: String! = "") on OBJECT | FIELD
 # `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
 # embedded in their parent instead. Order is unimportant.
 # `connectionFields`: a selection set containing fields that should be treated as Relay Connection fields. Order is unimportant.
-directive @typePolicy(
-    keyFields: String! = "",
-    embeddedFields: String! = "",
-    connectionFields: String! = "" @requiresOptIn(feature: "connectionFields"),
-) on OBJECT | INTERFACE | UNION
+directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "", connectionFields: String! = "") on OBJECT | INTERFACE | UNION
 
 # Attach extra information to a given field
 # `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
@@ -81,6 +81,8 @@ internal abstract class CodegenLayout(
   fun fragmentAdapterPackageName(filePath: String) = "${fragmentPackageName(filePath)}.adapter".stripDots()
   fun fragmentResponseFieldsPackageName(filePath: String) = "${fragmentPackageName(filePath)}.selections".stripDots()
 
+  fun paginationPackageName() = "$schemaPackageName.pagination"
+
   private fun String.stripDots() = this.removePrefix(".").removeSuffix(".")
 
   // ------------------------ Names ---------------------------------
@@ -109,6 +111,8 @@ internal abstract class CodegenLayout(
   internal fun operationTestBuildersWrapperName(operation: IrOperation) = operationName(operation) + "_TestBuilder"
   internal fun operationVariablesAdapterName(operation: IrOperation) = operationName(operation) + "_VariablesAdapter"
   internal fun operationSelectionsName(operation: IrOperation) = operationName(operation) + "Selections"
+
+  internal fun paginationName() = "Pagination"
 
   internal fun fragmentName(name: String) = capitalizedIdentifier(name) + "Impl"
   internal fun fragmentResponseAdapterWrapperName(name: String) = fragmentName(name) + "_ResponseAdapter"

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -22,6 +22,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.file.OperationBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.OperationResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.OperationSelectionsBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.OperationVariablesAdapterBuilder
+import com.apollographql.apollo3.compiler.codegen.kotlin.file.PaginationBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.SchemaBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.TestBuildersBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.file.UnionBuilder
@@ -195,6 +196,10 @@ internal class KotlinCodeGen(
 
     if (generateSchema) {
       builders.add(SchemaBuilder(context, generatedSchemaName, ir.objects, ir.interfaces, ir.unions))
+    }
+
+    if (ir.schema.connectionTypes.isNotEmpty()) {
+      builders.add(PaginationBuilder(context, ir.schema.connectionTypes))
     }
 
     /**

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -71,6 +71,7 @@ internal object KotlinSymbols {
   val List = ClassName("kotlin.collections", "List")
   val Map = ClassName("kotlin.collections", "Map")
   val Array = ClassName("kotlin", "Array")
+  val Set = ClassName("kotlin.collections", "Set")
 
   val Suppress = ClassName("kotlin", "Suppress")
   val JvmOverloads = ClassName("kotlin.jvm", "JvmOverloads")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/PaginationBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/PaginationBuilder.kt
@@ -1,0 +1,53 @@
+package com.apollographql.apollo3.compiler.codegen.kotlin.file
+
+import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
+import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+
+internal class PaginationBuilder(
+    context: KotlinContext,
+    private val connectionTypes: Set<String>,
+) : CgFileBuilder {
+  private val layout = context.layout
+  private val packageName = layout.paginationPackageName()
+  private val simpleName = layout.paginationName()
+
+  override fun prepare() {
+  }
+
+  override fun build(): CgFile {
+    return CgFile(
+        packageName = packageName,
+        fileName = simpleName,
+        typeSpecs = listOf(typeSpec())
+    )
+  }
+
+  private fun typeSpec(): TypeSpec {
+    return TypeSpec.objectBuilder(simpleName)
+        .addProperty(connectionTypesPropertySpec())
+        .build()
+  }
+
+  private fun connectionTypesPropertySpec(): PropertySpec {
+    val builder = CodeBlock.builder()
+    builder.add("setOf(\n")
+    builder.indent()
+    builder.add(
+        connectionTypes.map {
+          CodeBlock.of("%S", it)
+        }.joinToString(", ")
+    )
+    builder.unindent()
+    builder.add(")\n")
+
+    return PropertySpec.builder("connectionTypes", KotlinSymbols.Set.parameterizedBy(KotlinSymbols.String))
+        .initializer(builder.build())
+        .build()
+  }
+}

--- a/apollo-compiler/src/test/validation/schema/apollo_directive.expected
+++ b/apollo-compiler/src/test/validation/schema/apollo_directive.expected
@@ -1,2 +1,2 @@
-WARNING: ValidationError(6:0)
-Directive 'nonnull' is defined multiple times . First definition is : (apollo - v0.1.graphqls): (19, 1)
+WARNING: ValidationError (6:0)
+Directive 'nonnull' is defined multiple times. First definition is: (apollo-v0.1.graphqls): (19, 1)

--- a/apollo-compiler/src/test/validation/schema/apollo_directive.expected
+++ b/apollo-compiler/src/test/validation/schema/apollo_directive.expected
@@ -1,2 +1,2 @@
-WARNING: ValidationError (6:0)
-Directive 'nonnull' is defined multiple times. First definition is: (apollo.graphqls): (19, 1)
+WARNING: ValidationError(6:0)
+Directive 'nonnull' is defined multiple times . First definition is : (apollo - v0.1.graphqls): (19, 1)

--- a/apollo-compiler/src/test/validation/schema/apollo_directive.expected
+++ b/apollo-compiler/src/test/validation/schema/apollo_directive.expected
@@ -1,2 +1,2 @@
 WARNING: ValidationError (6:0)
-Directive 'nonnull' is defined multiple times. First definition is: (apollo-v0.1.graphqls): (19, 1)
+Directive 'nonnull' is defined multiple times. First definition is: (apollo-v0.1.graphqls): (12, 1)

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
@@ -27,3 +27,23 @@ class MetadataGeneratorContext(
 object EmptyMetadataGenerator : MetadataGenerator {
   override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> = emptyMap()
 }
+
+@ApolloExperimental
+class ConnectionMetadataGenerator(private val connectionTypes: Set<String>) : MetadataGenerator {
+  @Suppress("UNCHECKED_CAST")
+  override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
+    if (context.field.type.leafType().name in connectionTypes) {
+      obj as Map<String, Any?>
+      val edges = obj["edges"] as List<Map<String, Any?>>
+      val startCursor = edges.firstOrNull()?.get("cursor") as String?
+      val endCursor = edges.lastOrNull()?.get("cursor") as String?
+      return mapOf(
+          "startCursor" to startCursor,
+          "endCursor" to endCursor,
+          "before" to context.argumentValue("before"),
+          "after" to context.argumentValue("after"),
+      )
+    }
+    return emptyMap()
+  }
+}

--- a/tests/pagination/src/commonMain/graphql/pagination/operations.graphql
+++ b/tests/pagination/src/commonMain/graphql/pagination/operations.graphql
@@ -11,6 +11,20 @@ query UsersCursorBased($first: Int, $after: String, $last: Int, $before: String)
   }
 }
 
+query WithTypePolicyDirective($first: Int, $after: String, $last: Int, $before: String) {
+  usersCursorBased2(first: $first, after: $after, last: $last, before: $before) {
+    edges {
+      cursor
+      node {
+        id
+        name
+        email
+      }
+    }
+  }
+}
+
+
 query UsersOffsetBasedWithArray($offset: Int, $limit: Int) {
   usersOffsetBasedWithArray(offset: $offset, limit: $limit) {
     id

--- a/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
@@ -1,3 +1,5 @@
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@typePolicy", "@fieldPolicy"])
+
 type Query
 @typePolicy(embeddedFields: "usersCursorBased, usersOffsetBasedWithPage" connectionFields: "usersCursorBased2, usersCursorBased3")
 @fieldPolicy(forField: "usersCursorBased", paginationArgs: "first, after, last, before")

--- a/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
@@ -1,10 +1,12 @@
 type Query
-@typePolicy(embeddedFields: "usersCursorBased, usersOffsetBasedWithPage")
+@typePolicy(embeddedFields: "usersCursorBased, usersOffsetBasedWithPage" connectionFields: "usersCursorBased2, usersCursorBased3")
 @fieldPolicy(forField: "usersCursorBased", paginationArgs: "first, after, last, before")
 @fieldPolicy(forField: "usersOffsetBasedWithArray", paginationArgs: "offset, limit")
 @fieldPolicy(forField: "usersOffsetBasedWithPage", paginationArgs: "offset, limit")
 {
   usersCursorBased(first: Int = 10, after: String = null, last: Int = null, before: String = null): UserConnection!
+  usersCursorBased2(first: Int = 10, after: String = null, last: Int = null, before: String = null): UserConnection2!
+  usersCursorBased3(first: Int = 10, after: String = null, last: Int = null, before: String = null): UserConnection3!
 
   usersOffsetBasedWithArray(offset: Int = 0, limit: Int = 10): [User!]!
 
@@ -12,6 +14,16 @@ type Query
 }
 
 type UserConnection @typePolicy(embeddedFields: "pageInfo, edges") {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+}
+
+type UserConnection2 {
+  pageInfo: PageInfo!
+  edges: [UserEdge!]!
+}
+
+type UserConnection3 {
   pageInfo: PageInfo!
   edges: [UserEdge!]!
 }

--- a/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/CursorBasedPaginationTest.kt
@@ -2,11 +2,10 @@ package pagination
 
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.ConnectionMetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.ConnectionRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
-import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
-import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
@@ -40,9 +39,9 @@ class CursorBasedPaginationTest {
     val apolloStore = ApolloStore(
         normalizedCacheFactory = cacheFactory,
         cacheKeyGenerator = TypePolicyCacheKeyGenerator,
-        metadataGenerator = CursorPaginationMetadataGenerator(setOf("UserConnection")),
+        metadataGenerator = ConnectionMetadataGenerator(setOf("UserConnection")),
         apolloResolver = FieldPolicyApolloResolver,
-        recordMerger = FieldRecordMerger(CursorPaginationFieldMerger())
+        recordMerger = ConnectionRecordMerger
     )
     apolloStore.clearAll()
 
@@ -308,78 +307,6 @@ class CursorBasedPaginationTest {
     dataFromStore = apolloStore.readOperation(query1)
     assertEquals(data5, dataFromStore)
     assertChainedCachesAreEqual(apolloStore)
-  }
-
-  @Suppress("UNCHECKED_CAST")
-  private class CursorPaginationMetadataGenerator(private val connectionTypes: Set<String>) : MetadataGenerator {
-    override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
-      if (context.field.type.leafType().name in connectionTypes) {
-        obj as Map<String, Any?>
-        val edges = obj["edges"] as List<Map<String, Any?>>
-        val startCursor = edges.firstOrNull()?.get("cursor") as String?
-        val endCursor = edges.lastOrNull()?.get("cursor") as String?
-        return mapOf(
-            "startCursor" to startCursor,
-            "endCursor" to endCursor,
-            "before" to context.argumentValue("before"),
-            "after" to context.argumentValue("after"),
-        )
-      }
-      return emptyMap()
-    }
-  }
-
-  private class CursorPaginationFieldMerger : FieldRecordMerger.FieldMerger {
-    @Suppress("UNCHECKED_CAST")
-    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
-      val existingStartCursor = existing.metadata["startCursor"] as? String
-      val existingEndCursor = existing.metadata["endCursor"] as? String
-      val incomingStartCursor = incoming.metadata["startCursor"] as? String
-      val incomingEndCursor = incoming.metadata["endCursor"] as? String
-      val incomingBeforeArgument = incoming.metadata["before"] as? String
-      val incomingAfterArgument = incoming.metadata["after"] as? String
-
-      return if (incomingBeforeArgument == null && incomingAfterArgument == null) {
-        // Not a pagination query
-        incoming
-      } else if (existingStartCursor == null || existingEndCursor == null) {
-        // Existing is empty
-        incoming
-      } else if (incomingStartCursor == null || incomingEndCursor == null) {
-        // Incoming is empty
-        existing
-      } else {
-        val existingValue = existing.value as Map<String, Any?>
-        val existingList = existingValue["edges"] as List<*>
-        val incomingList = (incoming.value as Map<String, Any?>)["edges"] as List<*>
-
-        val mergedList: List<*>
-        val newStartCursor: String
-        val newEndCursor: String
-        if (incomingAfterArgument == existingEndCursor) {
-          mergedList = existingList + incomingList
-          newStartCursor = existingStartCursor
-          newEndCursor = incomingEndCursor
-        } else if (incomingBeforeArgument == existingStartCursor) {
-          mergedList = incomingList + existingList
-          newStartCursor = incomingStartCursor
-          newEndCursor = existingEndCursor
-        } else {
-          // We received a list which is neither the previous nor the next page.
-          // Handle this case by resetting the cache with this page
-          mergedList = incomingList
-          newStartCursor = incomingStartCursor
-          newEndCursor = incomingEndCursor
-        }
-
-        val mergedFieldValue = existingValue.toMutableMap()
-        mergedFieldValue["edges"] = mergedList
-        FieldRecordMerger.FieldInfo(
-            value = mergedFieldValue,
-            metadata = mapOf("startCursor" to newStartCursor, "endCursor" to newEndCursor)
-        )
-      }
-    }
   }
 }
 

--- a/tests/pagination/src/commonTest/kotlin/TypePolicyConnectionFieldsTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/TypePolicyConnectionFieldsTest.kt
@@ -1,0 +1,386 @@
+package pagination
+
+import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
+import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo3.testing.runTest
+import pagination.pagination.Pagination
+import pagination.test.WithTypePolicyDirectiveQuery_TestBuilder.Data
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TypePolicyConnectionFieldsTest {
+  @Test
+  fun typePolicyConnectionFieldsMemoryCache() {
+    typePolicyConnectionFields(MemoryCacheFactory())
+  }
+
+  @Test
+  fun typePolicyConnectionFieldsBlobSqlCache() {
+    typePolicyConnectionFields(SqlNormalizedCacheFactory(name = "blob", withDates = true))
+  }
+
+  @Test
+  fun typePolicyConnectionFieldsJsonSqlCache() {
+    typePolicyConnectionFields(SqlNormalizedCacheFactory(name = "json", withDates = false))
+  }
+
+  @Test
+  fun typePolicyConnectionFieldsChainedCache() {
+    typePolicyConnectionFields(MemoryCacheFactory().chain(SqlNormalizedCacheFactory(name = "json", withDates = false)))
+  }
+
+  private fun typePolicyConnectionFields(cacheFactory: NormalizedCacheFactory) = runTest {
+    val apolloStore = ApolloStore(
+        normalizedCacheFactory = cacheFactory,
+        cacheKeyGenerator = TypePolicyCacheKeyGenerator,
+        metadataGenerator = CursorPaginationMetadataGenerator(Pagination.connectionTypes),
+        apolloResolver = FieldPolicyApolloResolver,
+        recordMerger = FieldRecordMerger(CursorPaginationFieldMerger())
+    )
+    apolloStore.clearAll()
+
+    // First page
+    val query1 = WithTypePolicyDirectiveQuery(first = Optional.Present(2))
+    val data1 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx42"
+              node = node {
+                id = "42"
+              }
+            },
+            edge {
+              cursor = "xx43"
+              node = node {
+                id = "43"
+              }
+            },
+        )
+      }
+    }
+    apolloStore.writeOperation(query1, data1)
+    var dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data1, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page after
+    val query2 = WithTypePolicyDirectiveQuery(first = Optional.Present(2), after = Optional.Present("xx43"))
+    val data2 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx44"
+              node = node {
+                id = "44"
+              }
+            },
+            edge {
+              cursor = "xx45"
+              node = node {
+                id = "45"
+              }
+            },
+        )
+      }
+    }
+    apolloStore.writeOperation(query2, data2)
+    dataFromStore = apolloStore.readOperation(query1)
+    var expectedData = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx42"
+              node = node {
+                id = "42"
+              }
+            },
+            edge {
+              cursor = "xx43"
+              node = node {
+                id = "43"
+              }
+            },
+            edge {
+              cursor = "xx44"
+              node = node {
+                id = "44"
+              }
+            },
+            edge {
+              cursor = "xx45"
+              node = node {
+                id = "45"
+              }
+            },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page after
+    val query3 = WithTypePolicyDirectiveQuery(first = Optional.Present(2), after = Optional.Present("xx45"))
+    val data3 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx46"
+              node = node {
+                id = "46"
+              }
+            },
+            edge {
+              cursor = "xx47"
+              node = node {
+                id = "47"
+              }
+            },
+        )
+      }
+    }
+    apolloStore.writeOperation(query3, data3)
+    dataFromStore = apolloStore.readOperation(query1)
+    expectedData = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx42"
+              node = node {
+                id = "42"
+              }
+            },
+            edge {
+              cursor = "xx43"
+              node = node {
+                id = "43"
+              }
+            },
+            edge {
+              cursor = "xx44"
+              node = node {
+                id = "44"
+              }
+            },
+            edge {
+              cursor = "xx45"
+              node = node {
+                id = "45"
+              }
+            },
+            edge {
+              cursor = "xx46"
+              node = node {
+                id = "46"
+              }
+            },
+            edge {
+              cursor = "xx47"
+              node = node {
+                id = "47"
+              }
+            },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page before
+    val query4 = WithTypePolicyDirectiveQuery(last = Optional.Present(2), before = Optional.Present("xx42"))
+    val data4 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx40"
+              node = node {
+                id = "40"
+              }
+            },
+            edge {
+              cursor = "xx41"
+              node = node {
+                id = "41"
+              }
+            },
+        )
+      }
+    }
+    apolloStore.writeOperation(query4, data4)
+    dataFromStore = apolloStore.readOperation(query1)
+    expectedData = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx40"
+              node = node {
+                id = "40"
+              }
+            },
+            edge {
+              cursor = "xx41"
+              node = node {
+                id = "41"
+              }
+            },
+            edge {
+              cursor = "xx42"
+              node = node {
+                id = "42"
+              }
+            },
+            edge {
+              cursor = "xx43"
+              node = node {
+                id = "43"
+              }
+            },
+            edge {
+              cursor = "xx44"
+              node = node {
+                id = "44"
+              }
+            },
+            edge {
+              cursor = "xx45"
+              node = node {
+                id = "45"
+              }
+            },
+            edge {
+              cursor = "xx46"
+              node = node {
+                id = "46"
+              }
+            },
+            edge {
+              cursor = "xx47"
+              node = node {
+                id = "47"
+              }
+            },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Non-contiguous page (should reset)
+    val query5 = WithTypePolicyDirectiveQuery(first = Optional.Present(2), after = Optional.Present("xx50"))
+    val data5 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = listOf(
+            edge {
+              cursor = "xx50"
+              node = node {
+                id = "50"
+              }
+            },
+            edge {
+              cursor = "xx51"
+              node = node {
+                id = "51"
+              }
+            },
+        )
+      }
+    }
+    apolloStore.writeOperation(query5, data5)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Empty page (should keep previous result)
+    val query6 = WithTypePolicyDirectiveQuery(first = Optional.Present(2), after = Optional.Present("xx51"))
+    val data6 = WithTypePolicyDirectiveQuery.Data {
+      usersCursorBased2 = usersCursorBased2 {
+        edges = emptyList()
+      }
+    }
+    apolloStore.writeOperation(query6, data6)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private class CursorPaginationMetadataGenerator(private val connectionTypes: Set<String>) : MetadataGenerator {
+    override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
+      if (context.field.type.leafType().name in connectionTypes) {
+        obj as Map<String, Any?>
+        val edges = obj["edges"] as List<Map<String, Any?>>
+        val startCursor = edges.firstOrNull()?.get("cursor") as String?
+        val endCursor = edges.lastOrNull()?.get("cursor") as String?
+        return mapOf(
+            "startCursor" to startCursor,
+            "endCursor" to endCursor,
+            "before" to context.argumentValue("before"),
+            "after" to context.argumentValue("after"),
+        )
+      }
+      return emptyMap()
+    }
+  }
+
+  private class CursorPaginationFieldMerger : FieldRecordMerger.FieldMerger {
+    @Suppress("UNCHECKED_CAST")
+    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
+      val existingStartCursor = existing.metadata["startCursor"] as? String
+      val existingEndCursor = existing.metadata["endCursor"] as? String
+      val incomingStartCursor = incoming.metadata["startCursor"] as? String
+      val incomingEndCursor = incoming.metadata["endCursor"] as? String
+      val incomingBeforeArgument = incoming.metadata["before"] as? String
+      val incomingAfterArgument = incoming.metadata["after"] as? String
+
+      return if (incomingBeforeArgument == null && incomingAfterArgument == null) {
+        // Not a pagination query
+        incoming
+      } else if (existingStartCursor == null || existingEndCursor == null) {
+        // Existing is empty
+        incoming
+      } else if (incomingStartCursor == null || incomingEndCursor == null) {
+        // Incoming is empty
+        existing
+      } else {
+        val existingValue = existing.value as Map<String, Any?>
+        val existingList = existingValue["edges"] as List<*>
+        val incomingList = (incoming.value as Map<String, Any?>)["edges"] as List<*>
+
+        val mergedList: List<*>
+        val newStartCursor: String
+        val newEndCursor: String
+        if (incomingAfterArgument == existingEndCursor) {
+          mergedList = existingList + incomingList
+          newStartCursor = existingStartCursor
+          newEndCursor = incomingEndCursor
+        } else if (incomingBeforeArgument == existingStartCursor) {
+          mergedList = incomingList + existingList
+          newStartCursor = incomingStartCursor
+          newEndCursor = existingEndCursor
+        } else {
+          // We received a list which is neither the previous nor the next page.
+          // Handle this case by resetting the cache with this page
+          mergedList = incomingList
+          newStartCursor = incomingStartCursor
+          newEndCursor = incomingEndCursor
+        }
+
+        val mergedFieldValue = existingValue.toMutableMap()
+        mergedFieldValue["edges"] = mergedList
+        FieldRecordMerger.FieldInfo(
+            value = mergedFieldValue,
+            metadata = mapOf("startCursor" to newStartCursor, "endCursor" to newEndCursor)
+        )
+      }
+    }
+  }
+}
+


### PR DESCRIPTION
To simplify the Relay/Connection style pagination, a new `connectionsFields` argument is added to `@typePolicy`:

```graphql
extend type Query
@typePolicy(connectionFields: "sessions, rooms")

# Equivalent to:

extend type Query
@typePolicy(embeddedFields: "sessions, rooms")
@fieldPolicy(forField: "sessions", paginationArgs: "first, after, last, before")
@fieldPolicy(forField: "rooms", paginationArgs: "first, after, last, before")

extend type SessionConnection @typePolicy(embeddedFields: "edges")
extend type RoomConnection @typePolicy(embeddedFields: "edges")
```

This also generates a new `Pagination` object with a `connectionTypes: Set<String>` field, which can be passed to `ConnectionMetadataGenerator` (now available in `apollo-normalized-cache-api-incubating`, among with `ConnectionMetadataGenerator`).

The `connectionFields` argument must be opted-in by linking (importing) the `kotlin_labs` v0.2 directives like so:

```graphql
extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@typePolicy", "@fieldPolicy"])
```

See also [this PR](https://github.com/apollographql/specs/pull/24) that adds kotlin_labs v0.2 to the public specs site.