### PR TITLE
Data builders: only generate used fields

### DIFF
--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -101,6 +101,14 @@ class Schema internal constructor(
         ?: throw SchemaValidationException("Cannot find type `$name`")
   }
 
+  /**
+   * returns all possible types:
+   * - for an object, return this object
+   * - for an interface, returns all objects implementing this interface (possibly transitively)
+   * - for an union, returns all members
+   *
+   * TODO v4: It's unclear whether we need this for scalar and enums.
+   */
   fun possibleTypes(typeDefinition: GQLTypeDefinition): Set<String> {
     return when (typeDefinition) {
       is GQLUnionTypeDefinition -> typeDefinition.memberTypes.map { it.name }.toSet()

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -354,11 +354,19 @@ interface Service {
   val generateApolloMetadata: Property<Boolean>
 
   /**
-   * A list of [Regex] patterns for input/scalar/enum types that should be generated whether they are used by queries/fragments
-   * in this module. When using multiple modules, Apollo Kotlin will generate all the types by default in the root module
+   * A list of [Regex] patterns matching [schema coordinates](https://github.com/magicmark/graphql-spec/blob/add_field_coordinates/rfcs/SchemaCoordinates.md)
+   * for types and fields should be generated whether they are used by queries/fragments in this module.
+   *
+   * When using multiple modules, Apollo Kotlin will generate all the types by default in the root module
    * because the root module doesn't know what types are going to be used by dependent modules. This can be prohibitive in terms
    * of compilation speed for large projects. If that's the case, opt-in the types that are used by multiple dependent modules here.
    * You don't need to add types that are used by a single dependent module.
+   *
+   * Examples:
+   * - listOf(".*"): generate every type and every field in the schema
+   * - listOf("User"): generate the user type
+   * - listOf(".*User): generate all types ending with "User"
+   * - listOf("User\\..*"): generate all fields of type "User"
    *
    * Default value: if (generateApolloMetadata) listOf(".*") else listOf()
    */

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -355,7 +355,7 @@ interface Service {
 
   /**
    * A list of [Regex] patterns matching [schema coordinates](https://github.com/magicmark/graphql-spec/blob/add_field_coordinates/rfcs/SchemaCoordinates.md)
-   * for types and fields should be generated whether they are used by queries/fragments in this module.
+   * for types and fields that should be generated whether they are used by queries/fragments in this module or not.
    *
    * When using multiple modules, Apollo Kotlin will generate all the types by default in the root module
    * because the root module doesn't know what types are going to be used by dependent modules. This can be prohibitive in terms

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -26,7 +26,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
       customTypeMapping.convention(null as Map<String, String>?)
       includes.convention(null as List<String>?)
       excludes.convention(null as List<String>?)
-      alwaysGenerateTypesMatching.convention(null as Set<String>?)
+      alwaysGenerateTypesMatching.convention(null as List<String>?)
       sealedClassesForEnumsMatching.convention(null as List<String>?)
       classesForEnumsMatching.convention(null as List<String>?)
     } else {
@@ -34,7 +34,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
       customTypeMapping.set(null as Map<String, String>?)
       includes.set(null as List<String>?)
       excludes.set(null as List<String>?)
-      alwaysGenerateTypesMatching.set(null as Set<String>?)
+      alwaysGenerateTypesMatching.set(null as List<String>?)
       sealedClassesForEnumsMatching.set(null as List<String>?)
       classesForEnumsMatching.set(null as List<String>?)
     }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**

--- a/tests/data-builders-kotlin/src/main/graphql/operations.graphql
+++ b/tests/data-builders-kotlin/src/main/graphql/operations.graphql
@@ -37,6 +37,13 @@ query GetAnimal {
   }
 }
 
+query GetNode {
+  node {
+    id
+  }
+}
+
+
 query GetFeline {
   feline {
     ... on Cat {

--- a/tests/data-builders-kotlin/src/main/graphql/schema.graphqls
+++ b/tests/data-builders-kotlin/src/main/graphql/schema.graphqls
@@ -16,6 +16,12 @@ type Query {
   long3: Long3
   listOfListOfInt: [[Int]!]
   listOfListOfAnimal: [[Animal]!]
+  unusedType: UnusedType
+  node: Node
+}
+
+type UnusedType {
+  foo: String!
 }
 
 enum Direction {
@@ -27,13 +33,19 @@ type MutationRoot {
   nullableInt: Int
 }
 
+interface Node {
+  id: String!
+}
+
 interface Animal {
   species: String!
 }
 
-type Cat implements Animal & Animal2 {
+type Cat implements Animal & Animal2 & Node {
+  id: String!
   species: String!
   mustaches: Int!
+  unusedField: String!
 }
 
 type Lion implements Animal {

--- a/tests/data-builders-kotlin/src/test/kotlin/test/DataBuilderTest.kt
+++ b/tests/data-builders-kotlin/src/test/kotlin/test/DataBuilderTest.kt
@@ -10,9 +10,12 @@ import data.builders.GetDirectionQuery
 import data.builders.GetEverythingQuery
 import data.builders.GetFelineQuery
 import data.builders.GetIntQuery
+import data.builders.GetNodeQuery
 import data.builders.GetPartialQuery
 import data.builders.PutIntMutation
+import data.builders.type.CatBuilder
 import data.builders.type.Direction
+import data.builders.type.LionBuilder
 import data.builders.type.buildCat
 import data.builders.type.buildLion
 import kotlin.test.Test
@@ -68,6 +71,35 @@ class DataBuilderTest {
     assertEquals("Lion", data.animal.__typename)
     assertEquals("LionSpecies", data.animal.species)
     assertEquals("Rooooaaarr", data.animal.onLion?.roar)
+  }
+
+  @Test
+  fun unusedTypesAreNotGenerated() {
+    try {
+      Class.forName("data.builders.type.UnusedTypeBuilder")
+      error("The data.builders.type.UnusedTypeBuilder class should not exist")
+    } catch (_: ClassNotFoundException) {
+
+    }
+  }
+
+  @Test
+  fun fieldsOnInterfacesAreGeneratedInObjectBuilders() {
+    val data = GetNodeQuery.Data {
+      node = buildCat {
+        id = "42"
+      }
+    }
+
+    assertEquals("42", data.node?.id)
+  }
+
+  @Test
+  fun unusedFieldsAreNotGenerated() {
+    val methods = CatBuilder::class.java.declaredMethods
+
+    check(methods.any { it.name == "setMustaches" })
+    check(methods.none { it.name == "setUnusedField" })
   }
 
   @Test


### PR DESCRIPTION
This is a follow up of this [slack discussion](https://kotlinlang.slack.com/archives/C01A6KM1SBZ/p1666262315621899)

One of the main motivations behind data builders was to reduce the amount of generated code and make sure it's not subject to [exponential blowup](https://github.com/apollographql/apollo-kotlin/issues/3144).

Data builders generate code that is O(schemaSize) while test builders generate code that is O(sumOfResponseSizeOverAllOperations). In general this should be more predictable but if the schema is large, there is an upfront cost that make the data builders actually generate more code.

This pull request tracks field usages so that only fields that are used in operation are generated in builders.

@eduardb let me know what you think

