### PR TITLE
Fix Java codegen in synthetic fields when using optionals

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Optionals.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Optionals.kt
@@ -1,0 +1,61 @@
+package com.apollographql.apollo3.compiler.codegen.java.helpers
+
+import com.apollographql.apollo3.compiler.JavaNullable
+import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
+import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.L
+import com.apollographql.apollo3.compiler.codegen.java.T
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.TypeName
+
+internal fun JavaContext.wrapValueInOptional(value: CodeBlock, fieldType: TypeName): CodeBlock {
+  return if (!resolver.isOptional(fieldType)) {
+    CodeBlock.of(L, value)
+  } else {
+    when (nullableFieldStyle) {
+      JavaNullable.JAVA_OPTIONAL -> CodeBlock.of("$T.of($L)", JavaClassNames.JavaOptional, value)
+      JavaNullable.GUAVA_OPTIONAL -> CodeBlock.of("$T.of($L)", JavaClassNames.GuavaOptional, value)
+      else -> CodeBlock.of("$T.present($L)", JavaClassNames.Optional, value)
+    }
+  }
+}
+
+internal fun JavaContext.unwrapOptionalValue(value: CodeBlock, fieldType: TypeName): CodeBlock {
+  return if (!resolver.isOptional(fieldType)) {
+    CodeBlock.of(L, value)
+  } else {
+    when (nullableFieldStyle) {
+      JavaNullable.JAVA_OPTIONAL -> CodeBlock.of("$L.get()", value)
+      JavaNullable.GUAVA_OPTIONAL -> CodeBlock.of("$L.get()", value)
+      else -> CodeBlock.of("$L.getOrThrow()", value)
+    }
+  }
+}
+
+internal fun JavaContext.testOptionalValuePresence(value: CodeBlock, fieldType: TypeName): CodeBlock {
+  return if (!resolver.isOptional(fieldType)) {
+    CodeBlock.of("$L != null", value)
+  } else {
+    when (nullableFieldStyle) {
+      JavaNullable.JAVA_OPTIONAL -> CodeBlock.of("$L.isPresent()", value)
+      JavaNullable.GUAVA_OPTIONAL -> CodeBlock.of("$L.isPresent()", value)
+      else -> CodeBlock.of("$L instanceof $T", value, JavaClassNames.Present)
+    }
+  }
+}
+
+internal fun JavaContext.absentOptionalInitializer(): CodeBlock {
+  return when (nullableFieldStyle) {
+    JavaNullable.JAVA_OPTIONAL -> CodeBlock.of("$T.empty()", JavaClassNames.JavaOptional)
+    JavaNullable.GUAVA_OPTIONAL -> CodeBlock.of("$T.absent()", JavaClassNames.GuavaOptional)
+    else -> CodeBlock.of("$T.absent()", JavaClassNames.Optional)
+  }
+}
+
+internal fun JavaContext.absentOptionalInitializer(fieldType: TypeName): CodeBlock {
+  return if (!resolver.isOptional(fieldType)) {
+    CodeBlock.of("null")
+  } else {
+    absentOptionalInitializer()
+  }
+}

--- a/tests/java-nullability/src/main/graphql/operation.graphql
+++ b/tests/java-nullability/src/main/graphql/operation.graphql
@@ -18,5 +18,18 @@ query MyQuery(
   }
   nullableListOfNullableString
   nullableListOfNonNullableString
+  myUnion {
+    ... on A {
+      a
+    }
+    ... on B {
+      b
+    }
+  }
+  myInterface {
+    ... on C {
+      x
+    }
+  }
 }
 

--- a/tests/java-nullability/src/main/graphql/schema.graphqls
+++ b/tests/java-nullability/src/main/graphql/schema.graphqls
@@ -5,6 +5,8 @@ type Query {
   nonNullableMyType: MyType!
   nullableListOfNullableString: [String]
   nullableListOfNonNullableString: [String!]
+  myUnion: MyUnion
+  myInterface: MyInterface
 }
 
 input MyInput {
@@ -16,4 +18,26 @@ input MyInput {
 type MyType {
   nullableInt: Int
   nonNullableInt: Int!
+}
+
+union MyUnion = A|B
+
+type A {
+  a: String
+}
+
+type B {
+  b: String
+}
+
+interface MyInterface {
+  x: Int
+}
+
+type C implements MyInterface {
+  x: Int
+}
+
+type D implements MyInterface {
+  x: Int
 }

--- a/tests/java-nullability/src/test/java/test/AndroidAnnotationsTest.java
+++ b/tests/java-nullability/src/test/java/test/AndroidAnnotationsTest.java
@@ -142,7 +142,9 @@ public class AndroidAnnotationsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );
@@ -177,7 +179,9 @@ public class AndroidAnnotationsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );

