### PR TITLE
Enable sealed interfaces for fragment implementations

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
@@ -47,7 +47,7 @@ internal class FragmentBuilder(
           model = it,
           superClassName = if (it.id == fragment.dataModelGroup.baseModelId) KotlinSymbols.FragmentData else null,
           path = listOf(packageName, simpleName),
-          hasSubclassesInSamePackage = false,
+          hasSubclassesInSamePackage = true,
           adaptableWith = null
       )
     }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/fragment/AnimalFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/fragment/AnimalFragmentImpl.kt.expected
@@ -39,7 +39,7 @@ public class AnimalFragmentImpl() : Fragment<AnimalFragmentImpl.Data> {
   .selections(selections = AnimalFragmentSelections.__root)
   .build()
 
-  public interface Data : AnimalFragment, Fragment.Data {
+  public sealed interface Data : AnimalFragment, Fragment.Data {
     public override val __typename: String
 
     public companion object {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/HumanDetailsImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/HumanDetailsImpl.kt.expected
@@ -38,7 +38,7 @@ public class HumanDetailsImpl() : Fragment<HumanDetailsImpl.Data> {
   .selections(selections = HumanDetailsSelections.__root)
   .build()
 
-  public interface Data : HumanDetails, Fragment.Data {
+  public sealed interface Data : HumanDetails, Fragment.Data {
     public override val __typename: String
 
     /**

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/fragment/HeroDetailsImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/fragment/HeroDetailsImpl.kt.expected
@@ -39,7 +39,7 @@ public class HeroDetailsImpl() : Fragment<HeroDetailsImpl.Data> {
   .selections(selections = HeroDetailsSelections.__root)
   .build()
 
-  public interface Data : HeroDetails, Fragment.Data {
+  public sealed interface Data : HeroDetails, Fragment.Data {
     public override val __typename: String
 
     /**
@@ -52,7 +52,7 @@ public class HeroDetailsImpl() : Fragment<HeroDetailsImpl.Data> {
      */
     public override val friendsConnection: FriendsConnection
 
-    public interface FriendsConnection : HeroDetails.FriendsConnection {
+    public sealed interface FriendsConnection : HeroDetails.FriendsConnection {
       /**
        * The total number of friends
        */
@@ -63,13 +63,13 @@ public class HeroDetailsImpl() : Fragment<HeroDetailsImpl.Data> {
        */
       public override val edges: List<Edge?>?
 
-      public interface Edge : HeroDetails.FriendsConnection.Edge {
+      public sealed interface Edge : HeroDetails.FriendsConnection.Edge {
         /**
          * The character represented by this friendship edge
          */
         public override val node: Node?
 
-        public interface Node : HeroDetails.FriendsConnection.Edge.Node {
+        public sealed interface Node : HeroDetails.FriendsConnection.Edge.Node {
           /**
            * The name of the character
            */

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
@@ -38,7 +38,7 @@ public class IFragmentImpl() : Fragment<IFragmentImpl.Data> {
   .selections(selections = iFragmentSelections.__root)
   .build()
 
-  public interface Data : IFragment, Fragment.Data {
+  public sealed interface Data : IFragment, Fragment.Data {
     public override val __typename: String
 
     public companion object {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,11 +2,11 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  215406
-aggregate-kotlin-responseBased                                                                  56084
-aggregate-kotlin-operationBased                                                                 36566
-aggregate-kotlin-compat                                                                         37991
-aggregate-java-operationBased                                                                   84765
+aggregate-all                                                                                  215563
+aggregate-kotlin-responseBased                                                                  56021
+aggregate-kotlin-operationBased                                                                 36627
+aggregate-kotlin-compat                                                                         38047
+aggregate-java-operationBased                                                                   84868
 
 java-operationBased-fragments_with_defer_and_include_directives                                  5566
 kotlin-compat-fragments_with_defer_and_include_directives                                        3612
@@ -67,22 +67,22 @@ java-operationBased-fragment_spread_with_nested_fields                          
 kotlin-responseBased-multiple_fragments                                                          1028
 kotlin-responseBased-mutation_create_review                                                      1026
 java-operationBased-java_primitive_types                                                         1020
+java-operationBased-operationbased2_ex8                                                          1020
 kotlin-operationBased-root_query_fragment_with_nested_fragments                                  1019
 kotlin-responseBased-simple_fragment_with_inline_fragments                                       1019
 kotlin-responseBased-nested_conditional_inline                                                   1008
 kotlin-compat-named_fragment_delegate                                                            1007
 kotlin-responseBased-named_fragment_with_variables                                                999
 java-operationBased-simple_fragment                                                               996
-kotlin-responseBased-operationbased2_ex8                                                          989
 kotlin-operationBased-named_fragment_delegate                                                     983
 kotlin-compat-fragment_used_twice                                                                 956
 kotlin-compat-nested_conditional_inline                                                           948
 java-operationBased-fragments_same_type_condition                                                 946
 java-operationBased-simple_union                                                                  946
 java-operationBased-deprecated_merged_field                                                       926
+kotlin-responseBased-operationbased2_ex8                                                          926
 kotlin-compat-named_fragment_with_variables                                                       919
 java-operationBased-hero_details                                                                  918
-java-operationBased-operationbased2_ex8                                                           917
 java-operationBased-not_all_combinations_are_needed                                               916
 java-operationBased-inline_fragment_with_include_directive                                        905
 java-operationBased-fieldset_with_multiple_super                                                  900
@@ -128,6 +128,7 @@ kotlin-responseBased-simple_union                                               
 kotlin-operationBased-target_name                                                                 731
 kotlin-responseBased-root_query_inline_fragment                                                   726
 kotlin-compat-fragment_spread_with_include_directive                                              725
+kotlin-compat-operationbased2_ex8                                                                 718
 java-operationBased-introspection_query                                                           715
 java-operationBased-interface_on_interface                                                        713
 kotlin-compat-fragment_spread_with_nested_fields                                                  709
@@ -145,8 +146,8 @@ java-operationBased-monomorphic                                                 
 kotlin-compat-simple_union                                                                        670
 java-operationBased-interface_always_nested                                                       668
 java-operationBased-deprecation                                                                   665
+kotlin-operationBased-operationbased2_ex8                                                         664
 kotlin-compat-deprecated_merged_field                                                             662
-kotlin-compat-operationbased2_ex8                                                                 662
 kotlin-compat-inline_fragment_with_include_directive                                              656
 kotlin-compat-union_fragment                                                                      654
 kotlin-compat-not_all_combinations_are_needed                                                     653
@@ -176,7 +177,6 @@ kotlin-responseBased-inline_fragment_merge_fields                               
 kotlin-compat-inline_fragment_merge_fields                                                        607
 kotlin-operationBased-inline_fragment_with_include_directive                                      605
 kotlin-operationBased-fieldset_with_multiple_super                                                604
-kotlin-operationBased-operationbased2_ex8                                                         603
 kotlin-responseBased-inline_fragment_inside_inline_fragment                                       602
 java-operationBased-java8annotation                                                               601
 kotlin-operationBased-simple_inline_fragment                                                      598

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
@@ -41,7 +41,7 @@ public class AFragmentImpl() : Fragment<AFragmentImpl.Data> {
   public data class Data(
     public override val node: Node?,
   ) : AFragment, Fragment.Data {
-    public interface Node : AFragment.Node {
+    public sealed interface Node : AFragment.Node {
       public override val __typename: String
 
       public companion object {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/fragment/AnimalFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/fragment/AnimalFragmentImpl.kt.expected
@@ -42,7 +42,7 @@ public class AnimalFragmentImpl() : Fragment<AnimalFragmentImpl.Data> {
     public override val species: String,
     public override val parent: Parent,
   ) : AnimalFragment, Fragment.Data {
-    public interface Parent : AnimalFragment.Parent {
+    public sealed interface Parent : AnimalFragment.Parent {
       public override val __typename: String
 
       public override val species: String

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/fragment/HeroDetailsImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/fragment/HeroDetailsImpl.kt.expected
@@ -42,7 +42,7 @@ internal class HeroDetailsImpl() : Fragment<HeroDetailsImpl.Data> {
   .selections(selections = HeroDetailsSelections.__root)
   .build()
 
-  public interface Data : HeroDetails, Fragment.Data {
+  public sealed interface Data : HeroDetails, Fragment.Data {
     public override val __typename: String
 
     public companion object {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/fragment/HeroDetailsImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/fragment/HeroDetailsImpl.kt.expected
@@ -52,7 +52,7 @@ public class HeroDetailsImpl() : Fragment<HeroDetailsImpl.Data> {
   ) : HeroDetails, Fragment.Data {
     public fun friendsFilterNotNull(): List<Friend>? = friends?.filterNotNull()
 
-    public interface Friend : HeroDetails.Friend {
+    public sealed interface Friend : HeroDetails.Friend {
       public override val __typename: String
 
       /**


### PR DESCRIPTION
Follow up from https://github.com/apollographql/apollo-kotlin/pull/4427