### PR TITLE
Build scripts: shorten project names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,7 +51,7 @@ tasks.register("ciPublishRelease") {
   if (isTag()) {
     dependsOn(subprojectTasks("publishAllPublicationsToOssStagingRepository"))
     // Only publish plugins to the Gradle portal if everything else succeeded
-    finalizedBy(":libraries:apollo-gradle-plugin:publishPlugins")
+    finalizedBy(":apollo-gradle-plugin:publishPlugins")
   } else {
     doFirst {
       error("We are not on a tag, fail release publishing")
@@ -62,7 +62,7 @@ tasks.register("ciPublishRelease") {
 
 tasks.register("ciTestsGradle") {
   description = "Execute the Gradle tests (slow)"
-  dependsOn(":libraries:apollo-gradle-plugin:test")
+  dependsOn(":apollo-gradle-plugin:test")
 }
 
 tasks.register("ciTestsNoGradle") {
@@ -85,10 +85,10 @@ tasks.register("ciTestsNoGradle") {
   /**
    * Update the database schemas in CI
    */
-  dependsOn(":libraries:apollo-normalized-cache-sqlite:generateCommonMainJsonDatabaseSchema")
-  dependsOn(":libraries:apollo-normalized-cache-sqlite-incubating:generateCommonMainJsonDatabaseSchema")
-  dependsOn(":libraries:apollo-normalized-cache-sqlite-incubating:generateCommonMainBlobDatabaseSchema")
-  dependsOn(":libraries:apollo-normalized-cache-sqlite-incubating:generateCommonMainBlob2DatabaseSchema")
+  dependsOn(":apollo-normalized-cache-sqlite:generateCommonMainJsonDatabaseSchema")
+  dependsOn(":apollo-normalized-cache-sqlite-incubating:generateCommonMainJsonDatabaseSchema")
+  dependsOn(":apollo-normalized-cache-sqlite-incubating:generateCommonMainBlobDatabaseSchema")
+  dependsOn(":apollo-normalized-cache-sqlite-incubating:generateCommonMainBlob2DatabaseSchema")
 
   doLast {
     checkGitStatus()

--- a/libraries/apollo-adapters/build.gradle.kts
+++ b/libraries/apollo-adapters/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
+        api(project(":apollo-api"))
         api(golatac.lib("kotlinx.datetime"))
       }
     }

--- a/libraries/apollo-api-java/build.gradle.kts
+++ b/libraries/apollo-api-java/build.gradle.kts
@@ -8,7 +8,7 @@ apolloLibrary {
 }
 
 dependencies {
-  api(project(":libraries:apollo-api"))
+  api(project(":apollo-api"))
   api(golatac.lib("okhttp"))
   compileOnly(golatac.lib("guava.jre"))
 }

--- a/libraries/apollo-api/build.gradle.kts
+++ b/libraries/apollo-api/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
       dependencies {
         api(okio())
         api(golatac.lib("uuid"))
-        api(project(":libraries:apollo-annotations"))
+        api(project(":apollo-annotations"))
       }
     }
   }

--- a/libraries/apollo-ast/build.gradle.kts
+++ b/libraries/apollo-ast/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   antlr(golatac.lib("antlr"))
   implementation(golatac.lib("antlr.runtime"))
   api(okio())
-  api(project(":libraries:apollo-annotations"))
+  api(project(":apollo-annotations"))
 
   implementation(golatac.lib("kotlinx.serialization.json"))
 

--- a/libraries/apollo-cli/build.gradle.kts
+++ b/libraries/apollo-cli/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":libraries:apollo-tooling"))
-  implementation(project(":libraries:apollo-annotations"))
+  implementation(project(":apollo-tooling"))
+  implementation(project(":apollo-annotations"))
   implementation(golatac.lib("kotlinx.serialization.json"))
   implementation(golatac.lib("clikt"))
 }

