### PR TITLE
Make `canBeBatched` and `httpHeaders` orthogonal

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -82,7 +82,6 @@ private constructor(
 
     override fun canBeBatched(canBeBatched: Boolean?): Builder<D> = apply {
       this.canBeBatched = canBeBatched
-      if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
     }
 
     fun requestUuid(requestUuid: Uuid) = apply {

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
@@ -121,6 +121,9 @@ public class ApolloClient implements Closeable {
     if (apolloRequest.getEnableAutoPersistedQueries() != null) {
       requestBuilder.enableAutoPersistedQueries(apolloRequest.getEnableAutoPersistedQueries());
     }
+    if (apolloRequest.getCanBeBatched() != null) {
+      requestBuilder.addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, apolloRequest.getCanBeBatched().toString());
+    }
     DefaultApolloDisposable disposable = new DefaultApolloDisposable();
     ArrayList<ApolloInterceptor> interceptors = new ArrayList<>(this.interceptors);
     interceptors.add(networkInterceptor);
@@ -557,7 +560,6 @@ public class ApolloClient implements Closeable {
 
     @Override public Builder canBeBatched(@Nullable Boolean canBeBatched) {
       this.canBeBatched = canBeBatched;
-      if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString());
       return this;
     }
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -57,7 +57,6 @@ class ApolloCall<D : Operation.Data> internal constructor(
 
   override fun canBeBatched(canBeBatched: Boolean?) = apply {
     this.canBeBatched = canBeBatched
-    if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
   }
 
   fun copy(): ApolloCall<D> {

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -68,6 +68,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendApqExtensions(sendApqExtensions)
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
+        .canBeBatched(canBeBatched)
   }
 
   /**
@@ -92,6 +93,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendApqExtensions(sendApqExtensions)
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
+        .canBeBatched(canBeBatched)
         .build()
     return apolloClient.executeAsFlow(request)
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -170,7 +170,7 @@ private constructor(
           if (apolloRequest.canBeBatched != null) {
             // Because batching is handled at the HTTP level, move the information to HTTP headers
             // canBeBatched(apolloRequest.canBeBatched)
-            addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, "true")
+            addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, apolloRequest.canBeBatched.toString())
           }
         }
         .build()

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -22,6 +22,7 @@ import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.internal.Version2CustomTypeAdapterToAdapter
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
+import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo3.interceptor.AutoPersistedQueryInterceptor
 import com.apollographql.apollo3.interceptor.DefaultInterceptorChain
 import com.apollographql.apollo3.interceptor.NetworkInterceptor
@@ -166,6 +167,11 @@ private constructor(
           if (apolloRequest.enableAutoPersistedQueries != null) {
             enableAutoPersistedQueries(apolloRequest.enableAutoPersistedQueries)
           }
+          if (apolloRequest.canBeBatched != null) {
+            // Because batching is handled at the HTTP level, move the information to HTTP headers
+            // canBeBatched(apolloRequest.canBeBatched)
+            addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, "true")
+          }
         }
         .build()
 
@@ -235,7 +241,6 @@ private constructor(
 
     override fun canBeBatched(canBeBatched: Boolean?): Builder = apply {
       this.canBeBatched = canBeBatched
-      if (canBeBatched != null) addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
     }
 
     /**

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -128,7 +128,11 @@ class QueryBatchingTest {
         .build()
 
     val result1 = async {
-      apolloClient.query(GetLaunchQuery()).canBeBatched(false).execute()
+      apolloClient.query(GetLaunchQuery())
+          .canBeBatched(false)
+          // Override headers, make sure this doesn't change canBeBatched
+          .httpHeaders(listOf(HttpHeader("client0", "0")))
+          .execute()
     }
     val result2 = async {
       // Make sure GetLaunch2Query gets executed after GetLaunchQuery as there is no guarantee otherwise

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.ExecutionOptions.Companion.CAN_BE_BATCHED
+import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
@@ -199,8 +200,12 @@ class QueryBatchingTest {
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
         .httpBatching(batchIntervalMillis = 300)
-        .addHttpHeader("client0", "0")
-        .addHttpHeader("client1", "1")
+        .httpHeaders(
+            listOf(
+                HttpHeader("client0", "0"),
+                HttpHeader("client1", "1")
+            )
+        )
         .build()
 
     val result1 = async {
@@ -213,6 +218,10 @@ class QueryBatchingTest {
     result1.await()
     result2.await()
     val request = mockServer.takeRequest()
+    // Only one request must have been sent
+    assertFails {
+      mockServer.takeRequest()
+    }
     assertTrue(request.headers["client0"] == "0")
     assertTrue(request.headers["client1"] == "1")
     assertFalse(request.headers.keys.contains(CAN_BE_BATCHED))

--- a/tests/java-client/src/test/java/test/BatchingTest.java
+++ b/tests/java-client/src/test/java/test/BatchingTest.java
@@ -4,6 +4,7 @@ import batching.GetLaunch2Query;
 import batching.GetLaunchQuery;
 import com.apollographql.apollo3.api.ApolloResponse;
 import com.apollographql.apollo3.api.CustomScalarAdapters;
+import com.apollographql.apollo3.api.http.HttpHeader;
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader;
 import com.apollographql.apollo3.exception.ApolloException;
 import com.apollographql.apollo3.mockserver.MockRequest;
@@ -20,7 +21,10 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -177,6 +181,7 @@ public class BatchingTest {
     CountDownLatch latch = new CountDownLatch(2);
     apolloClient.query(new GetLaunchQuery())
         .canBeBatched(false)
+        .httpHeaders(Collections.singletonList(new HttpHeader("client0", "0")))
         .enqueue(new ApolloCallback<GetLaunchQuery.Data>() {
           @Override public void onResponse(@NotNull ApolloResponse<GetLaunchQuery.Data> response) {
             synchronized (items) {


### PR DESCRIPTION
Similar to https://github.com/apollographql/apollo-kotlin/pull/4509, store `canBeBatched` separately from HTTP headers until the very last moment to avoid them overwriting each other.