### PR TITLE
Build scripts: bump gr8 to 0.7

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -72,7 +72,7 @@ dokka-base = { group = "org.jetbrains.dokka", name = "dokka-base", version.ref =
 dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
 google-testing-compile = { group = "com.google.testing.compile", name = "compile-testing", version = "0.19" }
 google-testparameterinjector = { group = "com.google.testparameterinjector", name = "test-parameter-injector", version = "1.4" }
-gr8 = { group = "com.gradleup", name = "gr8-plugin", version = "0.6" }
+gr8 = { group = "com.gradleup", name = "gr8-plugin", version = "0.7" }
 #
 # See https://github.com/gradle/gradle/issues/1835
 # We use the Nokee[redistributed artifacts](https://docs.nokee.dev/manual/gradle-plugin-development.html#sec:gradle-dev-redistributed-gradle-api)


### PR DESCRIPTION
This enables Gradle build cache for GR8 tasks, meaning no more waiting for `shadowR8Jar` 🤞 

