### PR TITLE
Re-introduce @defer and use new payload format

### DIFF
--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -38,7 +38,8 @@ class DefaultHttpRequestComposer(
 
     val requestHeaders = listOf(
         HttpHeader(HEADER_APOLLO_OPERATION_ID, operation.id()),
-        HttpHeader(HEADER_APOLLO_OPERATION_NAME, operation.name())
+        HttpHeader(HEADER_APOLLO_OPERATION_NAME, operation.name()),
+        HttpHeader(HEADER_ACCEPT_NAME, HEADER_ACCEPT_VALUE),
     ) + (apolloRequest.httpHeaders ?: emptyList())
 
     val sendApqExtensions = apolloRequest.sendApqExtensions ?: false
@@ -77,6 +78,13 @@ class DefaultHttpRequestComposer(
     // https://www.apollographql.com/docs/apollo-server/security/cors/#preventing-cross-site-request-forgery-csrf
     // for details.
     const val HEADER_APOLLO_OPERATION_NAME = "X-APOLLO-OPERATION-NAME"
+
+    private const val HEADER_ACCEPT_NAME = "Accept"
+
+    // TODO The deferSpec=20220822 part is a temporary measure so early backend implementations of the @defer directive
+    // can recognize early client implementations and potentially reply in a compaible way.
+    // This should be removed in later versions.
+    private const val HEADER_ACCEPT_VALUE = "multipart/mixed; deferSpec=20220822, application/json"
 
     private fun <D : Operation.Data> buildGetUrl(
         serverUrl: String,

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -240,7 +240,7 @@ internal class ExecutableValidationScope(
       validateDirective(it, this) {
         variableUsages.add(it)
       }
-      if (it.name == "experimental_defer" && !path.startsWith('-')) it.validateDeferDirective(selectionSetParent, path)
+      if (it.name == "defer" && !path.startsWith('-')) it.validateDeferDirective(selectionSetParent, path)
     }
   }
 
@@ -277,7 +277,7 @@ internal class ExecutableValidationScope(
       validateDirective(it, this) {
         variableUsages.add(it)
       }
-      if (it.name == "experimental_defer" && !path.startsWith('-')) it.validateDeferDirective(selectionSetParent, path)
+      if (it.name == "defer" && !path.startsWith('-')) it.validateDeferDirective(selectionSetParent, path)
     }
   }
 

--- a/apollo-ast/src/main/resources/builtins.graphqls
+++ b/apollo-ast/src/main/resources/builtins.graphqls
@@ -133,7 +133,7 @@ directive @deprecated(
   reason: String = "No longer supported"
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
-directive @experimental_defer(
+directive @defer(
   label: String
   if: Boolean
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -770,7 +770,7 @@ internal fun List<GQLDirective>.toBooleanExpression(): BooleanExpression<BTerm> 
 }
 
 internal fun GQLDirective.toDeferBooleanExpression(): BooleanExpression<BTerm>? {
-  if (name != "experimental_defer") return null
+  if (name != "defer") return null
   val ifArgumentValue = arguments?.arguments?.firstOrNull { it.name == "if" }?.value ?: GQLBooleanValue(value = true)
 
   val labelArgumentValue = arguments?.arguments?.firstOrNull { it.name == "label" }?.value

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/TestOperation.graphql
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/TestOperation.graphql
@@ -1,13 +1,13 @@
 query SpreadSingleWithDefer {
   hero {
-    ...DroidDetails @experimental_defer
+    ...DroidDetails @defer
   }
 }
 
 query SpreadMultipleWithDefer {
   hero {
-    ...DroidDetails @experimental_defer(label: "a_first")
-    ...DroidDetails @experimental_defer(label: "a_second")
+    ...DroidDetails @defer(label: "a_first")
+    ...DroidDetails @defer(label: "a_second")
   }
 }
 
@@ -15,10 +15,10 @@ query SpreadMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $con
   hero {
     ...DroidDetails @include(if: $cond1)
     ...DroidDetails @skip(if: $cond2)
-    ...DroidDetails @experimental_defer(label: "b_first")
-    ...DroidDetails @experimental_defer(label: "b_second")
-    ...DroidDetails @experimental_defer(label: "b_third") @include(if: $cond3)
-    ...DroidDetails @experimental_defer(label: "b_fourth") @skip(if: $cond4)
+    ...DroidDetails @defer(label: "b_first")
+    ...DroidDetails @defer(label: "b_second")
+    ...DroidDetails @defer(label: "b_third") @include(if: $cond3)
+    ...DroidDetails @defer(label: "b_fourth") @skip(if: $cond4)
   }
 }
 
@@ -28,9 +28,9 @@ fragment DroidDetails on Droid {
 
 query SpreadMultipleWithDeferWithIf($cond: Boolean!) {
   hero {
-    ...CharacterDetails @experimental_defer(label: "c_first" if: false)
-    ...CharacterDetails2 @experimental_defer(label: "c_second" if: true)
-    ...CharacterDetails3 @experimental_defer(label: "c_third" if: $cond)
+    ...CharacterDetails @defer(label: "c_first" if: false)
+    ...CharacterDetails2 @defer(label: "c_second" if: true)
+    ...CharacterDetails3 @defer(label: "c_third" if: $cond)
   }
 }
 
@@ -48,7 +48,7 @@ fragment CharacterDetails3 on Droid {
 
 query InlineSingleWithDefer {
   hero {
-    ... on Droid @experimental_defer {
+    ... on Droid @defer {
       name
     }
   }
@@ -56,11 +56,11 @@ query InlineSingleWithDefer {
 
 query InlineMultipleWithDefer {
   hero {
-    ... on Droid @experimental_defer(label: "d_first") {
+    ... on Droid @defer(label: "d_first") {
       name
     }
 
-    ... on Droid @experimental_defer(label: "d_second") {
+    ... on Droid @defer(label: "d_second") {
       id
     }
   }
@@ -74,16 +74,16 @@ query InlineMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $con
     ... on Droid @skip(if: $cond2) {
       id
     }
-    ... on Droid @experimental_defer(label: "e_first") {
+    ... on Droid @defer(label: "e_first") {
       name
     }
-    ... on Droid @experimental_defer(label: "e_second") {
+    ... on Droid @defer(label: "e_second") {
       id
     }
-    ... on Droid @experimental_defer(label: "e_third") @include(if: $cond3) {
+    ... on Droid @defer(label: "e_third") @include(if: $cond3) {
       name
     }
-    ... on Droid @experimental_defer(label: "e_fourth") @skip(if: $cond4) {
+    ... on Droid @defer(label: "e_fourth") @skip(if: $cond4) {
       id
     }
   }
@@ -91,15 +91,15 @@ query InlineMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $con
 
 query InlineMultipleWithDeferWithIf($cond: Boolean!) {
   hero {
-    ... on Character @experimental_defer(label: "f_first" if: false) {
+    ... on Character @defer(label: "f_first" if: false) {
       id
     }
 
-    ... on Character @experimental_defer(label: "f_second" if: true) {
+    ... on Character @defer(label: "f_second" if: true) {
       name
     }
 
-    ... on Character @experimental_defer(label: "f_third" if: $cond) {
+    ... on Character @defer(label: "f_third" if: $cond) {
       name
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.java.expected
@@ -19,7 +19,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class InlineMultipleWithDefer implements Query<InlineMultipleWithDefer.Data> {
-  public static final String OPERATION_ID = "9811408b41402ad913abcd7bb5ce221d926a3c545f3f401706b25aefa816081e";
+  public static final String OPERATION_ID = "9331f0c719bafb010d29f76c720d4488f45c5196bf3fb8908b2be30bc546e355";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -28,16 +28,16 @@ public class InlineMultipleWithDefer implements Query<InlineMultipleWithDefer.Da
    * query InlineMultipleWithDefer {
    *   hero {
    *     __typename
-   *     ... on Droid @experimental_defer(label: "d_first") {
+   *     ... on Droid @defer(label: "d_first") {
    *       name
    *     }
-   *     ... on Droid @experimental_defer(label: "d_second") {
+   *     ... on Droid @defer(label: "d_second") {
    *       id
    *     }
    *   }
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDefer { hero { __typename ... on Droid @experimental_defer(label: \"d_first\") { name } ... on Droid @experimental_defer(label: \"d_second\") { id } } }";
+  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDefer { hero { __typename ... on Droid @defer(label: \"d_first\") { name } ... on Droid @defer(label: \"d_second\") { id } } }";
 
   public static final String OPERATION_NAME = "InlineMultipleWithDefer";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.java.expected
@@ -21,7 +21,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class InlineMultipleWithDeferAndInclude implements Query<InlineMultipleWithDeferAndInclude.Data> {
-  public static final String OPERATION_ID = "90fbc93ce8710e768303863f05c634101ecab0723c10e370c3b8c643ff30f96e";
+  public static final String OPERATION_ID = "f159c1ac4f33a49c5c9833e06a2606e2fc7ede812e119909eb45f95dc2aa01fc";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -36,22 +36,22 @@ public class InlineMultipleWithDeferAndInclude implements Query<InlineMultipleWi
    *     ... on Droid @skip(if: $cond2) {
    *       id
    *     }
-   *     ... on Droid @experimental_defer(label: "e_first") {
+   *     ... on Droid @defer(label: "e_first") {
    *       name
    *     }
-   *     ... on Droid @experimental_defer(label: "e_second") {
+   *     ... on Droid @defer(label: "e_second") {
    *       id
    *     }
-   *     ... on Droid @experimental_defer(label: "e_third") @include(if: $cond3) {
+   *     ... on Droid @defer(label: "e_third") @include(if: $cond3) {
    *       name
    *     }
-   *     ... on Droid @experimental_defer(label: "e_fourth") @skip(if: $cond4) {
+   *     ... on Droid @defer(label: "e_fourth") @skip(if: $cond4) {
    *       id
    *     }
    *   }
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $cond3: Boolean!, $cond4: Boolean!) { hero { __typename ... on Droid @include(if: $cond1) { name } ... on Droid @skip(if: $cond2) { id } ... on Droid @experimental_defer(label: \"e_first\") { name } ... on Droid @experimental_defer(label: \"e_second\") { id } ... on Droid @experimental_defer(label: \"e_third\") @include(if: $cond3) { name } ... on Droid @experimental_defer(label: \"e_fourth\") @skip(if: $cond4) { id } } }";
+  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $cond3: Boolean!, $cond4: Boolean!) { hero { __typename ... on Droid @include(if: $cond1) { name } ... on Droid @skip(if: $cond2) { id } ... on Droid @defer(label: \"e_first\") { name } ... on Droid @defer(label: \"e_second\") { id } ... on Droid @defer(label: \"e_third\") @include(if: $cond3) { name } ... on Droid @defer(label: \"e_fourth\") @skip(if: $cond4) { id } } }";
 
   public static final String OPERATION_NAME = "InlineMultipleWithDeferAndInclude";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.java.expected
@@ -21,7 +21,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class InlineMultipleWithDeferWithIf implements Query<InlineMultipleWithDeferWithIf.Data> {
-  public static final String OPERATION_ID = "3e777ab8534ca2847df43e92a828787127e9536d7c1ab8136985620443c2b991";
+  public static final String OPERATION_ID = "9dc79c78df7375c3d860d16df3ea839ea45c7f8420976f63414610d338f0caf1";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -30,19 +30,19 @@ public class InlineMultipleWithDeferWithIf implements Query<InlineMultipleWithDe
    * query InlineMultipleWithDeferWithIf($cond: Boolean!) {
    *   hero {
    *     __typename
-   *     ... on Character @experimental_defer(label: "f_first", if: false) {
+   *     ... on Character @defer(label: "f_first", if: false) {
    *       id
    *     }
-   *     ... on Character @experimental_defer(label: "f_second", if: true) {
+   *     ... on Character @defer(label: "f_second", if: true) {
    *       name
    *     }
-   *     ... on Character @experimental_defer(label: "f_third", if: $cond) {
+   *     ... on Character @defer(label: "f_third", if: $cond) {
    *       name
    *     }
    *   }
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDeferWithIf($cond: Boolean!) { hero { __typename ... on Character @experimental_defer(label: \"f_first\", if: false) { id } ... on Character @experimental_defer(label: \"f_second\", if: true) { name } ... on Character @experimental_defer(label: \"f_third\", if: $cond) { name } } }";
+  public static final String OPERATION_DOCUMENT = "query InlineMultipleWithDeferWithIf($cond: Boolean!) { hero { __typename ... on Character @defer(label: \"f_first\", if: false) { id } ... on Character @defer(label: \"f_second\", if: true) { name } ... on Character @defer(label: \"f_third\", if: $cond) { name } } }";
 
   public static final String OPERATION_NAME = "InlineMultipleWithDeferWithIf";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineSingleWithDefer.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/InlineSingleWithDefer.java.expected
@@ -19,7 +19,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class InlineSingleWithDefer implements Query<InlineSingleWithDefer.Data> {
-  public static final String OPERATION_ID = "da1ea6b7b54f4bc6e0754b9bbe45a002500fef00de7f3605a4efd02133c20def";
+  public static final String OPERATION_ID = "70222802c9192f810f19a54d31e039ce0fc3b8baac231841f0a0e8b4200c312b";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -28,13 +28,13 @@ public class InlineSingleWithDefer implements Query<InlineSingleWithDefer.Data> 
    * query InlineSingleWithDefer {
    *   hero {
    *     __typename
-   *     ... on Droid @experimental_defer {
+   *     ... on Droid @defer {
    *       name
    *     }
    *   }
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query InlineSingleWithDefer { hero { __typename ... on Droid @experimental_defer { name } } }";
+  public static final String OPERATION_DOCUMENT = "query InlineSingleWithDefer { hero { __typename ... on Droid @defer { name } } }";
 
   public static final String OPERATION_NAME = "InlineSingleWithDefer";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.java.expected
@@ -20,7 +20,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class SpreadMultipleWithDefer implements Query<SpreadMultipleWithDefer.Data> {
-  public static final String OPERATION_ID = "e52d7b5c6a99f54c7d8e7f1d6c4f6e604586b4c83b212436661068e98f4f7ad1";
+  public static final String OPERATION_ID = "7cd4d1b6a14f96cff4bbbdbd3b3ab1aa365ffc65e1515ff6e22935010543ad71";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -29,8 +29,8 @@ public class SpreadMultipleWithDefer implements Query<SpreadMultipleWithDefer.Da
    * query SpreadMultipleWithDefer {
    *   hero {
    *     __typename
-   *     ...DroidDetails @experimental_defer(label: "a_first")
-   *     ...DroidDetails @experimental_defer(label: "a_second")
+   *     ...DroidDetails @defer(label: "a_first")
+   *     ...DroidDetails @defer(label: "a_second")
    *   }
    * }
    *
@@ -38,7 +38,7 @@ public class SpreadMultipleWithDefer implements Query<SpreadMultipleWithDefer.Da
    *   name
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @experimental_defer(label: \"a_first\") ...DroidDetails @experimental_defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }";
+  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @defer(label: \"a_first\") ...DroidDetails @defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }";
 
   public static final String OPERATION_NAME = "SpreadMultipleWithDefer";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.java.expected
@@ -22,7 +22,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class SpreadMultipleWithDeferAndInclude implements Query<SpreadMultipleWithDeferAndInclude.Data> {
-  public static final String OPERATION_ID = "de31db86e7b05f57e3d3d700a4811e4aba6c56860dc18f94879165a5e04fcfe8";
+  public static final String OPERATION_ID = "1c9d61b4af65df2bfed92353244efbb66d20a35daf747507e66ed9d20dcd1517";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -33,10 +33,10 @@ public class SpreadMultipleWithDeferAndInclude implements Query<SpreadMultipleWi
    *     __typename
    *     ...DroidDetails @include(if: $cond1)
    *     ...DroidDetails @skip(if: $cond2)
-   *     ...DroidDetails @experimental_defer(label: "b_first")
-   *     ...DroidDetails @experimental_defer(label: "b_second")
-   *     ...DroidDetails @experimental_defer(label: "b_third") @include(if: $cond3)
-   *     ...DroidDetails @experimental_defer(label: "b_fourth") @skip(if: $cond4)
+   *     ...DroidDetails @defer(label: "b_first")
+   *     ...DroidDetails @defer(label: "b_second")
+   *     ...DroidDetails @defer(label: "b_third") @include(if: $cond3)
+   *     ...DroidDetails @defer(label: "b_fourth") @skip(if: $cond4)
    *   }
    * }
    *
@@ -44,7 +44,7 @@ public class SpreadMultipleWithDeferAndInclude implements Query<SpreadMultipleWi
    *   name
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $cond3: Boolean!, $cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: $cond1) ...DroidDetails @skip(if: $cond2) ...DroidDetails @experimental_defer(label: \"b_first\") ...DroidDetails @experimental_defer(label: \"b_second\") ...DroidDetails @experimental_defer(label: \"b_third\") @include(if: $cond3) ...DroidDetails @experimental_defer(label: \"b_fourth\") @skip(if: $cond4) } }  fragment DroidDetails on Droid { name }";
+  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDeferAndInclude($cond1: Boolean!, $cond2: Boolean!, $cond3: Boolean!, $cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: $cond1) ...DroidDetails @skip(if: $cond2) ...DroidDetails @defer(label: \"b_first\") ...DroidDetails @defer(label: \"b_second\") ...DroidDetails @defer(label: \"b_third\") @include(if: $cond3) ...DroidDetails @defer(label: \"b_fourth\") @skip(if: $cond4) } }  fragment DroidDetails on Droid { name }";
 
   public static final String OPERATION_NAME = "SpreadMultipleWithDeferAndInclude";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.java.expected
@@ -24,7 +24,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class SpreadMultipleWithDeferWithIf implements Query<SpreadMultipleWithDeferWithIf.Data> {
-  public static final String OPERATION_ID = "f98db9747dd000723759253dacdd7a4e45eaa6003e459c001799901f96abbd8f";
+  public static final String OPERATION_ID = "ecdac17ca37d6cbf3a6e5059904fabfd96193cbe0720eb27880026b518feec9f";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -33,9 +33,9 @@ public class SpreadMultipleWithDeferWithIf implements Query<SpreadMultipleWithDe
    * query SpreadMultipleWithDeferWithIf($cond: Boolean!) {
    *   hero {
    *     __typename
-   *     ...CharacterDetails @experimental_defer(label: "c_first", if: false)
-   *     ...CharacterDetails2 @experimental_defer(label: "c_second", if: true)
-   *     ...CharacterDetails3 @experimental_defer(label: "c_third", if: $cond)
+   *     ...CharacterDetails @defer(label: "c_first", if: false)
+   *     ...CharacterDetails2 @defer(label: "c_second", if: true)
+   *     ...CharacterDetails3 @defer(label: "c_third", if: $cond)
    *   }
    * }
    *
@@ -51,7 +51,7 @@ public class SpreadMultipleWithDeferWithIf implements Query<SpreadMultipleWithDe
    *   birthDate
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDeferWithIf($cond: Boolean!) { hero { __typename ...CharacterDetails @experimental_defer(label: \"c_first\", if: false) ...CharacterDetails2 @experimental_defer(label: \"c_second\", if: true) ...CharacterDetails3 @experimental_defer(label: \"c_third\", if: $cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }";
+  public static final String OPERATION_DOCUMENT = "query SpreadMultipleWithDeferWithIf($cond: Boolean!) { hero { __typename ...CharacterDetails @defer(label: \"c_first\", if: false) ...CharacterDetails2 @defer(label: \"c_second\", if: true) ...CharacterDetails3 @defer(label: \"c_third\", if: $cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }";
 
   public static final String OPERATION_NAME = "SpreadMultipleWithDeferWithIf";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.java.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.java.expected
@@ -20,7 +20,7 @@ import java.lang.Override;
 import java.lang.String;
 
 public class SpreadSingleWithDefer implements Query<SpreadSingleWithDefer.Data> {
-  public static final String OPERATION_ID = "d7b739ea7224dce16c1992e5df95207a06f4f92b8231db42098755afac7a6439";
+  public static final String OPERATION_ID = "fad1c3622a6f35d5fa4ad7b5e4a8d50525c350d4688837022f0f7a6f0aed2ba0";
 
   /**
    * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -29,7 +29,7 @@ public class SpreadSingleWithDefer implements Query<SpreadSingleWithDefer.Data> 
    * query SpreadSingleWithDefer {
    *   hero {
    *     __typename
-   *     ...DroidDetails @experimental_defer
+   *     ...DroidDetails @defer
    *   }
    * }
    *
@@ -37,7 +37,7 @@ public class SpreadSingleWithDefer implements Query<SpreadSingleWithDefer.Data> 
    *   name
    * }
    */
-  public static final String OPERATION_DOCUMENT = "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @experimental_defer } }  fragment DroidDetails on Droid { name }";
+  public static final String OPERATION_DOCUMENT = "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @defer } }  fragment DroidDetails on Droid { name }";
 
   public static final String OPERATION_NAME = "SpreadSingleWithDefer";
 

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.kt.expected
@@ -80,7 +80,7 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "9811408b41402ad913abcd7bb5ce221d926a3c545f3f401706b25aefa816081e"
+        "9331f0c719bafb010d29f76c720d4488f45c5196bf3fb8908b2be30bc546e355"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -89,10 +89,10 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
      * query InlineMultipleWithDefer {
      *   hero {
      *     __typename
-     *     ... on Droid @experimental_defer(label: "d_first") {
+     *     ... on Droid @defer(label: "d_first") {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "d_second") {
+     *     ... on Droid @defer(label: "d_second") {
      *       id
      *     }
      *   }
@@ -100,7 +100,7 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDefer { hero { __typename ... on Droid @experimental_defer(label: \"d_first\") { name } ... on Droid @experimental_defer(label: \"d_second\") { id } } }"
+          "query InlineMultipleWithDefer { hero { __typename ... on Droid @defer(label: \"d_first\") { name } ... on Droid @defer(label: \"d_second\") { id } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.kt.expected
@@ -129,7 +129,7 @@ public data class InlineMultipleWithDeferAndInclude(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "90fbc93ce8710e768303863f05c634101ecab0723c10e370c3b8c643ff30f96e"
+        "f159c1ac4f33a49c5c9833e06a2606e2fc7ede812e119909eb45f95dc2aa01fc"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -145,16 +145,16 @@ public data class InlineMultipleWithDeferAndInclude(
      *     ... on Droid @skip(if: $cond2) {
      *       id
      *     }
-     *     ... on Droid @experimental_defer(label: "e_first") {
+     *     ... on Droid @defer(label: "e_first") {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "e_second") {
+     *     ... on Droid @defer(label: "e_second") {
      *       id
      *     }
-     *     ... on Droid @experimental_defer(label: "e_third") @include(if: $cond3) {
+     *     ... on Droid @defer(label: "e_third") @include(if: $cond3) {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "e_fourth") @skip(if: $cond4) {
+     *     ... on Droid @defer(label: "e_fourth") @skip(if: $cond4) {
      *       id
      *     }
      *   }
@@ -162,7 +162,7 @@ public data class InlineMultipleWithDeferAndInclude(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ... on Droid @include(if: ${'$'}cond1) { name } ... on Droid @skip(if: ${'$'}cond2) { id } ... on Droid @experimental_defer(label: \"e_first\") { name } ... on Droid @experimental_defer(label: \"e_second\") { id } ... on Droid @experimental_defer(label: \"e_third\") @include(if: ${'$'}cond3) { name } ... on Droid @experimental_defer(label: \"e_fourth\") @skip(if: ${'$'}cond4) { id } } }"
+          "query InlineMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ... on Droid @include(if: ${'$'}cond1) { name } ... on Droid @skip(if: ${'$'}cond2) { id } ... on Droid @defer(label: \"e_first\") { name } ... on Droid @defer(label: \"e_second\") { id } ... on Droid @defer(label: \"e_third\") @include(if: ${'$'}cond3) { name } ... on Droid @defer(label: \"e_fourth\") @skip(if: ${'$'}cond4) { id } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDeferAndInclude"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.kt.expected
@@ -90,7 +90,7 @@ public data class InlineMultipleWithDeferWithIf(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "3e777ab8534ca2847df43e92a828787127e9536d7c1ab8136985620443c2b991"
+        "9dc79c78df7375c3d860d16df3ea839ea45c7f8420976f63414610d338f0caf1"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -99,13 +99,13 @@ public data class InlineMultipleWithDeferWithIf(
      * query InlineMultipleWithDeferWithIf($cond: Boolean!) {
      *   hero {
      *     __typename
-     *     ... on Character @experimental_defer(label: "f_first", if: false) {
+     *     ... on Character @defer(label: "f_first", if: false) {
      *       id
      *     }
-     *     ... on Character @experimental_defer(label: "f_second", if: true) {
+     *     ... on Character @defer(label: "f_second", if: true) {
      *       name
      *     }
-     *     ... on Character @experimental_defer(label: "f_third", if: $cond) {
+     *     ... on Character @defer(label: "f_third", if: $cond) {
      *       name
      *     }
      *   }
@@ -113,7 +113,7 @@ public data class InlineMultipleWithDeferWithIf(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ... on Character @experimental_defer(label: \"f_first\", if: false) { id } ... on Character @experimental_defer(label: \"f_second\", if: true) { name } ... on Character @experimental_defer(label: \"f_third\", if: ${'$'}cond) { name } } }"
+          "query InlineMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ... on Character @defer(label: \"f_first\", if: false) { id } ... on Character @defer(label: \"f_second\", if: true) { name } ... on Character @defer(label: \"f_third\", if: ${'$'}cond) { name } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDeferWithIf"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineSingleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/InlineSingleWithDefer.kt.expected
@@ -68,7 +68,7 @@ public class InlineSingleWithDefer() : Query<InlineSingleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "da1ea6b7b54f4bc6e0754b9bbe45a002500fef00de7f3605a4efd02133c20def"
+        "70222802c9192f810f19a54d31e039ce0fc3b8baac231841f0a0e8b4200c312b"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -77,15 +77,14 @@ public class InlineSingleWithDefer() : Query<InlineSingleWithDefer.Data> {
      * query InlineSingleWithDefer {
      *   hero {
      *     __typename
-     *     ... on Droid @experimental_defer {
+     *     ... on Droid @defer {
      *       name
      *     }
      *   }
      * }
      */
     public val OPERATION_DOCUMENT: String
-      get() =
-          "query InlineSingleWithDefer { hero { __typename ... on Droid @experimental_defer { name } } }"
+      get() = "query InlineSingleWithDefer { hero { __typename ... on Droid @defer { name } } }"
 
     public const val OPERATION_NAME: String = "InlineSingleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.kt.expected
@@ -68,7 +68,7 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "e52d7b5c6a99f54c7d8e7f1d6c4f6e604586b4c83b212436661068e98f4f7ad1"
+        "7cd4d1b6a14f96cff4bbbdbd3b3ab1aa365ffc65e1515ff6e22935010543ad71"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -77,8 +77,8 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
      * query SpreadMultipleWithDefer {
      *   hero {
      *     __typename
-     *     ...DroidDetails @experimental_defer(label: "a_first")
-     *     ...DroidDetails @experimental_defer(label: "a_second")
+     *     ...DroidDetails @defer(label: "a_first")
+     *     ...DroidDetails @defer(label: "a_second")
      *   }
      * }
      *
@@ -88,7 +88,7 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @experimental_defer(label: \"a_first\") ...DroidDetails @experimental_defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }"
+          "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @defer(label: \"a_first\") ...DroidDetails @defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.kt.expected
@@ -69,7 +69,7 @@ public data class SpreadMultipleWithDeferAndInclude(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "de31db86e7b05f57e3d3d700a4811e4aba6c56860dc18f94879165a5e04fcfe8"
+        "1c9d61b4af65df2bfed92353244efbb66d20a35daf747507e66ed9d20dcd1517"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -81,10 +81,10 @@ public data class SpreadMultipleWithDeferAndInclude(
      *     __typename
      *     ...DroidDetails @include(if: $cond1)
      *     ...DroidDetails @skip(if: $cond2)
-     *     ...DroidDetails @experimental_defer(label: "b_first")
-     *     ...DroidDetails @experimental_defer(label: "b_second")
-     *     ...DroidDetails @experimental_defer(label: "b_third") @include(if: $cond3)
-     *     ...DroidDetails @experimental_defer(label: "b_fourth") @skip(if: $cond4)
+     *     ...DroidDetails @defer(label: "b_first")
+     *     ...DroidDetails @defer(label: "b_second")
+     *     ...DroidDetails @defer(label: "b_third") @include(if: $cond3)
+     *     ...DroidDetails @defer(label: "b_fourth") @skip(if: $cond4)
      *   }
      * }
      *
@@ -94,7 +94,7 @@ public data class SpreadMultipleWithDeferAndInclude(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: ${'$'}cond1) ...DroidDetails @skip(if: ${'$'}cond2) ...DroidDetails @experimental_defer(label: \"b_first\") ...DroidDetails @experimental_defer(label: \"b_second\") ...DroidDetails @experimental_defer(label: \"b_third\") @include(if: ${'$'}cond3) ...DroidDetails @experimental_defer(label: \"b_fourth\") @skip(if: ${'$'}cond4) } }  fragment DroidDetails on Droid { name }"
+          "query SpreadMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: ${'$'}cond1) ...DroidDetails @skip(if: ${'$'}cond2) ...DroidDetails @defer(label: \"b_first\") ...DroidDetails @defer(label: \"b_second\") ...DroidDetails @defer(label: \"b_third\") @include(if: ${'$'}cond3) ...DroidDetails @defer(label: \"b_fourth\") @skip(if: ${'$'}cond4) } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDeferAndInclude"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.kt.expected
@@ -76,7 +76,7 @@ public data class SpreadMultipleWithDeferWithIf(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "f98db9747dd000723759253dacdd7a4e45eaa6003e459c001799901f96abbd8f"
+        "ecdac17ca37d6cbf3a6e5059904fabfd96193cbe0720eb27880026b518feec9f"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -85,9 +85,9 @@ public data class SpreadMultipleWithDeferWithIf(
      * query SpreadMultipleWithDeferWithIf($cond: Boolean!) {
      *   hero {
      *     __typename
-     *     ...CharacterDetails @experimental_defer(label: "c_first", if: false)
-     *     ...CharacterDetails2 @experimental_defer(label: "c_second", if: true)
-     *     ...CharacterDetails3 @experimental_defer(label: "c_third", if: $cond)
+     *     ...CharacterDetails @defer(label: "c_first", if: false)
+     *     ...CharacterDetails2 @defer(label: "c_second", if: true)
+     *     ...CharacterDetails3 @defer(label: "c_third", if: $cond)
      *   }
      * }
      *
@@ -105,7 +105,7 @@ public data class SpreadMultipleWithDeferWithIf(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ...CharacterDetails @experimental_defer(label: \"c_first\", if: false) ...CharacterDetails2 @experimental_defer(label: \"c_second\", if: true) ...CharacterDetails3 @experimental_defer(label: \"c_third\", if: ${'$'}cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }"
+          "query SpreadMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ...CharacterDetails @defer(label: \"c_first\", if: false) ...CharacterDetails2 @defer(label: \"c_second\", if: true) ...CharacterDetails3 @defer(label: \"c_third\", if: ${'$'}cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDeferWithIf"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/compat/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.kt.expected
@@ -68,7 +68,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "d7b739ea7224dce16c1992e5df95207a06f4f92b8231db42098755afac7a6439"
+        "fad1c3622a6f35d5fa4ad7b5e4a8d50525c350d4688837022f0f7a6f0aed2ba0"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -77,7 +77,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
      * query SpreadSingleWithDefer {
      *   hero {
      *     __typename
-     *     ...DroidDetails @experimental_defer
+     *     ...DroidDetails @defer
      *   }
      * }
      *
@@ -87,7 +87,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @experimental_defer } }  fragment DroidDetails on Droid { name }"
+          "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @defer } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadSingleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDefer.kt.expected
@@ -78,7 +78,7 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "9811408b41402ad913abcd7bb5ce221d926a3c545f3f401706b25aefa816081e"
+        "9331f0c719bafb010d29f76c720d4488f45c5196bf3fb8908b2be30bc546e355"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -87,10 +87,10 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
      * query InlineMultipleWithDefer {
      *   hero {
      *     __typename
-     *     ... on Droid @experimental_defer(label: "d_first") {
+     *     ... on Droid @defer(label: "d_first") {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "d_second") {
+     *     ... on Droid @defer(label: "d_second") {
      *       id
      *     }
      *   }
@@ -98,7 +98,7 @@ public class InlineMultipleWithDefer() : Query<InlineMultipleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDefer { hero { __typename ... on Droid @experimental_defer(label: \"d_first\") { name } ... on Droid @experimental_defer(label: \"d_second\") { id } } }"
+          "query InlineMultipleWithDefer { hero { __typename ... on Droid @defer(label: \"d_first\") { name } ... on Droid @defer(label: \"d_second\") { id } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferAndInclude.kt.expected
@@ -123,7 +123,7 @@ public data class InlineMultipleWithDeferAndInclude(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "90fbc93ce8710e768303863f05c634101ecab0723c10e370c3b8c643ff30f96e"
+        "f159c1ac4f33a49c5c9833e06a2606e2fc7ede812e119909eb45f95dc2aa01fc"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -139,16 +139,16 @@ public data class InlineMultipleWithDeferAndInclude(
      *     ... on Droid @skip(if: $cond2) {
      *       id
      *     }
-     *     ... on Droid @experimental_defer(label: "e_first") {
+     *     ... on Droid @defer(label: "e_first") {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "e_second") {
+     *     ... on Droid @defer(label: "e_second") {
      *       id
      *     }
-     *     ... on Droid @experimental_defer(label: "e_third") @include(if: $cond3) {
+     *     ... on Droid @defer(label: "e_third") @include(if: $cond3) {
      *       name
      *     }
-     *     ... on Droid @experimental_defer(label: "e_fourth") @skip(if: $cond4) {
+     *     ... on Droid @defer(label: "e_fourth") @skip(if: $cond4) {
      *       id
      *     }
      *   }
@@ -156,7 +156,7 @@ public data class InlineMultipleWithDeferAndInclude(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ... on Droid @include(if: ${'$'}cond1) { name } ... on Droid @skip(if: ${'$'}cond2) { id } ... on Droid @experimental_defer(label: \"e_first\") { name } ... on Droid @experimental_defer(label: \"e_second\") { id } ... on Droid @experimental_defer(label: \"e_third\") @include(if: ${'$'}cond3) { name } ... on Droid @experimental_defer(label: \"e_fourth\") @skip(if: ${'$'}cond4) { id } } }"
+          "query InlineMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ... on Droid @include(if: ${'$'}cond1) { name } ... on Droid @skip(if: ${'$'}cond2) { id } ... on Droid @defer(label: \"e_first\") { name } ... on Droid @defer(label: \"e_second\") { id } ... on Droid @defer(label: \"e_third\") @include(if: ${'$'}cond3) { name } ... on Droid @defer(label: \"e_fourth\") @skip(if: ${'$'}cond4) { id } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDeferAndInclude"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineMultipleWithDeferWithIf.kt.expected
@@ -87,7 +87,7 @@ public data class InlineMultipleWithDeferWithIf(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "3e777ab8534ca2847df43e92a828787127e9536d7c1ab8136985620443c2b991"
+        "9dc79c78df7375c3d860d16df3ea839ea45c7f8420976f63414610d338f0caf1"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -96,13 +96,13 @@ public data class InlineMultipleWithDeferWithIf(
      * query InlineMultipleWithDeferWithIf($cond: Boolean!) {
      *   hero {
      *     __typename
-     *     ... on Character @experimental_defer(label: "f_first", if: false) {
+     *     ... on Character @defer(label: "f_first", if: false) {
      *       id
      *     }
-     *     ... on Character @experimental_defer(label: "f_second", if: true) {
+     *     ... on Character @defer(label: "f_second", if: true) {
      *       name
      *     }
-     *     ... on Character @experimental_defer(label: "f_third", if: $cond) {
+     *     ... on Character @defer(label: "f_third", if: $cond) {
      *       name
      *     }
      *   }
@@ -110,7 +110,7 @@ public data class InlineMultipleWithDeferWithIf(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query InlineMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ... on Character @experimental_defer(label: \"f_first\", if: false) { id } ... on Character @experimental_defer(label: \"f_second\", if: true) { name } ... on Character @experimental_defer(label: \"f_third\", if: ${'$'}cond) { name } } }"
+          "query InlineMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ... on Character @defer(label: \"f_first\", if: false) { id } ... on Character @defer(label: \"f_second\", if: true) { name } ... on Character @defer(label: \"f_third\", if: ${'$'}cond) { name } } }"
 
     public const val OPERATION_NAME: String = "InlineMultipleWithDeferWithIf"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineSingleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/InlineSingleWithDefer.kt.expected
@@ -67,7 +67,7 @@ public class InlineSingleWithDefer() : Query<InlineSingleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "da1ea6b7b54f4bc6e0754b9bbe45a002500fef00de7f3605a4efd02133c20def"
+        "70222802c9192f810f19a54d31e039ce0fc3b8baac231841f0a0e8b4200c312b"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -76,15 +76,14 @@ public class InlineSingleWithDefer() : Query<InlineSingleWithDefer.Data> {
      * query InlineSingleWithDefer {
      *   hero {
      *     __typename
-     *     ... on Droid @experimental_defer {
+     *     ... on Droid @defer {
      *       name
      *     }
      *   }
      * }
      */
     public val OPERATION_DOCUMENT: String
-      get() =
-          "query InlineSingleWithDefer { hero { __typename ... on Droid @experimental_defer { name } } }"
+      get() = "query InlineSingleWithDefer { hero { __typename ... on Droid @defer { name } } }"
 
     public const val OPERATION_NAME: String = "InlineSingleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDefer.kt.expected
@@ -61,7 +61,7 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "e52d7b5c6a99f54c7d8e7f1d6c4f6e604586b4c83b212436661068e98f4f7ad1"
+        "7cd4d1b6a14f96cff4bbbdbd3b3ab1aa365ffc65e1515ff6e22935010543ad71"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -70,8 +70,8 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
      * query SpreadMultipleWithDefer {
      *   hero {
      *     __typename
-     *     ...DroidDetails @experimental_defer(label: "a_first")
-     *     ...DroidDetails @experimental_defer(label: "a_second")
+     *     ...DroidDetails @defer(label: "a_first")
+     *     ...DroidDetails @defer(label: "a_second")
      *   }
      * }
      *
@@ -81,7 +81,7 @@ public class SpreadMultipleWithDefer() : Query<SpreadMultipleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @experimental_defer(label: \"a_first\") ...DroidDetails @experimental_defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }"
+          "query SpreadMultipleWithDefer { hero { __typename ...DroidDetails @defer(label: \"a_first\") ...DroidDetails @defer(label: \"a_second\") } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDefer"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferAndInclude.kt.expected
@@ -62,7 +62,7 @@ public data class SpreadMultipleWithDeferAndInclude(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "de31db86e7b05f57e3d3d700a4811e4aba6c56860dc18f94879165a5e04fcfe8"
+        "1c9d61b4af65df2bfed92353244efbb66d20a35daf747507e66ed9d20dcd1517"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -74,10 +74,10 @@ public data class SpreadMultipleWithDeferAndInclude(
      *     __typename
      *     ...DroidDetails @include(if: $cond1)
      *     ...DroidDetails @skip(if: $cond2)
-     *     ...DroidDetails @experimental_defer(label: "b_first")
-     *     ...DroidDetails @experimental_defer(label: "b_second")
-     *     ...DroidDetails @experimental_defer(label: "b_third") @include(if: $cond3)
-     *     ...DroidDetails @experimental_defer(label: "b_fourth") @skip(if: $cond4)
+     *     ...DroidDetails @defer(label: "b_first")
+     *     ...DroidDetails @defer(label: "b_second")
+     *     ...DroidDetails @defer(label: "b_third") @include(if: $cond3)
+     *     ...DroidDetails @defer(label: "b_fourth") @skip(if: $cond4)
      *   }
      * }
      *
@@ -87,7 +87,7 @@ public data class SpreadMultipleWithDeferAndInclude(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: ${'$'}cond1) ...DroidDetails @skip(if: ${'$'}cond2) ...DroidDetails @experimental_defer(label: \"b_first\") ...DroidDetails @experimental_defer(label: \"b_second\") ...DroidDetails @experimental_defer(label: \"b_third\") @include(if: ${'$'}cond3) ...DroidDetails @experimental_defer(label: \"b_fourth\") @skip(if: ${'$'}cond4) } }  fragment DroidDetails on Droid { name }"
+          "query SpreadMultipleWithDeferAndInclude(${'$'}cond1: Boolean!, ${'$'}cond2: Boolean!, ${'$'}cond3: Boolean!, ${'$'}cond4: Boolean!) { hero { __typename ...DroidDetails @include(if: ${'$'}cond1) ...DroidDetails @skip(if: ${'$'}cond2) ...DroidDetails @defer(label: \"b_first\") ...DroidDetails @defer(label: \"b_second\") ...DroidDetails @defer(label: \"b_third\") @include(if: ${'$'}cond3) ...DroidDetails @defer(label: \"b_fourth\") @skip(if: ${'$'}cond4) } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDeferAndInclude"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadMultipleWithDeferWithIf.kt.expected
@@ -69,7 +69,7 @@ public data class SpreadMultipleWithDeferWithIf(
 
   public companion object {
     public const val OPERATION_ID: String =
-        "f98db9747dd000723759253dacdd7a4e45eaa6003e459c001799901f96abbd8f"
+        "ecdac17ca37d6cbf3a6e5059904fabfd96193cbe0720eb27880026b518feec9f"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -78,9 +78,9 @@ public data class SpreadMultipleWithDeferWithIf(
      * query SpreadMultipleWithDeferWithIf($cond: Boolean!) {
      *   hero {
      *     __typename
-     *     ...CharacterDetails @experimental_defer(label: "c_first", if: false)
-     *     ...CharacterDetails2 @experimental_defer(label: "c_second", if: true)
-     *     ...CharacterDetails3 @experimental_defer(label: "c_third", if: $cond)
+     *     ...CharacterDetails @defer(label: "c_first", if: false)
+     *     ...CharacterDetails2 @defer(label: "c_second", if: true)
+     *     ...CharacterDetails3 @defer(label: "c_third", if: $cond)
      *   }
      * }
      *
@@ -98,7 +98,7 @@ public data class SpreadMultipleWithDeferWithIf(
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ...CharacterDetails @experimental_defer(label: \"c_first\", if: false) ...CharacterDetails2 @experimental_defer(label: \"c_second\", if: true) ...CharacterDetails3 @experimental_defer(label: \"c_third\", if: ${'$'}cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }"
+          "query SpreadMultipleWithDeferWithIf(${'$'}cond: Boolean!) { hero { __typename ...CharacterDetails @defer(label: \"c_first\", if: false) ...CharacterDetails2 @defer(label: \"c_second\", if: true) ...CharacterDetails3 @defer(label: \"c_third\", if: ${'$'}cond) } }  fragment CharacterDetails on Droid { name }  fragment CharacterDetails2 on Droid { id }  fragment CharacterDetails3 on Droid { birthDate }"
 
     public const val OPERATION_NAME: String = "SpreadMultipleWithDeferWithIf"
   }

--- a/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/SpreadSingleWithDefer.kt.expected
@@ -61,7 +61,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
 
   public companion object {
     public const val OPERATION_ID: String =
-        "d7b739ea7224dce16c1992e5df95207a06f4f92b8231db42098755afac7a6439"
+        "fad1c3622a6f35d5fa4ad7b5e4a8d50525c350d4688837022f0f7a6f0aed2ba0"
 
     /**
      * The minimized GraphQL document being sent to the server to save a few bytes.
@@ -70,7 +70,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
      * query SpreadSingleWithDefer {
      *   hero {
      *     __typename
-     *     ...DroidDetails @experimental_defer
+     *     ...DroidDetails @defer
      *   }
      * }
      *
@@ -80,7 +80,7 @@ public class SpreadSingleWithDefer() : Query<SpreadSingleWithDefer.Data> {
      */
     public val OPERATION_DOCUMENT: String
       get() =
-          "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @experimental_defer } }  fragment DroidDetails on Droid { name }"
+          "query SpreadSingleWithDefer { hero { __typename ...DroidDetails @defer } }  fragment DroidDetails on Droid { name }"
 
     public const val OPERATION_NAME: String = "SpreadSingleWithDefer"
   }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/defer.graphql
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/defer.graphql
@@ -1,6 +1,6 @@
 query QueryWithDefer($withDetails: Boolean!) {
   field1
-  ... on Query @experimental_defer(if: $withDetails) {
+  ... on Query @defer(if: $withDetails) {
     field2
   }
 }

--- a/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/duplicate_labels.graphql
@@ -1,12 +1,12 @@
 query WithFragmentSpreads {
   computers {
-    ...ComputerFields @experimental_defer(label: "foobar")
+    ...ComputerFields @defer(label: "foobar")
   }
 }
 
 fragment ComputerFields on Computer {
   screen {
-    ...ScreenFields @experimental_defer(label: "foobar")
+    ...ScreenFields @defer(label: "foobar")
   }
 }
 

--- a/apollo-compiler/src/test/validation/operation/defer/duplicate_path_and_labels_inline.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/duplicate_path_and_labels_inline.graphql
@@ -6,10 +6,10 @@ query WithInlineFragments {
       year
       screen {
         resolution
-        ... on Screen @experimental_defer {
+        ... on Screen @defer {
           isColor
         }
-        ... on HasId @experimental_defer {
+        ... on HasId @defer {
           id
         }
       }

--- a/apollo-compiler/src/test/validation/operation/defer/duplicate_path_and_labels_spread.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/duplicate_path_and_labels_spread.graphql
@@ -7,13 +7,13 @@ query WithFragmentSpreads {
 
 fragment ComputerFields on Computer {
   screen {
-    ...ScreenFields @experimental_defer
+    ...ScreenFields @defer
   }
 }
 
 fragment ComputerFields2 on Computer {
   screen {
-    ...ScreenFields @experimental_defer
+    ...ScreenFields @defer
   }
 }
 

--- a/apollo-compiler/src/test/validation/operation/defer/fragment_used_twice_not_duplicate_labels.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/fragment_used_twice_not_duplicate_labels.graphql
@@ -1,14 +1,14 @@
 query Query1 {
   computers {
     id
-    ...ComputerFields @experimental_defer
+    ...ComputerFields @defer
   }
 }
 
 query Query2 {
   computers {
     id
-    ...ComputerFields @experimental_defer
+    ...ComputerFields @defer
   }
 }
 
@@ -18,7 +18,7 @@ fragment ComputerFields on Computer {
   screen {
     resolution
     # This is traversed twice, but it's not a duplicate label
-    ...ScreenFields @experimental_defer(label: "a")
+    ...ScreenFields @defer(label: "a")
   }
 }
 

--- a/apollo-compiler/src/test/validation/operation/defer/illegal_label.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/illegal_label.graphql
@@ -1,6 +1,6 @@
 query GetAnimal {
   animal {
-    ... on Cat @experimental_defer(label: "a/b") {
+    ... on Cat @defer(label: "a/b") {
       meow
     }
   }

--- a/apollo-compiler/src/test/validation/operation/defer/label_is_a_variable.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/label_is_a_variable.graphql
@@ -1,6 +1,6 @@
 query GetAnimal($label: String) {
   animal {
-    ... on Cat @experimental_defer(label: $label) {
+    ... on Cat @defer(label: $label) {
       meow
     }
   }

--- a/apollo-compiler/src/test/validation/operation/defer/root_field_mutation_or_subscription.graphql
+++ b/apollo-compiler/src/test/validation/operation/defer/root_field_mutation_or_subscription.graphql
@@ -1,5 +1,5 @@
 query GetAnimalQuery {
-  ... on Query @experimental_defer {
+  ... on Query @defer {
     animal {
       id
     }
@@ -7,7 +7,7 @@ query GetAnimalQuery {
 }
 
 subscription GetAnimalSubscription {
-  ... on Subscription @experimental_defer {
+  ... on Subscription @defer {
     animal {
       id
     }
@@ -15,7 +15,7 @@ subscription GetAnimalSubscription {
 }
 
 mutation CreateAnimalMutation {
-  ... on Mutation @experimental_defer {
+  ... on Mutation @defer {
     createSession
   }
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
@@ -6,6 +6,9 @@ import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
 import com.apollographql.apollo3.api.json.readAny
 import okio.BufferedSource
 
+private typealias JsonMap = Map<String, Any?>
+private typealias MutableJsonMap = MutableMap<String, Any?>
+
 /**
  * Utility class for merging GraphQL JSON payloads received in multiple chunks when using the `@defer` directive.
  *
@@ -19,8 +22,8 @@ import okio.BufferedSource
  */
 @ApolloInternal
 class DeferredJsonMerger {
-  private val _merged = mutableMapOf<String, Any?>()
-  val merged: Map<String, Any?> = _merged
+  private val _merged: MutableJsonMap = mutableMapOf()
+  val merged: JsonMap = _merged
 
   private val _mergedFragmentIds = mutableSetOf<DeferredFragmentIdentifier>()
   val mergedFragmentIds: Set<DeferredFragmentIdentifier> = _mergedFragmentIds
@@ -28,56 +31,64 @@ class DeferredJsonMerger {
   var hasNext: Boolean = true
     private set
 
-  fun merge(payload: BufferedSource): Map<String, Any?> {
+  fun merge(payload: BufferedSource): JsonMap {
     val payloadMap = jsonToMap(payload)
     return merge(payloadMap)
   }
 
-  fun merge(payload: Map<String, Any?>): Map<String, Any?> {
+  @Suppress("UNCHECKED_CAST")
+  fun merge(payload: JsonMap): JsonMap {
     if (merged.isEmpty()) {
       // Initial payload, no merging needed
       _merged += payload
       return merged
     }
 
-    mergeData(payload)
-    if (payload.containsKey("errors")) {
-      _merged["errors"] = payload["errors"]
-    } else {
-      _merged.remove("errors")
+    val incrementalList = payload["incremental"] as? List<JsonMap>
+    if (incrementalList != null) {
+      for (incrementalItem in incrementalList) {
+        mergeData(incrementalItem)
+        // Keep only the last errors and extensions, if any
+        if (incrementalItem.containsKey("errors")) {
+          _merged["errors"] = incrementalItem["errors"]
+        } else {
+          _merged.remove("errors")
+        }
+        if (incrementalItem.containsKey("extensions")) {
+          _merged["extensions"] = incrementalItem["extensions"]
+        } else {
+          _merged.remove("extensions")
+        }
+      }
     }
-    if (payload.containsKey("extensions")) {
-      _merged["extensions"] = payload["extensions"]
-    } else {
-      _merged.remove("extensions")
-    }
+
+    hasNext = payload["hasNext"] as Boolean? ?: false
 
     return merged
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun mergeData(payloadMap: Map<String, Any?>) {
-    val payloadData = payloadMap["data"] as Map<String, Any?>?
-    val payloadPath = payloadMap["path"] as List<Any>
-    val mergedData = merged["data"] as Map<String, Any?>
-    hasNext = payloadMap["hasNext"] as Boolean? ?: false
+  private fun mergeData(incrementalItem: JsonMap) {
+    val data = incrementalItem["data"] as JsonMap?
+    val path = incrementalItem["path"] as List<Any>
+    val mergedData = merged["data"] as JsonMap
 
     // payloadData can be null if there are errors
-    if (payloadData != null) {
-      val nodeToMergeInto = nodeAtPath(mergedData, payloadPath) as MutableMap<String, Any?>
-      deepMerge(nodeToMergeInto, payloadData)
+    if (data != null) {
+      val nodeToMergeInto = nodeAtPath(mergedData, path) as MutableJsonMap
+      deepMerge(nodeToMergeInto, data)
 
-      _mergedFragmentIds += DeferredFragmentIdentifier(path = payloadPath, label = payloadMap["label"] as String?)
+      _mergedFragmentIds += DeferredFragmentIdentifier(path = path, label = incrementalItem["label"] as String?)
     }
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun deepMerge(destination: MutableMap<String, Any?>, map: Map<String, Any?>) {
+  private fun deepMerge(destination: MutableJsonMap, map: JsonMap) {
     for ((key, value) in map) {
       if (destination.containsKey(key) && destination[key] is MutableMap<*, *>) {
         // Objects: merge recursively
-        val fieldDestination = destination[key] as MutableMap<String, Any?>
-        val fieldMap = value as? Map<String, Any?> ?: error("'$key' is an object in destination but not in map")
+        val fieldDestination = destination[key] as MutableJsonMap
+        val fieldMap = value as? JsonMap ?: error("'$key' is an object in destination but not in map")
         deepMerge(destination = fieldDestination, map = fieldMap)
       } else {
         // Other types: add / overwrite
@@ -87,21 +98,21 @@ class DeferredJsonMerger {
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun jsonToMap(json: BufferedSource): Map<String, Any?> = BufferedSourceJsonReader(json).readAny() as Map<String, Any?>
+  private fun jsonToMap(json: BufferedSource): JsonMap = BufferedSourceJsonReader(json).readAny() as JsonMap
 
 
   /**
    * Find the node in the [map] at the given [path].
    * @param path The path to the node to find, as a list of either `String` (name of field in object) or `Int` (index of element in array).
    */
-  private fun nodeAtPath(map: Map<String, Any?>, path: List<Any>): Any? {
+  private fun nodeAtPath(map: JsonMap, path: List<Any>): Any? {
     var node: Any? = map
     for (key in path) {
       node = if (node is List<*>) {
         node[key as Int]
       } else {
         @Suppress("UNCHECKED_CAST")
-        node as Map<String, Any?>
+        node as JsonMap
         node[key]
       }
     }
@@ -115,6 +126,6 @@ class DeferredJsonMerger {
   }
 }
 
-internal fun Map<String, Any?>.isDeferred(): Boolean {
+internal fun JsonMap.isDeferred(): Boolean {
   return keys.contains("hasNext")
 }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
@@ -18,7 +18,10 @@ private typealias MutableJsonMap = MutableMap<String, Any?>
  * The fields in `data` are merged into the node found in [merged] at `path` (for the first call to [merge], the payload is
  * copied to [merged] as-is).
  *
- * `errors` and `extensions` fields are not merged: they are copied as-is (if present) to the [merged] Map at each call to [merge].
+ * `errors` in incremental items (if present) are merged together in an array and then set to the `errors` field of the [merged] Map,
+ * at each call to [merge].
+ * `extensions` in incremental items (if present) are merged together in an array and then set to the `extensions/incremental` field of the
+ * [merged] Map, at each call to [merge].
  */
 @ApolloInternal
 class DeferredJsonMerger {
@@ -47,7 +50,7 @@ class DeferredJsonMerger {
     val incrementalList = payload["incremental"] as? List<JsonMap>
     if (incrementalList != null) {
       val mergedErrors = mutableListOf<JsonMap>()
-      val mergedExtensions: MutableJsonMap = mutableMapOf()
+      val mergedExtensions = mutableListOf<JsonMap>()
       for (incrementalItem in incrementalList) {
         mergeData(incrementalItem)
         // Merge errors and extensions (if any) of the incremental list
@@ -61,7 +64,7 @@ class DeferredJsonMerger {
         _merged.remove("errors")
       }
       if (mergedExtensions.isNotEmpty()) {
-        _merged["extensions"] = mergedExtensions
+        _merged["extensions"] = mapOf("incremental" to mergedExtensions)
       } else {
         _merged.remove("extensions")
       }

--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/internal/DeferredJsonMerger.kt
@@ -46,19 +46,24 @@ class DeferredJsonMerger {
 
     val incrementalList = payload["incremental"] as? List<JsonMap>
     if (incrementalList != null) {
+      val mergedErrors = mutableListOf<JsonMap>()
+      val mergedExtensions: MutableJsonMap = mutableMapOf()
       for (incrementalItem in incrementalList) {
         mergeData(incrementalItem)
-        // Keep only the last errors and extensions, if any
-        if (incrementalItem.containsKey("errors")) {
-          _merged["errors"] = incrementalItem["errors"]
-        } else {
-          _merged.remove("errors")
-        }
-        if (incrementalItem.containsKey("extensions")) {
-          _merged["extensions"] = incrementalItem["extensions"]
-        } else {
-          _merged.remove("extensions")
-        }
+        // Merge errors and extensions (if any) of the incremental list
+        (incrementalItem["errors"] as? List<JsonMap>)?.let { mergedErrors += it }
+        (incrementalItem["extensions"] as? JsonMap)?.let { mergedExtensions += it }
+      }
+      // Keep only this payload's errors and extensions, if any
+      if (mergedErrors.isNotEmpty()) {
+        _merged["errors"] = mergedErrors
+      } else {
+        _merged.remove("errors")
+      }
+      if (mergedExtensions.isNotEmpty()) {
+        _merged["extensions"] = mergedExtensions
+      } else {
+        _merged.remove("extensions")
       }
     }
 

--- a/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/internal/DeferJsonMergerTest.kt
+++ b/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/internal/DeferJsonMergerTest.kt
@@ -91,10 +91,14 @@ class DeferJsonMergerTest {
         },
         "hasNext": true,
         "extensions": {
-          "duration": {
-            "amount": 100,
-            "unit": "ms"
-          }
+          "incremental": [
+            {
+              "duration": {
+                "amount": 100,
+                "unit": "ms"
+              }
+            }
+          ]
         }
       }      
     """
@@ -158,10 +162,14 @@ class DeferJsonMergerTest {
         },
         "hasNext": true,
         "extensions": {
-          "duration": {
-            "amount": 25,
-            "unit": "ms"
-          }
+          "incremental": [
+            {
+              "duration": {
+                "amount": 25,
+                "unit": "ms"
+              }
+            }
+          ]
         }
       }
     """
@@ -321,11 +329,15 @@ class DeferJsonMergerTest {
         },
         "hasNext": true,
         "extensions": {
-          "value": 42,
-          "duration": {
-            "amount": 130,
-            "unit": "ms"
-          }
+          "incremental": [
+            {
+              "value": 42,
+              "duration": {
+                "amount": 130,
+                "unit": "ms"
+              }
+            }
+          ]
         },
         "errors": [
           {
@@ -452,10 +464,20 @@ class DeferJsonMergerTest {
         },
         "hasNext": true,
         "extensions": {
-          "duration": {
-            "amount": 25,
-            "unit": "ms"
-          }
+          "incremental": [
+            {
+              "duration": {
+                "amount": 100,
+                "unit": "ms"
+              }
+            },
+            {
+              "duration": {
+                "amount": 25,
+                "unit": "ms"
+              }
+            }
+          ]
         }
       }
     """
@@ -556,11 +578,15 @@ class DeferJsonMergerTest {
         },
         "hasNext": true,
         "extensions": {
-          "value": 42,
-          "duration": {
-            "amount": 130,
-            "unit": "ms"
-          }
+          "incremental": [
+            {
+              "value": 42,
+              "duration": {
+                "amount": 130,
+                "unit": "ms"
+              }
+            }
+          ]
         },
         "errors": [
           {

--- a/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/internal/DeferJsonMergerTest.kt
+++ b/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/internal/DeferJsonMergerTest.kt
@@ -44,25 +44,29 @@ class DeferJsonMergerTest {
 
     val payload2 = """
       {
-        "data": {
-          "cpu": "386",
-          "year": 1993,
-          "screen": {
-            "resolution": "640x480"
+        "incremental": [
+          {
+            "data": {
+              "cpu": "386",
+              "year": 1993,
+              "screen": {
+                "resolution": "640x480"
+              }
+            },
+            "path": [
+              "computers",
+              0
+            ],
+            "label": "query:Query1:0",
+            "extensions": {
+              "duration": {
+                "amount": 100,
+                "unit": "ms"
+              }
+            }
           }
-        },
-        "path": [
-          "computers",
-          0
         ],
-        "label": "query:Query1:0",
-        "hasNext": true,
-        "extensions": {
-          "duration": {
-            "amount": 100,
-            "unit": "ms"
-          }
-        }
+        "hasNext": true
       }
     """
     val mergedPayloads_1_2 = """
@@ -103,28 +107,33 @@ class DeferJsonMergerTest {
 
 
     val payload3 = """
-      {
-        "data": {
-          "cpu": "486",
-          "year": 1996,
-          "screen": {
-            "resolution": "640x480"
-          }
-        },
-        "path": [
-          "computers",
-          1
-        ],
-        "label": "query:Query1:0",
-        "hasNext": true,
-        "extensions": {
-          "duration": {
-            "amount": 25,
-            "unit": "ms"
-          }
+        {
+          "incremental": [
+            {
+              "data": {
+                "cpu": "486",
+                "year": 1996,
+                "screen": {
+                  "resolution": "640x480"
+                }
+              },
+              "path": [
+                "computers",
+                1
+              ],
+              "label": "query:Query1:0",
+              "extensions": {
+                "duration": {
+                  "amount": 25,
+                  "unit": "ms"
+                }
+              }
+            }
+          ],
+          "hasNext": true
         }
-      }
     """
+
     val mergedPayloads_1_2_3 = """
       {
         "data": {
@@ -167,33 +176,37 @@ class DeferJsonMergerTest {
 
 
     val payload4 = """
-      {
-        "data": null,
-        "path": [
-          "computers",
-          0,
-          "screen"
-        ],
-        "errors": [
-          {
-            "message": "Cannot resolve isColor",
-            "locations": [
-              {
-                "line": 12,
-                "column": 11
-              }
-            ],
-            "path": [
-              "computers",
-              0,
-              "screen",
-              "isColor"
-            ]
-          }
-        ],
-        "label": "fragment:ComputerFields:0",
-        "hasNext": true
-      }
+        {
+          "incremental": [
+            {
+              "data": null,
+              "path": [
+                "computers",
+                0,
+                "screen"
+              ],
+              "errors": [
+                {
+                  "message": "Cannot resolve isColor",
+                  "locations": [
+                    {
+                      "line": 12,
+                      "column": 11
+                    }
+                  ],
+                  "path": [
+                    "computers",
+                    0,
+                    "screen",
+                    "isColor"
+                  ]
+                }
+              ],
+              "label": "fragment:ComputerFields:0"
+            }
+          ],
+          "hasNext": true
+        }
     """
     val mergedPayloads_1_2_3_4 = """
       {
@@ -247,36 +260,40 @@ class DeferJsonMergerTest {
     ), deferredJsonMerger.mergedFragmentIds)
 
     val payload5 = """
-      {
-        "data": {
-          "isColor": false
-        },
-        "path": [
-          "computers",
-          1,
-          "screen"
-        ],
-        "errors": [
-          {
-            "message": "Another error",
-            "locations": [
-              {
-                "line": 1,
-                "column": 1
+        {
+          "incremental": [
+            {
+              "data": {
+                "isColor": false
+              },
+              "path": [
+                "computers",
+                1,
+                "screen"
+              ],
+              "errors": [
+                {
+                  "message": "Another error",
+                  "locations": [
+                    {
+                      "line": 1,
+                      "column": 1
+                    }
+                  ]
+                }
+              ],
+              "label": "fragment:ComputerFields:0",
+              "extensions": {
+                "value": 42,
+                "duration": {
+                  "amount": 130,
+                  "unit": "ms"
+                }
               }
-            ]
-          }
-        ],
-        "label": "fragment:ComputerFields:0",
-        "hasNext": false,
-        "extensions": {
-          "value": 42,
-          "duration": {
-            "amount": 130,
-            "unit": "ms"
-          }
+            }
+          ],
+          "hasNext": false
         }
-      }
     """
     val mergedPayloads_1_2_3_4_5 = """
       {

--- a/build-logic/src/main/kotlin/Node.kt
+++ b/build-logic/src/main/kotlin/Node.kt
@@ -1,5 +1,7 @@
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin
 import org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension
 
@@ -22,5 +24,10 @@ fun Project.configureNode() {
       // Drop the patch version because there shouldn't be any dependency change
       lockFileDirectory = projectDir.resolve("kotlin-js-store-${project.getKotlinPluginVersion().substringBeforeLast(".")}")
     }
+  }
+
+  // See https://youtrack.jetbrains.com/issue/KT-49774/KJS-Gradle-Errors-during-NPM-dependencies-resolution-in-parallel-build-lead-to-unfriendly-error-messages-like-Projects-must-be#focus=Comments-27-6271456.0-0
+  rootProject.plugins.withType(NodeJsRootPlugin::class.java) {
+    project.extensions.getByType(NodeJsRootExtension::class.java).nodeVersion = "16.17.0"
   }
 }

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
 
     val jsTest by getting {
       dependencies {
-        implementation(npm("graphql-helix", "1.12.0"))
+        implementation(npm("graphql-helix", "1.13.0"))
         implementation(npm("express", "4.17.3"))
         implementation(npm("ws", "8.2.2"))
         implementation(npm("graphql-ws", "5.5.0"))

--- a/tests/defer/src/commonMain/graphql/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/operation.graphql
@@ -1,7 +1,7 @@
 query WithFragmentSpreadsQuery {
   computers {
     id
-    ...ComputerFields @experimental_defer
+    ...ComputerFields @defer
   }
 }
 
@@ -10,7 +10,7 @@ fragment ComputerFields on Computer {
   year
   screen {
     resolution
-    ...ScreenFields @experimental_defer(label: "a")
+    ...ScreenFields @defer(label: "a")
   }
 }
 
@@ -22,12 +22,12 @@ fragment ScreenFields on Screen {
 query WithInlineFragmentsQuery {
   computers {
     id
-    ... on Computer @experimental_defer {
+    ... on Computer @defer {
       cpu
       year
       screen {
         resolution
-        ... on Screen @experimental_defer(label: "b") {
+        ... on Screen @defer(label: "b") {
           isColor
         }
       }
@@ -39,14 +39,14 @@ query WithInlineFragmentsQuery {
 mutation WithFragmentSpreadsMutation {
   computers {
     id
-    ...ComputerFields @experimental_defer(label: "c")
+    ...ComputerFields @defer(label: "c")
   }
 }
 
 subscription WithInlineFragmentsSubscription {
   count(to: 3) {
     value
-    ... on Counter @experimental_defer {
+    ... on Counter @defer {
       valueTimesTwo
     }
   }
@@ -55,7 +55,7 @@ subscription WithInlineFragmentsSubscription {
 subscription WithFragmentSpreadsSubscription {
   count(to: 3) {
     value
-    ...CounterFields @experimental_defer(label: "d")
+    ...CounterFields @defer(label: "d")
   }
 }
 

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -66,8 +66,8 @@ class DeferNormalizedCacheTest {
     // Fill the cache by doing a network only request
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
     apolloClient.query(WithFragmentSpreadsQuery()).fetchPolicy(FetchPolicy.NetworkOnly).toFlow().collect()
@@ -93,8 +93,8 @@ class DeferNormalizedCacheTest {
     // Fill the cache by doing a first request
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
     apolloClient.query(WithFragmentSpreadsQuery()).fetchPolicy(FetchPolicy.NetworkOnly).toFlow().collect()
@@ -128,8 +128,8 @@ class DeferNormalizedCacheTest {
 
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
 
@@ -168,8 +168,8 @@ class DeferNormalizedCacheTest {
 
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
 
@@ -208,8 +208,8 @@ class DeferNormalizedCacheTest {
 
     val jsonList1 = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList1)
 
@@ -235,8 +235,8 @@ class DeferNormalizedCacheTest {
 
     val jsonList2 = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"isColor":true},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":true},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList2)
 
@@ -271,8 +271,8 @@ class DeferNormalizedCacheTest {
 
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":null,"path":["computers",0,"screen"],"label":"b","errors":[{"message":"Cannot resolve isColor","locations":[{"line":1,"column":119}],"path":["computers",0,"screen","isColor"]}],"hasNext":false}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":null,"path":["computers",0,"screen"],"label":"b","errors":[{"message":"Cannot resolve isColor","locations":[{"line":1,"column":119}],"path":["computers",0,"screen","isColor"]}]}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
 
@@ -402,8 +402,8 @@ class DeferNormalizedCacheTest {
   fun mutation() = runTest(before = { setUp() }, after = { tearDown() }) {
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true,"label":"c"}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"label":"c"}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
     val networkActual = apolloClient.mutation(WithFragmentSpreadsMutation()).toFlow().toList().map { it.dataAssertNoErrors }
@@ -441,8 +441,8 @@ class DeferNormalizedCacheTest {
   fun mutationWithOptimisticDataFails() = runTest(before = { setUp() }, after = { tearDown() }) {
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true,"label":"c"}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"label":"c"}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":false}""",
     )
     mockServer.enqueueMultipart(jsonList)
     val responses = apolloClient.mutation(WithFragmentSpreadsMutation()).optimisticUpdates(

--- a/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
@@ -42,10 +42,10 @@ class DeferTest {
   fun deferWithFragmentSpreads() = runTest(before = { setUp() }, after = { tearDown() }) {
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"},{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":true,"label":"a"}""",
-        """{"data":{"isColor":true},"path":["computers",1,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":true},"path":["computers",1,"screen"],"label":"a"}],"hasNext":false}""",
     )
 
     val expectedDataList = listOf(
@@ -100,10 +100,10 @@ class DeferTest {
   fun deferWithInlineFragments() = runTest(before = { setUp() }, after = { tearDown() }) {
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"},{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":true,"label":"b"}""",
-        """{"data":{"isColor":true},"path":["computers",1,"screen"],"hasNext":false,"label":"b"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"b"}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":true},"path":["computers",1,"screen"],"label":"b"}],"hasNext":false}""",
     )
 
     val expectedDataList = listOf(
@@ -158,10 +158,10 @@ class DeferTest {
   fun deferWithFragmentSpreadsAndError() = runTest(before = { setUp() }, after = { tearDown() }) {
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"},{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":null,"path":["computers",0,"screen"],"label":"b","errors":[{"message":"Cannot resolve isColor","locations":[{"line":1,"column":119}],"path":["computers",0,"screen","isColor"]}],"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1],"hasNext":true}""",
-        """{"data":{"isColor":true},"path":["computers",1,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":null,"path":["computers",0,"screen"],"label":"b","errors":[{"message":"Cannot resolve isColor","locations":[{"line":1,"column":119}],"path":["computers",0,"screen","isColor"]}]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":true},"path":["computers",1,"screen"],"label":"a"}],"hasNext":false}""",
     )
 
     val query = WithFragmentSpreadsQuery()
@@ -266,10 +266,10 @@ class DeferTest {
 
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"},{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":true,"label":"a"}""",
-        """{"data":{"isColor":true},"path":["computers",1,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental": [{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1]}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":true}""",
+        """{"incremental": [{"data":{"isColor":true},"path":["computers",1,"screen"],"label":"a"}],"hasNext":false}""",
     )
 
     for ((index, json) in jsonList.withIndex()) {

--- a/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
+++ b/tests/defer/src/jsTest/kotlin/helix/HelixServer.kt
@@ -35,7 +35,7 @@ class HelixServer(
       if (shouldRenderGraphiQL(request)) {
         res.send(
             renderGraphiQL(dynamicObject {
-              subscriptionsEndpoint = "ws://localhost:4000/graphql"
+              subscriptionsEndpoint = "ws://localhost:$port/graphql"
             })
         )
         return@use null

--- a/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
@@ -24,15 +24,13 @@ import graphql.GraphQLStreamDirective
 import graphql.GraphQLString
 import helix.HelixServer
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
 import util.dynamicObject
 import util.jsAsyncIterator
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-@Ignore
-// TODO These tests are temporarily ignored while @defer has been renamed to @experimental_defer
-// See https://github.com/apollographql/apollo-kotlin/issues/4071
 class DeferWithHelixTest {
   private lateinit var helixServer: HelixServer
   private lateinit var apolloClient: ApolloClient

--- a/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
@@ -27,9 +27,14 @@ import kotlinx.coroutines.flow.toList
 import util.dynamicObject
 import util.jsAsyncIterator
 import kotlin.random.Random
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@Ignore
+// TODO These tests are temporarily ignored as the latest version of graphql-js
+// uses a package format which is incompatible with Kotlin/JS.
+// See https://youtrack.jetbrains.com/issue/KT-12784
 class DeferWithHelixTest {
   private lateinit var helixServer: HelixServer
   private lateinit var apolloClient: ApolloClient

--- a/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
+++ b/tests/defer/src/jsTest/kotlin/test/DeferWithHelixTest.kt
@@ -24,10 +24,9 @@ import graphql.GraphQLStreamDirective
 import graphql.GraphQLString
 import helix.HelixServer
 import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
 import util.dynamicObject
 import util.jsAsyncIterator
-import kotlin.test.Ignore
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -36,7 +35,7 @@ class DeferWithHelixTest {
   private lateinit var apolloClient: ApolloClient
 
   private suspend fun setUp() {
-    helixServer = HelixServer(schema)
+    helixServer = HelixServer(schema, port = Random.nextInt(1024, 65535))
     apolloClient = ApolloClient.Builder()
         .serverUrl(helixServer.url())
         .webSocketServerUrl(helixServer.webSocketUrl())

--- a/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
+++ b/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
@@ -52,10 +52,10 @@ class DeferJvmTest {
 
     val jsonList = listOf(
         """{"data":{"computers":[{"__typename":"Computer","id":"Computer1"},{"__typename":"Computer","id":"Computer2"}]},"hasNext":true}""",
-        """{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0],"hasNext":true}""",
-        """{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1],"hasNext":true}""",
-        """{"data":{"isColor":false},"path":["computers",0,"screen"],"hasNext":true,"label":"a"}""",
-        """{"data":{"isColor":true},"path":["computers",1,"screen"],"hasNext":false,"label":"a"}""",
+        """{"incremental":[{"data":{"cpu":"386","year":1993,"screen":{"__typename":"Screen","resolution":"640x480"}},"path":["computers",0]}],"hasNext":true}""",
+        """{"incremental":[{"data":{"cpu":"486","year":1996,"screen":{"__typename":"Screen","resolution":"800x600"}},"path":["computers",1]}],"hasNext":true}""",
+        """{"incremental":[{"data":{"isColor":false},"path":["computers",0,"screen"],"label":"a"}],"hasNext":true}""",
+        """{"incremental":[{"data":{"isColor":true},"path":["computers",1,"screen"],"label":"a"}],"hasNext":false}""",
     )
 
     for ((index, json) in jsonList.withIndex()) {

--- a/tests/integration-tests/src/commonTest/kotlin/test/LoggingInterceptorTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/LoggingInterceptorTest.kt
@@ -83,6 +83,7 @@ class LoggingInterceptorTest {
       Post http://0.0.0.0/
       X-APOLLO-OPERATION-ID: 7e7c85cbf5ef3af5641552c55965608a4e5d7243f3116a486d21c3a958d34235
       X-APOLLO-OPERATION-NAME: HeroName
+      accept: multipart/mixed; deferspec=20220822, application/json
       [end of headers]
 
       HTTP: 200
@@ -103,6 +104,7 @@ class LoggingInterceptorTest {
       Post http://0.0.0.0/
       X-APOLLO-OPERATION-ID: 7e7c85cbf5ef3af5641552c55965608a4e5d7243f3116a486d21c3a958d34235
       X-APOLLO-OPERATION-NAME: HeroName
+      accept: multipart/mixed; deferspec=20220822, application/json
       [end of headers]
       {"operationName":"HeroName","variables":{},"query":"query HeroName { hero { name } }"}
 

--- a/tests/kotlin-js-store-1.7/yarn.lock
+++ b/tests/kotlin-js-store-1.7/yarn.lock
@@ -411,10 +411,10 @@ google-protobuf@3.12.2:
   resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.12.2.tgz#50ce9f9b6281235724eb243d6a83e969a2176e53"
   integrity sha512-4CZhpuRr1d6HjlyrxoXoocoGFnRYgKULgMtikMddA9ztRyYR59Aondv2FioyxWVamRo0rF2XpYawkTCBEQOSkA==
 
-graphql-helix@1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/graphql-helix/-/graphql-helix-1.12.0.tgz#8a81e7c84489a0c6da968afdb54f9a979512baf9"
-  integrity sha512-wTu1m/ZFBCgzLPCg/dHO4cNy9JR5Sq/3RqDVblqrU3b/Yem7EXZtQMzG045tHqkCdbgcgQl+kIkXDur1yLfdtw==
+graphql-helix@1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/graphql-helix/-/graphql-helix-1.13.0.tgz#e64dad5ef5f622ef38c97fa033f56f3d953c0104"
+  integrity sha512-cqDKMoRywKjnL0ZWCTB0GOiBgsH6d3nU4JGDF6RuzAyd35tmalzKpSxkx3NNp4H5RvnKWnrukWzR51wUq277ng==
 
 graphql-ws@5.5.0:
   version "5.5.0"


### PR DESCRIPTION
- Rename @defer back (was temporarily named `@experimental_defer`, in #4074).
- Use the updated version of the spec which changes the format of the subsequent payloads (#4349):
They now are encapsulated in an `incremental` array field.

<table>
<tr>
	<td>Old format
	<td>New format
<tr>
	<td>

```json
// Payload 1
{
  "data": {
    "person": {
      "firstName": "John"
    }
  },
  "hasNext": true
}
```

<td>

```json
// Payload 1
{
  "data": {
    "person": {
      "firstName": "John"
    }
  },
  "hasNext": true
}
```

<tr>

<td>

```json
// Payload 2
{
  "data": {
    "lastName": "Doe"
  },
  "path": [
    "person"
  ],
  "hasNext": false
}





```

<td>

```json
// Payload 2
{
  "incremental": [
    {
      "data": {
        "lastName": "Doe"
      },
      "path": [
        "person"
      ]
    }
  ],
  "hasNext": false
}
```

</table>