### PR TITLE
Defer with router tests

### DIFF
--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -1,0 +1,52 @@
+name: defer-router-tests
+
+# TODO: Run on schedule instead of on pull requests
+on:
+  pull_request:
+    branches: [ '*' ]
+#  schedule:
+#    - cron: '0 3 * * *'
+
+jobs:
+  defer-with-router-tests:
+    runs-on: macos-11
+    if: github.repository == 'apollographql/apollo-kotlin'
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@d0651293c4a5a52e711f25b41b05b2212f385d28 #v3
+
+      - name: Install and run subgraph
+        working-directory: tests/defer/router/subgraphs/computers
+        run: |
+          npm install
+          APOLLO_PORT=4001 npm start &
+
+      - name: Install router
+        # TODO: Version of the router to test against is set here, we can either use "latest" (breaks reproducible builds)
+        # or keep a specific version but should update it regularly with new releases of the router (could Renovate help?)
+        run: |
+          curl -sSL https://router.apollo.dev/download/nix/v1.0.0-rc.0 | sh
+
+      - name: Run router
+        run: |
+          ./router --supergraph tests/defer/router/simple-supergraph.graphqls &
+
+      - name: Setup Java
+        uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 #v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee #v2.1.4
+
+      - name: Run Apollo Kotlin tests
+        env:
+          COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS: true
+        run: |
+          ulimit -c unlimited
+          # Workaround an issue where kotlinNpmInstall outputs
+          # 'Resolving NPM dependencies using yarn' returns 137
+          # ./gradlew compileKotlinJsIr compileKotlinJsLegacy
+          # ./gradlew --stop
+          ./gradlew --no-daemon --console plain -p tests :defer:allTests

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -25,7 +25,7 @@ jobs:
         # TODO: Version of the router to test against is set here, we can either use "latest" (breaks reproducible builds)
         # or keep a specific version but should update it regularly with new releases of the router (could Renovate help?)
         run: |
-          curl -sSL https://router.apollo.dev/download/nix/v1.0.0-rc.0 | sh
+          curl -sSL https://router.apollo.dev/download/nix/v1.0.0-rc.1 | sh
 
       - name: Run router
         run: |

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee #v2.1.4
 
-      - name: Run Apollo Kotlin tests
+      - name: Run Apollo Kotlin @defer tests
         env:
           COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS: true
         run: |

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -1,11 +1,8 @@
 name: defer-router-tests
 
-# TODO: Run on schedule instead of on pull requests
 on:
-  pull_request:
-    branches: [ '*' ]
-#  schedule:
-#    - cron: '0 3 * * *'
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   defer-with-router-tests:
@@ -22,10 +19,8 @@ jobs:
           APOLLO_PORT=4001 npm start &
 
       - name: Install router
-        # TODO: Version of the router to test against is set here, we can either use "latest" (breaks reproducible builds)
-        # or keep a specific version but should update it regularly with new releases of the router (could Renovate help?)
         run: |
-          curl -sSL https://router.apollo.dev/download/nix/v1.0.0-rc.1 | sh
+          curl -sSL https://router.apollo.dev/download/nix/latest | sh
 
       - name: Run router
         run: |

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -44,9 +44,4 @@ jobs:
         env:
           COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS: true
         run: |
-          ulimit -c unlimited
-          # Workaround an issue where kotlinNpmInstall outputs
-          # 'Resolving NPM dependencies using yarn' returns 137
-          # ./gradlew compileKotlinJsIr compileKotlinJsLegacy
-          # ./gradlew --stop
           ./gradlew --no-daemon --console plain -p tests :defer:allTests

