### PR TITLE
Pin GitHub actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'apollographql/apollo-kotlin'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: '11'

--- a/.github/workflows/kotlin-1-7.yml
+++ b/.github/workflows/kotlin-1-7.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: macos-11
     if: github.repository == 'apollographql/apollo-kotlin'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -33,7 +33,7 @@ jobs:
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3
         if: always()
         with:
           name: build-kotlin-1-7.zip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,8 +15,8 @@ jobs:
   tests-gradle:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: 11
@@ -32,7 +32,7 @@ jobs:
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3
         if: always()
         with:
           name: tests-gradle.zip
@@ -41,8 +41,8 @@ jobs:
   tests-no-gradle:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: 11
@@ -58,7 +58,7 @@ jobs:
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3
         if: always()
         with:
           name: tests-no-gradle.zip
@@ -67,12 +67,12 @@ jobs:
   tests-integration:
     runs-on: macos-11
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: 11
-      - uses: gradle/gradle-build-action@v2
+      - uses: gradle/gradle-build-action@aab26ac684526c7cb10f96e3c3734bbc51749736 #v2
       - name: Build with Gradle
         run: |
           ulimit -c unlimited
@@ -84,7 +84,7 @@ jobs:
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3
         if: always()
         with:
           name: tests-integration.zip

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: macos-11
     if: github.repository == 'apollographql/apollo-kotlin'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -37,7 +37,7 @@ jobs:
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 #v3
         if: always()
         with:
           name: push.zip

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: macos-11
     if: github.repository == 'apollographql/apollo-kotlin'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
         with:
           distribution: 'temurin'
           java-version: 11


### PR DESCRIPTION
Turns out we had most of them pinned already except the first-party ones (starting with "actions/") and  `gradle/gradle-build-action`. I'm still pinning all of them because even if we obvisouly trust GitHub, they might still get hacked and reducing the attack surface could help if that were (unfortunately) to happen.