### PR TITLE
🐘  Use `registerJavaGeneratingTask` 

### DIFF
--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -140,6 +140,7 @@ public final class com/apollographql/apollo3/gradle/api/Service$DefaultImpls {
 }
 
 public abstract interface class com/apollographql/apollo3/gradle/api/Service$DirectoryConnection {
+	public abstract fun connectToAllAndroidVariants ()V
 	public abstract fun connectToAndroidSourceSet (Ljava/lang/String;)V
 	public abstract fun connectToAndroidVariant (Ljava/lang/Object;)V
 	public abstract fun connectToJavaSourceSet (Ljava/lang/String;)V

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -754,6 +754,11 @@ interface Service {
      * @param name: the name of the source set. For an example, "main", "test" or "androidTest"
      * You can also use more qualified source sets like "demo", "debug" or "demoDebug"
      */
+    @Deprecated(
+        "This method doesn't mark the sources as \"generated\". This confuses some tools like lint that might do extra work on the generated files",
+        ReplaceWith("connectToAndroidVariant(variant)")
+    )
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_6_3)
     fun connectToAndroidSourceSet(name: String)
 
     /**

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -757,6 +757,12 @@ interface Service {
     fun connectToAndroidSourceSet(name: String)
 
     /**
+     * Connects the generated sources to all the Android variants
+     * Throws if the Android plugin is not applied
+     */
+    fun connectToAllAndroidVariants()
+
+    /**
      * Connects the generated sources to the given Android variant. This will
      * look up the most specific source set used by this variant. For an example, "demoDebug"
      *

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
@@ -10,14 +10,17 @@ import com.android.build.gradle.api.UnitTestVariant
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.gradle.api.androidExtensionOrThrow
 import com.apollographql.apollo3.gradle.api.kotlinProjectExtension
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
+import java.lang.reflect.Method
+import java.lang.reflect.ParameterizedType
 
-fun connectToAndroidSourceSet(project: Project, sourceSetName: String, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
+private fun Project.getVariants(): NamedDomainObjectContainer<BaseVariant> {
   val container = project.container(BaseVariant::class.java)
 
   val extension = project.androidExtensionOrThrow
@@ -27,16 +30,19 @@ fun connectToAndroidSourceSet(project: Project, sourceSetName: String, outputDir
         container.add(variant)
       }
     }
+
     is AppExtension -> {
       extension.applicationVariants.all { variant ->
         container.add(variant)
       }
     }
+
     is FeatureExtension -> {
       extension.featureVariants.all { variant ->
         container.add(variant)
       }
     }
+
     else -> error("Unsupported extension: $extension")
   }
 
@@ -48,13 +54,21 @@ fun connectToAndroidSourceSet(project: Project, sourceSetName: String, outputDir
       container.add(variant)
     }
   }
+  return container
+}
 
+fun connectToAndroidSourceSet(
+    project: Project,
+    sourceSetName: String,
+    outputDir: Provider<Directory>,
+    taskProvider: TaskProvider<out Task>,
+) {
   val kotlinSourceSet = project.kotlinProjectExtension?.sourceSets?.getByName(sourceSetName)?.kotlin
   if (kotlinSourceSet != null) {
     kotlinSourceSet.srcDir(outputDir)
   }
 
-  container.all {
+  project.getVariants().all {
     if (it.sourceSets.any { it.name == sourceSetName }) {
       if (kotlinSourceSet == null) {
         try {
@@ -76,25 +90,74 @@ fun connectToAndroidSourceSet(project: Project, sourceSetName: String, outputDir
   }
 }
 
+private val lazyRegisterJavaGeneratingTask: Method? = BaseVariant::class.java.declaredMethods.singleOrNull {
+  if (it.name != "registerJavaGeneratingTask") {
+    return@singleOrNull false
+  }
+
+  if (it.parameters.size != 2) {
+    return@singleOrNull false
+  }
+  val parameter0Type = it.parameters[0].parameterizedType
+  if (parameter0Type !is ParameterizedType) {
+    return@singleOrNull false
+  }
+  if (parameter0Type.rawType.typeName != "org.gradle.api.tasks.TaskProvider") {
+    return@singleOrNull false
+  }
+  val parameter1Type = it.parameters[1].parameterizedType
+  if (parameter1Type !is ParameterizedType) {
+    return@singleOrNull false
+  }
+  if (parameter1Type.rawType.typeName != "java.util.Collection") {
+    return@singleOrNull false
+  }
+  if (parameter1Type.actualTypeArguments.size != 1) {
+    return@singleOrNull false
+  }
+  if (parameter1Type.actualTypeArguments.single().typeName != "java.io.File") {
+    return@singleOrNull false
+  }
+
+  true
+}
+
 fun connectToAndroidVariant(project: Project, variant: Any, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
   check(variant is BaseVariant) {
     "Apollo: 'variant' must be an instance of an Android [BaseVariant]"
   }
-  /**
-   * Heuristic to get the variant-specific sourceSet from the variant name
-   * demoDebugAndroidTest -> androidTestDemoDebug
-   * demoDebugUnitTest -> testDemoDebug
-   * demoDebug -> demoDebug
-   */
-  val sourceSetName = when {
-    variant is TestVariant && variant.name.endsWith("AndroidTest") -> {
-      "androidTest${variant.name.removeSuffix("AndroidTest").capitalizeFirstLetter()}"
-    }
-    variant is UnitTestVariant && variant.name.endsWith("UnitTest") -> {
-      "test${variant.name.removeSuffix("UnitTest").capitalizeFirstLetter()}"
-    }
-    else -> variant.name
-  }
 
-  connectToAndroidSourceSet(project, sourceSetName, outputDir, taskProvider)
+  if (lazyRegisterJavaGeneratingTask != null) {
+    lazyRegisterJavaGeneratingTask.invoke(variant, taskProvider, listOf(outputDir.get().asFile))
+  } else {
+    /**
+     * Heuristic to get the variant-specific sourceSet from the variant name
+     * demoDebugAndroidTest -> androidTestDemoDebug
+     * demoDebugUnitTest -> testDemoDebug
+     * demoDebug -> demoDebug
+     */
+    val sourceSetName = when {
+      variant is TestVariant && variant.name.endsWith("AndroidTest") -> {
+        "androidTest${variant.name.removeSuffix("AndroidTest").capitalizeFirstLetter()}"
+      }
+
+      variant is UnitTestVariant && variant.name.endsWith("UnitTest") -> {
+        "test${variant.name.removeSuffix("UnitTest").capitalizeFirstLetter()}"
+      }
+
+      else -> variant.name
+    }
+
+    connectToAndroidSourceSet(project, sourceSetName, outputDir, taskProvider)
+  }
+}
+
+fun connectToAllAndroidVariants(project: Project, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
+  if (lazyRegisterJavaGeneratingTask != null) {
+    project.getVariants().all {
+      lazyRegisterJavaGeneratingTask.invoke(it, taskProvider, listOf(outputDir.get().asFile))
+    }
+  } else {
+    connectToAndroidSourceSet(project, "main", outputDir, taskProvider)
+  }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
@@ -90,6 +90,12 @@ fun connectToAndroidSourceSet(
   }
 }
 
