### PR TITLE
enableCompatibilityMetadataVariant

### DIFF
--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -54,7 +54,7 @@ fun Project.configureMppDefaults(withJs: Boolean = true, withLinux: Boolean = tr
 fun Project.okio(): String {
   val okioVersion = when (getKotlinPluginVersion()) {
     "1.6.10" -> "3.0.0"
-    else -> "3.1.0"
+    else -> "3.2.0"
   }
 
   return "${groovy.util.Eval.x(project, "x.dep.okio")}:$okioVersion"
@@ -63,7 +63,7 @@ fun Project.okio(): String {
 fun Project.okioNodeJs(): String {
   val okioVersion = when (getKotlinPluginVersion()) {
     "1.6.10" -> "3.0.0"
-    else -> "3.1.0"
+    else -> "3.2.0"
   }
 
   return "${groovy.util.Eval.x(project, "x.dep.okioNodeJs")}:$okioVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,7 @@ kotlin.mpp.stability.nowarn=true
 
 # Do not automatically add stdlib dependency
 kotlin.stdlib.default.dependency=false
+
+# Enable compatibility with non-hierarchical projects.
+# See https://kotlinlang.org/docs/multiplatform-hierarchy.html#for-library-authors
+kotlin.mpp.enableCompatibilityMetadataVariant=true


### PR DESCRIPTION
Okio 3.2.0 supports enableCompatibilityMetadataVariant so looks like we can too 🎉 