### PR TITLE
Fix registering Java scalars. 

### DIFF
--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -161,13 +161,13 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   override fun mapScalarToKotlinBoolean(graphQLName: String) = mapScalar(graphQLName, "kotlin.Boolean", "com.apollographql.apollo3.api.BooleanAdapter")
   override fun mapScalarToKotlinAny(graphQLName: String) = mapScalar(graphQLName, "kotlin.Any", "com.apollographql.apollo3.api.AnyAdapter")
 
-  override fun mapScalarToJavaString(graphQLName: String) = mapScalar(graphQLName, "java.lang.String", "com.apollographql.apollo3.api.StringAdapter")
-  override fun mapScalarToJavaInteger(graphQLName: String) = mapScalar(graphQLName, "java.lang.Integer", "com.apollographql.apollo3.api.IntAdapter")
-  override fun mapScalarToJavaDouble(graphQLName: String) = mapScalar(graphQLName, "java.lang.Double", "com.apollographql.apollo3.api.DoubleAdapter")
-  override fun mapScalarToJavaFloat(graphQLName: String) = mapScalar(graphQLName, "java.lang.Float", "com.apollographql.apollo3.api.FloatAdapter")
-  override fun mapScalarToJavaLong(graphQLName: String) = mapScalar(graphQLName, "java.lang.Long", "com.apollographql.apollo3.api.LongAdapter")
-  override fun mapScalarToJavaBoolean(graphQLName: String) = mapScalar(graphQLName, "java.lang.Boolean", "com.apollographql.apollo3.api.BooleanAdapter")
-  override fun mapScalarToJavaObject(graphQLName: String) = mapScalar(graphQLName, "java.lang.Object", "com.apollographql.apollo3.api.AnyAdapter")
+  override fun mapScalarToJavaString(graphQLName: String) = mapScalar(graphQLName, "java.lang.String", "com.apollographql.apollo3.api.Adapters.StringAdapter")
+  override fun mapScalarToJavaInteger(graphQLName: String) = mapScalar(graphQLName, "java.lang.Integer", "com.apollographql.apollo3.api.Adapters.IntAdapter")
+  override fun mapScalarToJavaDouble(graphQLName: String) = mapScalar(graphQLName, "java.lang.Double", "com.apollographql.apollo3.api.Adapters.DoubleAdapter")
+  override fun mapScalarToJavaFloat(graphQLName: String) = mapScalar(graphQLName, "java.lang.Float", "com.apollographql.apollo3.api.Adapters.FloatAdapter")
+  override fun mapScalarToJavaLong(graphQLName: String) = mapScalar(graphQLName, "java.lang.Long", "com.apollographql.apollo3.api.Adapters.LongAdapter")
+  override fun mapScalarToJavaBoolean(graphQLName: String) = mapScalar(graphQLName, "java.lang.Boolean", "com.apollographql.apollo3.api.Adapters.BooleanAdapter")
+  override fun mapScalarToJavaObject(graphQLName: String) = mapScalar(graphQLName, "java.lang.Object", "com.apollographql.apollo3.api.Adapters.AnyAdapter")
 
   override fun mapScalarToUpload(graphQLName: String) = mapScalar(graphQLName, "com.apollographql.apollo3.api.Upload", "com.apollographql.apollo3.api.UploadAdapter")
 }

--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -18,4 +18,7 @@ dependencies {
 apollo {
   packageName.set("javatest")
   generateModelBuilder.set(true)
+  mapScalarToJavaString("LanguageCode")
+  mapScalarToJavaObject("Json")
+  mapScalarToJavaLong("Long")
 }

--- a/tests/java-tests/src/main/graphql/operations.graphql
+++ b/tests/java-tests/src/main/graphql/operations.graphql
@@ -2,6 +2,12 @@ query GetRandom {
   random
 }
 
+query GetScalars {
+  languageCode
+  json
+  long
+}
+
 query Animal {
   animal {
     ... on Dog {

--- a/tests/java-tests/src/main/graphql/schema.graphqls
+++ b/tests/java-tests/src/main/graphql/schema.graphqls
@@ -2,6 +2,9 @@ type Query {
   random: Int!
   animal: Animal
   location: GeoPoint
+  languageCode: LanguageCode
+  long: Long
+  json: Json
 }
 
 type Mutation {
@@ -45,3 +48,9 @@ enum AnimalClass {
 }
 
 scalar GeoPoint
+
+scalar LanguageCode
+
+scalar Long
+
+scalar Json


### PR DESCRIPTION
Java doesn't have top-level properties so the properties are static fields of the `Adapters` class instead

Many thanks @parker for catching this.

Closes https://github.com/apollographql/apollo-kotlin/issues/4374