### PR TITLE
Add deprecation warnings

### DIFF
--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -20,6 +20,7 @@ public final class com/apollographql/apollo3/annotations/ApolloDeprecatedSince$V
 	public static final field v3_5_1 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_6_3 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_7_2 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
+	public static final field v3_7_5 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun values ()[Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 }

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
@@ -26,6 +26,7 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v3_4_1,
     v3_5_1,
     v3_6_3,
-    v3_7_2
+    v3_7_2,
+    v3_7_5,
   }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -118,6 +118,16 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   }
 
   override fun useVersion2Compat(rootPackageName: String?) {
+    project.logger.warn("""
+      Apollo: useVersion2Compat() is deprecated.
+      
+      Use packageNamesFromFilePaths(rootPackageName) instead and update your code to work with the operationBased generated models:
+      - remove `.fragments` synthetic fields
+      - replace inline fragments usage: `as${'$'}Fragment}` is now `on${'$'}Fragment}`
+      - if your fragments are not defined in the same directory as your schema, their package name has changed, update usages to the new package name that matches the location of the fragment. 
+      
+      You can read more details at https://www.apollographql.com/docs/kotlin/migration/3.0/
+      """.trimIndent())
     packageNamesFromFilePaths(rootPackageName)
     codegenModels.set(MODELS_COMPAT)
     useSchemaPackageNameForFragments.set(true)

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_7_5
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
@@ -226,6 +227,8 @@ fun <D : Query.Data> ApolloCall<D>.watch(
  *
  * Any [FetchPolicy] previously set will be ignored
  */
+@Deprecated("Use fetchPolicy(FetchPolicy.CacheAndNetwork) instead", ReplaceWith("fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()"))
+@ApolloDeprecatedSince(v3_7_5)
 fun <D : Query.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {
   return flow {
     var cacheException: ApolloException? = null
@@ -323,6 +326,8 @@ fun <T> MutableExecutionOptions<T>.doNotStore(doNotStore: Boolean) = addExecutio
  *
  * Default: false
  */
+@Deprecated("Will be removed in v4, where this is the default behavior", ReplaceWith(""))
+@ApolloDeprecatedSince(v3_7_5)
 fun <T> MutableExecutionOptions<T>.emitCacheMisses(emitCacheMisses: Boolean) = addExecutionContext(
     EmitCacheMissesContext(emitCacheMisses)
 )

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -326,8 +326,6 @@ fun <T> MutableExecutionOptions<T>.doNotStore(doNotStore: Boolean) = addExecutio
  *
  * Default: false
  */
-@Deprecated("Will be removed in v4, where this is the default behavior", ReplaceWith(""))
-@ApolloDeprecatedSince(v3_7_5)
 fun <T> MutableExecutionOptions<T>.emitCacheMisses(emitCacheMisses: Boolean) = addExecutionContext(
     EmitCacheMissesContext(emitCacheMisses)
 )

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ApolloCall
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_0_0
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v3_7_5
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
@@ -202,6 +203,8 @@ fun <D : Query.Data> ApolloCall<D>.watch(
  *
  * Any [FetchPolicy] previously set will be ignored
  */
+@Deprecated("Use fetchPolicy(FetchPolicy.CacheAndNetwork) instead", ReplaceWith("fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()"))
+@ApolloDeprecatedSince(v3_7_5)
 fun <D : Query.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> {
   return flow {
     var cacheException: ApolloException? = null
@@ -299,6 +302,8 @@ fun <T> MutableExecutionOptions<T>.doNotStore(doNotStore: Boolean) = addExecutio
  *
  * Default: false
  */
+@Deprecated("Will be removed in v4, where this is the default behavior", ReplaceWith(""))
+@ApolloDeprecatedSince(v3_7_5)
 fun <T> MutableExecutionOptions<T>.emitCacheMisses(emitCacheMisses: Boolean) = addExecutionContext(
     EmitCacheMissesContext(emitCacheMisses)
 )

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -302,8 +302,6 @@ fun <T> MutableExecutionOptions<T>.doNotStore(doNotStore: Boolean) = addExecutio
  *
  * Default: false
  */
-@Deprecated("Will be removed in v4, where this is the default behavior", ReplaceWith(""))
-@ApolloDeprecatedSince(v3_7_5)
 fun <T> MutableExecutionOptions<T>.emitCacheMisses(emitCacheMisses: Boolean) = addExecutionContext(
     EmitCacheMissesContext(emitCacheMisses)
 )


### PR DESCRIPTION
Add messages during Gradle execution when any of those is used:

- `useVersion2Compat()`
- `generateTestBuilders`
- `useSchemaPackageNameForFragments`
- `codegenModels.set("compat")`

There is no way to disable the warning besides actually migrating, which I think is ok.