### PR TITLE
Http cache: don't access the disk from the main thread in error case

### DIFF
--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo3/cache/http/HttpCacheExtensions.kt
@@ -3,6 +3,7 @@
 package com.apollographql.apollo3.cache.http
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.ConcurrencyInfo
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.ExecutionContext
@@ -22,6 +23,7 @@ import com.apollographql.apollo3.network.http.HttpInterceptorChain
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import java.io.File
@@ -131,7 +133,7 @@ fun ApolloClient.Builder.httpCache(
                 }
               }.onCompletion {
                 synchronized(apolloRequestToCacheKey) { apolloRequestToCacheKey.remove(request.requestUuid.toString()) }
-              }
+              }.flowOn(request.executionContext[ConcurrencyInfo]!!.dispatcher)
             } else {
               this
             }


### PR DESCRIPTION
Related to #4602.

Deleting cache entries in the error case was done on the thread calling `execute()` (normally, the main thread). This now happens on the the client's dispatcher (by default, `dispatchers.IO`)