### PR TITLE
More compiler wording

### DIFF
--- a/apollo-api/api/apollo-api.api
+++ b/apollo-api/api/apollo-api.api
@@ -352,18 +352,21 @@ public final class com/apollographql/apollo3/api/CompiledListType : com/apollogr
 	public fun <init> (Lcom/apollographql/apollo3/api/CompiledType;)V
 	public final fun getOfType ()Lcom/apollographql/apollo3/api/CompiledType;
 	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
+	public fun rawType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public abstract class com/apollographql/apollo3/api/CompiledNamedType : com/apollographql/apollo3/api/CompiledType {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getName ()Ljava/lang/String;
 	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
+	public fun rawType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public final class com/apollographql/apollo3/api/CompiledNotNullType : com/apollographql/apollo3/api/CompiledType {
 	public fun <init> (Lcom/apollographql/apollo3/api/CompiledType;)V
 	public final fun getOfType ()Lcom/apollographql/apollo3/api/CompiledType;
 	public fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
+	public fun rawType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public abstract class com/apollographql/apollo3/api/CompiledSelection {
@@ -371,6 +374,7 @@ public abstract class com/apollographql/apollo3/api/CompiledSelection {
 
 public abstract class com/apollographql/apollo3/api/CompiledType {
 	public abstract fun leafType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
+	public abstract fun rawType ()Lcom/apollographql/apollo3/api/CompiledNamedType;
 }
 
 public final class com/apollographql/apollo3/api/CompiledVariable {

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -139,19 +139,27 @@ class CompiledFragment internal constructor(
 data class CompiledCondition(val name: String, val inverted: Boolean)
 
 sealed class CompiledType {
+  @Deprecated("Use rawType instead", ReplaceWith("rawType()"))
   abstract fun leafType(): CompiledNamedType
+  abstract fun rawType(): CompiledNamedType
 }
 
 class CompiledNotNullType(val ofType: CompiledType) : CompiledType() {
-  override fun leafType() = ofType.leafType()
+  @Deprecated("Use rawType instead", ReplaceWith("rawType()"))
+  override fun leafType() = ofType.rawType()
+  override fun rawType() = ofType.rawType()
 }
 
 class CompiledListType(val ofType: CompiledType) : CompiledType() {
-  override fun leafType() = ofType.leafType()
+  @Deprecated("Use rawType instead", ReplaceWith("rawType()"))
+  override fun leafType() = ofType.rawType()
+  override fun rawType() = ofType.rawType()
 }
 
 sealed class CompiledNamedType(val name: String) : CompiledType() {
+  @Deprecated("Use rawType instead", ReplaceWith("rawType()"))
   override fun leafType() = this
+  override fun rawType() = this
 }
 
 /**

--- a/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/fakeResolver.kt
+++ b/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/fakeResolver.kt
@@ -21,7 +21,7 @@ interface FakeResolver {
    * You can get the type of the leaf type with:
    *
    * ```
-   * context.mergedField.type.leafType()
+   * context.mergedField.type.rawType()
    * ```
    *
    * @return a kotlin value representing the value at path `context.path`. Possible values include
@@ -45,7 +45,7 @@ interface FakeResolver {
   fun resolveMaybeNull(context: FakeResolverContext): Boolean
 
   /**
-   * @return a concrete type that implements the type in `context.mergedField.type.leafType()`
+   * @return a concrete type that implements the type in `context.mergedField.type.rawType()`
    */
   fun resolveTypename(context: FakeResolverContext): String
 }
@@ -230,7 +230,7 @@ class DefaultFakeResolver(val types: List<CompiledNamedType>) : FakeResolver {
   private var impl = mutableMapOf<String, Int>()
 
   override fun resolveLeaf(context: FakeResolverContext): Any {
-    return when (val name = context.mergedField.type.leafType().name) {
+    return when (val name = context.mergedField.type.rawType().name) {
       "Int" -> currentInt++
       "Float" -> currentFloat++
       "Boolean" -> (!currentBoolean).also { currentBoolean = it }
@@ -265,14 +265,14 @@ class DefaultFakeResolver(val types: List<CompiledNamedType>) : FakeResolver {
   }
 
   override fun resolveTypename(context: FakeResolverContext): String {
-    val leafType = context.mergedField.type.leafType()
-    val name = leafType.name
+    val rawType = context.mergedField.type.rawType()
+    val name = rawType.name
     val index = impl.getOrElse(name) { 0 }
 
     impl[name] = index + 1
 
     // XXX: Cache this computation
-    val possibleTypes = possibleTypes(types, leafType)
+    val possibleTypes = possibleTypes(types, rawType)
     return possibleTypes[index % possibleTypes.size].name
   }
 }

--- a/apollo-ast/api/apollo-ast.api
+++ b/apollo-ast/api/apollo-ast.api
@@ -1024,6 +1024,7 @@ public final class com/apollographql/apollo3/ast/GqlstringsKt {
 public final class com/apollographql/apollo3/ast/GqltypeKt {
 	public static final fun leafType (Lcom/apollographql/apollo3/ast/GQLType;)Lcom/apollographql/apollo3/ast/GQLNamedType;
 	public static final fun pretty (Lcom/apollographql/apollo3/ast/GQLType;)Ljava/lang/String;
+	public static final fun rawType (Lcom/apollographql/apollo3/ast/GQLType;)Lcom/apollographql/apollo3/ast/GQLNamedType;
 }
 
 public final class com/apollographql/apollo3/ast/GqltypedefinitionKt {

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/check_key_fields.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/check_key_fields.kt
@@ -60,7 +60,7 @@ private fun CheckKeyFieldsScope.checkFieldSet(path: String, selections: List<GQL
 
   mergedFields.forEach {
     val first = it.first()
-    val rawTypeName = first.field.definitionFromScope(schema, first.parentType)!!.type.leafType().name
+    val rawTypeName = first.field.definitionFromScope(schema, first.parentType)!!.type.rawType().name
     checkField(path + "." + first.field.name, it.flatMap { it.field.selectionSet?.selections ?: emptyList() }, rawTypeName)
   }
 }

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqlfield.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqlfield.kt
@@ -34,17 +34,16 @@ private val typeMetaFieldDefinition = GQLFieldDefinition(
 )
 
 fun GQLField.definitionFromScope(schema: Schema, rawTypename: String): GQLFieldDefinition? {
-  val typeDefinitionInScope = schema.typeDefinition(rawTypename)
-  return definitionFromScope(schema, typeDefinitionInScope)
+  return definitionFromScope(schema, schema.typeDefinition(rawTypename))
 }
 
-fun GQLField.definitionFromScope(schema: Schema, typeDefinitionInScope: GQLTypeDefinition): GQLFieldDefinition? {
+fun GQLField.definitionFromScope(schema: Schema, parentTypeDefinition: GQLTypeDefinition): GQLFieldDefinition? {
   return when {
     name == "__typename" -> listOf(typenameMetaFieldDefinition)
-    name == "__schema" && typeDefinitionInScope.name == schema.queryTypeDefinition.name -> listOf(schemaMetaFieldDefinition)
-    name == "__type" && typeDefinitionInScope.name == schema.queryTypeDefinition.name -> listOf(typeMetaFieldDefinition)
-    typeDefinitionInScope is GQLObjectTypeDefinition -> typeDefinitionInScope.fields
-    typeDefinitionInScope is GQLInterfaceTypeDefinition -> typeDefinitionInScope.fields
+    name == "__schema" && parentTypeDefinition.name == schema.queryTypeDefinition.name -> listOf(schemaMetaFieldDefinition)
+    name == "__type" && parentTypeDefinition.name == schema.queryTypeDefinition.name -> listOf(typeMetaFieldDefinition)
+    parentTypeDefinition is GQLObjectTypeDefinition -> parentTypeDefinition.fields
+    parentTypeDefinition is GQLInterfaceTypeDefinition -> parentTypeDefinition.fields
     else -> emptyList()
   }.firstOrNull { it.name == name }
 }

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqltype.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqltype.kt
@@ -1,9 +1,14 @@
 package com.apollographql.apollo3.ast
 
+@Deprecated("Use rawType instead", ReplaceWith("rawType()"))
+fun GQLType.leafType(): GQLNamedType = rawType()
 
-fun GQLType.leafType(): GQLNamedType = when (this) {
-  is GQLNonNullType -> type.leafType()
-  is GQLListType -> type.leafType()
+/**
+ * Returns the raw type. The raw type is the GQLNamedType without any list/nonnull wrapper types
+ */
+fun GQLType.rawType(): GQLNamedType = when (this) {
+  is GQLNonNullType -> type.rawType()
+  is GQLListType -> type.rawType()
   is GQLNamedType -> this
 }
 

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -158,11 +158,11 @@ internal class ExecutableValidationScope(
     }
   }
 
-  private fun GQLField.validate(typeDefinitionInScope: GQLTypeDefinition, path: String) {
-    val fieldDefinition = definitionFromScope(schema, typeDefinitionInScope)
+  private fun GQLField.validate(parentTypeDefinition: GQLTypeDefinition, path: String) {
+    val fieldDefinition = definitionFromScope(schema, parentTypeDefinition)
     if (fieldDefinition == null) {
       registerIssue(
-          message = "Can't query `$name` on type `${typeDefinitionInScope.name}`",
+          message = "Can't query `$name` on type `${parentTypeDefinition.name}`",
           sourceLocation = sourceLocation
       )
       return
@@ -220,7 +220,7 @@ internal class ExecutableValidationScope(
   }
 
 
-  private fun GQLInlineFragment.validate(typeDefinitionInScope: GQLTypeDefinition, selectionSetParent: GQLNode, path: String) {
+  private fun GQLInlineFragment.validate(parentTypeDefinition: GQLTypeDefinition, selectionSetParent: GQLNode, path: String) {
     val inlineFragmentTypeDefinition = typeDefinitions[typeCondition.name]
     if (inlineFragmentTypeDefinition == null) {
       registerIssue(
@@ -230,7 +230,7 @@ internal class ExecutableValidationScope(
       return
     }
 
-    if (!inlineFragmentTypeDefinition.sharesPossibleTypesWith(other = typeDefinitionInScope, schema = schema)) {
+    if (!inlineFragmentTypeDefinition.sharesPossibleTypesWith(other = parentTypeDefinition, schema = schema)) {
       registerIssue(
           message = "Inline fragment cannot be spread here as result can never be of type `${typeCondition.name}`",
           sourceLocation = typeCondition.sourceLocation
@@ -248,7 +248,7 @@ internal class ExecutableValidationScope(
     }
   }
 
-  private fun GQLFragmentSpread.validate(typeDefinitionInScope: GQLTypeDefinition, selectionSetParent: GQLNode, path: String) {
+  private fun GQLFragmentSpread.validate(parentTypeDefinition: GQLTypeDefinition, selectionSetParent: GQLNode, path: String) {
     val fragmentDefinition = fragmentDefinitions[name]
     if (fragmentDefinition == null) {
       registerIssue(
@@ -267,9 +267,9 @@ internal class ExecutableValidationScope(
       return
     }
 
-    if (!fragmentTypeDefinition.sharesPossibleTypesWith(other = typeDefinitionInScope, schema = schema)) {
+    if (!fragmentTypeDefinition.sharesPossibleTypesWith(other = parentTypeDefinition, schema = schema)) {
       registerIssue(
-          message = "Fragment `$name` cannot be spread here as result can never be of type `${typeDefinitionInScope.name}`",
+          message = "Fragment `$name` cannot be spread here as result can never be of type `${parentTypeDefinition.name}`",
           sourceLocation = sourceLocation
       )
       return
@@ -442,11 +442,11 @@ internal class ExecutableValidationScope(
     deferDirectivePathAndLabels[pathAndLabel] = sourceLocation
   }
 
-  private fun GQLSelectionSet.validate(typeDefinitionInScope: GQLTypeDefinition, selectionSetParent: GQLNode, path: String = "") {
+  private fun GQLSelectionSet.validate(parentTypeDefinition: GQLTypeDefinition, selectionSetParent: GQLNode, path: String = "") {
     if (selections.isEmpty()) {
       // This will never happen from parsing documents but is kept for reference and to catch bad manual document modifications
       registerIssue(
-          message = "Selection of type `${typeDefinitionInScope.name}` must have a selection of sub-fields",
+          message = "Selection of type `${parentTypeDefinition.name}` must have a selection of sub-fields",
           sourceLocation = sourceLocation
       )
       return
@@ -454,9 +454,9 @@ internal class ExecutableValidationScope(
 
     selections.forEach {
       when (it) {
-        is GQLField -> it.validate(typeDefinitionInScope, path)
-        is GQLInlineFragment -> it.validate(typeDefinitionInScope, selectionSetParent, path)
-        is GQLFragmentSpread -> it.validate(typeDefinitionInScope, selectionSetParent, path)
+        is GQLField -> it.validate(parentTypeDefinition, path)
+        is GQLInlineFragment -> it.validate(parentTypeDefinition, selectionSetParent, path)
+        is GQLFragmentSpread -> it.validate(parentTypeDefinition, selectionSetParent, path)
       }
     }
   }

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/add_required_fields.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/add_required_fields.kt
@@ -9,9 +9,8 @@ import com.apollographql.apollo3.ast.GQLSelectionSet
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.definitionFromScope
-import com.apollographql.apollo3.ast.implementsAbstractType
 import com.apollographql.apollo3.ast.isAbstract
-import com.apollographql.apollo3.ast.leafType
+import com.apollographql.apollo3.ast.rawType
 import com.apollographql.apollo3.ast.rootTypeDefinition
 
 fun addRequiredFields(
@@ -143,7 +142,7 @@ private fun GQLField.addRequiredFields(schema: Schema, addTypename: String, frag
       schema,
       addTypename,
       fragments,
-      typeDefinition.type.leafType().name,
+      typeDefinition.type.rawType().name,
       emptySet(),
       true
   )

--- a/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/merge_trivial_inline_fragments.kt
+++ b/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/merge_trivial_inline_fragments.kt
@@ -6,7 +6,7 @@ fun List<GQLSelection>.mergeTrivialInlineFragments(schema: Schema, rawTypename: 
   return flatMap {
     when (it) {
       is GQLField -> {
-        val parentType = it.definitionFromScope(schema, rawTypename)!!.type.leafType().name
+        val parentType = it.definitionFromScope(schema, rawTypename)!!.type.rawType().name
         listOf(
             it.copy(
                 selectionSet = it.selectionSet?.copy(

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
@@ -2,7 +2,17 @@ package com.apollographql.apollo3.compiler.codegen
 
 import com.squareup.moshi.JsonClass
 
-
+/**
+ * Additional resolver data generated alongside the models and adapters.
+ * This data maps a GraphQL identifier (such as a typename or model path) to its target class.
+ * This allows children modules to reference classes generated in parents (and know when to skip generating them).
+ */
+@JsonClass(generateAdapter = true)
+class ResolverInfo(
+    val magic: String,
+    val version: String,
+    val entries: List<ResolverEntry>
+)
 
 @JsonClass(generateAdapter = true)
 class ResolverClassName(val packageName: String, val simpleNames: List<String>) {
@@ -41,10 +51,4 @@ enum class ResolverKeyKind {
 class ResolverEntry(
     val key: ResolverKey,
     val className: ResolverClassName
-)
-@JsonClass(generateAdapter = true)
-class ResolverInfo(
-    val magic: String,
-    val version: String,
-    val entries: List<ResolverEntry>
 )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
@@ -194,7 +194,7 @@ internal fun readFromResponseCodeBlock(
       ).build()
 
   val suffix = CodeBlock.builder()
-      .add("return new $T(\n", context.resolver.resolveModel(model.id))
+      .add("return new $T(\n", context.resolver.resolveModel(model.path))
       .indent()
       .add(
           visibleProperties.map { property ->

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
@@ -194,7 +194,7 @@ internal fun readFromResponseCodeBlock(
       ).build()
 
   val suffix = CodeBlock.builder()
-      .add("return new $T(\n", context.resolver.resolveModel(model.path))
+      .add("return new $T(\n", context.resolver.resolveModel(model.id))
       .indent()
       .add(
           visibleProperties.map { property ->

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/MonomorphicFieldResponseAdapterBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/MonomorphicFieldResponseAdapterBuilder.kt
@@ -18,7 +18,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
 
   private val adapterName = model.modelName
   private val adaptedClassName by lazy {
-    context.resolver.resolveModel(model.path)
+    context.resolver.resolveModel(model.id)
   }
 
   private val nestedAdapterBuilders = model.modelGroups.map {
@@ -32,7 +32,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
 
   override fun prepare() {
     context.resolver.registerModelAdapter(
-        model.path,
+        model.id,
         (path + adapterName).toClassName()
     )
     nestedAdapterBuilders.map { it.prepare() }
@@ -45,7 +45,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
   private fun typeSpec(): TypeSpec {
     return TypeSpec.enumBuilder(adapterName)
         .addSuperinterface(
-            ParameterizedTypeName.get(JavaClassNames.Adapter, context.resolver.resolveModel(model.path))
+            ParameterizedTypeName.get(JavaClassNames.Adapter, context.resolver.resolveModel(model.id))
         )
         .apply {
           addModifiers(if (public) Modifier.PUBLIC else Modifier.PRIVATE)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/MonomorphicFieldResponseAdapterBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/MonomorphicFieldResponseAdapterBuilder.kt
@@ -18,7 +18,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
 
   private val adapterName = model.modelName
   private val adaptedClassName by lazy {
-    context.resolver.resolveModel(model.id)
+    context.resolver.resolveModel(model.path)
   }
 
   private val nestedAdapterBuilders = model.modelGroups.map {
@@ -32,7 +32,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
 
   override fun prepare() {
     context.resolver.registerModelAdapter(
-        model.id,
+        model.path,
         (path + adapterName).toClassName()
     )
     nestedAdapterBuilders.map { it.prepare() }
@@ -45,7 +45,7 @@ internal class MonomorphicFieldResponseAdapterBuilder(
   private fun typeSpec(): TypeSpec {
     return TypeSpec.enumBuilder(adapterName)
         .addSuperinterface(
-            ParameterizedTypeName.get(JavaClassNames.Adapter, context.resolver.resolveModel(model.id))
+            ParameterizedTypeName.get(JavaClassNames.Adapter, context.resolver.resolveModel(model.path))
         )
         .apply {
           addModifiers(if (public) Modifier.PUBLIC else Modifier.PRIVATE)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/ExecutableCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/ExecutableCommon.kt
@@ -57,7 +57,7 @@ internal fun adapterMethodSpec(
       .build()
 }
 
-internal fun rootFieldMethodSpec(context: JavaContext, typeInScope: String, selectionsClassName: ClassName): MethodSpec {
+internal fun rootFieldMethodSpec(context: JavaContext, parentType: String, selectionsClassName: ClassName): MethodSpec {
   return MethodSpec.methodBuilder(rootField)
       .addModifiers(Modifier.PUBLIC)
       .addAnnotation(JavaClassNames.Override)
@@ -67,7 +67,7 @@ internal fun rootFieldMethodSpec(context: JavaContext, typeInScope: String, sele
               .add("return new $T(\n", JavaClassNames.CompiledFieldBuilder)
               .indent()
               .add("$S,\n", Identifier.data)
-              .add("$L\n", context.resolver.resolveCompiledType(typeInScope))
+              .add("$L\n", context.resolver.resolveCompiledType(parentType))
               .unindent()
               .add(")\n")
               .add(".${Identifier.selections}($T.$root)\n", selectionsClassName)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ExecutableCommon.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/ExecutableCommon.kt
@@ -65,7 +65,7 @@ internal fun adapterFunSpec(
       .build()
 }
 
-internal fun rootFieldFunSpec(context: KotlinContext, typeInScope: String, selectionsClassName: ClassName): FunSpec {
+internal fun rootFieldFunSpec(context: KotlinContext, parentType: String, selectionsClassName: ClassName): FunSpec {
   return FunSpec.builder(rootField)
       .addModifiers(KModifier.OVERRIDE)
       .returns(KotlinSymbols.CompiledField)
@@ -74,7 +74,7 @@ internal fun rootFieldFunSpec(context: KotlinContext, typeInScope: String, selec
               .add("return·%T(\n", KotlinSymbols.CompiledFieldBuilder)
               .indent()
               .add("name·=·%S,\n", Identifier.data)
-              .add("type·=·%L\n", context.resolver.resolveCompiledType(typeInScope))
+              .add("type·=·%L\n", context.resolver.resolveCompiledType(parentType))
               .unindent()
               .add(")\n")
               .add(".$selections(selections·=·%T.$root)\n", selectionsClassName)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/TestBuildersBuilder.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
 import com.apollographql.apollo3.ast.GQLType
-import com.apollographql.apollo3.compiler.codegen.ClassNames
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.Data
 import com.apollographql.apollo3.compiler.codegen.Identifier.block
@@ -174,15 +173,15 @@ internal data class TCtor(
 )
 
 private fun IrProperty.tProperty(modelGroups: List<IrModelGroup>): TProperty {
-  val leafType = info.type.leafType()
+  val rawType = info.type.rawType()
 
   /**
    * Lookup the modelGroup for this property
    * This feels a bit weird because this is information we had before the tree gets split into properties and models
    * We might be able to remove that lookup
    */
-  val ctors = if (leafType is IrModelType) {
-    val leafPath = (leafType as? IrModelType)?.path
+  val ctors = if (rawType is IrModelType) {
+    val leafPath = (rawType as? IrModelType)?.path
     val modelGroup = modelGroups.single { it.baseModelId == leafPath }
     modelGroup.models.filter { !it.isInterface }.map {
       TCtor(
@@ -194,8 +193,8 @@ private fun IrProperty.tProperty(modelGroups: List<IrModelGroup>): TProperty {
   } else {
     emptyList()
   }
-  val enumName = if (leafType is IrEnumType) {
-    leafType.name
+  val enumName = if (rawType is IrEnumType) {
+    rawType.name
   } else {
     null
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/FieldMerger.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/FieldMerger.kt
@@ -20,7 +20,7 @@ internal data class MergedField(
     val selections: List<GQLSelection>,
     /**
      * The name of the rawType, without the NotNull/List decorations
-     * When selections is not empty, this is the type condition for these selections
+     * When selections are not empty, this is the type condition for these selections
      *
      * We cannot rely on [info.type] to get it because [info.type] represents a Kotlin model and lost this already
      */
@@ -30,12 +30,12 @@ internal data class MergedField(
 internal fun collectFields(
     allFragmentDefinitions: Map<String, GQLFragmentDefinition>,
     selections: List<GQLSelection>,
-    typenameInScope: String,
+    parentTypeDefinition: String,
     typeSet: TypeSet,
 ): List<FieldWithParent> {
   return selections.flatMap {
     when (it) {
-      is GQLField -> listOf(FieldWithParent(it, typenameInScope))
+      is GQLField -> listOf(FieldWithParent(it, parentTypeDefinition))
       is GQLInlineFragment -> {
         if (typeSet.contains(it.typeCondition.name)) {
           collectFields(allFragmentDefinitions, it.selectionSet.selections, it.typeCondition.name, typeSet)

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
@@ -209,7 +209,9 @@ internal data class IrSubtypeAccessor(
 ) : IrAccessor()
 
 /**
- * A Kotlin class or interface representing a GraphQL object field
+ * A class or interface representing a GraphQL object field
+ *
+ * Monomorphic fields will always be represented by a class while polymorphic fields will involve interfaces
  */
 internal data class IrModel(
     val modelName: String,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
@@ -215,7 +215,10 @@ internal data class IrSubtypeAccessor(
  */
 internal data class IrModel(
     val modelName: String,
-    val id: String,
+    /**
+     * The path to this field. See [IrModelType] for more details
+     */
+    val path: String,
     /**
      * The typeSet of this model.
      * Used by the adapters for ordering/making the code look nice
@@ -399,12 +402,16 @@ internal data class IrInputObjectType(override val name: String) : IrType(), IrN
 internal data class IrEnumType(override val name: String) : IrType(), IrNamedType
 
 /**
- * @param path a unique path identifying the model.
+ * @param path a unique path identifying a given model.
  *
- * fragmentData.$fragmentName.hero.friend
- * fragmentInterface.$fragmentName.hero.friend
- * operationData.$operationName.hero.friend
- * operationData.$operationName.hero.otherFriend
+ * For responseBased codegen
+ *
+ * operationData.$operationName.Query_data.Droid_hero
+ * fragmentData.$fragmentName.Query_data.Character_hero
+ * fragmentData.$fragmentName.Query_data.Droid_hero
+ * fragmentData.$fragmentName.Query_data.Human_hero
+ * fragmentData.$fragmentName.Query_data.Human_hero.Character_friend
+ * fragmentInterface.$fragmentName.Query_data.Character_hero
  * ?
  */
 internal data class IrModelType(val path: String) : IrType()

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
@@ -364,7 +364,7 @@ internal data class IrVariableValue(val name: String) : IrValue()
 
 
 internal sealed class IrType {
-  open fun leafType() = this
+  open fun rawType() = this
 }
 
 internal data class IrNonNullType(val ofType: IrType) : IrType() {
@@ -372,11 +372,11 @@ internal data class IrNonNullType(val ofType: IrType) : IrType() {
     check(ofType !is IrNonNullType)
   }
 
-  override fun leafType() = ofType.leafType()
+  override fun rawType() = ofType.rawType()
 }
 
 internal data class IrOptionalType(val ofType: IrType) : IrType() {
-  override fun leafType() = ofType.leafType()
+  override fun rawType() = ofType.rawType()
 }
 
 internal data class IrListType(val ofType: IrType) : IrType() {
@@ -384,7 +384,7 @@ internal data class IrListType(val ofType: IrType) : IrType() {
     check(ofType !is IrOptionalType)
   }
 
-  override fun leafType() = ofType.leafType()
+  override fun rawType() = ofType.rawType()
 }
 
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/Ir.kt
@@ -218,7 +218,7 @@ internal data class IrModel(
     /**
      * The path to this field. See [IrModelType] for more details
      */
-    val path: String,
+    val id: String,
     /**
      * The typeSet of this model.
      * Used by the adapters for ordering/making the code look nice

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -51,7 +51,7 @@ import com.apollographql.apollo3.ast.inferVariables
 import com.apollographql.apollo3.ast.internal.toConnectionFields
 import com.apollographql.apollo3.ast.internal.toEmbeddedFields
 import com.apollographql.apollo3.ast.isFieldNonNull
-import com.apollographql.apollo3.ast.leafType
+import com.apollographql.apollo3.ast.rawType
 import com.apollographql.apollo3.ast.optionalValue
 import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.responseName
@@ -171,7 +171,7 @@ internal class IrBuilder(
             }
             // Add all fields types
             typeDefinition.fields.forEach {
-              usedTypes.add(it.type.leafType().name)
+              usedTypes.add(it.type.rawType().name)
             }
           }
         }
@@ -201,7 +201,7 @@ internal class IrBuilder(
             }
             // Add all fields types
             typeDefinition.fields.forEach {
-              usedTypes.add(it.type.leafType().name)
+              usedTypes.add(it.type.rawType().name)
             }
           }
         }
@@ -682,7 +682,7 @@ internal class IrBuilder(
           info = info,
           condition = BooleanExpression.Or(fieldsWithSameResponseName.map { it.condition }.toSet()).simplify(),
           selections = childSelections,
-          rawTypeName = first.type.leafType().name,
+          rawTypeName = first.type.rawType().name,
       )
     }
   }

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -506,7 +506,7 @@ private fun ResponseFieldSet.toIrModel(parentResponseField: ResponseField): IrMo
       properties = responseFields.map { it.toIrProperty() },
       implements = implements,
       accessors = accessors,
-      path = path,
+      id = path,
       typeSet = typeSet,
       isInterface = isInterface,
       isFallback = isFallback,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -60,7 +60,7 @@ private data class ResponseField(
 )
 
 private data class ResponseFieldSet(
-    val path: String,
+    val id: String,
     val typeSet: TypeSet,
     val responseFields: List<ResponseField>,
     val possibleTypes: Set<String>,
@@ -209,7 +209,7 @@ private class FieldNodeBuilder(
         "Cannot find base model"
       }
       ret
-    }.path
+    }.id
   }
 
   /**
@@ -292,14 +292,14 @@ private class FieldNodeBuilder(
     /**
      * Patch the field with the type of the base model
      */
-    val baseModelId = fieldSetNodes.first { it.typeSet.size == 1 }.path
+    val baseModelId = fieldSetNodes.first { it.typeSet.size == 1 }.id
     val patchedInfo = info.copy(type = info.type.replacePlaceholder(baseModelId))
 
     /**
      * Patch the base fieldSet with the accessors
      */
     val patchedFieldSetNodes = fieldSetNodes.map {
-      if (it.path == baseModelId) {
+      if (it.id == baseModelId) {
         val subtypeAccessors = allTypeSets
             .filter { typeSet ->
               typeSet.size > 1
@@ -371,7 +371,7 @@ private class FieldNodeBuilder(
 
     val path = subpath(state.path, state.info, typeSet, isOther)
     val fieldSetNode = ResponseFieldSet(
-        path = path,
+        id = path,
         accessors = emptyList(),
         responseFields = mergedFields.map { mergedField ->
           buildFieldNode(
@@ -388,7 +388,7 @@ private class FieldNodeBuilder(
         },
         possibleTypes = modelDescriptor.shape.possibleTypes,
         typeSet = typeSet,
-        implements = implementedFieldSetNodes.map { it.path },
+        implements = implementedFieldSetNodes.map { it.id },
         isOther = isOther,
         isInterface = isInterface,
         isFallback = typeSet.size == 1 && isOther,
@@ -506,7 +506,7 @@ private fun ResponseFieldSet.toIrModel(parentResponseField: ResponseField): IrMo
       properties = responseFields.map { it.toIrProperty() },
       implements = implements,
       accessors = accessors,
-      id = path,
+      id = id,
       typeSet = typeSet,
       isInterface = isInterface,
       isFallback = isFallback,

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -360,7 +360,7 @@ private class FieldNodeBuilder(
         collectFields(
             allFragmentDefinitions = allFragmentDefinitions,
             selections = state.selections,
-            typenameInScope = state.rawTypename,
+            parentTypeDefinition = state.rawTypename,
             typeSet = typeSet,
         )
     )

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/SelectionSetsBuilder.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/SelectionSetsBuilder.kt
@@ -13,7 +13,7 @@ import com.apollographql.apollo3.ast.GQLSelection
 import com.apollographql.apollo3.ast.GQLType
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.definitionFromScope
-import com.apollographql.apollo3.ast.leafType
+import com.apollographql.apollo3.ast.rawType
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.keyArgs
 import com.apollographql.apollo3.compiler.codegen.paginationArgs
@@ -96,7 +96,7 @@ internal class SelectionSetsBuilder(
             condition = expression,
             selectionSetName = if (selectionSet != null) selectionSetName else null
         ),
-        nested = selectionSet?.selections?.walk(selectionSetName, false, fieldDefinition.type.leafType().name).orEmpty()
+        nested = selectionSet?.selections?.walk(selectionSetName, false, fieldDefinition.type.rawType().name).orEmpty()
     )
   }
 

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/usedFragments.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/usedFragments.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo3.ast.GQLInlineFragment
 import com.apollographql.apollo3.ast.GQLSelection
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.definitionFromScope
-import com.apollographql.apollo3.ast.leafType
+import com.apollographql.apollo3.ast.rawType
 
 internal fun usedFragments(
     schema: Schema,
@@ -19,7 +19,7 @@ internal fun usedFragments(
     when (it) {
       is GQLField -> {
         val fieldDefinition = it.definitionFromScope(schema, rawTypename)!!
-        usedFragments(schema, allFragmentDefinitions, it.selectionSet?.selections ?: emptyList(), fieldDefinition.type.leafType().name)
+        usedFragments(schema, allFragmentDefinitions, it.selectionSet?.selections ?: emptyList(), fieldDefinition.type.rawType().name)
       }
       is GQLInlineFragment -> {
         usedFragments(schema, allFragmentDefinitions, it.selectionSet.selections, it.typeCondition.name)

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
@@ -31,7 +31,7 @@ interface CacheKeyGenerator {
  * @param field the field representing the object or for lists, the field representing the list. `field.type` is not
  * always the type of the object. Especially, it can be any combination of [com.apollographql.apollo3.api.CompiledNotNullType]
  * and [com.apollographql.apollo3.api.CompiledListType].
- * Use `field.type.leafType()` to access the type of the object. For interface fields, it will be the interface type,
+ * Use `field.type.rawType()` to access the type of the object. For interface fields, it will be the interface type,
  * not concrete types.
  * @param variables the variables used in the operation where the object is normalized.
  */
@@ -45,7 +45,7 @@ class CacheKeyGeneratorContext(
  */
 object TypePolicyCacheKeyGenerator : CacheKeyGenerator {
   override fun cacheKeyForObject(obj: Map<String, Any?>, context: CacheKeyGeneratorContext): CacheKey? {
-    val keyFields = context.field.type.leafType().keyFields()
+    val keyFields = context.field.type.rawType().keyFields()
 
     return if (keyFields.isNotEmpty()) {
       CacheKey(obj["__typename"].toString(), keyFields.map { obj[it].toString() })

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
@@ -21,7 +21,7 @@ abstract class CacheKeyResolver : CacheResolver {
   /**
    * Return the computed the cache key for a composite field.
    *
-   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of object type, you can get the object typename with `field.type.rawType().name`
    * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
    * in the whole schema as it cannot be namespaced by the typename anymore.
    *
@@ -32,7 +32,7 @@ abstract class CacheKeyResolver : CacheResolver {
   /**
    * For a field that contains a list of objects, [listOfCacheKeysForField ] returns a list of [CacheKey]s where each [CacheKey] identifies an object.
    *
-   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of object type, you can get the object typename with `field.type.rawType().name`
    * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
    * in the whole schema as it cannot be namespaced by the typename anymore.
    *

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -203,7 +203,7 @@ object FieldPolicyCacheResolver : CacheResolver {
     }
 
     if (keyArgsValues.isNotEmpty()) {
-      return CacheKey(field.type.leafType().name, keyArgsValues)
+      return CacheKey(field.type.rawType().name, keyArgsValues)
     }
 
     return DefaultCacheResolver.resolveField(field, variables, parent, parentId)

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
@@ -32,7 +32,7 @@ object EmptyMetadataGenerator : MetadataGenerator {
 class ConnectionMetadataGenerator(private val connectionTypes: Set<String>) : MetadataGenerator {
   @Suppress("UNCHECKED_CAST")
   override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
-    if (context.field.type.leafType().name in connectionTypes) {
+    if (context.field.type.rawType().name in connectionTypes) {
       obj as Map<String, Any?>
       val edges = obj["edges"] as List<Map<String, Any?>>
       val startCursor = edges.firstOrNull()?.get("cursor") as String?

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -38,7 +38,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
   return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator)
-      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType())
+      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
 
 @ApolloExperimental
@@ -54,7 +54,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
   return Normalizer(variables, rootKey, cacheKeyGenerator, metadataGenerator)
-      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType())
+      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
 
 
@@ -129,7 +129,7 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
       variables = variables(customScalarAdapters),
       rootKey = cacheKey.key,
       rootSelections = rootField().selections,
-      rootTypename = rootField().type.leafType().name
+      rootTypename = rootField().type.rawType().name
   ).toMap()
 
   val reader = MapJsonReader(

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
@@ -123,7 +123,7 @@ internal class CacheBatchReader(
             }
             else -> throw IllegalStateException()
           }
-          value.registerCacheKeys(pendingReference.path + it.responseName, it.selections, it.type.leafType().name)
+          value.registerCacheKeys(pendingReference.path + it.responseName, it.selections, it.type.rawType().name)
 
           it.responseName to value
         }.toMap()
@@ -172,7 +172,7 @@ internal class CacheBatchReader(
             }
             else -> throw IllegalStateException()
           }
-          value.registerCacheKeys(path + it.responseName, it.selections, it.type.leafType().name)
+          value.registerCacheKeys(path + it.responseName, it.selections, it.type.rawType().name)
 
           it.responseName to value
         }.toMap()

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -30,8 +30,8 @@ internal class Normalizer(
 ) {
   private val records = mutableMapOf<String, Record>()
 
-  fun normalize(map: Map<String, Any?>, selections: List<CompiledSelection>, typeInScope: CompiledNamedType): Map<String, Record> {
-    buildRecord(map, rootKey, selections, typeInScope.name, typeInScope.embeddedFields)
+  fun normalize(map: Map<String, Any?>, selections: List<CompiledSelection>, parentType: CompiledNamedType): Map<String, Record> {
+    buildRecord(map, rootKey, selections, parentType.name, parentType.embeddedFields)
 
     return records
   }
@@ -53,12 +53,12 @@ internal class Normalizer(
       obj: Map<String, Any?>,
       key: String,
       selections: List<CompiledSelection>,
-      typeInScope: String,
+      parentType: String,
       embeddedFields: List<String>,
   ): Map<String, FieldInfo> {
 
     val typename = obj["__typename"] as? String
-    val allFields = collectFields(selections, typeInScope, typename)
+    val allFields = collectFields(selections, parentType, typename)
 
     val fields = obj.entries.mapNotNull { entry ->
       val compiledFields = allFields.filter { it.responseName == entry.key }
@@ -114,10 +114,10 @@ internal class Normalizer(
       obj: Map<String, Any?>,
       key: String,
       selections: List<CompiledSelection>,
-      typeInScope: String,
+      parentType: String,
       embeddedFields: List<String>,
   ): CacheKey {
-    val fields = buildFields(obj, key, selections, typeInScope, embeddedFields)
+    val fields = buildFields(obj, key, selections, parentType, embeddedFields)
     val fieldValues = fields.mapValues { it.value.fieldValue }
     val metadata = fields.mapValues { it.value.metadata }
     val record = Record(
@@ -218,15 +218,15 @@ internal class Normalizer(
     val fields = mutableListOf<CompiledField>()
   }
 
-  private fun collectFields(selections: List<CompiledSelection>, typeInScope: String, typename: String?, state: CollectState) {
+  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?, state: CollectState) {
     selections.forEach {
       when (it) {
         is CompiledField -> {
           state.fields.add(it)
         }
         is CompiledFragment -> {
-          if (typename in it.possibleTypes || it.typeCondition == typeInScope) {
-            collectFields(it.selections, typeInScope, typename, state)
+          if (typename in it.possibleTypes || it.typeCondition == parentType) {
+            collectFields(it.selections, parentType, typename, state)
           }
         }
       }
@@ -238,9 +238,9 @@ internal class Normalizer(
    * that's the case, we will collect less fields than we should and records will miss some values leading to more
    * cache miss
    */
-  private fun collectFields(selections: List<CompiledSelection>, typeInScope: String, typename: String?): List<CompiledField> {
+  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?): List<CompiledField> {
     val state = CollectState()
-    collectFields(selections, typeInScope, typename, state)
+    collectFields(selections, parentType, typename, state)
     return state.fields
   }
 

--- a/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -194,10 +194,10 @@ internal class Normalizer(
           key = path
         }
         if (embeddedFields.contains(field.name)) {
-          buildFields(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields)
+          buildFields(value, key, field.selections, field.type.rawType().name, field.type.rawType().embeddedFields)
               .mapValues { it.value.fieldValue }
         } else {
-          buildRecord(value, key, field.selections, field.type.leafType().name, field.type.leafType().embeddedFields)
+          buildRecord(value, key, field.selections, field.type.rawType().name, field.type.rawType().embeddedFields)
         }
       }
       else -> {

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator.kt
@@ -31,7 +31,7 @@ interface CacheKeyGenerator {
  * @param field the field representing the object or for lists, the field representing the list. `field.type` is not
  * always the type of the object. Especially, it can be any combination of [com.apollographql.apollo3.api.CompiledNotNullType]
  * and [com.apollographql.apollo3.api.CompiledListType].
- * Use `field.type.leafType()` to access the type of the object. For interface fields, it will be the interface type,
+ * Use `field.type.rawType()` to access the type of the object. For interface fields, it will be the interface type,
  * not concrete types.
  * @param variables the variables used in the operation where the object is normalized.
  */
@@ -45,7 +45,7 @@ class CacheKeyGeneratorContext(
  */
 object TypePolicyCacheKeyGenerator : CacheKeyGenerator {
   override fun cacheKeyForObject(obj: Map<String, Any?>, context: CacheKeyGeneratorContext): CacheKey? {
-    val keyFields = context.field.type.leafType().keyFields()
+    val keyFields = context.field.type.rawType().keyFields()
 
     return if (keyFields.isNotEmpty()) {
       CacheKey(obj["__typename"].toString(), keyFields.map { obj[it].toString() })

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKeyResolver.kt
@@ -21,7 +21,7 @@ abstract class CacheKeyResolver : CacheResolver {
   /**
    * Return the computed the cache key for a composite field.
    *
-   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of object type, you can get the object typename with `field.type.rawType().name`
    * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
    * in the whole schema as it cannot be namespaced by the typename anymore.
    *
@@ -32,7 +32,7 @@ abstract class CacheKeyResolver : CacheResolver {
   /**
    * For a field that contains a list of objects, [listOfCacheKeysForField ] returns a list of [CacheKey]s where each [CacheKey] identifies an object.
    *
-   * If the field is of object type, you can get the object typename with `field.type.leafType().name`
+   * If the field is of object type, you can get the object typename with `field.type.rawType().name`
    * If the field is of interface type, the concrete object typename is not predictable and the returned [CacheKey] must be unique
    * in the whole schema as it cannot be namespaced by the typename anymore.
    *

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -182,7 +182,7 @@ object FieldPolicyCacheResolver : CacheResolver {
     }
 
     if (keyArgsValues.isNotEmpty()) {
-      return CacheKey(field.type.leafType().name, keyArgsValues)
+      return CacheKey(field.type.rawType().name, keyArgsValues)
     }
 
     return DefaultCacheResolver.resolveField(field, variables, parent, parentId)

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -28,7 +28,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
   return Normalizer(variables, rootKey, cacheKeyGenerator)
-      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.leafType().name)
+      .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType().name)
 }
 
 fun <D : Executable.Data> Executable<D>.readDataFromCache(
@@ -72,7 +72,7 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
       variables = variables(customScalarAdapters),
       rootKey = cacheKey.key,
       rootSelections = rootField().selections,
-      rootTypename = rootField().type.leafType().name
+      rootTypename = rootField().type.rawType().name
   ).toMap()
 
   val reader = MapJsonReader(

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.cache.normalized.api.internal
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
@@ -115,7 +114,7 @@ internal class CacheBatchReader(
 
           val value = cacheResolver.resolveField(it, variables, record, record.key)
 
-          value.registerCacheKeys(pendingReference.path + it.responseName, it.selections, it.type.leafType().name)
+          value.registerCacheKeys(pendingReference.path + it.responseName, it.selections, it.type.rawType().name)
 
           it.responseName to value
         }.toMap()

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/CacheBatchReader.kt
@@ -35,7 +35,7 @@ internal class CacheBatchReader(
       val key: String,
       val path: List<Any>,
       val selections: List<CompiledSelection>,
-      val typeInScope: String,
+      val parentType: String,
   )
 
   /**
@@ -53,15 +53,15 @@ internal class CacheBatchReader(
   /**
    *
    */
-  private fun collect(selections: List<CompiledSelection>, typeInScope: String, typename: String?, state: CollectState) {
+  private fun collect(selections: List<CompiledSelection>, parentType: String, typename: String?, state: CollectState) {
     selections.forEach { compiledSelection ->
       when (compiledSelection) {
         is CompiledField -> {
           state.fields.add(compiledSelection)
         }
         is CompiledFragment -> {
-          if (typename in compiledSelection.possibleTypes || compiledSelection.typeCondition == typeInScope) {
-            collect(compiledSelection.selections, typeInScope, typename, state)
+          if (typename in compiledSelection.possibleTypes || compiledSelection.typeCondition == parentType) {
+            collect(compiledSelection.selections, parentType, typename, state)
           }
         }
       }
@@ -70,11 +70,11 @@ internal class CacheBatchReader(
 
   private fun collectAndMergeSameDirectives(
       selections: List<CompiledSelection>,
-      typeInScope: String,
+      parentType: String,
       typename: String?,
   ): List<CompiledField> {
     val state = CollectState()
-    collect(selections, typeInScope, typename, state)
+    collect(selections, parentType, typename, state)
     return state.fields.groupBy { (it.responseName) to it.condition }.values.map {
       it.first().newBuilder().selections(it.flatMap { it.selections }).build()
     }
@@ -85,7 +85,7 @@ internal class CacheBatchReader(
         PendingReference(
             key = rootKey,
             selections = rootSelections,
-            typeInScope = rootTypename,
+            parentType = rootTypename,
             path = emptyList()
         )
     )
@@ -106,7 +106,7 @@ internal class CacheBatchReader(
           }
         }
 
-        val collectedFields = collectAndMergeSameDirectives(pendingReference.selections, pendingReference.typeInScope, record["__typename"] as? String)
+        val collectedFields = collectAndMergeSameDirectives(pendingReference.selections, pendingReference.parentType, record["__typename"] as? String)
 
         val map = collectedFields.mapNotNull {
           if (it.shouldSkip(variables.valueMap)) {
@@ -131,21 +131,21 @@ internal class CacheBatchReader(
   /**
    * The path leading to this value
    */
-  private fun Any?.registerCacheKeys(path: List<Any>, selections: List<CompiledSelection>, typeInScope: String) {
+  private fun Any?.registerCacheKeys(path: List<Any>, selections: List<CompiledSelection>, parentType: String) {
     when (this) {
       is CacheKey -> {
         pendingReferences.add(
             PendingReference(
                 key = key,
                 selections = selections,
-                typeInScope = typeInScope,
+                parentType = parentType,
                 path = path
             )
         )
       }
       is List<*> -> {
         forEachIndexed { index, value ->
-          value.registerCacheKeys(path + index, selections, typeInScope)
+          value.registerCacheKeys(path + index, selections, parentType)
         }
       }
     }

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -142,7 +142,7 @@ internal class Normalizer(
             value as Map<String, Any?>,
             CacheKeyGeneratorContext(field, variables),
         )?.key ?: path
-        buildRecord(value, key, field.selections, field.type.leafType().name)
+        buildRecord(value, key, field.selections, field.type.rawType().name)
       }
       else -> {
         // scalar

--- a/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -25,8 +25,8 @@ internal class Normalizer(
 ) {
   private val records = mutableMapOf<String, Record>()
 
-  fun normalize(map: Map<String, Any?>, selections: List<CompiledSelection>, typeInScope: String): Map<String, Record> {
-    buildRecord(map, rootKey, selections, typeInScope)
+  fun normalize(map: Map<String, Any?>, selections: List<CompiledSelection>, parentType: String): Map<String, Record> {
+    buildRecord(map, rootKey, selections, parentType)
 
     return records
   }
@@ -41,11 +41,11 @@ internal class Normalizer(
       obj: Map<String, Any?>,
       key: String,
       selections: List<CompiledSelection>,
-      typeInScope: String,
+      parentType: String,
   ): CacheKey {
 
     val typename = obj["__typename"] as? String
-    val allFields = collectFields(selections, typeInScope, typename)
+    val allFields = collectFields(selections, parentType, typename)
 
     val record = Record(
         key = key,
@@ -155,15 +155,15 @@ internal class Normalizer(
     val fields = mutableListOf<CompiledField>()
   }
 
-  private fun collectFields(selections: List<CompiledSelection>, typeInScope: String, typename: String?, state: CollectState) {
+  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?, state: CollectState) {
     selections.forEach {
       when (it) {
         is CompiledField -> {
           state.fields.add(it)
         }
         is CompiledFragment -> {
-          if (typename in it.possibleTypes || it.typeCondition == typeInScope) {
-            collectFields(it.selections, typeInScope, typename, state)
+          if (typename in it.possibleTypes || it.typeCondition == parentType) {
+            collectFields(it.selections, parentType, typename, state)
           }
         }
       }
@@ -175,9 +175,9 @@ internal class Normalizer(
    * that's the case, we will collect less fields than we should and records will miss some values leading to more
    * cache miss
    */
-  private fun collectFields(selections: List<CompiledSelection>, typeInScope: String, typename: String?): List<CompiledField> {
+  private fun collectFields(selections: List<CompiledSelection>, parentType: String, typename: String?): List<CompiledField> {
     val state = CollectState()
-    collectFields(selections, typeInScope, typename, state)
+    collectFields(selections, parentType, typename, state)
     return state.fields
   }
 

--- a/design-docs/Glossary.md
+++ b/design-docs/Glossary.md
@@ -10,6 +10,10 @@ A small Glossary of the terms used during codegen. The [GraphQL Spec](https://sp
 This is the shape of the actual json as returned by the server. A given query can have multiple shapes depending the different type conditions at each field. While Field trees are in the GraphQL domain, Response shapes are in the Json domain and different Field trees can have the same response shape (http://spec.graphql.org/draft/#SameResponseShape())
 
 
+### Raw type
+
+The raw type is the named type without any list/nonnull wrapper types
+
 ### Leaf type
 
 A leaf type that doesn't contain fields or input fields. It's either a scalar or an enum
@@ -30,7 +34,7 @@ Synonym for object type
 Given a type condition, all the concrete types that can satisfy this type condition.
 
 
-### Type set
+### typeSet
 
 A set of type conditions from nested fragments and inline fragments. A type set can be abstract if no possible type will implement that exact type set. It is concrete else.
 

--- a/design-docs/Glossary.md
+++ b/design-docs/Glossary.md
@@ -7,8 +7,7 @@ A small Glossary of the terms used during codegen. The [GraphQL Spec](https://sp
 
 ### Response shape
 
-This is the shape of the actual json as returned by the server. A given query can have multiple shapes depending the different type conditions at each field. While Field trees are in the GraphQL domain, Response shapes are in the Json domain and different Field trees can have the same response shape (http://spec.graphql.org/draft/#SameResponseShape())
-
+This is the shape of the actual json as returned by the server. A given query can have multiple shapes depending on the different type conditions at each field. While selection sets are in the GraphQL domain, Response shapes are in the Json domain and different selection sets can have the same response shape (http://spec.graphql.org/draft/#SameResponseShape())
 
 ### Raw type
 
@@ -21,7 +20,7 @@ A leaf type that doesn't contain fields or input fields. It's either a scalar or
 
 ### Composite type
 
-A type that contains sub fields. It is an interface, object or union type
+A type that contains subfields. It is an interface, object or union type
 
 
 ### Concrete type

--- a/design-docs/Glossary.md
+++ b/design-docs/Glossary.md
@@ -2,22 +2,7 @@
 
 ## Glossary
 
-A small Glossary of the terms used during codegen. The [GraphQL Spec](https://spec.graphql.org/draft/) does a nice job of defining the common terms like `Field`, `SelectionSet`, etc... so I'm not adding these terms here. But it misses some concepts that we bumped across during codegen and that I'm trying to clarify here.
-
-
-### Field tree
-
-Every GraphQL operation queries a tree of fields starting from the root. Fields can be of scalar or compound type.
-
-
-### Fragment tree
-
-Each field in the field tree contains (possibly nested) fragments and inline fragments that define a tree of fragments. This makes a GraphQL query a somewhat 2-dimensional tree or “tree of tree” with a tree of fragments at each field node.
-
-
-### Field set
-
-A selection set containing only fields and no fragments. When combined they form a field tree.
+A small Glossary of the terms used during codegen. The [GraphQL Spec](https://spec.graphql.org/draft/) does a nice job of defining the common terms like `Field`, `SelectionSet`, etc... so I'm not adding these terms here. But it misses some concepts that we bumped into during codegen and that I'm trying to clarify here.
 
 
 ### Response shape
@@ -25,9 +10,9 @@ A selection set containing only fields and no fragments. When combined they form
 This is the shape of the actual json as returned by the server. A given query can have multiple shapes depending the different type conditions at each field. While Field trees are in the GraphQL domain, Response shapes are in the Json domain and different Field trees can have the same response shape (http://spec.graphql.org/draft/#SameResponseShape())
 
 
-### Scalar type
+### Leaf type
 
-A leaf type
+A leaf type that doesn't contain fields or input fields. It's either a scalar or an enum
 
 
 ### Composite type
@@ -93,30 +78,26 @@ type Panther implements Animal & WarmBlooded
 - [Animal, Pet] => [Turtle] (concrete)
 ```
 
+### parentType
 
-
-### Parent Type
-
-the type condition of the enclosing fragment in the fragment tree, if any or the type of the parent field if none
+the type condition of the enclosing fragment if any or else the type of the parent field 
 
 Example:
 
 ```
 {
     animal {
+        # parentType: Animal
         ... on Pet {
+            # parentType: Pet
             ...warmBlooded {
+                # parentType: WarmBlooded
                 temperature
             }
         }
     }
 }
 ```
-
-`Pet` is the ParentType of the `warmBlooded` fragment
-`WarmBlooded` is the ParentType of the `temperature` field
-
-
 
 ### Polymorphic field
 

--- a/tests/data-builders-java/src/test/java/test/DataBuilderTest.java
+++ b/tests/data-builders-java/src/test/java/test/DataBuilderTest.java
@@ -198,7 +198,7 @@ public class DataBuilderTest {
 
   static class MyFakeResolver implements FakeResolver {
     @NotNull @Override public Object resolveLeaf(@NotNull FakeResolverContext context) {
-      String name = context.getMergedField().getType().leafType().getName();
+      String name = context.getMergedField().getType().rawType().getName();
       Object ret = null;
       switch (name) {
         case "Long1": {

--- a/tests/data-builders-kotlin/src/test/kotlin/test/DataBuilderTest.kt
+++ b/tests/data-builders-kotlin/src/test/kotlin/test/DataBuilderTest.kt
@@ -168,7 +168,7 @@ class DataBuilderTest {
 
   class MyFakeResolver : FakeResolver {
     override fun resolveLeaf(context: FakeResolverContext): Any {
-      return when (context.mergedField.type.leafType().name) {
+      return when (context.mergedField.type.rawType().name) {
         "Long1" -> MyLong(45) // build-time
         "Long2" -> MyLong(46) // run-time
         "Long3" -> 47L // mapped to Any

--- a/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
@@ -101,7 +101,7 @@ class DeclarativeCacheTest {
           @Suppress("UNCHECKED_CAST")
           val isbns = field.resolveArgument("isbns", variables) as? List<String>
           if (isbns != null) {
-            return isbns.map { CacheKey.from(field.type.leafType().name, listOf(it)) }
+            return isbns.map { CacheKey.from(field.type.rawType().name, listOf(it)) }
           }
         }
 

--- a/tests/java-tests/src/test/java/test/ClientTest.java
+++ b/tests/java-tests/src/test/java/test/ClientTest.java
@@ -136,7 +136,7 @@ public class ClientTest {
 
     CacheKeyResolver cacheKeyResolver = new CacheKeyResolver() {
       @Override public CacheKey cacheKeyForField(@NotNull CompiledField field, @NotNull Executable.Variables variables) {
-        String typename = field.getType().leafType().getName();
+        String typename = field.getType().rawType().getName();
         Object id = field.resolveArgument("id", variables);
         if (id instanceof String) {
           return new CacheKey(typename, id.toString());

--- a/tests/models-fixtures/graphql/operations.graphql
+++ b/tests/models-fixtures/graphql/operations.graphql
@@ -10,9 +10,6 @@ fragment HeroWithFriendsFragment on Character {
     friends {
         ... HumanWithIdFragment
     }
-    ... on Droid {
-        primaryFunction
-    }
 }
 
 fragment HumanWithIdFragment on Human {

--- a/tests/models-fixtures/graphql/operations.graphql
+++ b/tests/models-fixtures/graphql/operations.graphql
@@ -10,6 +10,9 @@ fragment HeroWithFriendsFragment on Character {
     friends {
         ... HumanWithIdFragment
     }
+    ... on Droid {
+        primaryFunction
+    }
 }
 
 fragment HumanWithIdFragment on Human {

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPagePaginationTest.kt
@@ -178,7 +178,7 @@ class OffsetBasedWithPagePaginationTest {
 
   private class OffsetPaginationMetadataGenerator(private val typeName: String) : MetadataGenerator {
     override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
-      if (context.field.type.leafType().name == typeName) {
+      if (context.field.type.rawType().name == typeName) {
         return mapOf("offset" to context.argumentValue("offset"))
       }
       return emptyMap()


### PR DESCRIPTION
Ongoing work to document the compiler a bit more:
- typeInScope -> parentType: because this is what the spec uses. I find it a bit misling because "parent" could refer to the "parent" field or to the "parent" selection set but consistency with the spec is better here.
- typeDefinitionInScope -> parentTypeDefinition: same reason
- leafType -> rawType: a leaf type could be understood as a non-composite type (enum or scalar). We actually use this in some places in our codebase. Using `rawType` makes it clear this is for a named type without any non-null/list wrapper type

Edit: didn't realize I had `id` -> `path` changes in there... removing them for now
Edit2: they should be all gone now