### PR TITLE
Fix #2818

### DIFF
--- a/apollo-integration/build.gradle.kts
+++ b/apollo-integration/build.gradle.kts
@@ -57,6 +57,11 @@ configure<ApolloExtension> {
     rootPackageName.set("com.apollographql.apollo.integration.directives")
     generateKotlinModels.set(true)
   }
+  service("fragmentoverwrites") {
+    sourceFolder.set("com/apollographql/apollo/integration/fragmentoverwrites")
+    rootPackageName.set("com.apollographql.apollo.integration.fragmentoverwrites")
+    generateKotlinModels.set(true)
+  }
   service("sealedclasses") {
     sealedClassesForEnumsMatching.set(listOf(".*"))
     generateKotlinModels.set(true)

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/fragmentoverwrites/operations.graphql
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/fragmentoverwrites/operations.graphql
@@ -1,0 +1,15 @@
+query Home {
+    home {
+        ...sectionFragment
+        sectionA {
+            name
+        }
+    }
+}
+
+fragment sectionFragment on Home {
+    sectionA {
+        id
+        imageUrl
+    }
+}

--- a/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/fragmentoverwrites/schema.sdl
+++ b/apollo-integration/src/main/graphql/com/apollographql/apollo/integration/fragmentoverwrites/schema.sdl
@@ -1,0 +1,13 @@
+type Query {
+  home: Home!
+}
+
+type Home {
+  sectionA: SectionA
+}
+
+type SectionA {
+  id: String!
+  name: String!
+  imageUrl: String
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/FragmentOverwritesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/FragmentOverwritesTest.kt
@@ -1,0 +1,94 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.Utils.immediateExecutor
+import com.apollographql.apollo.Utils.immediateExecutorService
+import com.apollographql.apollo.Utils.mockResponse
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.ResponseField
+import com.apollographql.apollo.cache.normalized.CacheKey
+import com.apollographql.apollo.cache.normalized.CacheKeyResolver
+import com.apollographql.apollo.cache.normalized.lru.EvictionPolicy
+import com.apollographql.apollo.cache.normalized.lru.LruNormalizedCacheFactory
+import com.apollographql.apollo.coroutines.await
+import com.apollographql.apollo.fetcher.ApolloResponseFetchers
+import com.apollographql.apollo.integration.fragmentoverwrites.HomeQuery
+import com.apollographql.apollo.integration.fragmentoverwrites.fragment.SectionFragment
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import okhttp3.Dispatcher
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class FragmentOverwritesTest {
+
+    private lateinit var apolloClient: ApolloClient
+
+    @get:Rule
+    val server = MockWebServer()
+
+    private val cacheKeyResolver = object : CacheKeyResolver() {
+        override fun fromFieldArguments(field: ResponseField, variables: Operation.Variables): CacheKey {
+            return CacheKey.NO_KEY
+        }
+
+        override fun fromFieldRecordSet(field: ResponseField, recordSet: Map<String, Any>): CacheKey {
+            return (recordSet["id"] as? String)?.let { CacheKey.from(it) } ?: CacheKey.NO_KEY
+        }
+    }
+
+    @Before
+    fun setup() {
+        val okHttpClient = OkHttpClient.Builder()
+            .dispatcher(Dispatcher(immediateExecutorService()))
+            .build()
+
+        apolloClient = ApolloClient.builder()
+            .normalizedCache(LruNormalizedCacheFactory(EvictionPolicy.NO_EVICTION), cacheKeyResolver)
+            .okHttpClient(okHttpClient)
+            .dispatcher(immediateExecutor())
+            .serverUrl(server.url("/"))
+            .build()
+    }
+
+    @Test
+    fun `doesn't overwrite cache entries when using fragments`() {
+
+        server.enqueue(mockResponse("FragmentOverwritesTestHomeQueryResponse.json"))
+
+        runBlocking {
+            val networkResponse = apolloClient.query(HomeQuery()).await()
+
+            assertThat(networkResponse.data?.home?.sectionA?.name).isEqualTo("initialSectionName")
+
+            apolloClient.apolloStore.writeAndPublish(
+                HomeQuery(),
+                HomeQuery.Data(
+                    HomeQuery.Home(
+                        sectionA = HomeQuery.SectionA(
+                            name = "modifiedSectionName"
+                        ),
+                        fragments = HomeQuery.Home.Fragments(
+                            sectionFragment = SectionFragment(
+                                sectionA = SectionFragment.SectionA(
+                                    id = "section-id",
+                                    imageUrl = "modifiedUrl",
+                                ),
+                            )
+                        )
+                    )
+                )
+            ).execute()
+
+            val cacheResponse = apolloClient.query(HomeQuery())
+                .toBuilder()
+                .responseFetcher(ApolloResponseFetchers.CACHE_ONLY)
+                .build()
+                .await()
+
+            assertThat(cacheResponse.data?.home?.sectionA?.name).isEqualTo("modifiedSectionName")
+        }
+    }
+}

--- a/apollo-integration/src/test/java/com/apollographql/apollo/FragmentOverwritesTest.kt
+++ b/apollo-integration/src/test/java/com/apollographql/apollo/FragmentOverwritesTest.kt
@@ -62,6 +62,7 @@ class FragmentOverwritesTest {
             val networkResponse = apolloClient.query(HomeQuery()).await()
 
             assertThat(networkResponse.data?.home?.sectionA?.name).isEqualTo("initialSectionName")
+            assertThat(networkResponse.data?.home?.fragments?.sectionFragment?.sectionA?.imageUrl).isEqualTo("initialUrl")
 
             apolloClient.apolloStore.writeAndPublish(
                 HomeQuery(),
@@ -89,6 +90,7 @@ class FragmentOverwritesTest {
                 .await()
 
             assertThat(cacheResponse.data?.home?.sectionA?.name).isEqualTo("modifiedSectionName")
+            assertThat(cacheResponse.data?.home?.fragments?.sectionFragment?.sectionA?.imageUrl).isEqualTo("modifiedUrl")
         }
     }
 }

--- a/apollo-integration/src/test/resources/FragmentOverwritesTestHomeQueryResponse.json
+++ b/apollo-integration/src/test/resources/FragmentOverwritesTestHomeQueryResponse.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "home": {
+      "__typename": "Home",
+      "sectionA": {
+        "__typename": "SectionA",
+        "name": "initialSectionName",
+        "id": "section-id",
+        "imageUrl": "initialUrl"
+      }
+    }
+  }
+}

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.kt
@@ -46,9 +46,7 @@ class RealResponseWriter(private val operationVariables: Operation.Variables, pr
     }
     val nestedResponseWriter = RealResponseWriter(operationVariables, scalarTypeAdapters)
     marshaller.marshal(nestedResponseWriter)
