### PR TITLE
Always use String for defaultValue in introspection Json

### DIFF
--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1271,18 +1271,18 @@ public final class com/apollographql/apollo3/ast/introspection/IntrospectionSche
 }
 
 public final class com/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;
-	public final fun component6 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$Field$Argument;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getDefaultValue ()Ljava/lang/String;
 	public final fun getDeprecationReason ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;
@@ -1293,18 +1293,18 @@ public final class com/apollographql/apollo3/ast/introspection/IntrospectionSche
 }
 
 public final class com/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;
-	public final fun component6 ()Ljava/lang/Object;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/Object;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$TypeRef;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/introspection/IntrospectionSchema$Schema$InputField;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDefaultValue ()Ljava/lang/Object;
+	public final fun getDefaultValue ()Ljava/lang/String;
 	public final fun getDeprecationReason ()Ljava/lang/String;
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getName ()Ljava/lang/String;

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/IntrospectionSchema.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/IntrospectionSchema.kt
@@ -107,7 +107,7 @@ data class IntrospectionSchema(
         val isDeprecated: Boolean = false,
         val deprecationReason: String?,
         val type: TypeRef,
-        val defaultValue: Any?,
+        val defaultValue: String?,
     )
 
     @JsonClass(generateAdapter = true)
@@ -127,7 +127,7 @@ data class IntrospectionSchema(
           val isDeprecated: Boolean = false,
           val deprecationReason: String?,
           val type: TypeRef,
-          val defaultValue: Any?,
+          val defaultValue: String?,
       )
     }
 

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/schema_to_introspection.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/schema_to_introspection.kt
@@ -81,7 +81,7 @@ private class IntrospectionSchemaBuilder(private val schema: Schema) {
         isDeprecated = deprecationReason != null,
         deprecationReason = deprecationReason,
         type = type.toSchemaType(schema),
-        defaultValue = defaultValue?.toUtf8()
+        defaultValue = defaultValue?.toUtf8(indent = "")
     )
   }
 
@@ -101,7 +101,7 @@ private class IntrospectionSchemaBuilder(private val schema: Schema) {
         isDeprecated = deprecationReason != null,
         deprecationReason = deprecationReason,
         type = type.toSchemaType(schema),
-        defaultValue = defaultValue?.toKotlinValue(true),
+        defaultValue = defaultValue?.toUtf8(indent = ""),
     )
   }
 

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
@@ -3,7 +3,12 @@ package com.apollographql.apollo3.graphql.ast.test
 import com.apollographql.apollo3.ast.SDLWriter
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.internal.buffer
+import com.apollographql.apollo3.ast.introspection.IntrospectionSchema
+import com.apollographql.apollo3.ast.introspection.toGQLDocument
+import com.apollographql.apollo3.ast.introspection.toIntrospectionSchema
 import com.apollographql.apollo3.ast.toSchema
+import com.apollographql.apollo3.ast.toUtf8
+import com.squareup.moshi.Moshi
 import okio.Buffer
 import org.junit.Test
 import kotlin.test.assertEquals

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/introspection/IntrospectionTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/introspection/IntrospectionTest.kt
@@ -1,10 +1,16 @@
 package com.apollographql.apollo3.graphql.ast.test.introspection
 
 import com.apollographql.apollo3.ast.SourceAwareException
+import com.apollographql.apollo3.ast.introspection.IntrospectionSchema
+import com.apollographql.apollo3.ast.introspection.toIntrospectionSchema
 import com.apollographql.apollo3.ast.introspection.toSchemaGQLDocument
+import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.validateAsSchema
+import com.squareup.moshi.Moshi
+import okio.Buffer
 import org.junit.Test
 import java.io.File
+import kotlin.test.assertEquals
 
 class IntrospectionTest {
   @Test
@@ -14,5 +20,48 @@ class IntrospectionTest {
     } catch (e: SourceAwareException) {
       assert(e.message!!.contains("is defined multiple times"))
     }
+  }
+
+  /**
+   * Default values are encoded as Json strings representing their GraphQL value
+   */
+  @Test
+  fun defaultValues() {
+    val schema = """
+      type Query {
+         someField(arg: SomeInput): Int
+      }
+      
+      input SomeInput {
+         value1: Boolean = false
+         value2: Direction = South 
+         value3: OtherInput = {value: true, value2: [North, null, South]}
+         value4: [Int] = [0, null, 1]
+         value5: String = "South" 
+      }
+      
+      input OtherInput {
+         value1: Boolean = false
+         value2: [Direction] = South 
+      }
+      
+      enum Direction {
+        South,
+        North
+      }
+    """.trimIndent()
+
+    val introspectionSchema = Buffer().writeUtf8(schema)
+        .toSchema()
+        .toIntrospectionSchema()
+
+    val someInputType = introspectionSchema.__schema.types.first { it.name == "SomeInput" } as IntrospectionSchema.Schema.Type.InputObject
+    val someInputFields = someInputType.inputFields
+
+    assertEquals("false", someInputFields.first { it.name == "value1" }.defaultValue)
+    assertEquals("South", someInputFields.first { it.name == "value2" }.defaultValue)
+    assertEquals("{\n  value: true\n  value2: [North,null,South]\n}\n", someInputFields.first { it.name == "value3" }.defaultValue)
+    assertEquals("[0,null,1]", someInputFields.first { it.name == "value4" }.defaultValue)
+    assertEquals("\"South\"", someInputFields.first { it.name == "value5" }.defaultValue)
   }
 }

--- a/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/introspection/IntrospectionTest.kt
+++ b/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/introspection/IntrospectionTest.kt
@@ -60,7 +60,7 @@ class IntrospectionTest {
 
     assertEquals("false", someInputFields.first { it.name == "value1" }.defaultValue)
     assertEquals("South", someInputFields.first { it.name == "value2" }.defaultValue)
-    assertEquals("{\n  value: true\n  value2: [North,null,South]\n}\n", someInputFields.first { it.name == "value3" }.defaultValue)
+    assertEquals("{\nvalue: true\nvalue2: [North,null,South]\n}\n", someInputFields.first { it.name == "value3" }.defaultValue)
     assertEquals("[0,null,1]", someInputFields.first { it.name == "value4" }.defaultValue)
     assertEquals("\"South\"", someInputFields.first { it.name == "value5" }.defaultValue)
   }


### PR DESCRIPTION
See https://spec.graphql.org/draft/#sel-GAJXVHHDAAACB6B0lW

* Boolean `false` is encoded as `"false"` in introspection Json
* Enum `North` is encoded as `"North"` in introspection Json
* String `"North"` is encoded as `"\"North\""` in introspection Json
