### PR TITLE
Ignore empty defer payloads

### DIFF
--- a/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onSubscription
@@ -303,12 +304,15 @@ private constructor(
           }
           apolloResponse
         }
+
         is OperationError -> throw SubscriptionOperationException(request.operation.name(), response.payload)
         is NetworkError -> throw ApolloNetworkException("Network error while executing ${request.operation.name()}", response.cause)
 
         // Cannot happen as these events are filtered out upstream
         is OperationComplete, is GeneralError -> error("Unexpected event $response")
       }
+    }.filterNot {
+      deferredJsonMerger.isEmptyPayload
     }.onCompletion {
       messages.send(StopOperation(request))
     }

--- a/tests/defer/README.md
+++ b/tests/defer/README.md
@@ -1,5 +1,4 @@
 # Tests related to `@defer`
 
-At the moment the tests use `StreamingNSURLSessionHttpEngine` on Apple targets, which requires
-the [new Memory Manager](https://github.com/JetBrains/kotlin/blob/master/kotlin-native/NEW_MM.md). It is enabled on this
-project in `gradle.propertis`.
+Note: on Apple targets, the client is configured to use `StreamingNSURLSessionHttpEngine` which supports chunked
+encoding.  

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -62,3 +62,12 @@ subscription WithFragmentSpreadsSubscription {
 fragment CounterFields on Counter{
   valueTimesTwo
 }
+
+query SimpleDeferQuery {
+  computers {
+    id
+    ... on Computer @defer {
+      cpu
+    }
+  }
+}


### PR DESCRIPTION
When receiving a deferred payload with no `incremental` field, ignore it to avoid re-emitting the previously merged data.

Related to https://github.com/apollographql/router/issues/1687