### PR TITLE
Force-use AZUL vendor for java toolchain

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
 // 'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(8))
+  toolchain.vendor.set(JvmVendorSpec.AZUL)
 }
 
 gradlePlugin {


### PR DESCRIPTION
This fixes an issue with the unavailability of the adoptium JDK8  binaries on M1.

#### Background
While setting up the project on an M1 (ARM), the exception below was encountered:

```
What went wrong:
A problem occurred configuring root project 'apollo-kotlin'.
> Could not determine the dependencies of null.
   > Could not resolve all dependencies for configuration ':classpath'.
      > Failed to calculate the value of task ':build-logic:compileJava' property 'javaCompiler'.
         > Unable to download toolchain matching these requirements: {languageVersion=8, vendor=any, implementation=vendor-specific}
            > Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.
               > Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.
```

AZUL provides the binaries as required by the project and setting it as the toolchain vendor fixes the exception.