### PR TITLE
`apollo-runtime-java` add some Rx bindings

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -59,6 +59,7 @@ apollo-plugin = { group = "com.apollographql.apollo3", name = "apollo-gradle-plu
 apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apollo" }
 apollo-runtime-java = { group = "com.apollographql.apollo3", name = "apollo-runtime-java", version.ref = "apollo" }
 apollo-rx2 = { group = "com.apollographql.apollo3", name = "apollo-rx2-support", version.ref = "apollo" }
+apollo-rx3-java = { group = "com.apollographql.apollo3", name = "apollo-rx3-support-java", version.ref = "apollo" }
 apollo-testingsupport = { group = "com.apollographql.apollo3", name = "apollo-testing-support", version.ref = "apollo" }
 assertj = { group = "org.assertj", name = "assertj-core", version = "3.21.0" }
 atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version = "0.17.0" }

--- a/libraries/apollo-rx2-support-java/api/apollo-rx2-support-java.api
+++ b/libraries/apollo-rx2-support-java/api/apollo-rx2-support-java.api
@@ -1,0 +1,6 @@
+public class com/apollographql/apollo3/rx2/java/Rx2Apollo {
+	public fun <init> ()V
+	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/BackpressureStrategy;)Lio/reactivex/Flowable;
+	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/BackpressureStrategy;)Lio/reactivex/Single;
+}
+

--- a/libraries/apollo-rx2-support-java/build.gradle.kts
+++ b/libraries/apollo-rx2-support-java/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("apollo.library")
+}
+
+apolloLibrary {
+  javaModuleName("com.apollographql.apollo3.rx2.java")
+}
+
+dependencies {
+  api(golatac.lib("rx.java2"))
+  api(project(":libraries:apollo-runtime-java"))
+}

--- a/libraries/apollo-rx2-support-java/gradle.properties
+++ b/libraries/apollo-rx2-support-java/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=apollo-rx2-support-java
+POM_NAME=Apollo GraphQL Rx2 Support for Java
+POM_DESCRIPTION=Apollo GraphQL RxJava2 bindings for Java
+POM_PACKAGING=jar

--- a/libraries/apollo-rx2-support-java/src/main/java/com/apollographql/apollo3/rx2/java/Rx2Apollo.java
+++ b/libraries/apollo-rx2-support-java/src/main/java/com/apollographql/apollo3/rx2/java/Rx2Apollo.java
@@ -1,0 +1,57 @@
+package com.apollographql.apollo3.rx2.java;
+
+import com.apollographql.apollo3.api.ApolloResponse;
+import com.apollographql.apollo3.api.Operation;
+import com.apollographql.apollo3.exception.ApolloException;
+import com.apollographql.apollo3.runtime.java.ApolloCall;
+import com.apollographql.apollo3.runtime.java.ApolloCallback;
+import com.apollographql.apollo3.runtime.java.interceptor.ApolloDisposable;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import io.reactivex.annotations.CheckReturnValue;
+import io.reactivex.disposables.Disposable;
+import org.jetbrains.annotations.NotNull;
+
+import static com.apollographql.apollo3.api.java.Assertions.checkNotNull;
+
+public class Rx2Apollo {
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Flowable<ApolloResponse<T>> flowable(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
+    checkNotNull(call, "originalCall == null");
+    checkNotNull(backpressureStrategy, "backpressureStrategy == null");
+    return Flowable.create(emitter -> {
+      ApolloDisposable disposable = call.enqueue(new ApolloCallback<T>() {
+
+        @Override public void onResponse(@NotNull ApolloResponse<T> response) {
+          if (!emitter.isCancelled()) {
+            emitter.onNext(response);
+          }
+        }
+
+        @Override public void onFailure(@NotNull ApolloException e) {
+          if (!emitter.isCancelled()) {
+            emitter.onComplete();
+          }
+        }
+      });
+
+      emitter.setDisposable(new Disposable() {
+        @Override public void dispose() {
+          disposable.dispose();
+        }
+
+        @Override public boolean isDisposed() {
+          return disposable.isDisposed();
+        }
+      });
+    }, backpressureStrategy);
+  }
+
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
+    return flowable(call, backpressureStrategy).firstOrError();
+  }
+}

--- a/libraries/apollo-rx3-support-java/api/apollo-rx3-support-java.api
+++ b/libraries/apollo-rx3-support-java/api/apollo-rx3-support-java.api
@@ -1,0 +1,6 @@
+public class com/apollographql/apollo3/rx3/java/Rx3Apollo {
+	public fun <init> ()V
+	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/rxjava3/core/BackpressureStrategy;)Lio/reactivex/rxjava3/core/Flowable;
+	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/rxjava3/core/BackpressureStrategy;)Lio/reactivex/rxjava3/core/Single;
+}
+

