### PR TITLE
Defer Router e2e updates

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/AdapterContext.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/AdapterContext.kt
@@ -19,7 +19,7 @@ class AdapterContext private constructor(
     }
 
     return variables.valueMap.filter {
-      it.value == true
+      it.value == false
     }.keys
   }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
@@ -136,7 +136,7 @@ fun BooleanExpression<BTerm>.evaluate(
   val croppedPath = path?.drop(1)
   return evaluate {
     when (it) {
-      is BVariable -> variables.contains(it.name)
+      is BVariable -> !variables.contains(it.name)
       is BLabel -> adapterContext.hasDeferredFragment(croppedPath!!, it.label)
       is BPossibleTypes -> it.possibleTypes.contains(typename)
     }


### PR DESCRIPTION
A few releases of Router have been released and I looked at un-ignoring some of the e2e tests.

The test `doesNotDisableDeferWithNullIfArgument` was failing because of an issue on our side: when using `@defer(if=$variable)` and `variable` is not specified, it should default to `true`.

I found a simple but a bit 'hacky' fix. Here we re-use `BVariable` which was originally made to handle `@skip` and `@include`'s `if`, which is not nullable. We were passing the variables whose values were `true` and then checked if the variable in question is there.

Instead we can pass the variables whose values are `false`, and check that the variable in question is _not_ there. This effectively defaults to `true`, which is what we need for `@defer`, and doesn't impact `@skip` / `@include` since it cannot be omitted.

1 other test (`canDeferFragmentsOnTheTopLevelQueryField`) is still ignored because of a different Router issue

2 other tests are still ignored as the Router issues are pending.