### PR TITLE
🐘 Use Gradle exclusiveContent

### DIFF
--- a/gradle/repositories.gradle.kts
+++ b/gradle/repositories.gradle.kts
@@ -1,21 +1,33 @@
 listOf(pluginManagement.repositories, dependencyResolutionManagement.repositories).forEach {
   it.apply {
     mavenCentral()
-    google()
-    gradlePluginPortal {
-      content {
+
+    exclusiveContent {
+      forRepository(::google)
+      filter {
+        includeModuleByRegex("com\\.android.*", ".*")
+        includeModuleByRegex("androidx\\..*", ".*")
+        includeModuleByRegex("com.google.testing.platform", ".*")
+      }
+    }
+
+    exclusiveContent {
+      forRepository(::gradlePluginPortal)
+      filter {
         includeModule("org.gradle.kotlin.embedded-kotlin", "org.gradle.kotlin.embedded-kotlin.gradle.plugin")
-        includeGroup("org.gradle.kotlin")
+        includeModule("org.gradle.kotlin", "gradle-kotlin-dsl-plugins")
         includeModule("me.champeau.gradle", "japicmp-gradle-plugin")
         includeModule("com.gradle.publish", "plugin-publish-plugin")
         includeModule("com.github.ben-manes", "gradle-versions-plugin")
         // Because we use 1.6.10 during sync and this version is not on mavenCentral
-        includeModule("org.jetbrains.kotlin.plugin.serialization", "org.jetbrains.kotlin.plugin.serialization.gradle.plugin")
+        includeVersion("org.jetbrains.kotlin.plugin.serialization", "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", "1.6.10")
       }
     }
-    @Suppress("DEPRECATION")
-    jcenter {
-      content {
+
+    exclusiveContent {
+      @Suppress("DEPRECATION")
+      forRepository(::jcenter)
+      filter {
         // https://github.com/Kotlin/kotlinx-nodejs/issues/16
         includeModule("org.jetbrains.kotlinx", "kotlinx-nodejs")
       }


### PR DESCRIPTION
Everything but `mavenCentral()` gets the Gradle [exclusive content](https://docs.gradle.org/current/userguide/declaring_repositories.html#declaring_content_exclusively_found_in_one_repository) treatment. This makes builds more reproductible and speeds up dependency resolution as we don't need to search repos in order for those dependencies that are only in google or plugin portal.

Many thanks @yogurtearl for the heads up!

