### PR TITLE
Fix inferred variables in both nullable and non-nullable locations

### DIFF
--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1037,6 +1037,12 @@ public final class com/apollographql/apollo3/ast/GqlvalueKt {
 	public static final fun coerceInSchemaContextOrThrow (Lcom/apollographql/apollo3/ast/GQLValue;Lcom/apollographql/apollo3/ast/GQLType;Lcom/apollographql/apollo3/ast/Schema;)Lcom/apollographql/apollo3/ast/GQLValue;
 }
 
+public final class com/apollographql/apollo3/ast/InferredVariable {
+	public fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/ast/GQLType;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lcom/apollographql/apollo3/ast/GQLType;
+}
+
 public abstract class com/apollographql/apollo3/ast/Issue {
 	public synthetic fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/ast/SourceLocation;Lcom/apollographql/apollo3/ast/Issue$Severity;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getMessage ()Ljava/lang/String;

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/VariableUsage.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/VariableUsage.kt
@@ -8,3 +8,12 @@ class VariableUsage(
     val locationType: GQLType,
     val hasLocationDefaultValue: Boolean
 )
+
+/**
+ * A variable that is inferred from its usages in fragments
+ * This is used to create executable fragments
+ */
+class InferredVariable(
+    val name: String,
+    val type: GQLType,
+)

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -138,7 +138,7 @@ internal class ExecutableValidationScope(
     } else if (this !is GQLNonNullType && other is GQLNonNullType) {
       this.mergeWith(other.type)?.let { GQLNonNullType(SourceLocation.UNKNOWN, it) }
     } else if (this is GQLListType && other is GQLListType) {
-      this.type.mergeWith(other.type)
+      this.type.mergeWith(other.type)?.let { GQLListType(SourceLocation.UNKNOWN, it) }
     } else if (this is GQLListType && other !is GQLListType) {
       null
     } else if (this !is GQLListType && other is GQLListType) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -406,7 +406,7 @@ internal class IrBuilder(
   private fun InferredVariable.toIr(): IrVariable {
     var irType = type.toIr()
     if (type !is GQLNonNullType) {
-      // If the location is non-nullable, the variable might be omitted, make it optional
+      // If the type is nullable, the variable might be omitted, make it optional
       irType = irType.makeOptional()
     }
     return IrVariable(

--- a/tests/optional-variables/build.gradle.kts
+++ b/tests/optional-variables/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 apollo {
   packageName.set("optional.variables")
   generateOptionalOperationVariables.set(false)
+  generateFragmentImplementations.set(true)
 }

--- a/tests/optional-variables/src/main/graphql/operation.graphql
+++ b/tests/optional-variables/src/main/graphql/operation.graphql
@@ -22,3 +22,4 @@ query WithoutDirectiveNonNullableParams($param1: Int!, $param2: Float!) {
 query WithoutDirectiveDefaultValueParams($param1: Int = 0, $param2: Float! = 0.0) {
   field(param1: $param1, param2: $param2)
 }
+

--- a/tests/optional-variables/src/main/graphql/operationWithFragment.graphql
+++ b/tests/optional-variables/src/main/graphql/operationWithFragment.graphql
@@ -1,9 +1,9 @@
-query QueryWithFragment($param1: String!) {
+query QueryWithFragment($param1: String!, $param2: [[String!]]!) {
   ...fragment
 }
 
 fragment fragment on Query {
-  field2(mandatory: $param1)
-  field3(optional: $param1)
+  field2(mandatory: $param1, list: $param2)
+  field3(optional: $param1, list: $param2)
 }
 

--- a/tests/optional-variables/src/main/graphql/operationWithFragment.graphql
+++ b/tests/optional-variables/src/main/graphql/operationWithFragment.graphql
@@ -1,0 +1,9 @@
+query QueryWithFragment($param1: String!) {
+  ...fragment
+}
+
+fragment fragment on Query {
+  field2(mandatory: $param1)
+  field3(optional: $param1)
+}
+

--- a/tests/optional-variables/src/main/graphql/schema.graphqls
+++ b/tests/optional-variables/src/main/graphql/schema.graphqls
@@ -1,4 +1,6 @@
 type Query {
   field(param1: Int, param2: Float): Int
-}
 
+  field2(mandatory: String!): Int
+  field3(optional: String): Int
+}

--- a/tests/optional-variables/src/main/graphql/schema.graphqls
+++ b/tests/optional-variables/src/main/graphql/schema.graphqls
@@ -1,6 +1,6 @@
 type Query {
   field(param1: Int, param2: Float): Int
 
-  field2(mandatory: String!): Int
-  field3(optional: String): Int
+  field2(mandatory: String!, list: [[String!]]!): Int
+  field3(optional: String, list: [[String]]): Int
 }


### PR DESCRIPTION
When the same fragment uses the same variable in both nullable and non-nullable locations, infer the variable type as non-nullable.
Closes #4304 