--- a/tests/java-nullability/src/test/java/test/ApolloOptionalsTest.java
+++ b/tests/java-nullability/src/test/java/test/ApolloOptionalsTest.java
@@ -133,7 +133,9 @@ public class ApolloOptionalsTest {
         "            \"nonNullableInt\": 2\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     JsonReader jsonReader = new BufferedSourceJsonReader(buffer);
     MyQuery.Data actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
@@ -148,7 +150,9 @@ public class ApolloOptionalsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ Optional.absent(),
-            /* nullableListOfNonNullableString = */ Optional.absent()
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.absent(),
+            /* myInterface = */ Optional.absent()
         ),
         actualData
     );
@@ -166,7 +170,9 @@ public class ApolloOptionalsTest {
         "            \"nonNullableInt\": 4\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     jsonReader = new BufferedSourceJsonReader(buffer);
     actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
@@ -185,7 +191,48 @@ public class ApolloOptionalsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ Optional.absent(),
-            /* nullableListOfNonNullableString = */ Optional.absent()
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.absent(),
+            /* myInterface = */ Optional.absent()
+        ),
+        actualData
+    );
+
+    buffer.writeUtf8("{\n" +
+        "          \"nullableInt\": null,\n" +
+        "          \"nonNullableInt\": 1,\n" +
+        "          \"nullableMyType\": null,\n" +
+        "          \"nonNullableMyType\": {\n" +
+        "            \"nullableInt\": null,\n" +
+        "            \"nonNullableInt\": 2\n" +
+        "          },\n" +
+        "          \"nullableListOfNullableString\":  null,\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": {\n" +
+        "            \"__typename\": \"A\",\n" +
+        "            \"a\": \"a\"\n" +
+        "          },\n" +
+        "          \"myInterface\": {\n" +
+        "            \"__typename\": \"C\",\n" +
+        "            \"x\": 3\n" +
+        "          }\n" +
+        "      }");
+    jsonReader = new BufferedSourceJsonReader(buffer);
+    actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
+    Assert.assertEquals(
+        new MyQuery.Data(
+            /* nullableInt = */ Optional.absent(),
+            /* nonNullableInt = */ 1,
+            /* nullableMyType = */ Optional.absent(),
+            /* nonNullableMyType = */
+            new MyQuery.NonNullableMyType(
+                /* nullableInt = */ Optional.absent(),
+                /* nonNullableInt = */ 2
+            ),
+            /* nullableListOfNullableString = */ Optional.absent(),
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.present(new MyQuery.MyUnion("A", Optional.present(new MyQuery.OnA(Optional.present("a"))), Optional.absent())),
+            /* myInterface = */ Optional.present(new MyQuery.MyInterface("C", Optional.present(new MyQuery.OnC(Optional.present(3)))))
         ),
         actualData
     );

--- a/tests/java-nullability/src/test/java/test/GuavaOptionalsTest.java
+++ b/tests/java-nullability/src/test/java/test/GuavaOptionalsTest.java
@@ -133,7 +133,9 @@ public class GuavaOptionalsTest {
         "            \"nonNullableInt\": 2\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     ;
     JsonReader jsonReader = new BufferedSourceJsonReader(buffer);
@@ -149,7 +151,9 @@ public class GuavaOptionalsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ Optional.absent(),
-            /* nullableListOfNonNullableString = */ Optional.absent()
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.absent(),
+            /* myInterface = */ Optional.absent()
         ),
         actualData
     );
@@ -167,7 +171,9 @@ public class GuavaOptionalsTest {
         "            \"nonNullableInt\": 4\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     jsonReader = new BufferedSourceJsonReader(buffer);
     actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
@@ -186,7 +192,48 @@ public class GuavaOptionalsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ Optional.absent(),
-            /* nullableListOfNonNullableString = */ Optional.absent()
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.absent(),
+            /* myInterface = */ Optional.absent()
+        ),
+        actualData
+    );
+
+    buffer.writeUtf8("{\n" +
+        "          \"nullableInt\": null,\n" +
+        "          \"nonNullableInt\": 1,\n" +
+        "          \"nullableMyType\": null,\n" +
+        "          \"nonNullableMyType\": {\n" +
+        "            \"nullableInt\": null,\n" +
+        "            \"nonNullableInt\": 2\n" +
+        "          },\n" +
+        "          \"nullableListOfNullableString\":  null,\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": {\n" +
+        "            \"__typename\": \"A\",\n" +
+        "            \"a\": \"a\"\n" +
+        "          },\n" +
+        "          \"myInterface\": {\n" +
+        "            \"__typename\": \"C\",\n" +
+        "            \"x\": 3\n" +
+        "          }\n" +
+        "      }");
+    jsonReader = new BufferedSourceJsonReader(buffer);
+    actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
+    Assert.assertEquals(
+        new MyQuery.Data(
+            /* nullableInt = */ Optional.absent(),
+            /* nonNullableInt = */ 1,
+            /* nullableMyType = */ Optional.absent(),
+            /* nonNullableMyType = */
+            new MyQuery.NonNullableMyType(
+                /* nullableInt = */ Optional.absent(),
+                /* nonNullableInt = */ 2
+            ),
+            /* nullableListOfNullableString = */ Optional.absent(),
+            /* nullableListOfNonNullableString = */ Optional.absent(),
+            /* myUnion = */ Optional.of(new MyQuery.MyUnion("A", Optional.of(new MyQuery.OnA(Optional.of("a"))), Optional.absent())),
+            /* myInterface = */ Optional.of(new MyQuery.MyInterface("C", Optional.of(new MyQuery.OnC(Optional.of(3)))))
         ),
         actualData
     );

--- a/tests/java-nullability/src/test/java/test/JavaOptionalsTest.java
+++ b/tests/java-nullability/src/test/java/test/JavaOptionalsTest.java
@@ -133,7 +133,9 @@ public class JavaOptionalsTest {
         "            \"nonNullableInt\": 2\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     JsonReader jsonReader = new BufferedSourceJsonReader(buffer);
     MyQuery.Data actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
@@ -148,7 +150,9 @@ public class JavaOptionalsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ Optional.empty(),
-            /* nullableListOfNonNullableString = */ Optional.empty()
+            /* nullableListOfNonNullableString = */ Optional.empty(),
+            /* myUnion = */ Optional.empty(),
+            /* myEnum = */ Optional.empty()
         ),
         actualData
     );