--- a/libraries/apollo-rx3-support-java/build.gradle.kts
+++ b/libraries/apollo-rx3-support-java/build.gradle.kts
@@ -1,0 +1,16 @@
+/*
+ * This file is auto generated from apollo-rx2-support-java by rxjava3.main.kts, do not edit manually.
+ */
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("apollo.library")
+}
+
+apolloLibrary {
+  javaModuleName("com.apollographql.apollo3.rx3.java")
+}
+
+dependencies {
+  api(golatac.lib("rx.java3"))
+  api(project(":libraries:apollo-runtime-java"))
+}

--- a/libraries/apollo-rx3-support-java/gradle.properties
+++ b/libraries/apollo-rx3-support-java/gradle.properties
@@ -1,0 +1,7 @@
+#
+# This file is auto generated from apollo-rx2-support-java by rxjava3.main.kts, do not edit manually.
+#
+POM_ARTIFACT_ID=apollo-rx3-support-java
+POM_NAME=Apollo GraphQL Rx3 Support for Java
+POM_DESCRIPTION=Apollo GraphQL RxJava3 bindings for Java
+POM_PACKAGING=jar

--- a/libraries/apollo-rx3-support-java/src/main/java/com/apollographql/apollo3/rx3/java/Rx3Apollo.java
+++ b/libraries/apollo-rx3-support-java/src/main/java/com/apollographql/apollo3/rx3/java/Rx3Apollo.java
@@ -1,0 +1,60 @@
+/*
+ * This file is auto generated from apollo-rx2-support-java by rxjava3.main.kts, do not edit manually.
+ */
+package com.apollographql.apollo3.rx3.java;
+
+import com.apollographql.apollo3.api.ApolloResponse;
+import com.apollographql.apollo3.api.Operation;
+import com.apollographql.apollo3.exception.ApolloException;
+import com.apollographql.apollo3.runtime.java.ApolloCall;
+import com.apollographql.apollo3.runtime.java.ApolloCallback;
+import com.apollographql.apollo3.runtime.java.interceptor.ApolloDisposable;
+import io.reactivex.rxjava3.core.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.Single;
+import io.reactivex.rxjava3.annotations.CheckReturnValue;
+import io.reactivex.rxjava3.disposables.Disposable;
+import org.jetbrains.annotations.NotNull;
+
+import static com.apollographql.apollo3.api.java.Assertions.checkNotNull;
+
+public class Rx3Apollo {
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Flowable<ApolloResponse<T>> flowable(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
+    checkNotNull(call, "originalCall == null");
+    checkNotNull(backpressureStrategy, "backpressureStrategy == null");
+    return Flowable.create(emitter -> {
+      ApolloDisposable disposable = call.enqueue(new ApolloCallback<T>() {
+
+        @Override public void onResponse(@NotNull ApolloResponse<T> response) {
+          if (!emitter.isCancelled()) {
+            emitter.onNext(response);
+          }
+        }
+
+        @Override public void onFailure(@NotNull ApolloException e) {
+          if (!emitter.isCancelled()) {
+            emitter.onComplete();
+          }
+        }
+      });
+
+      emitter.setDisposable(new Disposable() {
+        @Override public void dispose() {
+          disposable.dispose();
+        }
+
+        @Override public boolean isDisposed() {
+          return disposable.isDisposed();
+        }
+      });
+    }, backpressureStrategy);
+  }
+
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
+    return flowable(call, backpressureStrategy).firstOrError();
+  }
+}

--- a/libraries/apollo-rx3-support/gradle.properties
+++ b/libraries/apollo-rx3-support/gradle.properties
@@ -1,6 +1,6 @@
-/*
- * This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
- */
+#
+# This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+#
 POM_ARTIFACT_ID=apollo-rx3-support
 POM_NAME=Apollo GraphQL Rx3 Support
 POM_DESCRIPTION=Apollo GraphQL RxJava3 bindings

--- a/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/-Rx3Extensions.kt
+++ b/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/-Rx3Extensions.kt
@@ -12,10 +12,10 @@ import com.apollographql.apollo3.api.Mutation
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
-import io.reactivex.rxjava3.annotations.CheckReturnValue
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Scheduler
 import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.annotations.CheckReturnValue
 import io.reactivex.rxjava3.schedulers.Schedulers
 import kotlinx.coroutines.rx3.asCoroutineDispatcher
 import kotlinx.coroutines.rx3.asFlowable

