### PR TITLE
Benchmarks: add a gcloud setup step

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
       - run: |
           # Build the benchmark apks
           ./gradlew -p benchmark assembleRelease assembleReleaseAndroidTest
-      # Step can be removed if/when gcloud is added to the macos image - See https://github.com/actions/virtual-environments/issues/6020
+      # Step can be removed if/when gcloud is added to the macos image - See https://github.com/actions/virtual-environments/issues/4639
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb #v0.6.0
       - name: microbenchmarks

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,10 +1,11 @@
 name: benchmarks
 
 on:
-#  pull_request:
-  #    branches: ['*']
-  schedule:
-    - cron: '0 3 * * *'
+  # TODO Testing only, must revert to schedule
+  pull_request:
+    branches: [ '*' ]
+#  schedule:
+#    - cron: '0 3 * * *'
 
 jobs:
   benchmarks:
@@ -29,6 +30,8 @@ jobs:
       - run: |
           # Build the benchmark apks
           ./gradlew -p benchmark assembleRelease assembleReleaseAndroidTest
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb #v0.6.0
       - name: microbenchmarks
         uses: martinbonnin/run-benchmarks@ef9043b9a646a109f7381a4bf20f82ead5cbd382 #main
         with:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,11 +1,10 @@
 name: benchmarks
 
 on:
-  # TODO Testing only, must revert to schedule
-  pull_request:
-    branches: [ '*' ]
-#  schedule:
-#    - cron: '0 3 * * *'
+  #  pull_request:
+  #    branches: [ '*' ]
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   benchmarks:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,6 +29,7 @@ jobs:
       - run: |
           # Build the benchmark apks
           ./gradlew -p benchmark assembleRelease assembleReleaseAndroidTest
+      # Step can be removed if/when gcloud is added to the macos image - See https://github.com/actions/virtual-environments/issues/6020
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb #v0.6.0
       - name: microbenchmarks


### PR DESCRIPTION
Image was changed to `macos-11` to execute native tests, but `gcloud` is not present on it, so this PR adds a step to install it.