--- a/libraries/apollo-compiler/build.gradle.kts
+++ b/libraries/apollo-compiler/build.gradle.kts
@@ -11,8 +11,8 @@ apolloLibrary {
 }
 
 dependencies {
-  implementation(project(":libraries:apollo-ast"))
-  implementation(project(":libraries:apollo-api")) {
+  implementation(project(":apollo-ast"))
+  implementation(project(":apollo-api")) {
     because("For BooleanExpression")
   }
   api(golatac.lib("poet.kotlin")) {
@@ -32,7 +32,7 @@ dependencies {
   testImplementation(golatac.lib("truth"))
   testImplementation(golatac.lib("kotlin.test.junit"))
   testImplementation(golatac.lib("google.testparameterinjector"))
-  testImplementation(project(":libraries:apollo-api-java")) {
+  testImplementation(project(":apollo-api-java")) {
     because("Generated Java code references Java and Guava Optionals")
   }
   testImplementation(golatac.lib("androidx.annotation")) {

--- a/libraries/apollo-gradle-plugin-external/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin-external/build.gradle.kts
@@ -14,9 +14,9 @@ dependencies {
   compileOnly(golatac.lib("kotlin.plugin.min"))
   compileOnly(golatac.lib("android.plugin.min"))
 
-  api(project(":libraries:apollo-compiler"))
-  implementation(project(":libraries:apollo-tooling"))
-  implementation(project(":libraries:apollo-ast"))
+  api(project(":apollo-compiler"))
+  implementation(project(":apollo-tooling"))
+  implementation(project(":apollo-ast"))
 }
 
 

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -27,9 +27,9 @@ dependencies {
    */
   add("gr8Classpath", "org.conscrypt:conscrypt-openjdk-uber:2.5.2")
 
-  add("shade", project(":libraries:apollo-gradle-plugin-external"))
+  add("shade", project(":apollo-gradle-plugin-external"))
 
-  testImplementation(project(":libraries:apollo-ast"))
+  testImplementation(project(":apollo-ast"))
   testImplementation(golatac.lib("junit"))
   testImplementation(golatac.lib("truth"))
   testImplementation(golatac.lib("assertj"))
@@ -116,14 +116,14 @@ configure<PublishingExtension> {
 }
 
 tasks.withType<Test> {
-  dependsOn(":libraries:apollo-annotations:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-api:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-ast:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-normalized-cache-api:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-mpp-utils:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-compiler:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-gradle-plugin-external:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":libraries:apollo-tooling:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-annotations:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-ast:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-normalized-cache-api:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-mpp-utils:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-gradle-plugin-external:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-tooling:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")
 
   inputs.dir("src/test/files")

--- a/libraries/apollo-http-cache/build.gradle.kts
+++ b/libraries/apollo-http-cache/build.gradle.kts
@@ -9,12 +9,12 @@ apolloLibrary {
 
 dependencies {
   api(golatac.lib("okhttp"))
-  api(project(":libraries:apollo-api"))
-  api(project(":libraries:apollo-runtime"))
+  api(project(":apollo-api"))
+  api(project(":apollo-runtime"))
   implementation(golatac.lib("moshi"))
   implementation(golatac.lib("kotlinx.datetime"))
 
-  testImplementation(project(":libraries:apollo-mockserver"))
+  testImplementation(project(":apollo-mockserver"))
   testImplementation(golatac.lib("kotlin.test.junit"))
   testImplementation(golatac.lib("truth"))
 }

--- a/libraries/apollo-idling-resource/build.gradle.kts
+++ b/libraries/apollo-idling-resource/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation(golatac.lib("androidx.espresso.idlingresource"))
-  api(project(":libraries:apollo-runtime"))
+  api(project(":apollo-runtime"))
 }
 
 android {

--- a/libraries/apollo-mockserver/build.gradle.kts
+++ b/libraries/apollo-mockserver/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-annotations"))
+        api(project(":apollo-annotations"))
         api(okio())
         implementation(golatac.lib("atomicfu")) {
           because("We need locks for native (we don't use the gradle plugin rewrite)")
@@ -31,10 +31,10 @@ kotlin {
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(project(":libraries:apollo-testing-support")) {
+        implementation(project(":apollo-testing-support")) {
           because("runTest")
         }
-        implementation(project(":libraries:apollo-runtime")) {
+        implementation(project(":apollo-runtime")) {
           because("We need HttpEngine for SocketTest")
         }
       }

--- a/libraries/apollo-mpp-utils/build.gradle.kts
+++ b/libraries/apollo-mpp-utils/build.gradle.kts
@@ -14,7 +14,7 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-annotations"))
+        api(project(":apollo-annotations"))
       }
     }
   }

--- a/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-mpp-utils"))
+        api(project(":apollo-api"))
+        api(project(":apollo-mpp-utils"))
         implementation(okio())
         api(golatac.lib("uuid"))
       }

--- a/libraries/apollo-normalized-cache-api/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-api/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-mpp-utils"))
+        api(project(":apollo-api"))
+        api(project(":apollo-mpp-utils"))
         implementation(okio())
         api(golatac.lib("uuid"))
       }

--- a/libraries/apollo-normalized-cache-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-incubating/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-runtime"))
-        api(project(":libraries:apollo-normalized-cache-api-incubating"))
+        api(project(":apollo-runtime"))
+        api(project(":apollo-normalized-cache-api-incubating"))
         api(golatac.lib("kotlinx.coroutines"))
         implementation(golatac.lib("atomicfu")) {
           because("Use of ReentrantLock in DefaultApolloStore for Apple (we don't use the gradle plugin rewrite)")

--- a/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
@@ -41,9 +41,9 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-normalized-cache-api-incubating"))
-        api(project(":libraries:apollo-normalized-cache-incubating"))
+        api(project(":apollo-api"))
+        api(project(":apollo-normalized-cache-api-incubating"))
+        api(project(":apollo-normalized-cache-incubating"))
       }
     }
 
@@ -80,7 +80,7 @@ kotlin {
     }
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(project(":libraries:apollo-testing-support"))
+        implementation(project(":apollo-testing-support"))
       }
     }
   }

--- a/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -28,9 +28,9 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-normalized-cache-api"))
-        api(project(":libraries:apollo-normalized-cache"))
+        api(project(":apollo-api"))
+        api(project(":apollo-normalized-cache-api"))
+        api(project(":apollo-normalized-cache"))
       }
     }
 
@@ -69,7 +69,7 @@ kotlin {
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(project(":libraries:apollo-testing-support"))
+        implementation(project(":apollo-testing-support"))
       }
     }
   }

