### PR TITLE
Rename `generateModelBuilder` to `generateModelBuilders` and add test

### DIFF
--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -18,6 +18,7 @@ public final class com/apollographql/apollo3/annotations/ApolloDeprecatedSince$V
 	public static final field v3_3_3 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_4_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_5_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
+	public static final field v3_6_3 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun values ()[Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 }

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
@@ -24,6 +24,7 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v3_3_2,
     v3_3_3,
     v3_4_1,
-    v3_5_1
+    v3_5_1,
+    v3_6_3
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -202,7 +202,7 @@ object ApolloCompiler {
             classesForEnumsMatching = options.classesForEnumsMatching,
             scalarMapping = options.scalarMapping,
             generateDataBuilders = options.generateDataBuilders,
-            generateModelBuilder = options.generateModelBuilder,
+            generateModelBuilders = options.generateModelBuilders,
             generatePrimitiveTypes = options.generatePrimitiveTypes,
             nullableFieldStyle = options.nullableFieldStyle,
             decapitalizeFields = options.decapitalizeFields,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -226,7 +226,7 @@ class Options(
      * Default value: false
      * Only valid for java models as kotlin has data classes
      */
-    val generateModelBuilder: Boolean = defaultGenerateModelBuilder,
+    val generateModelBuilders: Boolean = defaultGenerateModelBuilders,
 
     /**
      * A list of [Regex] patterns for GraphQL enums that should be generated as Kotlin sealed classes instead of the default Kotlin enums.
@@ -451,7 +451,7 @@ class Options(
     const val defaultGeneratedSchemaName = "__Schema"
     const val defaultGenerateTestBuilders = false
     const val defaultGenerateDataBuilders = false
-    const val defaultGenerateModelBuilder = false
+    const val defaultGenerateModelBuilders = false
     val defaultSealedClassesForEnumsMatching = emptyList<String>()
     val defaultClassesForEnumsMatching = listOf(".*")
     const val defaultGenerateOptionalOperationVariables = true

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodeGen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodeGen.kt
@@ -55,7 +55,7 @@ internal class JavaCodeGen(
     private val generateQueryDocument: Boolean,
     private val generateSchema: Boolean,
     private val generatedSchemaName: String,
-    private val generateModelBuilder: Boolean,
+    private val generateModelBuilders: Boolean,
     /**
      * Whether to flatten the models. This decision is left to the codegen. For fragments for an example, we
      * want to flatten at depth 1 to avoid name clashes, but it's ok to flatten fragment response adapters at
@@ -90,7 +90,7 @@ internal class JavaCodeGen(
     val context = JavaContext(
         layout = layout,
         resolver = JavaResolver(emptyList(), upstreamResolver, scalarMapping, generatePrimitiveTypes, nullableFieldStyle),
-        generateModelBuilder = generateModelBuilder,
+        generateModelBuilders = generateModelBuilders,
         nullableFieldStyle = nullableFieldStyle,
     )
     val builders = mutableListOf<JavaClassBuilder>()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaContext.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaContext.kt
@@ -5,6 +5,6 @@ import com.apollographql.apollo3.compiler.JavaNullable
 internal class JavaContext(
     val layout: JavaCodegenLayout,
     val resolver: JavaResolver,
-    val generateModelBuilder: Boolean,
+    val generateModelBuilders: Boolean,
     val nullableFieldStyle: JavaNullable,
 )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/model/ModelBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/model/ModelBuilder.kt
@@ -95,7 +95,7 @@ internal class ModelBuilder(
         .addSuperinterfaces(superInterfaces)
         .build()
         .let {
-          if (context.generateModelBuilder) {
+          if (context.generateModelBuilders) {
             it.addBuilder(context)
           } else {
             it

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -312,7 +312,7 @@ class CodegenTest {
         else -> listOf(".*")
       }
 
-      val generateModelBuilder = when (folder.name) {
+      val generateModelBuilders = when (folder.name) {
         "fragment_with_inline_fragment", "java_primitive_types", "java_apollo_optionals", "java_guava_optionals", "java_java_optionals",
         "simple_target_name", "java_jetbrains_annotations", "java_android_annotations", "java_jsr305_annotations",
         -> true
@@ -408,7 +408,7 @@ class CodegenTest {
           generateAsInternal = generateAsInternal,
           generateFilterNotNull = true,
           generateFragmentImplementations = generateFragmentImplementations,
-          generateModelBuilder = generateModelBuilder,
+          generateModelBuilders = generateModelBuilders,
           generateSchema = generateSchema,
           moduleName = folder.name,
           targetLanguage = targetLanguage,

--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -79,6 +79,7 @@ public abstract interface class com/apollographql/apollo3/gradle/api/Service {
 	public abstract fun getGenerateFragmentImplementations ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateKotlinModels ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateModelBuilder ()Lorg/gradle/api/provider/Property;
+	public abstract fun getGenerateModelBuilders ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateOperationOutput ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGenerateOptionalOperationVariables ()Lorg/gradle/api/provider/Property;
 	public abstract fun getGeneratePrimitiveTypes ()Lorg/gradle/api/provider/Property;

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -459,7 +459,17 @@ interface Service {
    * Default: false
    */
   @ApolloExperimental
+  @Deprecated("use generateModelBuilders instead", ReplaceWith("generateModelBuilders"))
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_6_3)
   val generateModelBuilder: Property<Boolean>
+
+  /**
+   * Whether to generate response model builders for Java.
+   *
+   * Default: false
+   */
+  @ApolloExperimental
+  val generateModelBuilders: Property<Boolean>
 
   /**
    * What codegen to use. One of "operationBased", "responseBased", "compat" or "experimental_operationBasedWithInterfaces"

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -23,7 +23,7 @@ import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateAsInt
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateDataBuilders
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFilterNotNull
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateFragmentImplementations
-import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateModelBuilder
+import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateModelBuilders
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateOptionalOperationVariables
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGeneratePrimitiveTypes
 import com.apollographql.apollo3.compiler.Options.Companion.defaultGenerateQueryDocument
@@ -128,7 +128,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val generateModelBuilder: Property<Boolean>
+  abstract val generateModelBuilders: Property<Boolean>
 
   @get:Input
   @get:Optional
@@ -329,7 +329,7 @@ abstract class ApolloGenerateSourcesTask : DefaultTask() {
         generateAsInternal = generateAsInternal.getOrElse(defaultGenerateAsInternal),
         generateFilterNotNull = generateFilterNotNull.getOrElse(defaultGenerateFilterNotNull),
         generateFragmentImplementations = generateFragmentImplementations.getOrElse(defaultGenerateFragmentImplementations),
-        generateModelBuilder = generateModelBuilder.getOrElse(defaultGenerateModelBuilder),
+        generateModelBuilders = generateModelBuilders.getOrElse(defaultGenerateModelBuilders),
         generateQueryDocument = generateQueryDocument.getOrElse(defaultGenerateQueryDocument),
         generateSchema = generateSchema.getOrElse(defaultGenerateSchema),
         generatedSchemaName = generatedSchemaName.getOrElse(defaultGeneratedSchemaName),

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -576,7 +576,7 @@ abstract class DefaultApolloExtension(
       task.generateQueryDocument.set(service.generateQueryDocument)
       task.generateSchema.set(service.generateSchema)
       task.generatedSchemaName.set(service.generatedSchemaName)
-      task.generateModelBuilder.set(service.generateModelBuilder)
+      task.generateModelBuilders.set(service.generateModelBuilders.orElse(service.generateModelBuilder))
       task.codegenModels.set(service.codegenModels)
       task.addTypename.set(service.addTypename)
       task.flattenModels.set(service.flattenModels)

--- a/tests/model-builders-java/build.gradle.kts
+++ b/tests/model-builders-java/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 apollo {
   packageName.set("model.builders")
   generateKotlinModels.set(false)
-  generateModelBuilder.set(true)
+  generateModelBuilders.set(true)
 }
 
 java {

--- a/tests/model-builders-java/build.gradle.kts
+++ b/tests/model-builders-java/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("com.apollographql.apollo3")
+  id("java")
+  id("apollo.test")
+}
+
+dependencies {
+  implementation("com.apollographql.apollo3:apollo-runtime")
+  testImplementation(golatac.lib("junit"))
+}
+
+apollo {
+  packageName.set("model.builders")
+  generateKotlinModels.set(false)
+  generateModelBuilder.set(true)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}

--- a/tests/model-builders-java/src/main/graphql/operations.graphql
+++ b/tests/model-builders-java/src/main/graphql/operations.graphql
@@ -1,0 +1,76 @@
+query GetInt {
+  nullableInt
+  nonNullableInt
+}
+
+query GetCustomScalar {
+  long1
+  long2
+  long3
+  listOfListOfLong1
+}
+
+query GetDirection {
+  direction
+}
+
+mutation PutInt {
+  nullableInt
+}
+
+query GetAliases {
+  aliasedNullableInt: nullableInt
+  cat {
+    species
+  }
+  aliasedCat: cat {
+    species
+  }
+}
+
+query GetAnimal {
+  animal {
+    species
+    ... on Lion {
+      roar
+    }
+  }
+}
+
+query GetFeline {
+  feline {
+    ... on Cat {
+      mustaches
+    }
+  }
+}
+
+query GetEverything {
+  nullableInt
+  nonNullableInt
+  listOfListOfInt
+  direction
+  listOfListOfAnimal {
+    species
+  }
+  cat {
+    mustaches
+  }
+  animal {
+    species
+  }
+  feline {
+    ... on Lion {
+      roar
+    }
+  }
+}
+
+query GetPartial {
+  listOfListOfAnimal {
+    species
+    ... on Lion {
+      roar
+    }
+  }
+}

--- a/tests/model-builders-java/src/main/graphql/schema.graphqls
+++ b/tests/model-builders-java/src/main/graphql/schema.graphqls
@@ -1,0 +1,55 @@
+schema {
+  query: Query
+  mutation: MutationRoot
+}
+
+type Query {
+  nullableInt: Int
+  nonNullableInt: Int!
+  direction: Direction!,
+  cat: Cat!
+  animal: Animal!
+  feline: Feline!
+  long1: Long1
+  listOfListOfLong1: [[Long1]!]
+  long2: Long2
+  long3: Long3
+  listOfListOfInt: [[Int]!]
+  listOfListOfAnimal: [[Animal]!]
+}
+
+enum Direction {
+  SOUTH,
+  NORTH
+}
+
+type MutationRoot {
+  nullableInt: Int
+}
+
+interface Animal {
+  species: String!
+}
+
+type Cat implements Animal & Animal2 {
+  species: String!
+  mustaches: Int!
+}
+
+type Lion implements Animal {
+  species: String!
+  roar: String!
+}
+
+union Feline = Cat | Lion
+
+# an interface that is not directly queried but still needs to be added because the data builders
+# will reference them
+interface Animal2 {
+  species: String!
+}
+union Feline2 = Cat | Lion
+
+scalar Long1
+scalar Long2
+scalar Long3

--- a/tests/model-builders-java/src/test/java/test/ModelBuilderTest.java
+++ b/tests/model-builders-java/src/test/java/test/ModelBuilderTest.java
@@ -1,0 +1,22 @@
+package test;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import model.builders.GetIntQuery;
+
+
+public class ModelBuilderTest {
+
+  @Test
+  public void simpleTest() {
+    GetIntQuery.Data data = GetIntQuery.Data.builder()
+        .nullableInt(null)
+        .nonNullableInt(42)
+        .build();
+
+    assertEquals(null, data.nullableInt);
+    assertEquals(Integer.valueOf(42), data.nonNullableInt);
+  }
+}


### PR DESCRIPTION
For consistency with other options (`generateDataBuilders`, `generateOptionalOperationVariables`, `generateKotlinModels` etc.. that all use a plural)