### PR TITLE
⚙️ Set same version of NodeJS in all modules

### DIFF
--- a/build-logic/src/main/kotlin/Node.kt
+++ b/build-logic/src/main/kotlin/Node.kt
@@ -26,8 +26,8 @@ fun Project.configureNode() {
     }
   }
 
-  // See https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0
+  // See https://youtrack.jetbrains.com/issue/KT-49774/KJS-Gradle-Errors-during-NPM-dependencies-resolution-in-parallel-build-lead-to-unfriendly-error-messages-like-Projects-must-be#focus=Comments-27-6271456.0-0
   rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
-    project.extensions.getByType(NodeJsRootExtension::class.java).nodeVersion = "16.10.0"
+    project.extensions.getByType(NodeJsRootExtension::class.java).nodeVersion = "16.17.0"
   }
 }

--- a/build-logic/src/main/kotlin/Node.kt
+++ b/build-logic/src/main/kotlin/Node.kt
@@ -1,5 +1,7 @@
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 
@@ -22,5 +24,10 @@ fun Project.configureNode() {
       // Drop the patch version because there shouldn't be any dependency change
       lockFileDirectory = projectDir.resolve("kotlin-js-store-${project.getKotlinPluginVersion().substringBeforeLast(".")}")
     }
+  }
+
+  // See https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0
+  rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
+    project.extensions.getByType(NodeJsRootExtension::class.java).nodeVersion = "16.10.0"
   }
 }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
   mavenCentral()
 }
 
-// See https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0
 rootProject.configureNode()
 
 tasks.register("ciBuild") {

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -15,6 +15,7 @@ repositories {
   mavenCentral()
 }
 
+// See https://youtrack.jetbrains.com/issue/KT-49109#focus=Comments-27-5259190.0-0
 rootProject.configureNode()
 
 tasks.register("ciBuild") {


### PR DESCRIPTION
This reverts #4343 because it appears that it's still necessary, not exactly sure why, but sourcesets were not seen as such in IJ on specific modules (e.g. `integration-tests`). A hint comes from [this comment](https://youtrack.jetbrains.com/issue/KT-49774/KJS-Gradle-Errors-during-NPM-dependencies-resolution-in-parallel-build-lead-to-unfriendly-error-messages-like-Projects-must-be#focus=Comments-27-6271456.0-0).

Before
![Screen Shot 2022-08-18 at 16 49 34](https://user-images.githubusercontent.com/372852/185427724-a68accf6-ef13-4948-bfce-9ff056803e21.png)

After
![Screen Shot 2022-08-18 at 16 48 53](https://user-images.githubusercontent.com/372852/185427787-ae45b571-9af2-4031-91d4-5934a76fbe2f.png)
