### PR TITLE
Connect test sourceSet only when testBuilders are enabled

### DIFF
--- a/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -297,16 +297,19 @@ abstract class DefaultApolloExtension(
         )
     )
 
-    if (service.testDirAction == null) {
-      service.testDirAction = defaultTestDirAction
+    @Suppress("DEPRECATION")
+    if (service.generateTestBuilders.getOrElse(false)) {
+      if (service.testDirAction == null) {
+        service.testDirAction = defaultTestDirAction
+      }
+      service.testDirAction!!.execute(
+          DefaultDirectoryConnection(
+              project = project,
+              task = codegenProvider,
+              outputDir = codegenProvider.flatMap { it.testDir }
+          )
+      )
     }
-    service.testDirAction!!.execute(
-        DefaultDirectoryConnection(
-            project = project,
-            task = codegenProvider,
-            outputDir = codegenProvider.flatMap { it.testDir }
-        )
-    )
 
     rootProvider.configure {
       it.dependsOn(codegenProvider)


### PR DESCRIPTION
When not using test builders, it is not necessary for the test Kotlin compile tasks to depend on the `generateXXXApolloSources`.

Related to https://github.com/apollographql/apollo-kotlin/issues/2492#issuecomment-1259434936