-    buffer.compute(field.responseName) { _, oldFieldDescriptor ->
-      deepMergeObjects(field, oldFieldDescriptor?.value, nestedResponseWriter.buffer)
-    }
+    buffer[field.responseName] = deepMergeObjects(field, buffer[field.responseName]?.value, nestedResponseWriter.buffer)
   }
 
   private fun deepMergeObjects(field: ResponseField, oldValue: Any?, newValue: Map<String, FieldDescriptor>): FieldDescriptor {

--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.kt
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/response/RealResponseWriter.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo.internal.response
 
-import com.apollographql.apollo.api.CustomTypeAdapter
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.ResponseField
 import com.apollographql.apollo.api.ScalarType
@@ -47,7 +46,24 @@ class RealResponseWriter(private val operationVariables: Operation.Variables, pr
     }
     val nestedResponseWriter = RealResponseWriter(operationVariables, scalarTypeAdapters)
     marshaller.marshal(nestedResponseWriter)
-    buffer[field.responseName] = FieldDescriptor(field, nestedResponseWriter.buffer)
+    buffer.compute(field.responseName) { _, oldFieldDescriptor ->
+      deepMergeObjects(field, oldFieldDescriptor?.value, nestedResponseWriter.buffer)
+    }
+  }
+
+  private fun deepMergeObjects(field: ResponseField, oldValue: Any?, newValue: Map<String, FieldDescriptor>): FieldDescriptor {
+    return if (oldValue == null || oldValue !is Map<*, *>) {
+      FieldDescriptor(field, newValue)
+    } else {
+      val oldMap = oldValue as Map<String, FieldDescriptor>
+
+      val mergedCommonValues = oldMap.keys.intersect(newValue.keys)
+          .filter { newValue[it]?.value is Map<*, *> }
+          .map { deepMergeObjects(oldMap[it]!!.field, oldMap[it]?.value, newValue[it]!!.value as Map<String, FieldDescriptor>) }
+          .associateBy { it.field.responseName }
+
+      FieldDescriptor(field, oldMap + newValue + mergedCommonValues)
+    }
   }
 
   override fun writeFragment(marshaller: ResponseFieldMarshaller?) {


### PR DESCRIPTION
Following the suggestion from [here](https://github.com/apollographql/apollo-kotlin/issues/2818#issuecomment-750851549):
> A quick fix might be to do the merge in RealResponseWriter so that we do not overwrite the entries in buffer. The different values will come from different ResponseField but maybe it's not a big issue.

Also added an integration test based on the [reproducer](https://github.com/martinbonnin/apollo-android-samples/blob/main/reproducers/2818-fragment-overwrites/src/main/kotlin/main.kt), as suggested by @BoD (thank you!).