### PR TITLE
Pass protocols to WebSocket constructor in `JSWebSocketEngine`

### DIFF
--- a/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
@@ -96,14 +96,14 @@ actual class DefaultWebSocketEngine : WebSocketEngine {
   // so it can be accessed inside js("") function
   @Suppress("UNUSED_PARAMETER", "UnsafeCastFromDynamic", "UNUSED_VARIABLE", "LocalVariableName")
   private fun createWebSocket(urlString_capturingHack: String, headers: Headers): WebSocket =
+      val protocolHeaderNames = headers.names().filter { it.equals("sec-websocket-protocol", true) }
+      val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
       if (PlatformUtils.IS_NODE) {
         val ws_capturingHack = js("eval('require')('ws')")
         val headers_capturingHack: dynamic = object {}
         headers.forEach { name, values ->
           headers_capturingHack[name] = values.joinToString(",")
         }
-        val protocolHeaderNames = headers.names().filter { it.equals("sec-websocket-protocol", true) }
-        val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
         js("new ws_capturingHack(urlString_capturingHack, protocols, { headers: headers_capturingHack })")
       } else {
         js("new WebSocket(urlString_capturingHack, protocols)")

--- a/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
@@ -95,19 +95,20 @@ actual class DefaultWebSocketEngine : WebSocketEngine {
   // Adding "_capturingHack" to reduce chances of JS IR backend to rename variable,
   // so it can be accessed inside js("") function
   @Suppress("UNUSED_PARAMETER", "UnsafeCastFromDynamic", "UNUSED_VARIABLE", "LocalVariableName")
-  private fun createWebSocket(urlString_capturingHack: String, headers: Headers): WebSocket =
-      val protocolHeaderNames = headers.names().filter { it.equals("sec-websocket-protocol", true) }
-      val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
-      if (PlatformUtils.IS_NODE) {
-        val ws_capturingHack = js("eval('require')('ws')")
-        val headers_capturingHack: dynamic = object {}
-        headers.forEach { name, values ->
-          headers_capturingHack[name] = values.joinToString(",")
-        }
-        js("new ws_capturingHack(urlString_capturingHack, protocols, { headers: headers_capturingHack })")
-      } else {
-        js("new WebSocket(urlString_capturingHack, protocols)")
+  private fun createWebSocket(urlString_capturingHack: String, headers: Headers): WebSocket {
+    val protocolHeaderNames = headers.names().filter { it.equals("sec-websocket-protocol", true) }
+    val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
+    return if (PlatformUtils.IS_NODE) {
+      val ws_capturingHack = js("eval('require')('ws')")
+      val headers_capturingHack: dynamic = object {}
+      headers.forEach { name, values ->
+        headers_capturingHack[name] = values.joinToString(",")
       }
+      js("new ws_capturingHack(urlString_capturingHack, protocols, { headers: headers_capturingHack })")
+    } else {
+      js("new WebSocket(urlString_capturingHack, protocols)")
+    }
+  }
 
   private suspend fun WebSocket.awaitConnection(): WebSocket = suspendCancellableCoroutine { continuation ->
     if (continuation.isCancelled) return@suspendCancellableCoroutine

--- a/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/JsWebSocketEngine.kt
@@ -106,7 +106,7 @@ actual class DefaultWebSocketEngine : WebSocketEngine {
         val protocols = protocolHeaderNames.mapNotNull { headers.getAll(it) }.flatten().toTypedArray()
         js("new ws_capturingHack(urlString_capturingHack, protocols, { headers: headers_capturingHack })")
       } else {
-        js("new WebSocket(urlString_capturingHack)")
+        js("new WebSocket(urlString_capturingHack, protocols)")
       }
 
   private suspend fun WebSocket.awaitConnection(): WebSocket = suspendCancellableCoroutine { continuation ->


### PR DESCRIPTION
Of note, subscription-transport-ws (I know it is old...) will close any connection that does not include the protocol header.

See: https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/server.ts#L132

@BoD called this out here: https://github.com/apollographql/apollo-kotlin/issues/4339