### PR TITLE
Fix providing linker flags to the Kotlin compiler with KGP 1.8

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/KotlinPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/KotlinPluginFacade.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 /**
  * A class that hides all references to the Kotlin plugin from the caller.
@@ -31,12 +32,10 @@ fun getKotlinTargetLanguage(project: Project, userSpecified: String?): TargetLan
 
 internal fun linkSqlite(project: Project) {
   val extension = project.kotlinMultiplatformExtension ?: return
-  extension.targets
-      .flatMap { it.compilations }
-      .filterIsInstance<KotlinNativeCompilation>()
-      .forEach { compilationUnit ->
-        compilationUnit.kotlinOptions.freeCompilerArgs += arrayOf("-linker-options", "-lsqlite3")
-      }
+
+  extension.targets.filterIsInstance<KotlinNativeTarget>()
+      .flatMap { it.binaries }
+      .forEach { it.linkerOpts("-lsqlite3") }
 }
 
 internal fun checkKotlinPluginVersion(project: Project) {


### PR DESCRIPTION
Same as https://github.com/cashapp/sqldelight/pull/3671/files/f5f277367f99aa63224a323b1f33a640904ea4c5

I briefly considered keeping the old code for backward compat with KGP 1.5, 1.6 or so but given this is only used in native, it should be pretty safe to assume users are running latest KGP (they need 1.7 at the moment to consume the artifacts anyway)