--- a/.idea/runConfigurations/DeferWithRouterTest.xml
+++ b/.idea/runConfigurations/DeferWithRouterTest.xml
@@ -1,0 +1,31 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="DeferWithRouterTest" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="env">
+        <map>
+          <entry key="COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS" value="true" />
+        </map>
+      </option>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/defer" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":defer:cleanJvmTest" />
+          <option value=":defer:jvmTest" />
+          <option value="--tests" />
+          <option value="&quot;test.DeferWithRouterTest&quot;" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/apollo-ast/src/main/resources/builtins.graphqls
+++ b/apollo-ast/src/main/resources/builtins.graphqls
@@ -135,5 +135,5 @@ directive @deprecated(
 
 directive @defer(
   label: String
-  if: Boolean
+  if: Boolean! = true
 ) on FRAGMENT_SPREAD | INLINE_FRAGMENT

--- a/tests/defer/README.md
+++ b/tests/defer/README.md
@@ -1,4 +1,18 @@
 # Tests related to `@defer`
 
 Note: on Apple targets, the client is configured to use `StreamingNSURLSessionHttpEngine` which supports chunked
-encoding.  
+encoding.
+
+## End-to-end tests with Apollo Router
+
+The tests in `DeferWithRouterTest` are not run by default (they are excluded in the gradle conf) because they
+expect an instance of [Apollo Router](https://www.apollographql.com/docs/router/) running locally.
+
+They are enabled only when running from the specific `defer-with-router-tests` CI workflow.
+
+To run them locally:
+
+1. Install and run the
+   subgraph: `cd tests/defer/router/subgraphs/computers && npm install && APOLLO_PORT=4001 npm start &`
+2. Run the router: `./router --supergraph tests/defer/router/simple-supergraph.graphqls &`
+3. Run the tests: `COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS=true ./gradlew -p tests :defer:allTests`

--- a/tests/defer/README.md
+++ b/tests/defer/README.md
@@ -13,6 +13,6 @@ They are enabled only when running from the specific `defer-with-router-tests` C
 To run them locally:
 
 1. Install and run the
-   subgraph: `cd tests/defer/router/subgraphs/computers && npm install && APOLLO_PORT=4001 npm start &`
-2. Run the router: `./router --supergraph tests/defer/router/simple-supergraph.graphqls &`
+   subgraph: `(cd tests/defer/router/subgraphs/computers && npm install && APOLLO_PORT=4001 npm start)&`
+2. Run the router: `path/to/router --supergraph tests/defer/router/simple-supergraph.graphqls &`
 3. Run the tests: `COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS=true ./gradlew -p tests :defer:allTests`

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -89,3 +89,13 @@ fun com.apollographql.apollo3.gradle.api.Service.configureConnection(generateKot
     }
   }
 }
+
+tasks.withType(AbstractTestTask::class.java) {
+  // Run the defer with Router tests only from a a specific CI job
+  val runDeferWithRouterTests = System.getenv("COM_APOLLOGRAPHQL_DEFER_WITH_ROUTER_TESTS").toBoolean()
+  if (runDeferWithRouterTests) {
+    filter.setIncludePatterns("test.DeferWithRouterTest")
+  } else {
+    filter.setExcludePatterns("test.DeferWithRouterTest")
+  }
+}

--- a/tests/defer/router/simple-supergraph-rover-config.yaml
+++ b/tests/defer/router/simple-supergraph-rover-config.yaml
@@ -1,0 +1,12 @@
+# Generate the supergraph schema with this command:
+#
+# rover supergraph compose --config ./simple-supergraph-rover-config.yaml > simple-supergraph.graphqls
+#
+# See https://www.apollographql.com/docs/federation/quickstart/local-composition/#1-provide-subgraph-details
+
+federation_version: 2
+subgraphs:
+  computers:
+    routing_url: http://localhost:4001/
+    schema:
+      file: ./subgraphs/computers/computers.graphqls

--- a/tests/defer/router/simple-supergraph.graphqls
+++ b/tests/defer/router/simple-supergraph.graphqls
@@ -30,6 +30,7 @@ type Computer
   year: Int!
   screen: Screen!
   errorField: String
+  nonNullErrorField: String!
 }
 
 scalar join__FieldSet

