### PR TITLE
use Data builders in our own tests, part 1

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -822,6 +822,8 @@ public abstract interface class com/apollographql/apollo3/api/Subscription$Data 
 public final class com/apollographql/apollo3/api/ToJsonKt {
 	public static final fun toJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/String;
 	public static synthetic fun toJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Ljava/lang/String;
+	public static final fun toResponseJson (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/lang/String;
+	public static synthetic fun toResponseJson$default (Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/api/UnionType : com/apollographql/apollo3/api/CompiledNamedType {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CustomScalarAdapters.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CustomScalarAdapters.kt
@@ -73,6 +73,10 @@ class CustomScalarAdapters private constructor(
     @JvmField
     val Empty = Builder().build()
 
+    /**
+     * Unsafe [CustomScalarAdapters]. They can only be used with `MapJsonReader` and will passthrough the values using
+     * `MapJsonReader.readAny`
+     */
     @JvmField
     val Unsafe = Builder().unsafe(true).build()
   }

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -2,10 +2,13 @@
 
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.internal.ResponseParser
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
+import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.writeObject
+import okio.Buffer
 import okio.use
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmOverloads
@@ -64,6 +67,15 @@ fun <D : Operation.Data> Operation<D>.parseJsonResponse(
               .build())
           .build()
   )
+}
+
+@JvmOverloads
+@ApolloExperimental
+fun <D : Operation.Data> Operation<D>.parseJsonResponse(
+    json: String,
+    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
+): ApolloResponse<D> {
+  return parseJsonResponse(Buffer().writeUtf8(json).jsonReader(), customScalarAdapters)
 }
 
 /**

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/toJson.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/toJson.kt
@@ -11,3 +11,10 @@ expect fun Operation.Data.toJson(jsonWriter: JsonWriter, customScalarAdapters: C
 fun Operation.Data.toJson(customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty): String = buildJsonString {
   toJson(this, customScalarAdapters)
 }
+
+fun Operation.Data.toResponseJson(customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty): String = buildJsonString {
+  beginObject()
+  name("data")
+  toJson(this, customScalarAdapters)
+  endObject()
+}

--- a/apollo-testing-support/api/apollo-testing-support.api
+++ b/apollo-testing-support/api/apollo-testing-support.api
@@ -10,6 +10,10 @@ public final class com/apollographql/apollo3/testing/ChannelsKt {
 public final class com/apollographql/apollo3/testing/MockserverKt {
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;J)V
 	public static synthetic fun enqueue$default (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JILjava/lang/Object;)V
+	public static final fun enqueueData (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JI)V
+	public static final fun enqueueData (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/util/Map;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JI)V
+	public static synthetic fun enqueueData$default (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JIILjava/lang/Object;)V
+	public static synthetic fun enqueueData$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/util/Map;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JIILjava/lang/Object;)V
 }
 
 public final class com/apollographql/apollo3/testing/ReadFileJvmKt {

--- a/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
+++ b/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
@@ -1,9 +1,12 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.toJson
+import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
 
@@ -19,3 +22,40 @@ fun <D : Operation.Data> MockServer.enqueue(
   enqueue(json, delayMs)
 }
 
+fun MockServer.enqueueData(
+    data: Map<String, Any?>,
+    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
+    delayMs: Long = 0,
+    statusCode: Int = 200
+) {
+
+  val response = buildJsonString {
+    AnyAdapter.toJson(this, customScalarAdapters, mapOf("data" to data))
+  }
+
+  enqueue(MockResponse.Builder()
+      .statusCode(statusCode)
+      .body(response)
+      .delayMillis(delayMs)
+      .build())
+}
+
+
+fun MockServer.enqueueData(
+    data: Operation.Data,
+    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
+    delayMs: Long = 0,
+    statusCode: Int = 200
+) {
+  val response = buildJsonString {
+    beginObject()
+    name("data")
+    data.toJson(this, customScalarAdapters)
+    endObject()
+  }
+  enqueue(MockResponse.Builder()
+      .statusCode(statusCode)
+      .body(response)
+      .delayMillis(delayMs)
+      .build())
+}

--- a/tests/coroutines-mt/src/appleTest/kotlin/macos/app/MainTest.kt
+++ b/tests/coroutines-mt/src/appleTest/kotlin/macos/app/MainTest.kt
@@ -1,35 +1,20 @@
 package macos.app
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.Adapter
-import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.json.JsonReader
-import com.apollographql.apollo3.api.json.JsonWriter
-import com.apollographql.apollo3.api.json.jsonReader
-import com.apollographql.apollo3.api.json.writeAny
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.mockserver.enqueue
 import com.apollographql.apollo3.mpp.currentThreadName
+import com.apollographql.apollo3.testing.enqueueData
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import okio.Buffer
-import kotlin.reflect.AssociatedObjectKey
-import kotlin.reflect.ExperimentalAssociatedObjects
-import kotlin.reflect.KClass
-import kotlin.reflect.findAssociatedObject
 import kotlin.test.Test
 
 class MainTest {
-  val json = """
-    {
-      "data": {
-        "random": 42
-      }
-    }
-  """.trimIndent()
+  private val data = GetRandomQuery.Data {
+    random = 42
+  }
 
   @Test
   fun coroutinesMtCanWork() = runTest {
@@ -37,7 +22,7 @@ class MainTest {
     withContext(Dispatchers.Default) {
       println("Current thread name: ${currentThreadName()}")
       val server = MockServer()
-      server.enqueue(json)
+      server.enqueueData(data)
       val response = ApolloClient.Builder()
           .serverUrl(server.url())
           .build()
@@ -50,7 +35,7 @@ class MainTest {
   @Test
   fun freezingTheStoreIsPossible() = runTest {
     val server = MockServer()
-    server.enqueue(json)
+    server.enqueueData(data)
     val client = ApolloClient.Builder().serverUrl(server.url()).normalizedCache(MemoryCacheFactory()).build()
     withContext(Dispatchers.Default) {
       val response = client.query(GetRandomQuery()).execute()

--- a/tests/http-cache/build.gradle.kts
+++ b/tests/http-cache/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
 
 apollo {
   packageName.set("httpcache")
+  generateDataBuilders.set(true)
 }

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
 
 apollo {
   packageName.set("com.example")
-  generateTestBuilders.set(true)
+  generateDataBuilders.set(true)
 }

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,3 +1,5 @@
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
 import com.example.GetCatIncludeFalseQuery
@@ -6,32 +8,30 @@ import com.example.GetCatIncludeVariableQuery
 import com.example.GetDogSkipFalseQuery
 import com.example.GetDogSkipTrueQuery
 import com.example.GetDogSkipVariableQuery
-import com.example.test.GetCatIncludeFalseQuery_TestBuilder
-import com.example.test.GetCatIncludeTrueQuery_TestBuilder
-import com.example.test.GetCatIncludeVariableQuery_TestBuilder
-import com.example.test.GetDogSkipFalseQuery_TestBuilder
-import com.example.test.GetDogSkipTrueQuery_TestBuilder
-import com.example.test.GetDogSkipVariableQuery_TestBuilder
+import com.example.type.buildCat
+import com.example.type.buildDog
+import com.example.type.buildQuery
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class IncludeTest {
+
+  private fun <D : Operation.Data> Operation<D>.parseData(data: Map<String, Any?>): ApolloResponse<D> {
+    return parseJsonResponse(MapJsonReader(mapOf("data" to data)))
+  }
+
   @Test
   fun includeVariableTrue() = runBlocking {
     val operation = GetCatIncludeVariableQuery(withCat = true)
 
-    val dataMap = GetCatIncludeVariableQuery_TestBuilder.DataBuilder().apply {
-      animal = catAnimal {
+    val data = buildQuery {
+      animal = buildCat {
         meow = "meeoooowwwww"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals("meeoooowwwww", response.dataAssertNoErrors.animal!!.onCat!!.meow)
   }
@@ -40,17 +40,13 @@ class IncludeTest {
   fun includeVariableFalse() = runBlocking {
     val operation = GetCatIncludeVariableQuery(withCat = false)
 
-    val dataMap = GetCatIncludeVariableQuery_TestBuilder.DataBuilder().apply {
-      animal = catAnimal {
+    val data = buildQuery {
+      animal = buildCat {
         meow = "meeoooowwwww"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals(null, response.dataAssertNoErrors.animal!!.onCat)
   }
@@ -59,17 +55,13 @@ class IncludeTest {
   fun includeHardcodedTrue() = runBlocking {
     val operation = GetCatIncludeTrueQuery()
 
-    val dataMap = GetCatIncludeTrueQuery_TestBuilder.DataBuilder().apply {
-      animal = catAnimal {
+    val data = buildQuery {
+      animal = buildCat {
         meow = "meeoooowwwww"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals("meeoooowwwww", response.dataAssertNoErrors.animal!!.onCat!!.meow)
   }
@@ -78,17 +70,13 @@ class IncludeTest {
   fun includeHardcodedFalse() = runBlocking {
     val operation = GetCatIncludeFalseQuery()
 
-    val dataMap = GetCatIncludeFalseQuery_TestBuilder.DataBuilder().apply {
-      animal = catAnimal {
+    val data = buildQuery {
+      animal = buildCat {
         meow = "meeoooowwwww"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals(null, response.dataAssertNoErrors.animal!!.onCat)
   }
@@ -97,17 +85,13 @@ class IncludeTest {
   fun skipVariableTrue() = runBlocking {
     val operation = GetDogSkipVariableQuery(withoutDog = true)
 
-    val dataMap = GetDogSkipVariableQuery_TestBuilder.DataBuilder().apply {
-      animal = dogAnimal {
+    val data = buildQuery {
+      animal = buildDog {
         barf = "ouaf"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals(null, response.dataAssertNoErrors.animal!!.dogFragment)
   }
@@ -116,17 +100,13 @@ class IncludeTest {
   fun skipVariableFalse() = runBlocking {
     val operation = GetDogSkipVariableQuery(withoutDog = false)
 
-    val dataMap = GetDogSkipVariableQuery_TestBuilder.DataBuilder().apply {
-      animal = dogAnimal {
+    val data = buildQuery {
+      animal = buildDog {
         barf = "ouaf"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals("ouaf", response.dataAssertNoErrors.animal!!.dogFragment!!.barf)
   }
@@ -135,17 +115,13 @@ class IncludeTest {
   fun skipHardcodedTrue() = runBlocking {
     val operation = GetDogSkipTrueQuery()
 
-    val dataMap = GetDogSkipTrueQuery_TestBuilder.DataBuilder().apply {
-      animal = dogAnimal {
+    val data = buildQuery {
+      animal = buildDog {
         barf = "ouaf"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals(null, response.dataAssertNoErrors.animal!!.dogFragment)
   }
@@ -154,17 +130,13 @@ class IncludeTest {
   fun skipHardcodedFalse() = runBlocking {
     val operation = GetDogSkipFalseQuery()
 
-    val dataMap = GetDogSkipFalseQuery_TestBuilder.DataBuilder().apply {
-      animal = dogAnimal {
+    val data = buildQuery {
+      animal = buildDog {
         barf = "ouaf"
       }
-    }.build()
+    }
 
-    val response = operation.parseJsonResponse(
-        MapJsonReader(
-            mapOf("data" to dataMap)
-        )
-    )
+    val response = operation.parseData(data)
 
     assertEquals("ouaf", response.dataAssertNoErrors.animal!!.dogFragment!!.barf)
   }

--- a/tests/ios-test/build.gradle.kts
+++ b/tests/ios-test/build.gradle.kts
@@ -25,4 +25,5 @@ kotlin {
 
 apollo {
   packageName.set("ios.test")
+  generateDataBuilders.set(true)
 }

--- a/tests/ios-test/src/commonTest/kotlin/iOSTest.kt
+++ b/tests/ios-test/src/commonTest/kotlin/iOSTest.kt
@@ -1,25 +1,20 @@
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.testing.enqueueData
 import com.apollographql.apollo3.testing.internal.runTest
+import ios.test.type.buildQuery
 import kotlin.test.Test
 
 class iOSTest {
   @Test
-  fun canRunIOSTest() = runTest() {
+  fun canRunIOSTest() = runTest {
     val mockServer = MockServer()
     val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).build()
-    val response = """
-    {
-      "data": {
-        "random": 42
-      }
-    }
-  """.trimIndent()
-    mockServer.enqueue(response)
 
-    apolloClient.dispose()
+    mockServer.enqueueData(buildQuery { random = 42 })
+
+    apolloClient.close()
     mockServer.stop()
   }
 }

--- a/tests/models-compat/build.gradle.kts
+++ b/tests/models-compat/build.gradle.kts
@@ -30,6 +30,7 @@ apollo {
     srcDir(file("../models-fixtures/graphql"))
     packageName.set("codegen.models")
     generateFragmentImplementations.set(true)
+    generateDataBuilders.set(true)
     codegenModels.set("compat")
   }
 
@@ -40,6 +41,7 @@ apollo {
           srcDir(it)
           packageName.set(it.name)
           codegenModels.set(MODELS_COMPAT)
+          generateDataBuilders.set(true)
         }
       }
 }

--- a/tests/models-compat/src/commonTest/kotlin/test/AdapterBijectionTest.kt
+++ b/tests/models-compat/src/commonTest/kotlin/test/AdapterBijectionTest.kt
@@ -3,6 +3,8 @@ package test
 import codegen.models.HeroAndFriendsWithFragmentsQuery
 import codegen.models.fragment.HeroWithFriendsFragment
 import codegen.models.fragment.HumanWithIdFragment
+import codegen.models.type.buildDroid
+import codegen.models.type.buildHuman
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.jsonReader
@@ -15,37 +17,22 @@ class AdapterBijectionTest {
   @Test
   fun namedFragments() = bijection(
       HeroAndFriendsWithFragmentsQuery(),
-      HeroAndFriendsWithFragmentsQuery.Data(
-          HeroAndFriendsWithFragmentsQuery.Hero(
-              __typename = "Droid",
-              fragments = HeroAndFriendsWithFragmentsQuery.Hero.Fragments(
-                  heroWithFriendsFragment = HeroWithFriendsFragment(
-                      id = "2001",
-                      name = "R222-D222",
-                      friends = listOf(
-                          HeroWithFriendsFragment.Friend(
-                              __typename = "Human",
-                              fragments = HeroWithFriendsFragment.Friend.Fragments(
-                                  humanWithIdFragment = HumanWithIdFragment(
-                                      id = "1006",
-                                      name = "SuperMan"
-                                  )
-                              )
-                          ),
-                          HeroWithFriendsFragment.Friend(
-                              __typename = "Human",
-                              fragments = HeroWithFriendsFragment.Friend.Fragments(
-                                  humanWithIdFragment = HumanWithIdFragment(
-                                      id = "1004",
-                                      name = "Beast"
-                                  )
-                              )
-                          ),
-                      )
-                  )
-              )
+      HeroAndFriendsWithFragmentsQuery.Data {
+        hero = buildDroid {
+          id = "2001"
+          name = "R222-D222"
+          friends = listOf(
+              buildHuman {
+                id = "1006"
+                name = "SuperMan"
+              },
+              buildHuman {
+                id = "1004"
+                name = "Beast"
+              }
           )
-      )
+        }
+      }
   )
 
   private fun <D : Operation.Data> bijection(operation: Operation<D>, data: D) {


### PR DESCRIPTION
Dogfooding the data builders, I realized 2 things:

* We'd need `Executable.Data.toJson` instead of just `Operation.Data.toJson` (for fragments), same for Data builders
* Being able to specify the runtime adapters in `buildQuery()` would be nice

I'll add the two points above before continuing the dog fooding

see #4016 