### PR TITLE
Introduce HttpFetchPolicyContext

### DIFF
--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -626,7 +626,7 @@ val response = apolloClient.query(request)
                       .execute()
 ```
 
-Do make it consistent with the normalized cache, the default `httpFetchPolicy` is now `HttpFetchPolicy.CacheFirst`. To keep the same behaviour as 2.0, use `HttpFetchPolicy.NetworkOnly`.
+To make it consistent with the normalized cache, the default `httpFetchPolicy` is now `HttpFetchPolicy.CacheFirst`. To keep the same behaviour as 2.0, use `HttpFetchPolicy.NetworkOnly`.
 
 ### Optional values
 

--- a/docs/source/migration/3.0.mdx
+++ b/docs/source/migration/3.0.mdx
@@ -626,6 +626,8 @@ val response = apolloClient.query(request)
                       .execute()
 ```
 
+Do make it consistent with the normalized cache, the default `httpFetchPolicy` is now `HttpFetchPolicy.CacheFirst`. To keep the same behaviour as 2.0, use `HttpFetchPolicy.NetworkOnly`.
+
 ### Optional values
 
 #### The `Optional` class

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -23,6 +23,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
+import kotlin.test.fail
 
 class HttpCacheTest {
   lateinit var mockServer: MockServer
@@ -47,7 +48,7 @@ class HttpCacheTest {
   }
 
   private suspend fun tearDown() {
-    apolloClient.dispose()
+    apolloClient.close()
     mockServer.stop()
   }
 
@@ -230,6 +231,24 @@ class HttpCacheTest {
     // Should not have been cached
     assertFailsWith<HttpCacheMissException> {
       apolloClient.query(GetRandomQuery()).httpFetchPolicy(HttpFetchPolicy.CacheOnly).execute()
+    }
+  }
+
+  @Test
+  fun CanSetTheDefaultBehaviourAtTheClientLevel() = runTest(before = { before() }, after = { tearDown() }) {
+    apolloClient = apolloClient.newBuilder()
+        .httpFetchPolicy(HttpFetchPolicy.CacheOnly)
+        .build()
+
+    mockServer.enqueueData(data)
+
+    try {
+      var response = apolloClient.query(GetRandomQuery())
+          .addHttpHeader("foo", "bar")
+          .execute()
+      fail("An exception was expected")
+    } catch (e: Exception) {
+
     }
   }
 }

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -52,7 +52,7 @@ class HttpCacheTest {
   }
 
   @Test
-  fun CacheFirst() = runTest(before = { before() }, after = { tearDown() }) {
+  fun DefaultIsCacheFirst() = runTest(before = { before() }, after = { tearDown() }) {
     mockServer.enqueueData(data)
 
     runBlocking {
@@ -61,6 +61,23 @@ class HttpCacheTest {
       assertEquals(false, response.isFromHttpCache)
 
       response = apolloClient.query(GetRandomQuery()).execute()
+      assertEquals(42, response.data?.random)
+      assertEquals(true, response.isFromHttpCache)
+    }
+  }
+
+  @Test
+  fun CacheFirst() = runTest(before = { before() }, after = { tearDown() }) {
+    mockServer.enqueueData(data)
+
+    runBlocking {
+      var response = apolloClient.query(GetRandomQuery()).execute()
+      assertEquals(42, response.data?.random)
+      assertEquals(false, response.isFromHttpCache)
+
+      response = apolloClient.query(GetRandomQuery())
+          .httpFetchPolicy(HttpFetchPolicy.CacheFirst)
+          .execute()
       assertEquals(42, response.data?.random)
       assertEquals(true, response.isFromHttpCache)
     }
@@ -215,5 +232,4 @@ class HttpCacheTest {
       apolloClient.query(GetRandomQuery()).httpFetchPolicy(HttpFetchPolicy.CacheOnly).execute()
     }
   }
-
 }

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -243,7 +243,7 @@ class HttpCacheTest {
     mockServer.enqueueData(data)
 
     try {
-      var response = apolloClient.query(GetRandomQuery())
+      apolloClient.query(GetRandomQuery())
           .addHttpHeader("foo", "bar")
           .execute()
       fail("An exception was expected")


### PR DESCRIPTION
- add a test and mention in the migration guide
- introduce HttpFetchPolicyContext

This postpones the moment when the `HttpFetchPolicy` is turned into a `HTTP header`  allowing to set a default `HttpFetchPolicy` on the `ApolloClient.Builder`:

```kotlin
val apolloClient = ApolloClient.Builder()
        // Default to NetworkOnly
        .httpFetchPolicy(HttpFetchPolicy.NetworkOnly)
        .serverUrl(mockServer.url())
        .httpCache(dir, Long.MAX_VALUE)
        .build()

val response = apolloClient.query(GetRandomQuery())
          // it's possible to set HTTP headers without losing the default HttpFetchPolicy
          .addHttpHeader("foo", "bar")
          .execute()        
```
See https://github.com/apollographql/apollo-kotlin/issues/4497