### PR TITLE
🧽  Make the build output less noisy

### DIFF
--- a/apollo-adapters/src/appleMain/kotlin/com/apollographql/apollo3/adapter/BigDecimal.kt
+++ b/apollo-adapters/src/appleMain/kotlin/com/apollographql/apollo3/adapter/BigDecimal.kt
@@ -23,6 +23,7 @@ actual class BigDecimal internal constructor(private val raw: NSDecimalNumber) :
   actual fun negate(): BigDecimal = BigDecimal(NSDecimalNumber(int = 0).decimalNumberBySubtracting(raw))
 
   actual fun signum(): Int {
+    @OptIn(kotlinx.cinterop.UnsafeNumber::class)
     val result = raw.compare(NSDecimalNumber(int = 0)).toInt()
     return when {
       result < 0 -> -1

--- a/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -32,6 +32,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.file.UnionBuilder
 import com.apollographql.apollo3.compiler.ir.Ir
 import com.apollographql.apollo3.compiler.operationoutput.OperationOutput
 import com.apollographql.apollo3.compiler.operationoutput.findOperationId
+import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/TestQuery.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/TestQuery.kt.expected
@@ -14,11 +14,11 @@ import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
 import com.example.custom_scalar_type.adapter.TestQuery_ResponseAdapter
 import com.example.custom_scalar_type.selections.TestQuerySelections
-import java.lang.Long
 import java.util.Date
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
+import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
@@ -60,7 +60,7 @@ public class TestQuery() : Query<TestQuery.Data> {
       /**
        * The name of the character
        */
-      public val name: java.lang.String,
+      public val name: String,
       /**
        * The date character was born.
        */
@@ -76,11 +76,11 @@ public class TestQuery() : Query<TestQuery.Data> {
       /**
        * Profile link
        */
-      public val profileLink: java.lang.String,
+      public val profileLink: String,
       /**
        * Links
        */
-      public val links: List<java.lang.String>,
+      public val links: List<String>,
     )
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/adapter/TestQuery_ResponseAdapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/adapter/TestQuery_ResponseAdapter.kt.expected
@@ -15,9 +15,9 @@ import com.apollographql.apollo3.api.nullable
 import com.apollographql.apollo3.api.obj
 import com.example.custom_scalar_type.TestQuery
 import com.example.custom_scalar_type.type.GraphQLID
-import java.lang.Long
 import java.util.Date
 import kotlin.Any
+import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
@@ -58,12 +58,12 @@ public object TestQuery_ResponseAdapter {
       public override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
           TestQuery.Data.Hero {
         var _id: Long? = null
-        var _name: java.lang.String? = null
+        var _name: String? = null
         var _birthDate: Date? = null
         var _appearanceDates: List<Date>? = null
         var _fieldWithUnsupportedType: Any? = null
-        var _profileLink: java.lang.String? = null
-        var _links: List<java.lang.String>? = null
+        var _profileLink: String? = null
+        var _links: List<String>? = null
 
         while(true) {
           when (reader.selectName(RESPONSE_NAMES)) {

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLID.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLID.kt.expected
@@ -15,6 +15,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLID {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("ID", "java.lang.Long")
+    public val type: CustomScalarType = CustomScalarType("ID", "kotlin.Long")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLString.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLString.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLString {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("String", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("String", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/URL.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/URL.kt.expected
@@ -12,6 +12,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class URL {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("URL", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("URL", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/TestQuery.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/TestQuery.kt.expected
@@ -57,7 +57,7 @@ public data class TestQuery(
       /**
        * Comment about the movie
        */
-      public val commentary: java.lang.String?,
+      public val commentary: String?,
     )
   }
 

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/adapter/TestQuery_ResponseAdapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/adapter/TestQuery_ResponseAdapter.kt.expected
@@ -53,7 +53,7 @@ public object TestQuery_ResponseAdapter {
       public override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
           TestQuery.Data.CreateReview {
         var _stars: Int? = null
-        var _commentary: java.lang.String? = null
+        var _commentary: String? = null
 
         while(true) {
           when (reader.selectName(RESPONSE_NAMES)) {

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLID.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLID.kt.expected
@@ -15,6 +15,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLID {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("ID", "java.lang.Long")
+    public val type: CustomScalarType = CustomScalarType("ID", "kotlin.Long")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLString.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLString.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLString {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("String", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("String", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewInput.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewInput.kt.expected
@@ -6,10 +6,10 @@
 package com.example.input_object_type.type
 
 import com.apollographql.apollo3.api.Optional
-import java.lang.String
 import java.util.Date
 import kotlin.Boolean
 import kotlin.Int
+import kotlin.String
 import kotlin.collections.List
 
 /**

--- a/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/URL.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/URL.kt.expected
@@ -12,6 +12,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class URL {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("URL", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("URL", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,11 +2,11 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  204076
-aggregate-kotlin-responseBased                                                                  52619
+aggregate-all                                                                                  204157
+aggregate-kotlin-responseBased                                                                  52273
 aggregate-kotlin-operationBased                                                                 35445
 aggregate-kotlin-compat                                                                         36830
-aggregate-java-operationBased                                                                   79182
+aggregate-java-operationBased                                                                   79609
 
 java-operationBased-fragments_with_defer_and_include_directives                                  5566
 kotlin-compat-fragments_with_defer_and_include_directives                                        3612
@@ -14,22 +14,22 @@ kotlin-operationBased-fragments_with_defer_and_include_directives               
 kotlin-responseBased-fragment_with_inline_fragment                                               2378
 java-operationBased-fragment_with_inline_fragment                                                2172
 java-operationBased-nested_named_fragments                                                       1857
-java-operationBased-mutation_create_review                                                       1795
-java-operationBased-__schema                                                                     1703
+java-operationBased-mutation_create_review                                                       1787
+java-operationBased-__schema                                                                     1694
 java-operationBased-union_inline_fragments                                                       1630
 java-operationBased-unique_type_name                                                             1611
-java-operationBased-input_object_type                                                            1606
 java-operationBased-inline_fragment_intersection                                                 1598
-java-operationBased-mutation_create_review_semantic_naming                                       1591
+java-operationBased-input_object_type                                                            1598
 kotlin-responseBased-nested_named_fragments                                                      1591
+java-operationBased-mutation_create_review_semantic_naming                                       1582
 java-operationBased-root_query_fragment_with_nested_fragments                                    1561
 kotlin-compat-fragment_with_inline_fragment                                                      1486
 java-operationBased-named_fragment_delegate                                                      1458
-java-operationBased-named_fragment_with_variables                                                1387
+java-operationBased-named_fragment_with_variables                                                1386
 kotlin-responseBased-named_fragment_delegate                                                     1339
 kotlin-responseBased-unique_type_name                                                            1323
 kotlin-compat-nested_named_fragments                                                             1310
-java-operationBased-nested_conditional_inline                                                    1304
+java-operationBased-nested_conditional_inline                                                    1303
 java-operationBased-fragment_used_twice                                                          1271
 java-operationBased-multiple_fragments                                                           1260
 java-operationBased-nested_field_with_multiple_fieldsets                                         1254
@@ -42,7 +42,7 @@ kotlin-responseBased-inline_fragment_intersection                               
 kotlin-compat-inline_fragment_intersection                                                       1174
 java-operationBased-named_fragment_inside_inline_fragment                                        1157
 java-operationBased-fragments_with_type_condition                                                1152
-java-operationBased-target_name                                                                  1142
+java-operationBased-target_name                                                                  1139
 kotlin-compat-unique_type_name                                                                   1123
 kotlin-operationBased-inline_fragment_intersection                                               1111
 kotlin-operationBased-union_inline_fragments                                                     1111
@@ -60,6 +60,10 @@ java-operationBased-inline_fragments_with_friends                               
 java-operationBased-fragment_spread_with_nested_fields                                           1028
 kotlin-responseBased-multiple_fragments                                                          1028
 kotlin-responseBased-mutation_create_review                                                      1026
+java-operationBased-java_guava_optionals                                                         1023
+java-operationBased-java_java_optionals                                                          1023
+java-operationBased-java_apollo_optionals                                                        1022
+java-operationBased-java_primitive_types                                                         1022
 kotlin-operationBased-root_query_fragment_with_nested_fragments                                  1019
 kotlin-responseBased-simple_fragment_with_inline_fragments                                       1019
 kotlin-responseBased-nested_conditional_inline                                                   1008
@@ -75,11 +79,7 @@ java-operationBased-deprecated_merged_field                                     
 kotlin-compat-named_fragment_with_variables                                                       919
 java-operationBased-hero_details                                                                  918
 java-operationBased-not_all_combinations_are_needed                                               916
-java-operationBased-java_apollo_optionals                                                         907
-java-operationBased-java_primitive_types                                                          906
 java-operationBased-inline_fragment_with_include_directive                                        905
-java-operationBased-java_guava_optionals                                                          903
-java-operationBased-java_java_optionals                                                           903
 java-operationBased-fieldset_with_multiple_super                                                  900
 java-operationBased-simple_inline_fragment                                                        900
 kotlin-compat-multiple_fragments                                                                  883
@@ -127,7 +127,7 @@ java-operationBased-interface_on_interface                                      
 kotlin-compat-fragment_spread_with_nested_fields                                                  709
 kotlin-operationBased-inline_fragments_with_friends                                               708
 kotlin-responseBased-fragments_same_type_condition                                                707
-java-operationBased-input_object_variable_and_argument                                            705
+java-operationBased-input_object_variable_and_argument                                            704
 kotlin-compat-root_query_inline_fragment                                                          700
 java-operationBased-root_query_fragment                                                           697
 kotlin-operationBased-simple_fragment_with_inline_fragments                                       695
@@ -138,7 +138,7 @@ kotlin-compat-fragments_same_type_condition                                     
 java-operationBased-monomorphic                                                                   670
 kotlin-compat-simple_union                                                                        670
 java-operationBased-interface_always_nested                                                       668
-java-operationBased-deprecation                                                                   667
+java-operationBased-deprecation                                                                   666
 kotlin-compat-deprecated_merged_field                                                             662
 kotlin-compat-inline_fragment_with_include_directive                                              656
 kotlin-compat-union_fragment                                                                      654
@@ -154,11 +154,11 @@ kotlin-responseBased-test_inline                                                
 kotlin-compat-fieldset_with_multiple_super                                                        632
 kotlin-responseBased-fragment_with_multiple_fieldsets                                             629
 java-operationBased-field_with_include_directive                                                  628
-java-operationBased-hero_name_query_long_name                                                     628
+java-operationBased-hero_name_query_long_name                                                     627
 kotlin-compat-named_fragment_without_implementation                                               626
 kotlin-responseBased-named_fragment_without_implementation                                        622
-java-operationBased-variable_default_value                                                        620
 kotlin-operationBased-deprecated_merged_field                                                     619
+java-operationBased-variable_default_value                                                        619
 kotlin-responseBased-hero_details                                                                 615
 kotlin-operationBased-inline_fragment_inside_inline_fragment                                      615
 kotlin-operationBased-not_all_combinations_are_needed                                             615
@@ -200,7 +200,7 @@ kotlin-compat-path_vs_flat_accessors                                            
 kotlin-operationBased-fragment_with_multiple_fieldsets                                            524
 kotlin-responseBased-input_object_variable_and_argument                                           519
 kotlin-responseBased-root_query_fragment                                                          519
-java-operationBased-antlr_tokens                                                                  518
+java-operationBased-antlr_tokens                                                                  517
 kotlin-responseBased-typename_always_first                                                        516
 kotlin-responseBased-interface_on_interface                                                       513
 java-operationBased-subscriptions                                                                 512
@@ -254,7 +254,6 @@ kotlin-responseBased-java8annotation                                            
 kotlin-responseBased-antlr_tokens                                                                 374
 kotlin-responseBased-arguments_hardcoded                                                          365
 kotlin-responseBased-subscriptions                                                                362
-kotlin-responseBased-enums_as_sealed                                                              346
 kotlin-responseBased-operation_id_generator                                                       327
 kotlin-responseBased-merged_include                                                               325
 kotlin-responseBased-big_query                                                                    319

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/CreateReviewForEpisode.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/CreateReviewForEpisode.kt.expected
@@ -59,11 +59,11 @@ internal data class CreateReviewForEpisode(
       /**
        * Comment about the movie
        */
-      public val commentary: java.lang.String?,
+      public val commentary: String?,
       /**
        * for test purpose only
        */
-      public val listOfListOfString: List<List<java.lang.String>>?,
+      public val listOfListOfString: List<List<String>>?,
       /**
        * for test purpose only
        */
@@ -81,7 +81,7 @@ internal data class CreateReviewForEpisode(
         /**
          * The name of the character
          */
-        public val name: java.lang.String,
+        public val name: String,
       )
     }
   }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/adapter/CreateReviewForEpisode_ResponseAdapter.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/adapter/CreateReviewForEpisode_ResponseAdapter.kt.expected
@@ -58,8 +58,8 @@ internal object CreateReviewForEpisode_ResponseAdapter {
       public override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
           CreateReviewForEpisode.Data.CreateReview {
         var _stars: Int? = null
-        var _commentary: java.lang.String? = null
-        var _listOfListOfString: List<List<java.lang.String>>? = null
+        var _commentary: String? = null
+        var _listOfListOfString: List<List<String>>? = null
         var _listOfListOfEnum: List<List<Episode>>? = null
         var _listOfListOfCustom: List<List<Date>>? = null
         var _listOfListOfObject: List<List<CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject>>? = null
@@ -127,7 +127,7 @@ internal object CreateReviewForEpisode_ResponseAdapter {
         public override fun fromJson(reader: JsonReader,
             customScalarAdapters: CustomScalarAdapters):
             CreateReviewForEpisode.Data.CreateReview.ListOfListOfObject {
-          var _name: java.lang.String? = null
+          var _name: String? = null
 
           while(true) {
             when (reader.selectName(RESPONSE_NAMES)) {

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLID.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLID.kt.expected
@@ -15,6 +15,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class GraphQLID {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("ID", "java.lang.Long")
+    public val type: CustomScalarType = CustomScalarType("ID", "kotlin.Long")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLString.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLString.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class GraphQLString {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("String", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("String", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/ReviewInput.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/ReviewInput.kt.expected
@@ -6,10 +6,10 @@
 package com.example.mutation_create_review.type
 
 import com.apollographql.apollo3.api.Optional
-import java.lang.String
 import java.util.Date
 import kotlin.Boolean
 import kotlin.Int
+import kotlin.String
 import kotlin.collections.List
 
 /**

--- a/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/URL.kt.expected
+++ b/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/URL.kt.expected
@@ -12,6 +12,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class URL {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("URL", "java.lang.String")
+    public val type: CustomScalarType = CustomScalarType("URL", "kotlin.String")
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/KotlinCompiler.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/KotlinCompiler.kt
@@ -15,7 +15,6 @@ object KotlinCompiler {
       sources = kotlinFiles
 
       this.allWarningsAsErrors = allWarningsAsErrors
-      this.suppressWarnings
       inheritClassPath = true
       verbose = false
     }.compile()

--- a/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/KotlinCompiler.kt
+++ b/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/KotlinCompiler.kt
@@ -15,8 +15,9 @@ object KotlinCompiler {
       sources = kotlinFiles
 
       this.allWarningsAsErrors = allWarningsAsErrors
+      this.suppressWarnings
       inheritClassPath = true
-      verbose = true
+      verbose = false
     }.compile()
 
     if (result.exitCode != KotlinCompilation.ExitCode.OK) {

--- a/apollo-compiler/src/test/kotlin/com/example/MyStringAdapter.kt
+++ b/apollo-compiler/src/test/kotlin/com/example/MyStringAdapter.kt
@@ -5,13 +5,12 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-class MyStringAdapter : Adapter<java.lang.String> {
-  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): java.lang.String {
-    return reader.nextString()!! as java.lang.String
+class MyStringAdapter : Adapter<String> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): String {
+    return reader.nextString()!!
   }
 
-  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: java.lang.String) {
-    writer.value(value as String)
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: String) {
+    writer.value(value)
   }
 }

--- a/apollo-compiler/src/test/kotlin/com/example/UrlAdapter.kt
+++ b/apollo-compiler/src/test/kotlin/com/example/UrlAdapter.kt
@@ -5,13 +5,12 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 
-@Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
-object UrlAdapter : Adapter<java.lang.String> {
-  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): java.lang.String {
-    return reader.nextString()!! as java.lang.String
+object UrlAdapter : Adapter<String> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): String {
+    return reader.nextString()!!
   }
 
-  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: java.lang.String) {
-    writer.value(value as String)
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: String) {
+    writer.value(value)
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ConfigurationCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ConfigurationCacheTests.kt
@@ -27,7 +27,7 @@ class ConfigurationCacheTests {
 
     dir.resolve("build.gradle.kts").replaceInText("ENDPOINT", server.url("/").toString())
 
-    val buildResult = TestUtils.executeGradle(
+    TestUtils.executeGradle(
         dir,
         "--configuration-cache",
         "generateApolloSources",

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DeprecationTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DeprecationTests.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.gradle.test
 
 import com.apollographql.apollo3.gradle.util.TestUtils
 import com.google.common.truth.Truth
-import junit.framework.Assert.fail
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Assert
@@ -44,7 +43,7 @@ class DeprecationTests {
       """.trimIndent())
       try {
         TestUtils.executeTask("generateServiceApolloSources", dir)
-        fail("generateServiceApolloSources was expected to fail")
+        Assert.fail("generateServiceApolloSources was expected to fail")
       } catch (e: UnexpectedBuildFailure) {
         Truth.assertThat(e.message).contains("Warnings found and 'failOnWarnings' is true, aborting")
       }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleBuildCacheTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleBuildCacheTests.kt
@@ -25,12 +25,10 @@ class GradleBuildCacheTests {
         replaceInText("../../..", "../../../..")
       }
 
-      println("Generate sources project1")
       var result = TestUtils.executeTask("generateServiceApolloSources", project1, "--build-cache")
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":module:generateServiceApolloSources")!!.outcome)
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":checkServiceApolloDuplicates")!!.outcome)
 
-      println("Generate sources project2")
       result = TestUtils.executeTask("generateServiceApolloSources", project2, "--build-cache")
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":module:generateServiceApolloSources")!!.outcome)
       Assert.assertEquals(TaskOutcome.FROM_CACHE, result.task(":checkServiceApolloDuplicates")!!.outcome)

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleVersionTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleVersionTests.kt
@@ -5,9 +5,9 @@ import com.apollographql.apollo3.gradle.internal.DefaultApolloExtension.Companio
 import com.apollographql.apollo3.gradle.util.TestUtils
 import com.apollographql.apollo3.gradle.util.TestUtils.withTestProject
 import com.google.common.truth.Truth
-import junit.framework.Assert.fail
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Assert
 import org.junit.Test
 import java.io.File
 
@@ -34,7 +34,7 @@ class GradleVersionTests {
       dir.setApolloPluginVersion()
       try {
         TestUtils.executeGradleWithVersion(dir, "5.4","generateApolloSources")
-        fail("Compiling with an old version of Gradle should fail")
+        Assert.fail("Compiling with an old version of Gradle should fail")
       } catch (e: UnexpectedBuildFailure) {
         Truth.assertThat(e.message).contains("apollo-android requires Gradle version $MIN_GRADLE_VERSION or greater")
       }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/KotlinDSLTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/KotlinDSLTests.kt
@@ -2,9 +2,9 @@ package com.apollographql.apollo3.gradle.test
 
 import com.apollographql.apollo3.gradle.util.TestUtils
 import com.apollographql.apollo3.gradle.util.generatedChild
+import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.hamcrest.CoreMatchers
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -36,7 +36,7 @@ class KotlinDSLTests {
         TestUtils.executeGradle(dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        Assert.assertThat(e.message, CoreMatchers.containsString("Unresolved reference: services"))
+        Truth.assertThat(e.message).contains("Unresolved reference: services")
       }
       Assert.assertNotNull(exception)
     }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
@@ -4,8 +4,6 @@ import com.apollographql.apollo3.compiler.ApolloMetadata
 import com.apollographql.apollo3.gradle.util.TestUtils
 import com.apollographql.apollo3.gradle.util.replaceInText
 import com.google.common.truth.Truth
-import junit.framework.Assert.assertTrue
-import junit.framework.Assert.fail
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Assert
@@ -46,7 +44,7 @@ class MultiModulesTests {
     TestUtils.withTestProject("multi-modules-duplicates") { dir ->
       try {
         TestUtils.executeTask(":node1:generateApolloSources", dir)
-        fail("the build did not detect duplicate classes")
+        Assert.fail("the build did not detect duplicate classes")
       } catch (e: UnexpectedBuildFailure) {
         Truth.assertThat(e.message).contains("duplicate")
         Truth.assertThat(e.message).contains("in modules: node1,node2")
@@ -75,13 +73,13 @@ class MultiModulesTests {
     TestUtils.withTestProject("multi-modules-custom-scalar") { dir ->
       TestUtils.executeTaskAndAssertSuccess(":leaf:assemble", dir)
       // Date is generated in the root module
-      assertTrue(File(dir, "root/build/generated/source/apollo/service/com/library/type/Date.kt").exists())
+      Assert.assertTrue(File(dir, "root/build/generated/source/apollo/service/com/library/type/Date.kt").exists())
       // Leaf metadata doesn't contain anything regarding Date
       val metadata = ApolloMetadata.readFrom(File(dir, "leaf/build/generated/metadata/apollo/service/metadata.json"))
       Truth.assertThat(metadata.compilerMetadata.resolverInfo.entries.map { it.key.id }).doesNotContain("Date")
       // But contains GeoPoint
       Truth.assertThat(metadata.compilerMetadata.resolverInfo.entries.map { it.key.id }).doesNotContain("Date")
-      assertTrue(File(dir, "leaf/build/generated/source/apollo/service/com/library/type/GeoPoint.kt").exists())
+      Assert.assertTrue(File(dir, "leaf/build/generated/source/apollo/service/com/library/type/GeoPoint.kt").exists())
     }
   }
 
@@ -90,7 +88,7 @@ class MultiModulesTests {
     TestUtils.withTestProject("multi-modules-custom-scalar-defined-in-leaf") { dir ->
       try {
         TestUtils.executeTaskAndAssertSuccess(":leaf:assemble", dir)
-        fail("the build did not detect scalar mapping registered in leaf module")
+        Assert.fail("the build did not detect scalar mapping registered in leaf module")
       } catch (e: UnexpectedBuildFailure) {
         Truth.assertThat(e.message).contains("Mapping scalars can only be done in the schema module")
       }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/OperationIdGeneratorTests.kt
@@ -5,11 +5,10 @@ import com.apollographql.apollo3.gradle.util.TestUtils.withSimpleProject
 import com.apollographql.apollo3.gradle.util.TestUtils.withTestProject
 import com.apollographql.apollo3.gradle.util.generatedChild
 import com.apollographql.apollo3.gradle.util.replaceInText
-import junit.framework.Assert.assertTrue
+import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
-import org.hamcrest.CoreMatchers
 import org.junit.Assert
-import org.junit.Ignore
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
 
@@ -132,10 +131,8 @@ class OperationIdGeneratorTests {
 
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateServiceApolloSources")!!.outcome)
 
-      Assert.assertThat(
-          dir.generatedChild("service/com/example/GreetingQuery.kt").readText(),
-          CoreMatchers.containsString("OPERATION_ID: String = \"GreetingCustomId\"")
-      )
+      Truth.assertThat(dir.generatedChild("service/com/example/GreetingQuery.kt").readText())
+          .contains("OPERATION_ID: String = \"GreetingCustomId\"")
 
       // Change the implementation of the operation ID generator and check again
       File(dir,"build.gradle.kts").replaceInText("CustomId", "anotherCustomId")
@@ -145,10 +142,8 @@ class OperationIdGeneratorTests {
 
       Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":generateServiceApolloSources")!!.outcome)
 
-      Assert.assertThat(
-          dir.generatedChild("service/com/example/GreetingQuery.kt").readText(),
-          CoreMatchers.containsString("anotherCustomId")
-      )
+      Truth.assertThat(dir.generatedChild("service/com/example/GreetingQuery.kt").readText())
+          .contains("anotherCustomId")
     }
   }
 }

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/ServiceTests.kt
@@ -9,11 +9,9 @@ import com.apollographql.apollo3.gradle.util.replaceInText
 import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
-import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -216,7 +214,7 @@ class ServiceTests {
         TestUtils.executeTask("generateApolloSources", dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        assertThat(e.message, containsString("All apollo versions should be the same"))
+        Truth.assertThat(e.message).contains("All apollo versions should be the same")
       }
       assertNotNull(exception)
     }
@@ -238,7 +236,7 @@ class ServiceTests {
         TestUtils.executeTask("checkApolloVersions", dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        assertThat(e.message, containsString("All apollo versions should be the same"))
+        Truth.assertThat(e.message).contains("All apollo versions should be the same")
       }
       assertNotNull(exception)
     }
@@ -252,7 +250,7 @@ class ServiceTests {
         TestUtils.executeTask("generateApolloSources", dir)
       } catch (e: UnexpectedBuildFailure) {
         exception = e
-        assertThat(e.message, containsString("All apollo versions should be the same"))
+        Truth.assertThat(e.message).contains("All apollo versions should be the same")
       }
       assertNotNull(exception)
     }
@@ -279,10 +277,10 @@ class ServiceTests {
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
       val expectedOperationId = "292319c237e71c9dfec7a7d7f993e9c91bd81361a786f251840e105f4b6c9145"
       val operationOutput = File(dir, "build/generated/operationOutput/apollo/service/operationOutput.json")
-      assertThat(operationOutput.readText(), containsString(expectedOperationId))
+      Truth.assertThat(operationOutput.readText()).contains(expectedOperationId)
 
       val queryJavaFile = dir.generatedChild("service/com/example/DroidDetailsQuery.kt")
-      assertThat(queryJavaFile.readText(), containsString(expectedOperationId))
+      Truth.assertThat(queryJavaFile.readText()).contains(expectedOperationId)
     }
   }
 
@@ -370,13 +368,13 @@ class ServiceTests {
       TestUtils.executeTask("build", dir)
 
       assertTrue(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").isFile)
-      assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText(), containsString("internal class"))
+      Truth.assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText()).contains("internal class")
 
       assertTrue(dir.generatedChild("service/com/example/type/DateTime.kt").isFile)
-      assertThat(dir.generatedChild("service/com/example/type/DateTime.kt").readText(), containsString("internal class DateTime"))
+      Truth.assertThat(dir.generatedChild("service/com/example/type/DateTime.kt").readText()).contains("internal class DateTime")
 
       assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
-      assertThat(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").readText(), containsString("internal data class"))
+      Truth.assertThat(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").readText()).contains("internal data class")
     }
   }
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/UpToDateTests.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/UpToDateTests.kt
@@ -5,11 +5,9 @@ import com.apollographql.apollo3.gradle.util.TestUtils
 import com.apollographql.apollo3.gradle.util.TestUtils.withSimpleProject
 import com.apollographql.apollo3.gradle.util.generatedChild
 import com.apollographql.apollo3.gradle.util.replaceInText
+import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
-import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertThat
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.io.File
@@ -35,7 +33,7 @@ class UpToDateTests {
     assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
   }
 
-  fun `nothing changed, task up to date`(dir: File) {
+  private fun `nothing changed, task up to date`(dir: File) {
     val result = TestUtils.executeTask("generateApolloSources", dir)
 
     assertEquals(TaskOutcome.UP_TO_DATE, result.task(":generateApolloSources")!!.outcome)
@@ -46,7 +44,7 @@ class UpToDateTests {
     assertTrue(dir.generatedChild("service/com/example/fragment/SpeciesInformation.kt").isFile)
   }
 
-  fun `adding a custom scalar to the build script re-generates the CustomScalars`(dir: File) {
+  private fun `adding a custom scalar to the build script re-generates the CustomScalars`(dir: File) {
     val apolloBlock = """
       
       apollo {
@@ -74,14 +72,14 @@ class UpToDateTests {
       var result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText(), containsString("classification"))
+      Truth.assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText()).contains("classification")
 
       File(dir, "src/main/graphql/com/example/DroidDetails.graphql").replaceInText("classification", "")
 
       result = TestUtils.executeTask("generateApolloSources", dir, "-i")
 
       assertEquals(TaskOutcome.SUCCESS, result.task(":generateApolloSources")!!.outcome)
-      assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText(), not(containsString("classification")))
+      Truth.assertThat(dir.generatedChild("service/com/example/DroidDetailsQuery.kt").readText()).doesNotContain("classification")
     }
   }
 

--- a/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -1,13 +1,13 @@
 package com.apollographql.apollo3.gradle.util
 
 
+import com.google.common.truth.Truth
+import okio.blackholeSink
+import okio.buffer
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
 import org.junit.Assert
-import org.junit.Assert.assertThat
 import java.io.File
 
 object TestUtils {
@@ -33,7 +33,7 @@ object TestUtils {
     block(dest)
 
     // It's ok to not delete the directory as it will be deleted before next test
-    // During developement, it's easy to keep the testProject around to investigate if something goes wrong
+    // During development, it's easy to keep the testProject around to investigate if something goes wrong
     // dest.deleteRecursively()
   }
 
@@ -162,9 +162,12 @@ object TestUtils {
   }
 
   fun executeGradleWithVersion(projectDir: File, gradleVersion: String?, vararg args: String): BuildResult {
+    val output = blackholeSink().buffer()
+    val error = blackholeSink().buffer()
+
     return GradleRunner.create()
-        .forwardStdOutput(System.out.writer())
-        .forwardStdError(System.err.writer())
+        .forwardStdOutput(output.outputStream().writer())
+        .forwardStdError(error.outputStream().writer())
         .withProjectDir(projectDir)
         .withDebug(true)
         .withArguments("--stacktrace", *args)
@@ -182,17 +185,7 @@ object TestUtils {
 
   fun assertFileContains(projectDir: File, path: String, content: String) {
     val text = projectDir.generatedChild(path).readText()
-    assertThat(text, containsString(content))
-  }
-
-  fun assertFileDoesNotContain(projectDir: File, path: String, content: String) {
-    val text = projectDir.generatedChild(path).readText()
-    assertThat(text, not(containsString(content)))
-  }
-
-  fun fileContains(projectDir: File, path: String, content: String): Boolean {
-    return projectDir.generatedChild(path).readText()
-        .contains(content)
+    Truth.assertThat(text).contains(content)
   }
 
   fun fixturesDirectory() = File(System.getProperty("user.dir"), "src/test/files")

--- a/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/cwd.kt
+++ b/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/cwd.kt
@@ -11,6 +11,7 @@ fun cwd(): String {
   return memScoped {
     val maxSize = 1024
     val buf = allocArray<ByteVar>(maxSize)
+    @OptIn(kotlinx.cinterop.UnsafeNumber::class)
     getcwd(buf, maxSize.convert())?.toKString() ?: "?"
   }
 }

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -13,6 +13,7 @@ import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.AbstractDokkaTask
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.dokka.gradle.DokkaTaskPartial
+import com.android.build.api.dsl.LibraryExtension
 
 fun Project.configurePublishing() {
   apply {
@@ -27,6 +28,11 @@ fun Project.configurePublishing() {
   }
   pluginManager.withPlugin("org.jetbrains.kotlin.multiplatform") {
     configureDokka()
+  }
+  pluginManager.withPlugin("com.android.library") {
+    extensions.findByType(LibraryExtension::class.java)!!.publishing {
+      singleVariant("release")
+    }
   }
   configurePublishingInternal()
 }


### PR DESCRIPTION
Keeping the campsite clean. This shut downs a bunch of logs in the build output