### PR TITLE
Java runtime: make ApolloClient implement Closeable

### DIFF
--- a/libraries/apollo-runtime-java/api/apollo-runtime-java.api
+++ b/libraries/apollo-runtime-java/api/apollo-runtime-java.api
@@ -7,7 +7,8 @@ public abstract interface class com/apollographql/apollo3/runtime/java/ApolloCal
 	public abstract fun onResponse (Lcom/apollographql/apollo3/api/ApolloResponse;)V
 }
 
-public class com/apollographql/apollo3/runtime/java/ApolloClient {
+public class com/apollographql/apollo3/runtime/java/ApolloClient : java/io/Closeable {
+	public fun close ()V
 	public fun execute (Lcom/apollographql/apollo3/api/ApolloRequest;Lcom/apollographql/apollo3/runtime/java/ApolloCallback;)Lcom/apollographql/apollo3/runtime/java/ApolloDisposable;
 	public fun getCustomScalarAdapters ()Lcom/apollographql/apollo3/api/CustomScalarAdapters;
 	public fun mutation (Lcom/apollographql/apollo3/api/Mutation;)Lcom/apollographql/apollo3/runtime/java/ApolloCall;

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -64,6 +64,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
     private val maxBatchSize: Int = 10,
     private val exposeErrorBody: Boolean = false,
 ) : HttpInterceptor {
+  private val creationTime = currentTimeMillis()
   private val dispatcher = CloseableSingleThreadDispatcher()
   private val scope = CoroutineScope(dispatcher.coroutineDispatcher)
   private val mutex = Mutex()
@@ -102,7 +103,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
       executePendingRequests()
     } else {
       scope.launch {
-        delay(batchIntervalMillis - (currentTimeMillis() % batchIntervalMillis) - 1)
+        delay(batchIntervalMillis - ((currentTimeMillis() - creationTime) % batchIntervalMillis) - 1)
         executePendingRequests()
       }
     }

--- a/libraries/apollo-rx2-support-java/api/apollo-rx2-support-java.api
+++ b/libraries/apollo-rx2-support-java/api/apollo-rx2-support-java.api
@@ -1,6 +1,8 @@
 public class com/apollographql/apollo3/rx2/java/Rx2Apollo {
 	public fun <init> ()V
+	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;)Lio/reactivex/Flowable;
 	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/BackpressureStrategy;)Lio/reactivex/Flowable;
+	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;)Lio/reactivex/Single;
 	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/BackpressureStrategy;)Lio/reactivex/Single;
 }
 

--- a/libraries/apollo-rx2-support-java/src/main/java/com/apollographql/apollo3/rx2/java/Rx2Apollo.java
+++ b/libraries/apollo-rx2-support-java/src/main/java/com/apollographql/apollo3/rx2/java/Rx2Apollo.java
@@ -57,7 +57,19 @@ public class Rx2Apollo {
 
   @NotNull
   @CheckReturnValue
+  public static <T extends Operation.Data> Flowable<ApolloResponse<T>> flowable(@NotNull final ApolloCall<T> call) {
+    return flowable(call, BackpressureStrategy.BUFFER);
+  }
+
+  @NotNull
+  @CheckReturnValue
   public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
     return flowable(call, backpressureStrategy).firstOrError();
+  }
+
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call) {
+    return single(call, BackpressureStrategy.BUFFER);
   }
 }

--- a/libraries/apollo-rx3-support-java/api/apollo-rx3-support-java.api
+++ b/libraries/apollo-rx3-support-java/api/apollo-rx3-support-java.api
@@ -1,6 +1,8 @@
 public class com/apollographql/apollo3/rx3/java/Rx3Apollo {
 	public fun <init> ()V
+	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;)Lio/reactivex/rxjava3/core/Flowable;
 	public static fun flowable (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/rxjava3/core/BackpressureStrategy;)Lio/reactivex/rxjava3/core/Flowable;
+	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;)Lio/reactivex/rxjava3/core/Single;
 	public static fun single (Lcom/apollographql/apollo3/runtime/java/ApolloCall;Lio/reactivex/rxjava3/core/BackpressureStrategy;)Lio/reactivex/rxjava3/core/Single;
 }
 