--- a/tests/defer/router/simple-supergraph.graphqls
+++ b/tests/defer/router/simple-supergraph.graphqls
@@ -1,0 +1,72 @@
+# This file was generated with this command:
+#
+# rover supergraph compose --config ./simple-supergraph-rover-config.yaml > simple-supergraph.graphqls
+#
+# See also: https://www.apollographql.com/docs/federation/quickstart/local-composition/#2-perform-composition
+
+schema
+@link(url: "https://specs.apollo.dev/link/v1.0")
+@link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Computer
+@join__type(graph: COMPUTERS)
+{
+  id: ID!
+  cpu: String!
+  year: Int!
+  screen: Screen!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  COMPUTERS @join__graph(name: "computers", url: "http://localhost:4001/")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+@join__type(graph: COMPUTERS)
+{
+  computers: [Computer!]!
+}
+
+type Query
+@join__type(graph: COMPUTERS)
+{
+  computers: [Computer!]!
+  computer(id: ID!): Computer
+}
+
+type Screen
+@join__type(graph: COMPUTERS)
+{
+  resolution: String!
+  isColor: Boolean!
+}

--- a/tests/defer/router/simple-supergraph.graphqls
+++ b/tests/defer/router/simple-supergraph.graphqls
@@ -5,8 +5,8 @@
 # See also: https://www.apollographql.com/docs/federation/quickstart/local-composition/#2-perform-composition
 
 schema
-@link(url: "https://specs.apollo.dev/link/v1.0")
-@link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
@@ -23,12 +23,13 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
 type Computer
-@join__type(graph: COMPUTERS)
+  @join__type(graph: COMPUTERS)
 {
   id: ID!
   cpu: String!
   year: Int!
   screen: Screen!
+  errorField: String
 }
 
 scalar join__FieldSet
@@ -52,20 +53,20 @@ enum link__Purpose {
 }
 
 type Mutation
-@join__type(graph: COMPUTERS)
+  @join__type(graph: COMPUTERS)
 {
   computers: [Computer!]!
 }
 
 type Query
-@join__type(graph: COMPUTERS)
+  @join__type(graph: COMPUTERS)
 {
   computers: [Computer!]!
   computer(id: ID!): Computer
 }
 
 type Screen
-@join__type(graph: COMPUTERS)
+  @join__type(graph: COMPUTERS)
 {
   resolution: String!
   isColor: Boolean!

--- a/tests/defer/router/subgraphs/computers/computers.graphqls
+++ b/tests/defer/router/subgraphs/computers/computers.graphqls
@@ -1,0 +1,20 @@
+type Query {
+  computers: [Computer!]!
+  computer(id: ID!): Computer
+}
+
+type Mutation {
+  computers: [Computer!]!
+}
+
+type Computer {
+  id: ID!
+  cpu: String!
+  year: Int!
+  screen: Screen!
+}
+
+type Screen {
+  resolution: String!
+  isColor: Boolean!
+}

--- a/tests/defer/router/subgraphs/computers/computers.graphqls
+++ b/tests/defer/router/subgraphs/computers/computers.graphqls
@@ -12,6 +12,7 @@ type Computer {
   cpu: String!
   year: Int!
   screen: Screen!
+  errorField: String
 }
 
 type Screen {

--- a/tests/defer/router/subgraphs/computers/computers.graphqls
+++ b/tests/defer/router/subgraphs/computers/computers.graphqls
@@ -13,6 +13,7 @@ type Computer {
   year: Int!
   screen: Screen!
   errorField: String
+  nonNullErrorField: String!
 }
 
 type Screen {

--- a/tests/defer/router/subgraphs/computers/computers.js
+++ b/tests/defer/router/subgraphs/computers/computers.js
@@ -15,9 +15,14 @@ const resolvers = {
             return computers;
         },
         computer: (_, args, context) => {
-            return computers.find(p => p.id == args.id);
+            return computers.find(p => p.id === args.id);
         }
     },
+    Computer: {
+        errorField: (_, args, context) => {
+            throw new Error("Error field");
+        }
+    }
 }
 const server = new ApolloServer({typeDefs, resolvers});
 server.listen({port: port}).then(({url}) => {

--- a/tests/defer/router/subgraphs/computers/computers.js
+++ b/tests/defer/router/subgraphs/computers/computers.js
@@ -1,0 +1,27 @@
+const {ApolloServer, gql} = require('apollo-server');
+const {readFileSync} = require('fs');
+
+const port = process.env.APOLLO_PORT || 4000;
+
+const computers = [
+    {id: 'Computer1', cpu: "386", year: 1993, screen: {resolution: "640x480", isColor: false}},
+    {id: 'Computer2', cpu: "486", year: 1996, screen: {resolution: "800x600", isColor: true}},
+]
+
+const typeDefs = gql(readFileSync('./computers.graphqls', {encoding: 'utf-8'}));
+const resolvers = {
+    Query: {
+        computers: (_, args, context) => {
+            return computers;
+        },
+        computer: (_, args, context) => {
+            return computers.find(p => p.id == args.id);
+        }
+    },
+}
+const server = new ApolloServer({typeDefs, resolvers});
+server.listen({port: port}).then(({url}) => {
+    console.log(`🚀 Computers subgraph ready at ${url}`);
+}).catch(err => {
+    console.error(err)
+});

--- a/tests/defer/router/subgraphs/computers/computers.js
+++ b/tests/defer/router/subgraphs/computers/computers.js
@@ -23,7 +23,7 @@ const resolvers = {
             throw new Error("Error field");
         },
         nonNullErrorField: (_, args, context) => {
-            throw new Error("Error field");
+            return null;
         }
     }
 }

--- a/tests/defer/router/subgraphs/computers/computers.js
+++ b/tests/defer/router/subgraphs/computers/computers.js
@@ -21,6 +21,9 @@ const resolvers = {
     Computer: {
         errorField: (_, args, context) => {
             throw new Error("Error field");
+        },
+        nonNullErrorField: (_, args, context) => {
+            throw new Error("Error field");
         }
     }
 }

--- a/tests/defer/router/subgraphs/computers/package.json
+++ b/tests/defer/router/subgraphs/computers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "subgraph-computers",
-  "version": "1.1.27",
+  "version": "1.1.0",
   "description": "",
   "main": "computers.js",
   "scripts": {

--- a/tests/defer/router/subgraphs/computers/package.json
+++ b/tests/defer/router/subgraphs/computers/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "subgraph-computers",
+  "version": "1.1.27",
+  "description": "",
+  "main": "computers.js",
+  "scripts": {
+    "start": "node computers.js"
+  },
+  "dependencies": {
+    "apollo-server": "3.10.1",
+    "graphql": "16.5.0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT"
+}

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -71,3 +71,12 @@ query SimpleDeferQuery {
     }
   }
 }
+
+query CanDisableDeferUsingIfArgumentQuery {
+  computers {
+    id
+    ... on Computer @defer(if: false) {
+      cpu
+    }
+  }
+}

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -80,3 +80,40 @@ query CanDisableDeferUsingIfArgumentQuery {
     }
   }
 }
