### PR TITLE
Enable Gradle's build cache

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,13 +23,13 @@ jobs:
           ulimit -c unlimited
           # Workaround an issue where kotlinNpmInstall outputs
           # 'Resolving NPM dependencies using yarn' returns 137
-          ./gradlew compileKotlinJsIr compileKotlinJsLegacy
+          ./gradlew --no-build-cache compileKotlinJsIr compileKotlinJsLegacy
           ./gradlew --stop
-          ./gradlew ciBuild
+          ./gradlew --no-build-cache ciBuild
           ./gradlew --stop
-          ./gradlew -p tests ciBuild
-          ./gradlew dokkaHtmlMultiModule
-          ./gradlew ciPublishSnapshot
+          ./gradlew --no-build-cache -p tests ciBuild
+          ./gradlew --no-build-cache dokkaHtmlMultiModule
+          ./gradlew --no-build-cache ciPublishSnapshot
         env:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee #v2.1.4
       - name: Build with Gradle
         run: |
-          ./gradlew ciPublishRelease -Pgradle.publish.key="${{ secrets.GRADLE_PUBLISH_KEY }}" -Pgradle.publish.secret="${{ secrets.GRADLE_PUBLISH_SECRET }}"
+          ./gradlew --no-build-cache ciPublishRelease -Pgradle.publish.key="${{ secrets.GRADLE_PUBLISH_KEY }}" -Pgradle.publish.secret="${{ secrets.GRADLE_PUBLISH_SECRET }}"
         env:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -21,6 +21,9 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="50" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
     </JetCodeStyleSettings>
+    <Properties>
+      <option name="KEEP_BLANK_LINES" value="true" />
+    </Properties>
     <XML>
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </XML>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,7 @@ kotlin.stdlib.default.dependency=false
 # Enable compatibility with non-hierarchical projects.
 # See https://kotlinlang.org/docs/multiplatform-hierarchy.html#for-library-authors
 kotlin.mpp.enableCompatibilityMetadataVariant=true
+
+# Enable the build cache
+# See https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching=true

--- a/tests/gradle.properties
+++ b/tests/gradle.properties
@@ -6,3 +6,7 @@ kotlin.mpp.stability.nowarn=true
 xcodeproj=samples/multiplatform/kmp-ios-app/kmp-ios-app.xcodeproj
 
 android.useAndroidX=true
+
+# Enable the build cache
+# See https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching=true


### PR DESCRIPTION
Enable Gradle's build cache. 

I manually disabled it on the CI for the push and tag workflows, to minimize the risk of non-reproducible builds there.