### PR TITLE
Doc: Fixed title in schema download instructions

### DIFF
--- a/docs/source/shared/download-schema.mdx
+++ b/docs/source/shared/download-schema.mdx
@@ -16,6 +16,6 @@ If your GraphQL endpoint requires authentication, you can pass custom HTTP heade
 ```bash:title=(shell)
 ./gradlew downloadApolloSchema \
   --endpoint="https://your.domain/graphql/endpoint" \
-  --schema="app/src/main/graphql/com/example" \
+  --schema="app/src/main/graphql/com/example/schema.json" \
   --header="Authorization: Bearer $TOKEN"
 ```


### PR DESCRIPTION
I ran into an issue when copying a command from the schema download instructions. It looks like there was a typo in the docs. This PR fixes it. 