--- a/libraries/apollo-rx3-support-java/src/main/java/com/apollographql/apollo3/rx3/java/Rx3Apollo.java
+++ b/libraries/apollo-rx3-support-java/src/main/java/com/apollographql/apollo3/rx3/java/Rx3Apollo.java
@@ -60,7 +60,19 @@ public class Rx3Apollo {
 
   @NotNull
   @CheckReturnValue
+  public static <T extends Operation.Data> Flowable<ApolloResponse<T>> flowable(@NotNull final ApolloCall<T> call) {
+    return flowable(call, BackpressureStrategy.BUFFER);
+  }
+
+  @NotNull
+  @CheckReturnValue
   public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call, @NotNull BackpressureStrategy backpressureStrategy) {
     return flowable(call, backpressureStrategy).firstOrError();
+  }
+
+  @NotNull
+  @CheckReturnValue
+  public static <T extends Operation.Data> Single<ApolloResponse<T>> single(@NotNull final ApolloCall<T> call) {
+    return single(call, BackpressureStrategy.BUFFER);
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.api.ExecutionOptions.Companion.CAN_BE_BATCHED
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.mpp.currentTimeMillis
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -64,6 +65,7 @@ class QueryBatchingTest {
         .serverUrl(mockServer.url())
         .httpBatching(batchIntervalMillis = 300)
         .build()
+    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery()).execute()
@@ -93,7 +95,7 @@ class QueryBatchingTest {
   }
 
   @Test
-  fun queriesAreNotBatchedIfSubmittedFarAppart() = runTest(before = { setUp() }, after = { tearDown() }) {
+  fun queriesAreNotBatchedIfSubmittedFarApart() = runTest(before = { setUp() }, after = { tearDown() }) {
     mockServer.enqueue("""[{"data":{"launch":{"id":"83"}}}]""")
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
@@ -155,6 +157,7 @@ class QueryBatchingTest {
         // Opt out by default
         .canBeBatched(false)
         .build()
+    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery())
@@ -202,6 +205,7 @@ class QueryBatchingTest {
         .addHttpHeader("client0", "0")
         .addHttpHeader("client1", "1")
         .build()
+    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery()).execute()
@@ -229,6 +233,7 @@ class QueryBatchingTest {
         .serverUrl(mockServer.url())
         .httpBatching(batchIntervalMillis = 300)
         .build()
+    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery())
@@ -255,5 +260,10 @@ class QueryBatchingTest {
     assertFalse(request.headers.keys.contains("query2-only"))
     assertFalse(request.headers.keys.contains("query1+query2-different-value"))
     assertFalse(request.headers.keys.contains(CAN_BE_BATCHED))
+  }
+
+  private suspend fun alignWithCurrentTime(batchIntervalMillis: Int) {
+    // Pending requests in BatchingHttpInterceptor are scheduled with a delay that depends on the current time. Align with it to ensure the tests are reproducible
+    delay(batchIntervalMillis - currentTimeMillis() % batchIntervalMillis - 1)
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.api.ExecutionOptions.Companion.CAN_BE_BATCHED
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
-import com.apollographql.apollo3.mpp.currentTimeMillis
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -65,7 +64,6 @@ class QueryBatchingTest {
         .serverUrl(mockServer.url())
         .httpBatching(batchIntervalMillis = 300)
         .build()
-    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery()).execute()
@@ -157,7 +155,6 @@ class QueryBatchingTest {
         // Opt out by default
         .canBeBatched(false)
         .build()
-    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery())
@@ -205,7 +202,6 @@ class QueryBatchingTest {
         .addHttpHeader("client0", "0")
         .addHttpHeader("client1", "1")
         .build()
-    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery()).execute()
@@ -233,7 +229,6 @@ class QueryBatchingTest {
         .serverUrl(mockServer.url())
         .httpBatching(batchIntervalMillis = 300)
         .build()
-    alignWithCurrentTime(300)
 
     val result1 = async {
       apolloClient.query(GetLaunchQuery())
@@ -260,10 +255,5 @@ class QueryBatchingTest {
     assertFalse(request.headers.keys.contains("query2-only"))
     assertFalse(request.headers.keys.contains("query1+query2-different-value"))
     assertFalse(request.headers.keys.contains(CAN_BE_BATCHED))
-  }
-
-  private suspend fun alignWithCurrentTime(batchIntervalMillis: Int) {
-    // Pending requests in BatchingHttpInterceptor are scheduled with a delay that depends on the current time. Align with it to ensure the tests are reproducible
-    delay(batchIntervalMillis - currentTimeMillis() % batchIntervalMillis - 1)
   }
 }


### PR DESCRIPTION
Also unrelated: make `BackpressureStrategy.BUFFER` the default in Rx adapters