--- a/libraries/apollo-normalized-cache/build.gradle.kts
+++ b/libraries/apollo-normalized-cache/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-runtime"))
-        api(project(":libraries:apollo-normalized-cache-api"))
+        api(project(":apollo-runtime"))
+        api(project(":apollo-normalized-cache-api"))
         api(golatac.lib("kotlinx.coroutines"))
         implementation(golatac.lib("atomicfu")) {
           because("Use of ReentrantLock in DefaultApolloStore for Apple (we don't use the gradle plugin rewrite)")

--- a/libraries/apollo-runtime-java/build.gradle.kts
+++ b/libraries/apollo-runtime-java/build.gradle.kts
@@ -8,5 +8,5 @@ apolloLibrary {
 }
 
 dependencies {
-  api(project(":libraries:apollo-api-java"))
+  api(project(":apollo-api-java"))
 }

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -14,8 +14,8 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-mpp-utils"))
+        api(project(":apollo-api"))
+        api(project(":apollo-mpp-utils"))
         api(okio())
         api(golatac.lib("uuid"))
         api(golatac.lib("kotlinx.coroutines"))
@@ -24,8 +24,8 @@ kotlin {
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(project(":libraries:apollo-mockserver"))
-        implementation(project(":libraries:apollo-testing-support"))
+        implementation(project(":apollo-mockserver"))
+        implementation(project(":apollo-testing-support"))
       }
     }
 

