### PR TITLE
Bump main to 4.0.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ pluginManagement {
 }
 ```
 
-And then use the `3.7.4-SNAPSHOT` version for the plugin and libraries.
+And then use the `4.0.0-SNAPSHOT` version for the plugin and libraries.
 
 ## Requirements
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -210,7 +210,7 @@ pluginManagement {
   }
 }
 ```
-And then use the `3.7.4-SNAPSHOT` version for the plugin and libraries.
+And then use the `4.0.0-SNAPSHOT` version for the plugin and libraries.
 
 ## Contributing
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Publishing defaults, could ultimately be moved to build scripts
 GROUP=com.apollographql.apollo3
-VERSION_NAME=3.7.4-SNAPSHOT
+VERSION_NAME=4.0.0-SNAPSHOT
 
 POM_URL=https://github.com/apollographql/apollo-kotlin/
 POM_SCM_URL=https://github.com/apollographql/apollo-kotlin/

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -7,7 +7,7 @@ android-sdkversion-target = "30"
 androidx-sqlite = "2.1.0"
 antlr = "4.9.3"
 # This is used by the gradle integration tests to get the artifacts locally
-apollo = "3.7.4-SNAPSHOT"
+apollo = "4.0.0-SNAPSHOT"
 cache = "2.0.2"
 dokka = "1.7.10"
 guava = "31.1-jre"


### PR DESCRIPTION
3.x releases will happen from a branch. `main` is now for 4.x  