### PR TITLE
IJ plugin: use Gradle's continuous mode

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/listeners/GradleListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/listeners/GradleListener.kt
@@ -11,8 +11,8 @@ class GradleListener : ExternalSystemTaskNotificationListenerAdapter() {
   override fun onSuccess(id: ExternalSystemTaskId) {
     logd()
     if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == ExternalSystemTaskType.RESOLVE_PROJECT) {
-      // Gradle sync finished, restart Gradle continuous codegen.
-      id.findProject()?.apolloProjectService()?.restartContinuousGradleCodegen()
+      // Gradle sync finished, notify project service
+      id.findProject()?.apolloProjectService()?.notifyGradleHasSynced()
     }
   }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/listeners/GradleListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/listeners/GradleListener.kt
@@ -1,0 +1,18 @@
+package com.apollographql.ijplugin.listeners
+
+import com.apollographql.ijplugin.services.apolloProjectService
+import com.apollographql.ijplugin.util.logd
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType
+import org.jetbrains.kotlin.idea.framework.GRADLE_SYSTEM_ID
+
+class GradleListener : ExternalSystemTaskNotificationListenerAdapter() {
+  override fun onSuccess(id: ExternalSystemTaskId) {
+    logd()
+    if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == ExternalSystemTaskType.RESOLVE_PROJECT) {
+      // Gradle sync finished, restart Gradle continuous codegen.
+      id.findProject()?.apolloProjectService()?.restartContinuousGradleCodegen()
+    }
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/services/ApolloProjectService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/services/ApolloProjectService.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.project.Project
 interface ApolloProjectService {
   val isApolloAndroid2Project: Boolean
   val isApolloKotlin3Project: Boolean
+
+  fun restartContinuousGradleCodegen()
 }
 
 fun Project.apolloProjectService() = service<ApolloProjectService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/services/ApolloProjectService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/services/ApolloProjectService.kt
@@ -7,7 +7,7 @@ interface ApolloProjectService {
   val isApolloAndroid2Project: Boolean
   val isApolloKotlin3Project: Boolean
 
-  fun restartContinuousGradleCodegen()
+  fun notifyGradleHasSynced()
 }
 
 fun Project.apolloProjectService() = service<ApolloProjectService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Apollo.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Apollo.kt
@@ -7,11 +7,9 @@ import com.intellij.openapi.project.rootManager
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
 
-val Project.isApolloAndroid2Project: Boolean
-  get() = dependsOn("com.apollographql.apollo")
+fun Project.isApolloAndroid2Project(): Boolean = dependsOn("com.apollographql.apollo")
 
-val Project.isApolloKotlin3Project: Boolean
-  get() = dependsOn("com.apollographql.apollo3")
+fun Project.isApolloKotlin3Project(): Boolean = dependsOn("com.apollographql.apollo3")
 
 private fun Project.dependsOn(groupId: String): Boolean {
   var found = false
@@ -28,5 +26,5 @@ private fun Project.dependsOn(groupId: String): Boolean {
 }
 
 fun Module.apolloGeneratedSourcesRoot(): VirtualFile? {
-  return this.rootManager.contentRoots.first { it.path.contains("generated/source/apollo") }
+  return this.rootManager.contentRoots.firstOrNull { it.path.contains("generated/source/apollo") }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Apollo.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Apollo.kt
@@ -1,8 +1,11 @@
 package com.apollographql.ijplugin.util
 
 import com.intellij.openapi.components.service
+import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.rootManager
 import com.intellij.openapi.roots.ProjectRootManager
+import com.intellij.openapi.vfs.VirtualFile
 
 val Project.isApolloAndroid2Project: Boolean
   get() = dependsOn("com.apollographql.apollo")
@@ -22,4 +25,8 @@ private fun Project.dependsOn(groupId: String): Boolean {
     }
   }
   return found
+}
+
+fun Module.apolloGeneratedSourcesRoot(): VirtualFile? {
+  return this.rootManager.contentRoots.first { it.path.contains("generated/source/apollo") }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Disposable.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Disposable.kt
@@ -1,0 +1,6 @@
+package com.apollographql.ijplugin.util
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+
+fun Disposable?.isNullOrDisposed() = this == null || Disposer.isDisposed(this)

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,8 @@
     <codeInsight.lineMarkerProvider language="UAST"
                                     implementationClass="com.apollographql.ijplugin.navigation.OperationUsageMarkerProvider" />
 
+    <externalSystemTaskNotificationListener implementation="com.apollographql.ijplugin.listeners.GradleListener" />
+
   </extensions>
 
   <applicationListeners>


### PR DESCRIPTION
Don't observe GQL files ourselves, instead let Gradle do it.
Also, observe project root changes to dynamically determine if current project is an "Apollo project" or not.