+
+query DoesNotDisableDeferWithNullIfArgumentQuery($shouldDefer: Boolean) {
+  computers {
+    id
+    ... on Computer @defer(if: $shouldDefer) {
+      cpu
+    }
+  }
+}
+
+query CanDeferFragmentsOnTheTopLevelQueryFieldQuery {
+  ...FragmentOnQuery @defer
+}
+
+fragment FragmentOnQuery on Query {
+  computers {
+    id
+  }
+}
+
+query CanDeferAFragmentThatIsAlsoNotDeferredDeferredFragmentIsFirstQuery {
+  computer(id: "Computer1") {
+    screen {
+      ...ScreenFields @defer
+      ...ScreenFields
+    }
+  }
+}
+
+query CanDeferAFragmentThatIsAlsoNotDeferredNotDeferredFragmentIsFirstQuery {
+  computer(id: "Computer1") {
+    screen {
+      ...ScreenFields
+      ...ScreenFields @defer
+    }
+  }
+}

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -117,3 +117,14 @@ query CanDeferAFragmentThatIsAlsoNotDeferredNotDeferredFragmentIsFirstQuery {
     }
   }
 }
+
+query HandlesErrorsThrownInDeferredFragmentsQuery {
+  computer(id: "Computer1") {
+    id
+    ...ComputerErrorField @defer
+  }
+}
+
+fragment ComputerErrorField on Computer {
+  errorField
+}

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -128,3 +128,14 @@ query HandlesErrorsThrownInDeferredFragmentsQuery {
 fragment ComputerErrorField on Computer {
   errorField
 }
+
+query HandlesNonNullableErrorsThrownInDeferredFragmentsQuery {
+  computer(id: "Computer1") {
+    id
+    ...ComputerNonNullableErrorField @defer
+  }
+}
+
+fragment ComputerNonNullableErrorField on Computer {
+  nonNullErrorField
+}

--- a/tests/defer/src/commonMain/graphql/base/operation.graphql
+++ b/tests/defer/src/commonMain/graphql/base/operation.graphql
@@ -139,3 +139,14 @@ query HandlesNonNullableErrorsThrownInDeferredFragmentsQuery {
 fragment ComputerNonNullableErrorField on Computer {
   nonNullErrorField
 }
+
+query HandlesNonNullableErrorsThrownOutsideDeferredFragmentsQuery {
+  computer(id: "Computer1") {
+    nonNullErrorField
+    ...ComputerIdField @defer
+  }
+}
+
+fragment ComputerIdField on Computer {
+  id
+}

--- a/tests/defer/src/commonMain/graphql/base/schema.graphqls
+++ b/tests/defer/src/commonMain/graphql/base/schema.graphqls
@@ -1,5 +1,6 @@
 type Query {
   computers: [Computer!]!
+  computer(id: ID!): Computer
 }
 
 type Mutation {

--- a/tests/defer/src/commonMain/graphql/base/schema.graphqls
+++ b/tests/defer/src/commonMain/graphql/base/schema.graphqls
@@ -22,6 +22,7 @@ type Computer {
   year: Int!
   screen: Screen!
   errorField: String
+  nonNullErrorField: String!
 }
 
 type Screen {

--- a/tests/defer/src/commonMain/graphql/base/schema.graphqls
+++ b/tests/defer/src/commonMain/graphql/base/schema.graphqls
@@ -21,6 +21,7 @@ type Computer {
   cpu: String!
   year: Int!
   screen: Screen!
+  errorField: String
 }
 
 type Screen {

--- a/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
@@ -1,6 +1,7 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.testing.internal.runTest
 import defer.CanDeferAFragmentThatIsAlsoNotDeferredDeferredFragmentIsFirstQuery
 import defer.CanDeferAFragmentThatIsAlsoNotDeferredNotDeferredFragmentIsFirstQuery
@@ -140,7 +141,7 @@ class DeferWithRouterTest {
             )
         ),
     )
-    val actualDataList = apolloClient.query(DoesNotDisableDeferWithNullIfArgumentQuery()).toFlow().toList().map { it.dataAssertNoErrors }
+    val actualDataList = apolloClient.query(DoesNotDisableDeferWithNullIfArgumentQuery(Optional.Absent)).toFlow().toList().map { it.dataAssertNoErrors }
     assertEquals(expectedDataList, actualDataList)
   }
 

--- a/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
@@ -1,0 +1,126 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.testing.internal.runTest
+import defer.CanDisableDeferUsingIfArgumentQuery
+import defer.WithFragmentSpreadsQuery
+import defer.WithInlineFragmentsQuery
+import defer.fragment.ComputerFields
+import defer.fragment.ScreenFields
+import kotlinx.coroutines.flow.toList
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * End-to-end tests for `@defer`.
+ *
+ * These tests are not run by default (they are excluded in the gradle conf) because they expect an instance of
+ * [Apollo Router](https://www.apollographql.com/docs/router/) running locally.
+ *
+ * They are enabled only when running from the specific `defer-with-router-tests` CI workflow.
+ */
+class DeferWithRouterTest {
+  private lateinit var apolloClient: ApolloClient
+
+  private fun setUp() {
+    apolloClient = ApolloClient.Builder()
+        .httpEngine(getStreamingHttpEngine())
+        .serverUrl("http://localhost:4000/")
+        .build()
+  }
+
+  private fun tearDown() {
+    apolloClient.close()
+  }
+
+  @Test
+  fun deferWithFragmentSpreads() = runTest(before = { setUp() }, after = { tearDown() }) {
+    // Expected payloads:
+    // {"data":{"computers":[{"id":"Computer1"},{"id":"Computer2"}]},"hasNext":true}
+    // {"hasNext":true,"incremental":[{"data":{"cpu":"386","year":1993,"screen":{"resolution":"640x480"}},"path":["computers",0]},{"data":{"cpu":"486","year":1996,"screen":{"resolution":"800x600"}},"path":["computers",1]}]}
+    // {"hasNext":false,"incremental":[{"label":"a","data":{"isColor":false},"path":["computers",0,"screen"]},{"label":"a","data":{"isColor":true},"path":["computers",1,"screen"]}]}
+    val expectedDataList = listOf(
+        WithFragmentSpreadsQuery.Data(
+            listOf(
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null),
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer2", null),
+            )
+        ),
+        WithFragmentSpreadsQuery.Data(
+            listOf(
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                    ComputerFields.Screen("Screen", "640x480", null))),
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer2", ComputerFields("486", 1996,
+                    ComputerFields.Screen("Screen", "800x600", null))),
+            )
+        ),
+        WithFragmentSpreadsQuery.Data(
+            listOf(
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                    ComputerFields.Screen("Screen", "640x480",
+                        ScreenFields(false)))),
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer2", ComputerFields("486", 1996,
+                    ComputerFields.Screen("Screen", "800x600",
+                        ScreenFields(true)))),
+            )
+        ),
+    )
+
+    val actualDataList = apolloClient.query(WithFragmentSpreadsQuery()).toFlow().toList().map { it.dataAssertNoErrors }
+    assertEquals(expectedDataList, actualDataList)
+  }
+
+  @Test
+  fun deferWithInlineFragments() = runTest(before = { setUp() }, after = { tearDown() }) {
+    // Expected payloads:
+    // {"data":{"computers":[{"id":"Computer1"},{"id":"Computer2"}]},"hasNext":true}
+    // {"hasNext":true,"incremental":[{"data":{"cpu":"386","year":1993,"screen":{"resolution":"640x480"}},"path":["computers",0]},{"data":{"cpu":"486","year":1996,"screen":{"resolution":"800x600"}},"path":["computers",1]}]}
+    // {"hasNext":false,"incremental":[{"label":"b","data":{"isColor":false},"path":["computers",0,"screen"]},{"label":"b","data":{"isColor":true},"path":["computers",1,"screen"]}]}
+    val expectedDataList = listOf(
+        WithInlineFragmentsQuery.Data(
+            listOf(
+                WithInlineFragmentsQuery.Computer("Computer", "Computer1", null),
+                WithInlineFragmentsQuery.Computer("Computer", "Computer2", null),
+            )
+        ),
+        WithInlineFragmentsQuery.Data(
+            listOf(
+                WithInlineFragmentsQuery.Computer("Computer", "Computer1", WithInlineFragmentsQuery.OnComputer("386", 1993,
+                    WithInlineFragmentsQuery.Screen("Screen", "640x480", null))),
+                WithInlineFragmentsQuery.Computer("Computer", "Computer2", WithInlineFragmentsQuery.OnComputer("486", 1996,
+                    WithInlineFragmentsQuery.Screen("Screen", "800x600", null))),
+            )
+        ),
+        WithInlineFragmentsQuery.Data(
+            listOf(
+                WithInlineFragmentsQuery.Computer("Computer", "Computer1", WithInlineFragmentsQuery.OnComputer("386", 1993,
+                    WithInlineFragmentsQuery.Screen("Screen", "640x480",
+                        WithInlineFragmentsQuery.OnScreen(false)))),
+                WithInlineFragmentsQuery.Computer("Computer", "Computer2", WithInlineFragmentsQuery.OnComputer("486", 1996,
+                    WithInlineFragmentsQuery.Screen("Screen", "800x600",
+                        WithInlineFragmentsQuery.OnScreen(true)))),
+            )
+        ),
+    )
+    val actualDataList = apolloClient.query(WithInlineFragmentsQuery()).toFlow().toList().map { it.dataAssertNoErrors }
+    assertEquals(expectedDataList, actualDataList)
+  }
+
+  @Test
+  fun canDisableDeferUsingIfArgument() = runTest(before = { setUp() }, after = { tearDown() }) {
+    // Expected payloads:
+    // {"data":{"computers":[{"id":"Computer1","cpu":"386"},{"id":"Computer2","cpu":"486"}]}}
+    val expectedDataList = listOf(
+        CanDisableDeferUsingIfArgumentQuery.Data(
+            listOf(
+                CanDisableDeferUsingIfArgumentQuery.Computer("Computer", "Computer1", CanDisableDeferUsingIfArgumentQuery.OnComputer("386")),
+                CanDisableDeferUsingIfArgumentQuery.Computer("Computer", "Computer2", CanDisableDeferUsingIfArgumentQuery.OnComputer("486")),
+            )
+        ),
+    )
+    val actualDataList = apolloClient.query(CanDisableDeferUsingIfArgumentQuery()).toFlow().toList().map { it.dataAssertNoErrors }
+    assertEquals(expectedDataList, actualDataList)
+  }
+
+
+}


### PR DESCRIPTION
Adds `@defer` tests running against the [Apollo Router](https://www.apollographql.com/docs/router/).