### PR TITLE
remove IllegalStateException from IDLE / TERMINATED state in terminate and responseCallback 

### DIFF
--- a/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
+++ b/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java
@@ -363,8 +363,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         return Optional.fromNullable(originalCallback.get());
       case IDLE:
       case TERMINATED:
-        throw new IllegalStateException(
-            CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+        return Optional.absent();
       default:
         throw new IllegalStateException("Unknown state");
     }
@@ -380,8 +379,7 @@ public final class RealApolloCall<T> implements ApolloQueryCall<T>, ApolloMutati
         return Optional.fromNullable(originalCallback.getAndSet(null));
       case IDLE:
       case TERMINATED:
-        throw new IllegalStateException(
-            CallState.IllegalStateMessage.forCurrentState(state.get()).expected(ACTIVE, CANCELED));
+        return Optional.absent();
       default:
         throw new IllegalStateException("Unknown state");
     }


### PR DESCRIPTION
@martinbonnin Here is the PR in reference to this [thread](https://github.com/apollographql/apollo-kotlin/blob/92aa7b56b1bb268e95fdf93811dc61821d090bd6/apollo-runtime/src/main/java/com/apollographql/apollo/internal/RealApolloCall.java#L366).