### PR TITLE
Add a flag to disable fieldsCanMerge validation on disjoint types

### DIFF
--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1010,6 +1010,8 @@ public final class com/apollographql/apollo3/ast/GqlnodeKt {
 public final class com/apollographql/apollo3/ast/GqloperationdefinitionKt {
 	public static final fun rootTypeDefinition (Lcom/apollographql/apollo3/ast/GQLOperationDefinition;Lcom/apollographql/apollo3/ast/Schema;)Lcom/apollographql/apollo3/ast/GQLTypeDefinition;
 	public static final fun validate (Lcom/apollographql/apollo3/ast/GQLOperationDefinition;Lcom/apollographql/apollo3/ast/Schema;Ljava/util/Map;)Ljava/util/List;
+	public static final fun validate (Lcom/apollographql/apollo3/ast/GQLOperationDefinition;Lcom/apollographql/apollo3/ast/Schema;Ljava/util/Map;Z)Ljava/util/List;
+	public static synthetic fun validate$default (Lcom/apollographql/apollo3/ast/GQLOperationDefinition;Lcom/apollographql/apollo3/ast/Schema;Ljava/util/Map;ZILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class com/apollographql/apollo3/ast/GqlstringsKt {

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
@@ -26,9 +26,9 @@ fun BufferedSource.toSchema(filePath: String? = null): Schema = parseAsGQLDocume
  * See [parseAsGQLDocument] and [validateAsExecutable] for more granular error reporting
  */
 @ApolloExperimental
-fun BufferedSource.toExecutableDefinitions(schema: Schema, filePath: String? = null, fieldOnDisjointTypesMustMerge: Boolean = false): List<GQLDefinition> = parseAsGQLDocument(filePath)
+fun BufferedSource.toExecutableDefinitions(schema: Schema, filePath: String? = null, fieldsOnDisjointTypesMustMerge: Boolean = true): List<GQLDefinition> = parseAsGQLDocument(filePath)
     .valueAssertNoErrors()
-    .validateAsExecutable(schema, fieldOnDisjointTypesMustMerge)
+    .validateAsExecutable(schema, fieldsOnDisjointTypesMustMerge)
     .valueAssertNoErrors()
 
 /**
@@ -87,14 +87,14 @@ fun GQLDocument.validateAsSchemaAndAddApolloDefinition(): GQLResult<Schema> {
 /**
  * Validates the given document as an executable document.
  *
- * @param fieldOnDisjointTypesMustMerge if true, the FieldsInSetCanMerge validation is not run.
+ * @param fieldsOnDisjointTypesMustMerge Whether fields with different shape are disallowed to be merged in disjoint types.
  *
  * @return  a [GQLResult] containing the operation and fragment definitions in 'value', along with any potential issues
  */
 @ApolloExperimental
-fun GQLDocument.validateAsExecutable(schema: Schema, fieldOnDisjointTypesMustMerge: Boolean): GQLResult<List<GQLDefinition>> {
+fun GQLDocument.validateAsExecutable(schema: Schema, fieldsOnDisjointTypesMustMerge: Boolean = true): GQLResult<List<GQLDefinition>> {
   val fragments = definitions.filterIsInstance<GQLFragmentDefinition>().associateBy { it.name }
-  val issues = ExecutableValidationScope(schema, fragments, fieldOnDisjointTypesMustMerge).validate(this)
+  val issues = ExecutableValidationScope(schema, fragments, fieldsOnDisjointTypesMustMerge).validate(this)
   return GQLResult(definitions, issues)
 }
 
@@ -105,7 +105,7 @@ fun GQLDocument.validateAsExecutable(schema: Schema, fieldOnDisjointTypesMustMer
 fun GQLFragmentDefinition.inferVariables(
     schema: Schema,
     fragments: Map<String, GQLFragmentDefinition>,
-    fieldOnDisjointTypesMustMerge: Boolean
-) = ExecutableValidationScope(schema, fragments, fieldOnDisjointTypesMustMerge).inferFragmentVariables(this)
+    fieldsOnDisjointTypesMustMerge: Boolean
+) = ExecutableValidationScope(schema, fragments, fieldsOnDisjointTypesMustMerge).inferFragmentVariables(this)
 
 

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
@@ -87,7 +87,8 @@ fun GQLDocument.validateAsSchemaAndAddApolloDefinition(): GQLResult<Schema> {
 /**
  * Validates the given document as an executable document.
  *
- * @param fieldsOnDisjointTypesMustMerge Whether fields with different shape are disallowed to be merged in disjoint types.
+ * @param fieldsOnDisjointTypesMustMerge set to false to relax the standard GraphQL [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge())
+ * and allow fields of different types at the same Json path as long as their parent types are disjoint.
  *
  * @return  a [GQLResult] containing the operation and fragment definitions in 'value', along with any potential issues
  */

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqloperationdefinition.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqloperationdefinition.kt
@@ -9,8 +9,9 @@ fun GQLOperationDefinition.rootTypeDefinition(schema: Schema) = when (operationT
   else -> null
 }
 
+@JvmOverloads
 fun GQLOperationDefinition.validate(
     schema: Schema,
     fragments: Map<String, GQLFragmentDefinition>,
-    fieldOnDisjointTypesMustMerge: Boolean,
-) = ExecutableValidationScope(schema, fragments, fieldOnDisjointTypesMustMerge).validateOperation(this)
+    fieldsOnDisjointTypesMustMerge: Boolean = true,
+) = ExecutableValidationScope(schema, fragments, fieldsOnDisjointTypesMustMerge).validateOperation(this)

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqloperationdefinition.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqloperationdefinition.kt
@@ -12,4 +12,5 @@ fun GQLOperationDefinition.rootTypeDefinition(schema: Schema) = when (operationT
 fun GQLOperationDefinition.validate(
     schema: Schema,
     fragments: Map<String, GQLFragmentDefinition>,
-) = ExecutableValidationScope(schema, fragments).validateOperation(this)
+    fieldOnDisjointTypesMustMerge: Boolean,
+) = ExecutableValidationScope(schema, fragments, fieldOnDisjointTypesMustMerge).validateOperation(this)

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -45,12 +45,12 @@ import com.apollographql.apollo3.ast.sharesPossibleTypesWith
  * @param fragmentDefinitions: all the fragments in the current compilation unit.
  * This is required to check the type conditions as well as fields merging
  *
- * @param fieldOnDisjointTypesMustMerge if true, the FieldsInSetCanMerge validation is not run.
+ * @param fieldsOnDisjointTypesMustMerge Whether fields with different shape are disallowed to be merged in disjoint types.
  */
 internal class ExecutableValidationScope(
     private val schema: Schema,
     private val fragmentDefinitions: Map<String, GQLFragmentDefinition>,
-    private val fieldOnDisjointTypesMustMerge: Boolean,
+    private val fieldsOnDisjointTypesMustMerge: Boolean,
 ) : ValidationScope {
   override val typeDefinitions = schema.typeDefinitions
   override val directiveDefinitions = schema.directiveDefinitions
@@ -510,9 +510,6 @@ internal class ExecutableValidationScope(
   }
 
   private fun fieldsInSetCanMerge(fieldsWithParent: List<FieldWithParent>) {
-    if (fieldOnDisjointTypesMustMerge) {
-      return
-    }
     fieldsWithParent.groupBy { it.field.responseName() }
         .values
         .forEach { fieldsForName ->
@@ -643,6 +640,9 @@ internal class ExecutableValidationScope(
 
   // 5.3.2 2.1
   private fun haveSameResponseShape(fieldWithParentA: FieldWithParent, fieldWithParentB: FieldWithParent): Boolean {
+    if (!fieldsOnDisjointTypesMustMerge) {
+      return true
+    }
     val fieldA = fieldWithParentA.field
     val fieldB = fieldWithParentB.field
 

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -44,10 +44,13 @@ import com.apollographql.apollo3.ast.sharesPossibleTypesWith
 /**
  * @param fragmentDefinitions: all the fragments in the current compilation unit.
  * This is required to check the type conditions as well as fields merging
+ *
+ * @param fieldOnDisjointTypesMustMerge if true, the FieldsInSetCanMerge validation is not run.
  */
 internal class ExecutableValidationScope(
     private val schema: Schema,
     private val fragmentDefinitions: Map<String, GQLFragmentDefinition>,
+    private val fieldOnDisjointTypesMustMerge: Boolean,
 ) : ValidationScope {
   override val typeDefinitions = schema.typeDefinitions
   override val directiveDefinitions = schema.directiveDefinitions
@@ -507,6 +510,9 @@ internal class ExecutableValidationScope(
   }
 
   private fun fieldsInSetCanMerge(fieldsWithParent: List<FieldWithParent>) {
+    if (fieldOnDisjointTypesMustMerge) {
+      return
+    }
     fieldsWithParent.groupBy { it.field.responseName() }
         .values
         .forEach { fieldsForName ->

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -45,7 +45,8 @@ import com.apollographql.apollo3.ast.sharesPossibleTypesWith
  * @param fragmentDefinitions: all the fragments in the current compilation unit.
  * This is required to check the type conditions as well as fields merging
  *
- * @param fieldsOnDisjointTypesMustMerge Whether fields with different shape are disallowed to be merged in disjoint types.
+ * @param fieldsOnDisjointTypesMustMerge set to false to relax the standard GraphQL [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge())
+ * and allow fields of different types at the same Json path as long as their parent types are disjoint.
  */
 internal class ExecutableValidationScope(
     private val schema: Schema,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -83,7 +83,7 @@ object ApolloCompiler {
     val validationResult = GQLDocument(
         definitions = definitions + incomingFragments,
         filePath = null
-    ).validateAsExecutable(options.schema)
+    ).validateAsExecutable(options.schema, options.fieldOnDisjointTypesMustMerge)
 
     validationResult.issues.checkNoErrors()
 
@@ -160,7 +160,8 @@ object ApolloCompiler {
         scalarMapping = options.scalarMapping,
         codegenModels = options.codegenModels,
         generateOptionalOperationVariables = options.generateOptionalOperationVariables,
-        generateDataBuilders = options.generateDataBuilders
+        generateDataBuilders = options.generateDataBuilders,
+        fieldOnDisjointTypesMustMerge = options.fieldOnDisjointTypesMustMerge
     ).build()
 
     if (debugDir != null) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -83,7 +83,7 @@ object ApolloCompiler {
     val validationResult = GQLDocument(
         definitions = definitions + incomingFragments,
         filePath = null
-    ).validateAsExecutable(options.schema, options.fieldOnDisjointTypesMustMerge)
+    ).validateAsExecutable(options.schema, options.fieldsOnDisjointTypesMustMerge)
 
     validationResult.issues.checkNoErrors()
 
@@ -161,7 +161,7 @@ object ApolloCompiler {
         codegenModels = options.codegenModels,
         generateOptionalOperationVariables = options.generateOptionalOperationVariables,
         generateDataBuilders = options.generateDataBuilders,
-        fieldOnDisjointTypesMustMerge = options.fieldOnDisjointTypesMustMerge
+        fieldsOnDisjointTypesMustMerge = options.fieldsOnDisjointTypesMustMerge
     ).build()
 
     if (debugDir != null) {

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -189,7 +189,14 @@ class Options(
      */
     val addJvmOverloads: Boolean = false,
     val addTypename: String = defaultAddTypename,
-    val requiresOptInAnnotation: String? = defaultRequiresOptInAnnotation
+    val requiresOptInAnnotation: String? = defaultRequiresOptInAnnotation,
+
+    /**
+     * Whether to merge fields in disjoint types without the FieldsInSetCanMerge validate.
+     *
+     * If true, disable the FieldsInSetCanMerge validation.
+     */
+    val fieldOnDisjointTypesMustMerge: Boolean = defaultFieldOnDisjointTypesMustMerge
 ) {
 
   /**
@@ -247,7 +254,8 @@ class Options(
       generateOptionalOperationVariables: Boolean = this.generateOptionalOperationVariables,
       addJvmOverloads: Boolean = this.addJvmOverloads,
       addTypename: String = this.addTypename,
-      requiresOptInAnnotation: String? = this.requiresOptInAnnotation
+      requiresOptInAnnotation: String? = this.requiresOptInAnnotation,
+      fieldOnDisjointTypesMustMerge: Boolean = this.fieldOnDisjointTypesMustMerge
   ) = Options(
       executableFiles = executableFiles,
       schema = schema,
@@ -284,6 +292,7 @@ class Options(
       addJvmOverloads = addJvmOverloads,
       addTypename = addTypename,
       requiresOptInAnnotation = requiresOptInAnnotation,
+      fieldOnDisjointTypesMustMerge = fieldOnDisjointTypesMustMerge
   )
 
   companion object {
@@ -314,6 +323,7 @@ class Options(
     const val defaultGenerateOptionalOperationVariables = true
     const val defaultUseSchemaPackageNameForFragments = false
     const val defaultAddJvmOverloads = false
+    const val defaultFieldOnDisjointTypesMustMerge = false
   }
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -192,11 +192,16 @@ class Options(
     val requiresOptInAnnotation: String? = defaultRequiresOptInAnnotation,
 
     /**
-     * Whether to merge fields in disjoint types without the FieldsInSetCanMerge validate.
+     * Whether fields with different shape are disallowed to be merged in disjoint types.
      *
-     * If true, disable the FieldsInSetCanMerge validation.
+     * Note: setting this to `false` relaxes the standard GraphQL [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge()) validation which may still be
+     * run on the backend.
+     *
+     * See also [issue 4320](https://github.com/apollographql/apollo-kotlin/issues/4320)
+     *
+     * Default: true.
      */
-    val fieldOnDisjointTypesMustMerge: Boolean = defaultFieldOnDisjointTypesMustMerge
+    val fieldsOnDisjointTypesMustMerge: Boolean = defaultFieldsOnDisjointTypesMustMerge,
 ) {
 
   /**
@@ -255,7 +260,7 @@ class Options(
       addJvmOverloads: Boolean = this.addJvmOverloads,
       addTypename: String = this.addTypename,
       requiresOptInAnnotation: String? = this.requiresOptInAnnotation,
-      fieldOnDisjointTypesMustMerge: Boolean = this.fieldOnDisjointTypesMustMerge
+      fieldsOnDisjointTypesMustMerge: Boolean = this.fieldsOnDisjointTypesMustMerge
   ) = Options(
       executableFiles = executableFiles,
       schema = schema,
@@ -292,7 +297,7 @@ class Options(
       addJvmOverloads = addJvmOverloads,
       addTypename = addTypename,
       requiresOptInAnnotation = requiresOptInAnnotation,
-      fieldOnDisjointTypesMustMerge = fieldOnDisjointTypesMustMerge
+      fieldsOnDisjointTypesMustMerge = fieldsOnDisjointTypesMustMerge
   )
 
   companion object {
@@ -323,7 +328,7 @@ class Options(
     const val defaultGenerateOptionalOperationVariables = true
     const val defaultUseSchemaPackageNameForFragments = false
     const val defaultAddJvmOverloads = false
-    const val defaultFieldOnDisjointTypesMustMerge = false
+    const val defaultFieldsOnDisjointTypesMustMerge = true
   }
 }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -74,6 +74,7 @@ internal class IrBuilder(
     private val codegenModels: String,
     private val generateOptionalOperationVariables: Boolean,
     private val generateDataBuilders: Boolean,
+    private val fieldOnDisjointTypesMustMerge: Boolean,
 ) : FieldMerger {
   private val usedTypes = mutableListOf<String>()
 
@@ -454,7 +455,7 @@ internal class IrBuilder(
   private fun GQLFragmentDefinition.toIr(): IrFragmentDefinition {
     val typeDefinition = schema.typeDefinition(typeCondition.name)
 
-    val inferredVariables = inferVariables(schema, allFragmentDefinitions)
+    val inferredVariables = inferVariables(schema, allFragmentDefinitions, fieldOnDisjointTypesMustMerge)
 
     val interfaceModelGroup = builder.buildFragmentInterface(
         fragmentName = name

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -74,7 +74,7 @@ internal class IrBuilder(
     private val codegenModels: String,
     private val generateOptionalOperationVariables: Boolean,
     private val generateDataBuilders: Boolean,
-    private val fieldOnDisjointTypesMustMerge: Boolean,
+    private val fieldsOnDisjointTypesMustMerge: Boolean,
 ) : FieldMerger {
   private val usedTypes = mutableListOf<String>()
 
@@ -455,7 +455,7 @@ internal class IrBuilder(
   private fun GQLFragmentDefinition.toIr(): IrFragmentDefinition {
     val typeDefinition = schema.typeDefinition(typeCondition.name)
 
-    val inferredVariables = inferVariables(schema, allFragmentDefinitions, fieldOnDisjointTypesMustMerge)
+    val inferredVariables = inferVariables(schema, allFragmentDefinitions, fieldsOnDisjointTypesMustMerge)
 
     val interfaceModelGroup = builder.buildFragmentInterface(
         fragmentName = name

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/FieldsOnDisjointTypesMustMergeTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/FieldsOnDisjointTypesMustMergeTest.kt
@@ -1,0 +1,33 @@
+package com.apollographql.apollo3.compiler
+
+import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.validateAsExecutable
+import com.apollographql.apollo3.compiler.TestUtils.checkExpected
+import com.apollographql.apollo3.compiler.TestUtils.findSchema
+import com.apollographql.apollo3.compiler.TestUtils.serialize
+import okio.buffer
+import okio.source
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class FieldsOnDisjointTypesMustMergeTest {
+  private val graphQLFile = File("src/test/validation/operation/fields_on_disjoint_types_must_merge/different_shapes.graphql")
+
+  @Test
+  fun testEnableFieldsOnDisjointTypesMustMerge() = checkExpected(graphQLFile) { schema ->
+    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+    val issues = parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldsOnDisjointTypesMustMerge = true).issues
+    issues.serialize()
+  }
+
+  @Test
+  fun testDisableFieldsOnDisjointTypesMustMerge() {
+    val schema = findSchema(graphQLFile.parentFile)!!
+    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+
+    val issues = parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema, fieldsOnDisjointTypesMustMerge = false).issues
+
+    assertTrue(issues.isEmpty())
+  }
+}

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
@@ -67,7 +67,7 @@ internal object TestUtils {
     return File(parentFile, "$nameWithoutExtension.$newExtension")
   }
 
-  private fun findSchema(dir: File): Schema? {
+  fun findSchema(dir: File): Schema? {
     return listOf("graphqls", "sdl", "json").map { File(dir, "schema.$it") }
         .firstOrNull { it.exists() }
         ?.let {

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
@@ -1,15 +1,16 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
-import com.apollographql.apollo3.ast.introspection.toSchema
 import com.apollographql.apollo3.ast.introspection.toSchemaGQLDocument
-import com.apollographql.apollo3.ast.validateAsSchema
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import com.google.common.truth.Truth.assertThat
 import okio.Buffer
 import java.io.File
 
 internal object TestUtils {
+  private const val separator = "\n------------\n"
+
   internal fun shouldUpdateTestFixtures(): Boolean {
     if (System.getenv("updateTestFixtures") != null) {
       return true
@@ -113,6 +114,10 @@ internal object TestUtils {
     } else {
       assertThat(actual).isEqualTo(expected)
     }
+  }
+
+  fun List<Issue>.serialize() = joinToString(separator) {
+    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
   }
 }
 

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -26,7 +26,8 @@ class ValidationTest(name: String, private val graphQLFile: File) {
       if (parseResult.issues.isNotEmpty()) {
         parseResult.issues
       } else {
-        parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldsOnDisjointTypesMustMerge = true).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
+        val mustMerge = graphQLFile.name != "merging_allowed.graphql"
+        parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldsOnDisjointTypesMustMerge = mustMerge).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
           checkCapitalizedFields(parseResult.value!!.definitions)
         } else {
           emptyList()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -1,10 +1,10 @@
 package com.apollographql.apollo3.compiler
 
-import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.validateAsExecutable
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import com.apollographql.apollo3.compiler.TestUtils.checkExpected
+import com.apollographql.apollo3.compiler.TestUtils.serialize
 import com.apollographql.apollo3.compiler.TestUtils.testParametersForGraphQLFilesIn
 import okio.buffer
 import okio.source
@@ -16,11 +16,6 @@ import java.io.File
 @Suppress("UNUSED_PARAMETER")
 @RunWith(Parameterized::class)
 class ValidationTest(name: String, private val graphQLFile: File) {
-  private val separator = "\n------------\n"
-
-  private fun List<Issue>.serialize() = joinToString(separator) {
-    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
-  }
 
   @Test
   fun testValidation() = checkExpected(graphQLFile) { schema ->

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -5,72 +5,54 @@ import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.validateAsExecutable
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import com.apollographql.apollo3.compiler.TestUtils.checkExpected
-import com.apollographql.apollo3.compiler.TestUtils.findSchema
 import com.apollographql.apollo3.compiler.TestUtils.testParametersForGraphQLFilesIn
 import okio.buffer
 import okio.source
 import org.junit.Test
-import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.io.File
-import kotlin.test.assertTrue
 
 @Suppress("UNUSED_PARAMETER")
-@RunWith(Enclosed::class)
-class ValidationTest {
+@RunWith(Parameterized::class)
+class ValidationTest(name: String, private val graphQLFile: File) {
+  private val separator = "\n------------\n"
 
-  @RunWith(Parameterized::class)
-  class ValidationParamTest(name: String, private val graphQLFile: File) {
-    private val separator = "\n------------\n"
-
-    private fun List<Issue>.serialize() = joinToString(separator) {
-      "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
-    }
-
-    @Test
-    fun testValidation() = checkExpected(graphQLFile) { schema ->
-      // Don't use absolute path for filePath because it depends on the machine where the test is run
-      val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
-
-      val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
-        if (parseResult.issues.isNotEmpty()) {
-          parseResult.issues
-        } else {
-          parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldOnDisjointTypesMustMerge = false).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
-            checkCapitalizedFields(parseResult.value!!.definitions)
-          } else {
-            emptyList()
-          }
-        }
-      } else {
-        if (parseResult.issues.isNotEmpty()) {
-          parseResult.issues
-        } else {
-          val schemaResult = parseResult.valueAssertNoErrors().validateAsSchemaAndAddApolloDefinition()
-          schemaResult.issues +
-              (schemaResult.value?.let { checkApolloReservedEnumValueNames(it) } ?: emptyList()) +
-              (schemaResult.value?.let { checkApolloTargetNameClashes(it) } ?: emptyList())
-        }
-      }
-      issues.serialize()
-    }
-
-    companion object {
-      @JvmStatic
-      @Parameterized.Parameters(name = "{0}")
-      fun data() = testParametersForGraphQLFilesIn("src/test/validation/")
-    }
+  private fun List<Issue>.serialize() = joinToString(separator) {
+    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
   }
 
   @Test
-  fun testFieldOnDisjointTypesMustMerge() {
-    val file = File("src/test/validation/operation/fields_in_set_can_merge/different_shapes.graphql")
-    val schema = findSchema(file.parentFile)!!
-    val parseResult = file.source().buffer().parseAsGQLDocument(filePath = file.name)
+  fun testValidation() = checkExpected(graphQLFile) { schema ->
+    // Don't use absolute path for filePath because it depends on the machine where the test is run
+    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
 
-    val issues = parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema, fieldOnDisjointTypesMustMerge = true).issues
+    val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
+      if (parseResult.issues.isNotEmpty()) {
+        parseResult.issues
+      } else {
+        parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldsOnDisjointTypesMustMerge = true).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
+          checkCapitalizedFields(parseResult.value!!.definitions)
+        } else {
+          emptyList()
+        }
+      }
+    } else {
+      if (parseResult.issues.isNotEmpty()) {
+        parseResult.issues
+      } else {
+        val schemaResult = parseResult.valueAssertNoErrors().validateAsSchemaAndAddApolloDefinition()
+        schemaResult.issues +
+            (schemaResult.value?.let { checkApolloReservedEnumValueNames(it) } ?: emptyList()) +
+            (schemaResult.value?.let { checkApolloTargetNameClashes(it) } ?: emptyList())
+      }
+    }
+    issues.serialize()
+  }
 
-    assertTrue(issues.isEmpty())
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0}")
+    fun data() = testParametersForGraphQLFilesIn("src/test/validation/")
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -5,54 +5,72 @@ import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.validateAsExecutable
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import com.apollographql.apollo3.compiler.TestUtils.checkExpected
+import com.apollographql.apollo3.compiler.TestUtils.findSchema
 import com.apollographql.apollo3.compiler.TestUtils.testParametersForGraphQLFilesIn
 import okio.buffer
 import okio.source
 import org.junit.Test
+import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.io.File
+import kotlin.test.assertTrue
 
 @Suppress("UNUSED_PARAMETER")
-@RunWith(Parameterized::class)
-class ValidationTest(name: String, private val graphQLFile: File) {
-  private val separator = "\n------------\n"
+@RunWith(Enclosed::class)
+class ValidationTest {
 
-  private fun List<Issue>.serialize() = joinToString(separator) {
-    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
+  @RunWith(Parameterized::class)
+  class ValidationParamTest(name: String, private val graphQLFile: File) {
+    private val separator = "\n------------\n"
+
+    private fun List<Issue>.serialize() = joinToString(separator) {
+      "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.position})\n${it.message}"
+    }
+
+    @Test
+    fun testValidation() = checkExpected(graphQLFile) { schema ->
+      // Don't use absolute path for filePath because it depends on the machine where the test is run
+      val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+
+      val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
+        if (parseResult.issues.isNotEmpty()) {
+          parseResult.issues
+        } else {
+          parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!, fieldOnDisjointTypesMustMerge = false).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
+            checkCapitalizedFields(parseResult.value!!.definitions)
+          } else {
+            emptyList()
+          }
+        }
+      } else {
+        if (parseResult.issues.isNotEmpty()) {
+          parseResult.issues
+        } else {
+          val schemaResult = parseResult.valueAssertNoErrors().validateAsSchemaAndAddApolloDefinition()
+          schemaResult.issues +
+              (schemaResult.value?.let { checkApolloReservedEnumValueNames(it) } ?: emptyList()) +
+              (schemaResult.value?.let { checkApolloTargetNameClashes(it) } ?: emptyList())
+        }
+      }
+      issues.serialize()
+    }
+
+    companion object {
+      @JvmStatic
+      @Parameterized.Parameters(name = "{0}")
+      fun data() = testParametersForGraphQLFilesIn("src/test/validation/")
+    }
   }
 
   @Test
-  fun testValidation() = checkExpected(graphQLFile) { schema ->
-    // Don't use absolute path for filePath because it depends on the machine where the test is run
-    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+  fun testFieldOnDisjointTypesMustMerge() {
+    val file = File("src/test/validation/operation/fields_in_set_can_merge/different_shapes.graphql")
+    val schema = findSchema(file.parentFile)!!
+    val parseResult = file.source().buffer().parseAsGQLDocument(filePath = file.name)
 
-    val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
-      if (parseResult.issues.isNotEmpty()) {
-        parseResult.issues
-      } else {
-        parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema!!).issues + if (graphQLFile.name == "capitalized_fields_disallowed.graphql") {
-          checkCapitalizedFields(parseResult.value!!.definitions)
-        } else {
-          emptyList()
-        }
-      }
-    } else {
-      if (parseResult.issues.isNotEmpty()) {
-        parseResult.issues
-      } else {
-        val schemaResult = parseResult.valueAssertNoErrors().validateAsSchemaAndAddApolloDefinition()
-        schemaResult.issues +
-            (schemaResult.value?.let { checkApolloReservedEnumValueNames(it) } ?: emptyList()) +
-            (schemaResult.value?.let { checkApolloTargetNameClashes(it) } ?: emptyList())
-      }
-    }
-    issues.serialize()
-  }
+    val issues = parseResult.valueAssertNoErrors().validateAsExecutable(schema = schema, fieldOnDisjointTypesMustMerge = true).issues
 
-  companion object {
-    @JvmStatic
-    @Parameterized.Parameters(name = "{0}")
-    fun data() = testParametersForGraphQLFilesIn("src/test/validation/")
+    assertTrue(issues.isEmpty())
   }
 }

--- a/apollo-compiler/src/test/validation/operation/fields_in_set_can_merge/merging_allowed.graphql
+++ b/apollo-compiler/src/test/validation/operation/fields_in_set_can_merge/merging_allowed.graphql
@@ -1,0 +1,10 @@
+query GetAnimal {
+    animal {
+        ... on Cat {
+            meow
+        }
+        ... on Dog {
+            meow: id
+        }
+    }
+}

--- a/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/different_shapes.expected
+++ b/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/different_shapes.expected
@@ -1,0 +1,11 @@
+ERROR: ValidationError (9:6)
+`value` cannot be merged with `value` (at different_shapes.graphql: (12, 7)): they have different shapes. Use different aliases on the fields to fetch both if this was intentional.
+------------
+ERROR: ValidationError (12:6)
+`value` cannot be merged with `value` (at different_shapes.graphql: (9, 7)): they have different shapes. Use different aliases on the fields to fetch both if this was intentional.
+------------
+ERROR: ValidationError (9:6)
+`value` cannot be merged with `value` (at different_shapes.graphql: (12, 7)): they have different shapes. Use different aliases on the fields to fetch both if this was intentional.
+------------
+ERROR: ValidationError (12:6)
+`value` cannot be merged with `value` (at different_shapes.graphql: (9, 7)): they have different shapes. Use different aliases on the fields to fetch both if this was intentional.

--- a/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/different_shapes.graphql
+++ b/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/different_shapes.graphql
@@ -1,0 +1,14 @@
+query GetFoo {
+  foo {
+    ...PropertyValue
+  }
+}
+fragment PropertyValue on PropertyValue {
+  __typename
+  ... on PropertyValueBoolean {
+      value
+  }
+  ... on PropertyValueInt {
+      value
+  }
+}

--- a/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/schema.graphqls
+++ b/apollo-compiler/src/test/validation/operation/fields_on_disjoint_types_must_merge/schema.graphqls
@@ -1,0 +1,13 @@
+type Query {
+  foo: PropertyValue
+}
+union PropertyValue = PropertyValueBoolean | PropertyValueInt
+
+type PropertyValueBoolean {
+  name: String!
+  value: Boolean
+}
+type PropertyValueInt {
+  name: String!
+  value: Int
+}

--- a/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -69,6 +69,7 @@ public abstract interface class com/apollographql/apollo3/gradle/api/Service {
 	public abstract fun getDebugDir ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getExcludes ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getFailOnWarnings ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFieldsOnDisjointTypesMustMerge ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFlattenModels ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateApolloMetadata ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateAsInternal ()Lorg/gradle/api/provider/Property;

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -543,10 +543,14 @@ interface Service {
   val requiresOptInAnnotation: Property<String>
 
   /**
-   * Whether to merge fields in disjoint types without the FieldsInSetCanMerge validate.
-   * If true, disable the FieldsInSetCanMerge validation.
+   * Whether fields with different shape are disallowed to be merged in disjoint types.
    *
-   * Default value: false
+   * Note: setting this to `false` relaxes the standard GraphQL [FieldsInSetCanMerge](https://spec.graphql.org/draft/#FieldsInSetCanMerge()) validation which may still be
+   * run on the backend.
+   *
+   * See also [issue 4320](https://github.com/apollographql/apollo-kotlin/issues/4320)
+   *
+   * Default: true.
    */
   val fieldsOnDisjointTypesMustMerge: Property<Boolean>
 

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -548,7 +548,7 @@ interface Service {
    *
    * Default value: false
    */
-  val fieldOnDisjointTypesMustMerge: Property<Boolean>
+  val fieldsOnDisjointTypesMustMerge: Property<Boolean>
 
   /**
    * A shorthand method that configures defaults that match Apollo Android 2.x codegen

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -543,6 +543,14 @@ interface Service {
   val requiresOptInAnnotation: Property<String>
 
   /**
+   * Whether to merge fields in disjoint types without the FieldsInSetCanMerge validate.
+   * If true, disable the FieldsInSetCanMerge validation.
+   *
+   * Default value: false
+   */
+  val fieldOnDisjointTypesMustMerge: Property<Boolean>
+
+  /**
    * A shorthand method that configures defaults that match Apollo Android 2.x codegen
    *
    * In practice, it does the following:

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -16,7 +16,7 @@ import com.apollographql.apollo3.compiler.Options.Companion.defaultAlwaysGenerat
 import com.apollographql.apollo3.compiler.Options.Companion.defaultCodegenModels
 import com.apollographql.apollo3.compiler.Options.Companion.defaultRequiresOptInAnnotation
 import com.apollographql.apollo3.compiler.Options.Companion.defaultFailOnWarnings
-import com.apollographql.apollo3.compiler.Options.Companion.defaultFieldOnDisjointTypesMustMerge
+import com.apollographql.apollo3.compiler.Options.Companion.defaultFieldsOnDisjointTypesMustMerge
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateAsInternal
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateDataBuilders
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFilterNotNull
@@ -212,7 +212,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val fieldOnDisjointTypesMustMerge: Property<Boolean>
+  abstract val fieldsOnDisjointTypesMustMerge: Property<Boolean>
 
   @TaskAction
   fun taskAction() {
@@ -314,7 +314,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         generateOptionalOperationVariables = generateOptionalOperationVariables.getOrElse(defaultGenerateOptionalOperationVariables),
         addJvmOverloads = addJvmOverloads.getOrElse(defaultAddJvmOverloads),
         requiresOptInAnnotation = requiresOptInAnnotation.getOrElse(defaultRequiresOptInAnnotation),
-        fieldOnDisjointTypesMustMerge = fieldOnDisjointTypesMustMerge.getOrElse(defaultFieldOnDisjointTypesMustMerge)
+        fieldsOnDisjointTypesMustMerge = fieldsOnDisjointTypesMustMerge.getOrElse(defaultFieldsOnDisjointTypesMustMerge)
     )
 
     val outputCompilerMetadata = ApolloCompiler.write(options)

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -16,6 +16,7 @@ import com.apollographql.apollo3.compiler.Options.Companion.defaultAlwaysGenerat
 import com.apollographql.apollo3.compiler.Options.Companion.defaultCodegenModels
 import com.apollographql.apollo3.compiler.Options.Companion.defaultRequiresOptInAnnotation
 import com.apollographql.apollo3.compiler.Options.Companion.defaultFailOnWarnings
+import com.apollographql.apollo3.compiler.Options.Companion.defaultFieldOnDisjointTypesMustMerge
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateAsInternal
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateDataBuilders
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFilterNotNull
@@ -209,6 +210,10 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
   @get:Optional
   abstract val requiresOptInAnnotation: Property<String>
 
+  @get:Input
+  @get:Optional
+  abstract val fieldOnDisjointTypesMustMerge: Property<Boolean>
+
   @TaskAction
   fun taskAction() {
     val metadata = metadataFiles.files.toList().map { ApolloMetadata.readFrom(it) }
@@ -309,6 +314,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         generateOptionalOperationVariables = generateOptionalOperationVariables.getOrElse(defaultGenerateOptionalOperationVariables),
         addJvmOverloads = addJvmOverloads.getOrElse(defaultAddJvmOverloads),
         requiresOptInAnnotation = requiresOptInAnnotation.getOrElse(defaultRequiresOptInAnnotation),
+        fieldOnDisjointTypesMustMerge = fieldOnDisjointTypesMustMerge.getOrElse(defaultFieldOnDisjointTypesMustMerge)
     )
 
     val outputCompilerMetadata = ApolloCompiler.write(options)

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -572,7 +572,7 @@ abstract class DefaultApolloExtension(
       task.generateOptionalOperationVariables.set(service.generateOptionalOperationVariables)
       task.languageVersion.set(service.languageVersion)
       task.requiresOptInAnnotation.set(service.requiresOptInAnnotation)
-      task.fieldOnDisjointTypesMustMerge.set(service.fieldOnDisjointTypesMustMerge)
+      task.fieldsOnDisjointTypesMustMerge.set(service.fieldsOnDisjointTypesMustMerge)
     }
   }
 

--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -572,6 +572,7 @@ abstract class DefaultApolloExtension(
       task.generateOptionalOperationVariables.set(service.generateOptionalOperationVariables)
       task.languageVersion.set(service.languageVersion)
       task.requiresOptInAnnotation.set(service.requiresOptInAnnotation)
+      task.fieldOnDisjointTypesMustMerge.set(service.fieldOnDisjointTypesMustMerge)
     }
   }
 


### PR DESCRIPTION
re #4320

Basically, I skip `fieldsInSetCanMerge` if the `fieldOnDisjointTypesMustMerge` flag is `true`.
Please let me know if that's the expectation.