--- a/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/Rx3Apollo.kt
+++ b/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/Rx3Apollo.kt
@@ -8,10 +8,10 @@ import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
-import io.reactivex.rxjava3.annotations.CheckReturnValue
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.core.Scheduler
 import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.annotations.CheckReturnValue
 import io.reactivex.rxjava3.schedulers.Schedulers
 
 class Rx3Apollo private constructor() {

--- a/scripts/rxjava3.main.kts
+++ b/scripts/rxjava3.main.kts
@@ -6,41 +6,56 @@ import java.io.File
  * You need kotlin 1.3.70+ installed on your machine
  */
 
-check(File("settings.gradle.kts").let { it.exists() && it.readText().contains("rootProject.name = \"apollo-android\"") }) {
+check(File("settings.gradle.kts").let { it.exists() && it.readText().contains("rootProject.name = \"apollo-kotlin\"") }) {
   "This script needs to be called from the root of the project"
 }
 
-val rx3Dir = File("apollo-rx3-support")
-rx3Dir.deleteRecursively()
-File("apollo-rx2-support").copyRecursively(rx3Dir, overwrite = true)
+copyFiles(rx3DirName = "apollo-rx3-support", rx2DirName = "apollo-rx2-support")
+copyFiles(rx3DirName = "apollo-rx3-support-java", rx2DirName = "apollo-rx2-support-java")
+
+fun copyFiles(rx3DirName: String, rx2DirName: String) {
+  val librariesDir = File("libraries")
+  val rx3Dir = File(librariesDir, rx3DirName)
+  rx3Dir.deleteRecursively()
+  File(librariesDir, rx2DirName).copyRecursively(rx3Dir, overwrite = true)
 
 
-rx3Dir.walk().filter { it.name == "rx2" }.forEach {
-  it.renameTo(File(it.parentFile, "rx3"))
-}
+  rx3Dir.walk().filter { it.name == "rx2" }.forEach {
+    it.renameTo(File(it.parentFile, "rx3"))
+  }
 
-rx3Dir.walk().filter { it.name.contains("Rx2") }.forEach {
-  it.renameTo(File(it.parentFile, it.name.replace("Rx2", "Rx3")))
-}
+  rx3Dir.walk().filter { it.name.contains("Rx2") }.forEach {
+    it.renameTo(File(it.parentFile, it.name.replace("Rx2", "Rx3")))
+  }
 
-rx3Dir.walk().filter { it.isFile && (it.extension == "kt" || it.extension == "properties" || it.extension == "kts") }.forEach {
-  val header = """
+  rx3Dir.walk().filter { it.isFile && (it.extension == "kt" || it.extension == "properties" || it.extension == "kts" || it.extension == "java") }.forEach {
+    val header = if (it.extension == "properties") """
+    |#
+    |# This file is auto generated from $rx2DirName by rxjava3.main.kts, do not edit manually.
+    |#
+    |
+  """.trimMargin()
+    else """
     |/*
-    | * This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+    | * This file is auto generated from $rx2DirName by rxjava3.main.kts, do not edit manually.
     | */
     |
   """.trimMargin()
-  it.writeText(
-      header + it.readText()
-          .replace("com.apollographql.apollo3.rx2", "com.apollographql.apollo3.rx3")
-          .replace("Rx2", "Rx3")
-          .replace("rx2", "rx3")
-          .replace("RxJava2", "RxJava3")
-          .replace("import io.reactivex.annotations", "import io.reactivex.rxjava3.annotations")
-          .replace("import io.reactivex.Flowable", "import io.reactivex.rxjava3.core.Flowable")
-          .replace("import io.reactivex.Scheduler", "import io.reactivex.rxjava3.core.Scheduler")
-          .replace("import io.reactivex.Single", "import io.reactivex.rxjava3.core.Single")
-          .replace("import io.reactivex.schedulers.Schedulers", "import io.reactivex.rxjava3.schedulers.Schedulers")
-  )
+      
+    it.writeText(
+        header + it.readText()
+            .replace("com.apollographql.apollo3.rx2", "com.apollographql.apollo3.rx3")
+            .replace("Rx2", "Rx3")
+            .replace("rx2", "rx3")
+            .replace("java2", "java3")
+            .replace("RxJava2", "RxJava3")
+            .replace("import io.reactivex.annotations", "import io.reactivex.rxjava3.annotations")
+            .replace("import io.reactivex.Flowable", "import io.reactivex.rxjava3.core.Flowable")
+            .replace("import io.reactivex.Scheduler", "import io.reactivex.rxjava3.core.Scheduler")
+            .replace("import io.reactivex.Single", "import io.reactivex.rxjava3.core.Single")
+            .replace("import io.reactivex.schedulers.Schedulers", "import io.reactivex.rxjava3.schedulers.Schedulers")
+            .replace("import io.reactivex.disposables.Disposable", "import io.reactivex.rxjava3.disposables.Disposable")
+            .replace("import io.reactivex.BackpressureStrategy", "import io.reactivex.rxjava3.core.BackpressureStrategy")
+    )
+  }
 }
-

--- a/tests/java-client/build.gradle.kts
+++ b/tests/java-client/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
   implementation(golatac.lib("apollo.runtime.java"))
   implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("rx.java3"))
+  implementation(golatac.lib("apollo.rx3.java"))
   testImplementation(golatac.lib("junit"))
   testImplementation(golatac.lib("truth"))
 }

--- a/tests/java-client/src/test/java/test/ClientTest.java
+++ b/tests/java-client/src/test/java/test/ClientTest.java
@@ -1,20 +1,13 @@
 package test;
 
 import com.apollographql.apollo3.api.ApolloResponse;
-import com.apollographql.apollo3.api.Operation;
-import com.apollographql.apollo3.exception.ApolloException;
 import com.apollographql.apollo3.mockserver.MockResponse;
 import com.apollographql.apollo3.mockserver.MockServer;
-import com.apollographql.apollo3.runtime.java.ApolloCall;
-import com.apollographql.apollo3.runtime.java.ApolloCallback;
 import com.apollographql.apollo3.runtime.java.ApolloClient;
-import com.apollographql.apollo3.runtime.java.interceptor.ApolloDisposable;
+import com.apollographql.apollo3.rx3.java.Rx3Apollo;
 import com.google.common.truth.Truth;
-import io.reactivex.rxjava3.annotations.CheckReturnValue;
 import io.reactivex.rxjava3.annotations.NonNull;
 import io.reactivex.rxjava3.core.BackpressureStrategy;
-import io.reactivex.rxjava3.core.Flowable;
-import io.reactivex.rxjava3.disposables.Disposable;
 import javatest.CreateCatMutation;
 import javatest.GetRandomQuery;
 import kotlin.coroutines.Continuation;
@@ -23,8 +16,6 @@ import kotlin.coroutines.EmptyCoroutineContext;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
-
-import static com.apollographql.apollo3.api.java.Assertions.checkNotNull;
 
 public class ClientTest {
   MockServer mockServer;
@@ -52,45 +43,12 @@ public class ClientTest {
   @Test
   public void simple() {
     mockServer.enqueue(new MockResponse.Builder().body("{\"data\": {\"random\": 42}}").build());
-    @NonNull ApolloResponse<GetRandomQuery.Data> queryResponse = from(apolloClient.query(GetRandomQuery.builder().build()), BackpressureStrategy.BUFFER).blockingFirst();
+    @NonNull ApolloResponse<GetRandomQuery.Data> queryResponse = Rx3Apollo.single(apolloClient.query(GetRandomQuery.builder().build()), BackpressureStrategy.BUFFER).blockingGet();
     Truth.assertThat(queryResponse.dataAssertNoErrors().random).isEqualTo(42);
 
     mockServer.enqueue(new MockResponse.Builder().body("{\"data\": {\"createAnimal\": {\"__typename\": \"Cat\", \"species\": \"cat\", \"habitat\": {\"temperature\": 10.5}}}}").build());
-    @NonNull ApolloResponse<CreateCatMutation.Data> mutationResponse = from(apolloClient.mutation(CreateCatMutation.builder().build()), BackpressureStrategy.BUFFER).blockingFirst();
+    @NonNull ApolloResponse<CreateCatMutation.Data> mutationResponse = Rx3Apollo.single(apolloClient.mutation(CreateCatMutation.builder().build()), BackpressureStrategy.BUFFER).blockingGet();
     Truth.assertThat(mutationResponse.dataAssertNoErrors().createAnimal.catFragment.species).isEqualTo("cat");
-  }
-
-  @NotNull
-  @CheckReturnValue
-  public static <T extends Operation.Data> Flowable<ApolloResponse<T>> from(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
-    checkNotNull(call, "originalCall == null");
-    checkNotNull(backpressureStrategy, "backpressureStrategy == null");
-    return Flowable.create(emitter -> {
-      ApolloDisposable disposable = call.enqueue(new ApolloCallback<T>() {
-
-        @Override public void onResponse(@NotNull ApolloResponse<T> response) {
-          if (!emitter.isCancelled()) {
-            emitter.onNext(response);
-          }
-        }
-
-        @Override public void onFailure(@NotNull ApolloException e) {
-          if (!emitter.isCancelled()) {
-            emitter.onComplete();
-          }
-        }
-      });
-
-      emitter.setDisposable(new Disposable() {
-        @Override public void dispose() {
-          disposable.dispose();
-        }
-
-        @Override public boolean isDisposed() {
-          return disposable.isDisposed();
-        }
-      });
-    }, backpressureStrategy);
   }
 
 }


### PR DESCRIPTION
Stole what was in the unit test and put it in a dedicated module + updated the script for Rx3 vs Rx2 a bit.