@@ -166,7 +170,9 @@ public class JavaOptionalsTest {
         "            \"nonNullableInt\": 4\n" +
         "          },\n" +
         "          \"nullableListOfNullableString\":  null,\n" +
-        "          \"nullableListOfNonNullableString\": null\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": null,\n" +
+        "          \"myInterface\": null\n" +
         "      }");
     jsonReader = new BufferedSourceJsonReader(buffer);
     actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
@@ -185,7 +191,48 @@ public class JavaOptionalsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ Optional.empty(),
-            /* nullableListOfNonNullableString = */ Optional.empty()
+            /* nullableListOfNonNullableString = */ Optional.empty(),
+            /* myUnion = */ Optional.empty(),
+            /* myEnum = */ Optional.empty()
+        ),
+        actualData
+    );
+
+    buffer.writeUtf8("{\n" +
+        "          \"nullableInt\": null,\n" +
+        "          \"nonNullableInt\": 1,\n" +
+        "          \"nullableMyType\": null,\n" +
+        "          \"nonNullableMyType\": {\n" +
+        "            \"nullableInt\": null,\n" +
+        "            \"nonNullableInt\": 2\n" +
+        "          },\n" +
+        "          \"nullableListOfNullableString\":  null,\n" +
+        "          \"nullableListOfNonNullableString\": null,\n" +
+        "          \"myUnion\": {\n" +
+        "            \"__typename\": \"A\",\n" +
+        "            \"a\": \"a\"\n" +
+        "          },\n" +
+        "          \"myInterface\": {\n" +
+        "            \"__typename\": \"C\",\n" +
+        "            \"x\": 3\n" +
+        "          }\n" +
+        "      }");
+    jsonReader = new BufferedSourceJsonReader(buffer);
+    actualData = query.adapter().fromJson(jsonReader, CustomScalarAdapters.Empty);
+    Assert.assertEquals(
+        new MyQuery.Data(
+            /* nullableInt = */ Optional.empty(),
+            /* nonNullableInt = */ 1,
+            /* nullableMyType = */ Optional.empty(),
+            /* nonNullableMyType = */
+            new MyQuery.NonNullableMyType(
+                /* nullableInt = */ Optional.empty(),
+                /* nonNullableInt = */ 2
+            ),
+            /* nullableListOfNullableString = */ Optional.empty(),
+            /* nullableListOfNonNullableString = */ Optional.empty(),
+            /* myUnion = */ Optional.of(new MyQuery.MyUnion("A", Optional.of(new MyQuery.OnA(Optional.of("a"))), Optional.empty())),
+            /* myInterface = */ Optional.of(new MyQuery.MyInterface("C", Optional.of(new MyQuery.OnC(Optional.of(3)))))
         ),
         actualData
     );

--- a/tests/java-nullability/src/test/java/test/JetbrainsAnnotationsTest.java
+++ b/tests/java-nullability/src/test/java/test/JetbrainsAnnotationsTest.java
@@ -146,7 +146,9 @@ public class JetbrainsAnnotationsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );
@@ -181,7 +183,9 @@ public class JetbrainsAnnotationsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );

--- a/tests/java-nullability/src/test/java/test/Jsr305AnnotationsTest.java
+++ b/tests/java-nullability/src/test/java/test/Jsr305AnnotationsTest.java
@@ -142,7 +142,9 @@ public class Jsr305AnnotationsTest {
                 /* nonNullableInt = */ 2
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );
@@ -177,7 +179,9 @@ public class Jsr305AnnotationsTest {
                 /* nonNullableInt = */ 4
             ),
             /* nullableListOfNullableString = */ null,
-            /* nullableListOfNonNullableString = */ null
+            /* nullableListOfNonNullableString = */ null,
+            /* myUnion = */ null,
+            /* myEnum = */ null
         ),
         actualData
     );


### PR DESCRIPTION
A fix for #4529.

Nullability was handled as `null` in areas related to synthetic fields in adapters, even when using optionals.