### PR TITLE
[Data Builders] add support for custom scalars

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -245,6 +245,13 @@ public final class com/apollographql/apollo3/api/BooleanExpressions {
 	public static final fun variable (Ljava/lang/String;)Lcom/apollographql/apollo3/api/BooleanExpression;
 }
 
+public final class com/apollographql/apollo3/api/BuilderProperty {
+	public fun <init> (Lcom/apollographql/apollo3/api/Adapter;)V
+	public final fun getAdapter ()Lcom/apollographql/apollo3/api/Adapter;
+	public final fun getValue (Lcom/apollographql/apollo3/api/ObjectBuilder;Lkotlin/reflect/KProperty;)Ljava/lang/Object;
+	public final fun setValue (Lcom/apollographql/apollo3/api/ObjectBuilder;Lkotlin/reflect/KProperty;Ljava/lang/Object;)V
+}
+
 public final class com/apollographql/apollo3/api/CompiledArgument {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;Z)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -370,7 +377,8 @@ public final class com/apollographql/apollo3/api/CompiledVariable {
 public final class com/apollographql/apollo3/api/CustomScalarAdapters : com/apollographql/apollo3/api/ExecutionContext$Element {
 	public static final field Empty Lcom/apollographql/apollo3/api/CustomScalarAdapters;
 	public static final field Key Lcom/apollographql/apollo3/api/CustomScalarAdapters$Key;
-	public synthetic fun <init> (Ljava/util/Map;Lcom/apollographql/apollo3/api/AdapterContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final field Unsafe Lcom/apollographql/apollo3/api/CustomScalarAdapters;
+	public synthetic fun <init> (Ljava/util/Map;Lcom/apollographql/apollo3/api/AdapterContext;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun fold (Ljava/lang/Object;Lkotlin/jvm/functions/Function2;)Ljava/lang/Object;
 	public fun get (Lcom/apollographql/apollo3/api/ExecutionContext$Key;)Lcom/apollographql/apollo3/api/ExecutionContext$Element;
 	public final fun getAdapterContext ()Lcom/apollographql/apollo3/api/AdapterContext;
@@ -390,6 +398,7 @@ public final class com/apollographql/apollo3/api/CustomScalarAdapters$Builder {
 	public final fun addAll (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/CustomScalarAdapters$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/api/CustomScalarAdapters;
 	public final fun clear ()V
+	public final fun unsafe (Z)Lcom/apollographql/apollo3/api/CustomScalarAdapters$Builder;
 	public final fun variables (Lcom/apollographql/apollo3/api/Executable$Variables;)Lcom/apollographql/apollo3/api/CustomScalarAdapters$Builder;
 }
 
@@ -671,7 +680,7 @@ public final class com/apollographql/apollo3/api/ObjectAdapter : com/apollograph
 
 public abstract class com/apollographql/apollo3/api/ObjectBuilder {
 	public fun <init> ()V
-	protected final fun get__fields ()Ljava/util/Map;
+	public final fun get__fields ()Ljava/util/Map;
 	public final fun get__typename ()Ljava/lang/String;
 	public final fun set (Ljava/lang/String;Ljava/lang/Object;)V
 	public final fun set__typename (Ljava/lang/String;)V
@@ -998,6 +1007,7 @@ public abstract interface class com/apollographql/apollo3/api/json/JsonReader : 
 }
 
 public final class com/apollographql/apollo3/api/json/JsonReader$Token : java/lang/Enum {
+	public static final field ANY Lcom/apollographql/apollo3/api/json/JsonReader$Token;
 	public static final field BEGIN_ARRAY Lcom/apollographql/apollo3/api/json/JsonReader$Token;
 	public static final field BEGIN_OBJECT Lcom/apollographql/apollo3/api/json/JsonReader$Token;
 	public static final field BOOLEAN Lcom/apollographql/apollo3/api/json/JsonReader$Token;
@@ -1060,6 +1070,7 @@ public final class com/apollographql/apollo3/api/json/MapJsonReader : com/apollo
 	public fun nextNull ()Ljava/lang/Void;
 	public fun nextNumber ()Lcom/apollographql/apollo3/api/json/JsonNumber;
 	public fun nextString ()Ljava/lang/String;
+	public final fun nextValue ()Ljava/lang/Object;
 	public fun peek ()Lcom/apollographql/apollo3/api/json/JsonReader$Token;
 	public fun rewind ()V
 	public fun selectName (Ljava/util/List;)I

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
@@ -4,6 +4,7 @@ package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
+import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.json.MapJsonReader.Companion.buffer
 import com.apollographql.apollo3.api.json.MapJsonWriter
 import com.apollographql.apollo3.api.json.buildJsonString
@@ -179,6 +180,21 @@ val AnyAdapter = object : Adapter<Any> {
 
   override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: Any) {
     toJson(writer, value)
+  }
+}
+
+internal class UnsafeAdapter<T>: Adapter<T> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): T {
+    check (reader is MapJsonReader) {
+      "UnsafeAdapter only supports MapJsonReader"
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return reader.nextValue() as T
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: T) {
+    error("UnsafeAdapter.toJson is not implemented")
   }
 }
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ObjectBuilder.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ObjectBuilder.kt
@@ -1,11 +1,11 @@
 package com.apollographql.apollo3.api
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.json.MapJsonReader
+import com.apollographql.apollo3.api.json.MapJsonWriter
 
 @Suppress("PropertyName")
 abstract class ObjectBuilder {
-  protected val __fields = mutableMapOf<String, Any?>()
+  val __fields = mutableMapOf<String, Any?>()
 
   var __typename: String by __fields
 
@@ -13,4 +13,25 @@ abstract class ObjectBuilder {
     __fields[key] = value
   }
 }
+
+/**
+ * A property delegate that stores the given property as it would be serialized in a Json
+ * This is needed in Data Builders because the serializer only work from Json
+ */
+class BuilderProperty<T>(val adapter: Adapter<T>) {
+  operator fun getValue(thisRef: ObjectBuilder, property: kotlin.reflect.KProperty<*>): T {
+    // XXX: remove this cast as MapJsonReader can tak any value
+    @Suppress("UNCHECKED_CAST")
+    val data = thisRef.__fields[property.name] as Map<String, Any?>
+    return adapter.fromJson(MapJsonReader(data), CustomScalarAdapters.Empty)
+  }
+
+  operator fun setValue(thisRef: ObjectBuilder, property: kotlin.reflect.KProperty<*>, value: T) {
+
+    thisRef.__fields[property.name] = MapJsonWriter().apply {
+      adapter.toJson(this, CustomScalarAdapters.Empty, value)
+    }.root()
+  }
+}
+
 

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/JsonReader.kt
@@ -236,6 +236,11 @@ interface JsonReader : Closeable {
      * The end of the JSON stream. This sentinel value is returned by [JsonReader.peek] to signal that the JSON-encoded value has no
      * more tokens.
      */
-    END_DOCUMENT
+    END_DOCUMENT,
+
+    /**
+     * A reference to an in-memory value that is reader-specific. Not all readers may support this
+     */
+    ANY
   }
 }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
@@ -76,7 +76,7 @@ constructor(
     is JsonNumber -> JsonReader.Token.NUMBER
     is String -> JsonReader.Token.STRING
     is Boolean -> JsonReader.Token.BOOLEAN
-    else -> error("Unsupported value $any")
+    else -> JsonReader.Token.ANY
   }
 
   /**
@@ -316,6 +316,14 @@ constructor(
       is JsonNumber -> value
       else -> error("Expected JsonNumber but got $value instead")
     }.also {
+      advanceIterator()
+    }
+  }
+
+  fun nextValue(): Any {
+    val data = peekedData ?: throw JsonDataException("Expected a non-null value at path ${getPathAsString()}")
+
+    return data.also {
       advanceIterator()
     }
   }

--- a/apollo-api/src/commonTest/kotlin/test/PathTest.kt
+++ b/apollo-api/src/commonTest/kotlin/test/PathTest.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.api.json.JsonReader.Token.NAME
 import com.apollographql.apollo3.api.json.JsonReader.Token.NULL
 import com.apollographql.apollo3.api.json.JsonReader.Token.NUMBER
 import com.apollographql.apollo3.api.json.JsonReader.Token.STRING
+import com.apollographql.apollo3.api.json.JsonReader.Token.ANY
 import com.apollographql.apollo3.api.json.MapJsonReader.Companion.buffer
 import okio.Buffer
 import okio.ByteString.Companion.encodeUtf8
@@ -79,6 +80,7 @@ class PathTest {
         LONG -> jsonReader.nextLong()
         BOOLEAN -> jsonReader.nextBoolean()
         NULL -> jsonReader.nextNull()
+        ANY -> jsonReader.skipValue()
 
         END_DOCUMENT -> break@loop
       }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -153,7 +153,8 @@ object ApolloCompiler {
         alwaysGenerateTypesMatching = alwaysGenerateTypesMatching,
         scalarMapping = options.scalarMapping,
         codegenModels = options.codegenModels,
-        generateOptionalOperationVariables = options.generateOptionalOperationVariables
+        generateOptionalOperationVariables = options.generateOptionalOperationVariables,
+        generateDataBuilders = options.generateDataBuilders
     ).build()
 
     if (debugDir != null) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/ClassNames.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/ClassNames.kt
@@ -17,6 +17,7 @@ internal object ClassNames {
   val InterfaceTypeBuilder = ResolverClassName(apolloApiPackageName, "InterfaceType", "Builder")
 
   val ObjectBuilder = ResolverClassName(apolloApiPackageName, "ObjectBuilder")
+  val BuilderProperty = ResolverClassName(apolloApiPackageName, "BuilderProperty")
   val JsonReader = ResolverClassName(apolloApiJsonPackageName, "JsonReader")
   val JsonWriter = ResolverClassName(apolloApiJsonPackageName, "JsonWriter")
   val CustomScalarAdapters = ResolverClassName(apolloApiPackageName, "CustomScalarAdapters")

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -21,6 +21,7 @@ internal object KotlinSymbols {
   val InterfaceType = ClassNames.InterfaceType.toKotlinPoetClassName()
   val InterfaceTypeBuilder = ClassNames.InterfaceTypeBuilder.toKotlinPoetClassName()
   val ObjectBuilder = ClassNames.ObjectBuilder.toKotlinPoetClassName()
+  val BuilderProperty = ClassNames.BuilderProperty.toKotlinPoetClassName()
 
   val JsonReader = ClassNames.JsonReader.toKotlinPoetClassName()
   val JsonWriter = ClassNames.JsonWriter.toKotlinPoetClassName()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InterfaceBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InterfaceBuilder.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDepreca
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.apollographql.apollo3.compiler.ir.IrCompositeType2
+import com.apollographql.apollo3.compiler.ir.IrNonNullType2
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 
@@ -40,7 +41,7 @@ internal class InterfaceBuilder(
   private fun IrInterface.mapTypeSpec(): TypeSpec {
     return TypeSpec
         .interfaceBuilder(layout.mapName(name))
-        .addSuperinterfaces(implements.map { context.resolver.resolveIrType2(IrCompositeType2(it)) })
+        .addSuperinterfaces(implements.map { context.resolver.resolveIrType2(IrNonNullType2(IrCompositeType2(it))) })
         .build()
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ObjectBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ObjectBuilder.kt
@@ -91,7 +91,14 @@ internal class ObjectBuilder(
   private fun IrMapProperty.toPropertySpec(): PropertySpec {
     return PropertySpec.builder(layout.propertyName(name), context.resolver.resolveIrType2(type))
         .mutable(true)
-        .delegate(CodeBlock.of(Identifier.__fields))
+        .apply {
+          val initializer = context.resolver.adapterInitializer2(type)
+          if (initializer == null) {
+            delegate(CodeBlock.of(Identifier.__fields))
+          } else {
+            delegate(CodeBlock.of("%T(%L)", KotlinSymbols.BuilderProperty, initializer))
+          }
+        }
         .build()
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ObjectBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ObjectBuilder.kt
@@ -10,6 +10,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDepreca
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.ir.IrMapProperty
 import com.apollographql.apollo3.compiler.ir.IrCompositeType2
+import com.apollographql.apollo3.compiler.ir.IrNonNullType2
 import com.apollographql.apollo3.compiler.ir.IrObject
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
@@ -70,7 +71,7 @@ internal class ObjectBuilder(
                 )
                 .build()
         )
-        .addSuperinterfaces(superTypes.map { context.resolver.resolveIrType2(IrCompositeType2(it)) })
+        .addSuperinterfaces(superTypes.map { context.resolver.resolveIrType2(IrNonNullType2(IrCompositeType2(it))) })
         .addSuperinterface(
             superinterface = MapOfStringToNullableAny,
             delegate = CodeBlock.of(Identifier.__fields)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
@@ -193,7 +193,7 @@ internal class OperationBuilder(
         .addCode(
             CodeBlock.builder()
                 .addStatement(
-                    "return·%L.fromJson(%T(%M($block)),·%T.Empty)",
+                    "return·%L.fromJson(%T(%M($block)),·%T.Unsafe)",
                     context.resolver.adapterInitializer(operation.dataProperty.info.type, requiresBuffering = false),
                     KotlinSymbols.MapJsonReader,
                     context.resolver.resolveBuilderFun(operation.operationType.typeName),

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**

--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**

--- a/tests/data-builders/build.gradle.kts
+++ b/tests/data-builders/build.gradle.kts
@@ -12,4 +12,6 @@ dependencies {
 apollo {
   packageName.set("data.builders")
   generateDataBuilders.set(true)
+  mapScalar("Long1", "MyLong", "MyLongAdapter")
+  mapScalar("Long2", "MyLong")
 }

--- a/tests/data-builders/src/main/graphql/operations.graphql
+++ b/tests/data-builders/src/main/graphql/operations.graphql
@@ -1,9 +1,27 @@
-query GetStuff {
+query GetInt {
   nullableInt
   nonNullableInt
-  alias: nullableInt
 }
 
-mutation PutStuff {
+mutation PutInt {
   nullableInt
+}
+
+query GetAliases {
+  aliasedNullableInt: nullableInt
+  cat {
+    species
+  }
+  aliasedCat: cat {
+    species
+  }
+}
+
+query GetAnimal {
+  animal {
+    species
+    ... on Lion {
+      roar
+    }
+  }
 }

--- a/tests/data-builders/src/main/graphql/operations.graphql
+++ b/tests/data-builders/src/main/graphql/operations.graphql
@@ -3,6 +3,16 @@ query GetInt {
   nonNullableInt
 }
 
+query GetCustomScalar {
+  long1
+  long2
+  long3
+}
+
+query GetDirection {
+  direction
+}
+
 mutation PutInt {
   nullableInt
 }
@@ -22,6 +32,14 @@ query GetAnimal {
     species
     ... on Lion {
       roar
+    }
+  }
+}
+
+query GetFeline {
+  feline {
+    ... on Cat {
+      mustaches
     }
   }
 }

--- a/tests/data-builders/src/main/graphql/schema.graphqls
+++ b/tests/data-builders/src/main/graphql/schema.graphqls
@@ -6,8 +6,40 @@ schema {
 type Query {
   nullableInt: Int
   nonNullableInt: Int!
+  direction: Direction!,
+  cat: Cat!
+  animal: Animal!
+  feline: Feline!
+}
+
+enum Direction {
+  SOUTH,
+  NORTH
 }
 
 type MutationRoot {
   nullableInt: Int
 }
+
+interface Animal {
+  species: String!
+}
+
+type Cat implements Animal & Animal2 {
+  species: String!
+  mustaches: Int!
+}
+
+type Lion implements Animal {
+  species: String!
+  roar: String!
+}
+
+union Feline = Cat | Lion
+
+# an interface that is not directly queried but still needs to be added because the data builders
+# will reference them
+interface Animal2 {
+  species: String!
+}
+union Feline2 = Cat | Lion

--- a/tests/data-builders/src/main/graphql/schema.graphqls
+++ b/tests/data-builders/src/main/graphql/schema.graphqls
@@ -10,6 +10,9 @@ type Query {
   cat: Cat!
   animal: Animal!
   feline: Feline!
+  long1: Long1
+  long2: Long2
+  long3: Long3
 }
 
 enum Direction {
@@ -43,3 +46,7 @@ interface Animal2 {
   species: String!
 }
 union Feline2 = Cat | Lion
+
+scalar Long1
+scalar Long2
+scalar Long3

--- a/tests/data-builders/src/main/kotlin/MyLong.kt
+++ b/tests/data-builders/src/main/kotlin/MyLong.kt
@@ -1,0 +1,17 @@
+import com.apollographql.apollo3.api.Adapter
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.json.JsonReader
+import com.apollographql.apollo3.api.json.JsonWriter
+
+class MyLong(val value: Long)
+
+
+object MyLongAdapter: Adapter<MyLong> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): MyLong {
+    return MyLong(reader.nextString()!!.toLong())
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: MyLong) {
+    writer.value(value.value.toString())
+  }
+}

--- a/tests/data-builders/src/test/kotlin/test/DataBuilderTest.kt
+++ b/tests/data-builders/src/test/kotlin/test/DataBuilderTest.kt
@@ -1,9 +1,14 @@
 package test
 
+import MyLong
 import data.builders.GetAliasesQuery
 import data.builders.GetAnimalQuery
+import data.builders.GetCustomScalarQuery
+import data.builders.GetDirectionQuery
+import data.builders.GetFelineQuery
 import data.builders.GetIntQuery
 import data.builders.PutIntMutation
+import data.builders.type.Direction
 import data.builders.type.buildCat
 import data.builders.type.buildLion
 import kotlin.test.Test
@@ -34,8 +39,8 @@ class DataBuilderTest {
     }
 
     assertEquals(50, data.aliasedNullableInt)
-    assertEquals("Cat", data.cat?.species)
-    assertEquals("AliasedCat", data.aliasedCat?.species)
+    assertEquals("Cat", data.cat.species)
+    assertEquals("AliasedCat", data.aliasedCat.species)
   }
 
   @Test
@@ -56,8 +61,56 @@ class DataBuilderTest {
       }
     }
 
-    assertEquals("Lion", data.animal?.__typename)
-    assertEquals("LionSpecies", data.animal?.species)
-    assertEquals("Rooooaaarr", data.animal?.onLion?.roar)
+    assertEquals("Lion", data.animal.__typename)
+    assertEquals("LionSpecies", data.animal.species)
+    assertEquals("Rooooaaarr", data.animal.onLion?.roar)
+  }
+
+  @Test
+  fun unionTest1() {
+    val data = GetFelineQuery.Data {
+      feline = buildLion {
+        species = "LionSpecies"
+        roar = "Rooooaaarr"
+      }
+    }
+
+    assertEquals("Lion", data.feline.__typename)
+    assertEquals(null, data.feline.onCat)
+  }
+
+  @Test
+  fun unionTest2() {
+    val data = GetFelineQuery.Data {
+      feline = buildCat {
+        species = "CatSpecies"
+        mustaches = 5
+      }
+    }
+
+    assertEquals("Cat", data.feline.__typename)
+    assertEquals(5, data.feline.onCat?.mustaches)
+  }
+
+  @Test
+  fun enumTest() {
+    val data = GetDirectionQuery.Data {
+      direction = Direction.NORTH
+    }
+
+    assertEquals(Direction.NORTH, data.direction)
+  }
+
+  @Test
+  fun customScalarTest() {
+    val data = GetCustomScalarQuery.Data {
+      long1 = MyLong(42)
+      long2 = MyLong(43)
+      long3 = 44
+    }
+
+    assertEquals(42, data.long1?.value)
+    assertEquals(43, data.long2?.value)
+    assertEquals(44, data.long3)
   }
 }

--- a/tests/data-builders/src/test/kotlin/test/DataBuilderTest.kt
+++ b/tests/data-builders/src/test/kotlin/test/DataBuilderTest.kt
@@ -1,21 +1,63 @@
 package test
 
-import data.builders.GetStuffQuery
+import data.builders.GetAliasesQuery
+import data.builders.GetAnimalQuery
+import data.builders.GetIntQuery
+import data.builders.PutIntMutation
+import data.builders.type.buildCat
+import data.builders.type.buildLion
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DataBuilderTest {
   @Test
-  fun simpleTest() {
-    val data = GetStuffQuery.Data {
+  fun nullabilityTest() {
+    val data = GetIntQuery.Data {
       nullableInt = null
       nonNullableInt = 42
-
-      this["alias"] = 50
     }
 
     assertEquals(null, data.nullableInt)
     assertEquals(42, data.nonNullableInt)
-    assertEquals(50, data.alias)
+  }
+
+  @Test
+  fun aliasTest() {
+    val data = GetAliasesQuery.Data {
+      this["aliasedNullableInt"] = 50
+      cat = buildCat {
+        species = "Cat"
+      }
+      this["aliasedCat"] = buildCat {
+        species = "AliasedCat"
+      }
+    }
+
+    assertEquals(50, data.aliasedNullableInt)
+    assertEquals("Cat", data.cat?.species)
+    assertEquals("AliasedCat", data.aliasedCat?.species)
+  }
+
+  @Test
+  fun mutationTest() {
+    val data = PutIntMutation.Data {
+      nullableInt = null
+    }
+
+    assertEquals(null, data.nullableInt)
+  }
+
+  @Test
+  fun interfaceTest() {
+    val data = GetAnimalQuery.Data {
+      animal = buildLion {
+        species = "LionSpecies"
+        roar = "Rooooaaarr"
+      }
+    }
+
+    assertEquals("Lion", data.animal?.__typename)
+    assertEquals("LionSpecies", data.animal?.species)
+    assertEquals("Rooooaaarr", data.animal?.onLion?.roar)
   }
 }


### PR DESCRIPTION
Custom scalars are a bit weird because:
* Our adapters know only about Json so theorically only strings, boolean, numbers, objects and arrays
* But Kotlin callsites want to specify them as Kotlin classes like `Date`, `GeoPoint`, etc...

This PR does a few tricks to make this work:
1. introduce a new "ANY" token in the `JsonReader` API. This allows a `MapJsonReader` to read any value from Map as-is though `UnsafeAdapter`
2. Use `UnsafeAdapter` always for custom scalars whose adapter is registered at runtime. This saves the need to pass an instance of `CustomScalarAdapters` around
3. For custom scalars whose adapter is registered at compile time, the value is serialized before being put in the `__fields` map so that the adapters can read it

It's not super pretty but it works. And I can't really see a better way without adding more abstraction layers that will certainly add a small performance penalty in the nominal case.


See https://github.com/apollographql/apollo-kotlin/issues/4016