--- a/libraries/apollo-rx2-support-java/build.gradle.kts
+++ b/libraries/apollo-rx2-support-java/build.gradle.kts
@@ -9,5 +9,5 @@ apolloLibrary {
 
 dependencies {
   api(golatac.lib("rx.java2"))
-  api(project(":libraries:apollo-runtime-java"))
+  api(project(":apollo-runtime-java"))
 }

--- a/libraries/apollo-rx2-support/build.gradle.kts
+++ b/libraries/apollo-rx2-support/build.gradle.kts
@@ -8,10 +8,10 @@ apolloLibrary {
 }
 
 dependencies {
-  implementation(project(":libraries:apollo-api"))
+  implementation(project(":apollo-api"))
   api(golatac.lib("rx.java2"))
   api(golatac.lib("kotlinx.coroutines.rx2"))
 
-  api(project(":libraries:apollo-runtime"))
-  api(project(":libraries:apollo-normalized-cache"))
+  api(project(":apollo-runtime"))
+  api(project(":apollo-normalized-cache"))
 }

--- a/libraries/apollo-rx3-support-java/build.gradle.kts
+++ b/libraries/apollo-rx3-support-java/build.gradle.kts
@@ -12,5 +12,5 @@ apolloLibrary {
 
 dependencies {
   api(golatac.lib("rx.java3"))
-  api(project(":libraries:apollo-runtime-java"))
+  api(project(":apollo-runtime-java"))
 }

--- a/libraries/apollo-rx3-support/build.gradle.kts
+++ b/libraries/apollo-rx3-support/build.gradle.kts
@@ -11,10 +11,10 @@ apolloLibrary {
 }
 
 dependencies {
-  implementation(project(":libraries:apollo-api"))
+  implementation(project(":apollo-api"))
   api(golatac.lib("rx.java3"))
   api(golatac.lib("kotlinx.coroutines.rx3"))
 
-  api(project(":libraries:apollo-runtime"))
-  api(project(":libraries:apollo-normalized-cache"))
+  api(project(":apollo-runtime"))
+  api(project(":apollo-normalized-cache"))
 }

--- a/libraries/apollo-testing-support/build.gradle.kts
+++ b/libraries/apollo-testing-support/build.gradle.kts
@@ -13,9 +13,9 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(project(":libraries:apollo-api"))
-        api(project(":libraries:apollo-runtime"))
-        api(project(":libraries:apollo-mockserver"))
+        api(project(":apollo-api"))
+        api(project(":apollo-runtime"))
+        api(project(":apollo-mockserver"))
         api(golatac.lib("kotlinx.coroutines"))
         implementation(golatac.lib("atomicfu")) {
           because("We need locks in TestNetworkTransportHandler (we don't use the gradle plugin rewrite)")

--- a/libraries/apollo-tooling/build.gradle.kts
+++ b/libraries/apollo-tooling/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 }
 
 dependencies {
-  implementation(project(":libraries:apollo-annotations"))
-  implementation(project(":libraries:apollo-ast"))
-  api(project(":libraries:apollo-compiler"))
+  implementation(project(":apollo-annotations"))
+  implementation(project(":apollo-ast"))
+  api(project(":apollo-compiler"))
   implementation(golatac.lib("moshi"))
   implementation(golatac.lib("moshix.sealed.runtime"))
   implementation(golatac.lib("okhttp"))

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,8 @@ rootProject.projectDir
     .filter { it.name.startsWith("apollo-") }
     .filter { File(it, "build.gradle.kts").exists() }
     .forEach {
-      include(":libraries:${it.name}")
+      include(it.name)
+      project(":${it.name}").projectDir = it
     }
 
 pluginManagement {


### PR DESCRIPTION
You can now type `./gradlew :apollo-gradle-plugin:test` instead of `./gradlew :libraries:apollo-gradle-plugin:test`