+/**
+ * This uses https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/api/BaseVariant.java;l=539;drc=5ac687029454dec1e7bd50697dabbc24d5a9943c
+ *
+ * There's a newer API in 7.3 where AGP decides where the sources are put but we're not using that just yet
+ * https://github.com/android/gradle-recipes/blob/agp-7.3/Kotlin/addJavaSourceFromTask/app/build.gradle.kts
+ */
 private val lazyRegisterJavaGeneratingTask: Method? = BaseVariant::class.java.declaredMethods.singleOrNull {
   if (it.name != "registerJavaGeneratingTask") {
     return@singleOrNull false

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -372,7 +372,7 @@ abstract class DefaultApolloExtension(
       }
 
       project.androidExtension != null -> {
-        connection.connectToAndroidSourceSet("main")
+        connection.connectToAllAndroidVariants()
       }
 
       project.kotlinProjectExtension != null -> {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -372,7 +372,12 @@ abstract class DefaultApolloExtension(
       }
 
       project.androidExtension != null -> {
-        connection.connectToAllAndroidVariants()
+        if (registerDefaultService) {
+          // The default service is created from `afterEvaluate` and it looks like it's too late to register new sources
+          connection.connectToKotlinSourceSet("main")
+        } else {
+          connection.connectToAllAndroidVariants()
+        }
       }
 
       project.kotlinProjectExtension != null -> {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -374,7 +374,7 @@ abstract class DefaultApolloExtension(
       project.androidExtension != null -> {
         if (registerDefaultService) {
           // The default service is created from `afterEvaluate` and it looks like it's too late to register new sources
-          connection.connectToKotlinSourceSet("main")
+          connection.connectToAndroidSourceSet("main")
         } else {
           connection.connectToAllAndroidVariants()
         }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultDirectoryConnection.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultDirectoryConnection.kt
@@ -33,4 +33,8 @@ internal class DefaultDirectoryConnection(
   override fun connectToAndroidSourceSet(name: String) {
     connectToAndroidSourceSet(project, name, outputDir, task)
   }
+
+  override fun connectToAllAndroidVariants() {
+    connectToAllAndroidVariants(project, outputDir, task)
+  }
 }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**
@@ -122,6 +122,8 @@ tasks.withType<Test> {
   dependsOn(":libraries:apollo-normalized-cache-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":libraries:apollo-mpp-utils:publishAllPublicationsToPluginTestRepository")
   dependsOn(":libraries:apollo-compiler:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":libraries:apollo-gradle-plugin-external:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":libraries:apollo-tooling:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")
 
   inputs.dir("src/test/files")


### PR DESCRIPTION
Use `variant.registerJavaGeneratingTask` instead of `kotlin.sourceSets["main"].kotlin.serDir()` so that the generated sources are marked as "generated" and not picked up by lint (by default). 

This doesn't use the new AGP variant APIs just yet since they're incubating and also change the codegen task output dir so it's a potentially more intrusive change. 

Closes https://github.com/apollographql/apollo-kotlin/issues/4478