### PR TITLE
Relocate the plugin without obfuscating it

### DIFF
--- a/apollo-gradle-plugin/build.gradle.kts
+++ b/apollo-gradle-plugin/build.gradle.kts
@@ -112,12 +112,6 @@ configure<PublishingExtension> {
         }
       }
     }
-    if (relocateJar && name == "pluginMaven") {
-      this as MavenPublication
-      artifact(file("build/gr8/shadow/mapping.txt")) {
-        classifier = "mapping"
-      }
-    }
   }
 }
 

--- a/apollo-gradle-plugin/rules.pro
+++ b/apollo-gradle-plugin/rules.pro
@@ -4,7 +4,6 @@
 -keep class kotlin.Metadata { *; }
 -keep class kotlin.Unit { *; }
 
-
 # We need to keep type arguments (Signature) for Gradle to be able to instantiate abstract models like `Property`
 # Else it fails with
 # 'Declaration of property alwaysGenerateTypesMatching does not include any type arguments in its property type interface org.gradle.api.provider.SetProperty'
@@ -53,6 +52,8 @@
 
 # Makes it easier to debug on MacOS case-insensitive filesystem when unzipping the jars
 -dontusemixedcaseclassnames
+# Keep class names to make debugging easier
+-dontobfuscate
 -repackageclasses com.apollographql.relocated
 
 # Allow to repackage com.moshi.JsonAdapter.lenient

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ dokka-base = { group = "org.jetbrains.dokka", name = "dokka-base", version.ref =
 dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
 google-testing-compile = { group = "com.google.testing.compile", name = "compile-testing", version = "0.19" }
 google-testparameterinjector = { group = "com.google.testparameterinjector", name = "test-parameter-injector", version = "1.4" }
-gr8 = { group = "com.gradleup", name = "gr8-plugin", version = "0.4" }
+gr8 = { group = "com.gradleup", name = "gr8-plugin", version = "0.6" }
 #
 # See https://github.com/gradle/gradle/issues/1835
 # We use the Nokee[redistributed artifacts](https://docs.nokee.dev/manual/gradle-plugin-development.html#sec:gradle-dev-redistributed-gradle-api)


### PR DESCRIPTION
- Bump to gr8 0.6
- remove our own mapping publishing, gr8 is doing it now
