### PR TITLE
Unbreak Gradle Sync

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -37,9 +37,13 @@ dependencies {
   if (System.getProperty("idea.sync.active") == null) {
     implementation(golatac.lib("kotlin.plugin"))
     runtimeOnly(golatac.lib("ksp"))
+    // XXX: This is only needed for tests. We could have different build logic for different
+    // builds but this seems just overkill for now
+    runtimeOnly(golatac.lib("kotlin.allopen"))
   } else {
     implementation(golatac.lib("kotlin.plugin.duringideasync"))
     runtimeOnly(golatac.lib("ksp.duringideasync"))
+    runtimeOnly(golatac.lib("kotlin.allopen.duringideasync"))
   }
 
   runtimeOnly(golatac.lib("sqldelight.plugin"))
@@ -47,9 +51,6 @@ dependencies {
   runtimeOnly(golatac.lib("benmanes.versions"))
   runtimeOnly(golatac.lib("gr8"))
   runtimeOnly(golatac.lib("kotlinx.binarycompatibilityvalidator"))
-  // XXX: This is only needed for tests. We could have different build logic for different
-  // builds but this seems just overkill for now
-  runtimeOnly(golatac.lib("kotlin.allopen"))
 }
 
 // This shuts down a warning in Kotlin 1.5.30:

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -86,6 +86,7 @@ guava-jre = { group = "com.google.guava", name = "guava", version.ref = "guava" 
 jetbrains-annotations = { group = "org.jetbrains", name = "annotations", version.ref = "jetbrains-annotations" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 kotlin-allopen = { group = "org.jetbrains.kotlin", name = "kotlin-allopen", version.ref = "kotlin-plugin" }
+kotlin-allopen-duringideasync = { group = "org.jetbrains.kotlin", name = "kotlin-allopen", version.ref = "kotlin-plugin-duringideasync" }
 kotlin-compiletesting = { group = "com.github.tschuchortdev", name = "kotlin-compile-testing", version = "1.4.6" }
 # The main kotlin version for build-logic and Gradle tests
 kotlin-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin-plugin" }


### PR DESCRIPTION
While working on https://github.com/apollographql/apollo-kotlin/pull/4505, I tried bumping Kotlin to 1.7.21, which required aligning `kotlin-allopen` with `1.7.21`. I ended up not bumping Kotlin but still bumping `kotlin-allopen` which broke the HMPP workaround