### PR TITLE
Fix item wrongly removed from http cache when error in subscriptions

### DIFF
--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/CachingHttpInterceptor.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/CachingHttpInterceptor.kt
@@ -191,6 +191,8 @@ class CachingHttpInterceptor(
      */
     const val CACHE_KEY_HEADER = "X-APOLLO-CACHE-KEY"
 
+    internal const val REQUEST_UUID_HEADER = "X-APOLLO-REQUEST-UUID"
+
     /**
      * Cache fetch strategy http header
      */

--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -81,7 +81,12 @@ fun ApolloClient.Builder.httpCache(
       synchronized(apolloRequestToCacheKey) {
         apolloRequestToCacheKey[requestUuid] = cacheKey
       }
-      return chain.proceed(request.newBuilder().addHeader(CachingHttpInterceptor.CACHE_KEY_HEADER, cacheKey).build())
+      return chain.proceed(
+          request.newBuilder()
+              .headers(request.headers.filterNot { it.name == CachingHttpInterceptor.REQUEST_UUID_HEADER })
+              .addHeader(CachingHttpInterceptor.CACHE_KEY_HEADER, cacheKey)
+              .build()
+      )
     }
   }).addHttpInterceptor(
       cachingHttpInterceptor

--- a/tests/http-cache/src/main/graphql/operations.graphql
+++ b/tests/http-cache/src/main/graphql/operations.graphql
@@ -9,3 +9,7 @@ query GetRandom2 {
 mutation SetRandom {
   setRandom
 }
+
+subscription RandomSubscription {
+  random
+}

--- a/tests/http-cache/src/main/graphql/schema.graphqls
+++ b/tests/http-cache/src/main/graphql/schema.graphqls
@@ -6,3 +6,7 @@ type Query {
 type Mutation {
   setRandom: String
 }
+
+type Subscription {
+  random: Int!
+}


### PR DESCRIPTION
Issue encountered [here](https://community.apollographql.com/t/apollo-v3-http-cache-isnt-working-not-able-to-debug-the-caching-process-after-migrating-from-2-x-x-to-3-x-x/5101).

For the http cache, we add 2 interceptors:
1. an `HttpInterceptor` that deals with caching
2. an `ApolloInterceptor` which cleans up the cache if there was an error

The cache key is computed in 1. and used in 2. But 1. is executed for queries and mutations only, whereas 2. is also executed for subscriptions. When a subscription resulted in an error, an arbitrary (the most recent one) cache key would be incorrectly cleared from the cache. The proposed fix is to do this cleanup only for queries and mutations.