### PR TITLE
Publish IJ plugin snapshots

### DIFF
--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -1,0 +1,29 @@
+name: Publish IntelliJ plugin snapshot
+
+on:
+  pull_request:
+    branches: [ '*' ]
+#  schedule:
+#    - cron: '0 0 * * 0'
+
+jobs:
+  publish-intellij-plugin:
+    name: Publish IntelliJ plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+
+      - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Increment snapshot version
+        run: ./scripts/increment-ij-plugin-snapshot.main.kts
+        env:
+          COM_APOLLOGRAPHQL_IJ_PLUGIN_SNAPSHOT: true
+
+      - name: Publish snapshot to Repsy
+        run: ./gradlew --no-build-cache :intellij-plugin:publishAllPublicationsToRepsyIjPluginSnapshots
+        env:
+          COM_APOLLOGRAPHQL_IJ_PLUGIN_SNAPSHOT: true

--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -30,3 +30,5 @@ jobs:
         run: ./gradlew --no-build-cache :intellij-plugin:publishAllPublicationsToRepsyIjPluginSnapshots
         env:
           COM_APOLLOGRAPHQL_IJ_PLUGIN_SNAPSHOT: true
+          IJ_PLUGIN_REPSY_USERNAME: ${{ secrets.IJ_PLUGIN_REPSY_USERNAME }}
+          IJ_PLUGIN_REPSY_PASSWORD: ${{ secrets.IJ_PLUGIN_REPSY_PASSWORD }}

--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -1,10 +1,10 @@
 name: Publish IntelliJ plugin snapshot
 
 on:
-  pull_request:
-    branches: [ '*' ]
-#  schedule:
-#    - cron: '0 0 * * 0'
+#  pull_request:
+  #    branches: [ '*' ]
+  schedule:
+    - cron: '0 0 * * 0'
 
 jobs:
   publish-intellij-plugin:

--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -19,7 +19,10 @@ jobs:
           java-version: 11
 
       - name: Increment snapshot version
-        run: ./scripts/increment-ij-plugin-snapshot.main.kts
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          ./scripts/increment-ij-plugin-snapshot.main.kts
         env:
           COM_APOLLOGRAPHQL_IJ_PLUGIN_SNAPSHOT: true
 

--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -150,13 +150,20 @@ tasks.named("test").configure {
   dependsOn("downloadMockJdk")
 }
 
+// See https://plugins.jetbrains.com/docs/intellij/custom-plugin-repository.html
 tasks.register("generateUpdatePluginsXml") {
   val filePath = "build/publications/updatePlugins.xml"
   val pluginName = properties("pluginName")
   val version = properties("VERSION_NAME")
+  val pluginSinceBuild = properties("pluginSinceBuild")
+  val pluginUntilBuild = properties("pluginUntilBuild")
+  inputs.property("pluginName", pluginName)
+  inputs.property("version", version)
+  inputs.property("pluginSinceBuild", pluginSinceBuild)
+  inputs.property("pluginUntilBuild", pluginUntilBuild)
   outputs.file(filePath)
+  outputs.cacheIf { true }
   doLast {
-    // See https://plugins.jetbrains.com/docs/intellij/custom-plugin-repository.html
     file(filePath).writeText(
         """
         <plugins>
@@ -164,7 +171,7 @@ tasks.register("generateUpdatePluginsXml") {
               id="$pluginName"
               url="https://s01.oss.sonatype.org/content/repositories/snapshots/com/apollographql/$pluginName/$version/$pluginName-$version.zip"
               version="$version">
-            <idea-version since-build="${properties("pluginSinceBuild")}" until-build="${properties("pluginUntilBuild")}"/>
+            <idea-version since-build="$pluginSinceBuild" until-build="$pluginUntilBuild"/>
             <name>Apollo GraphQL (Snapshot)</name>
           </plugin>
         </plugins>

--- a/intellij-plugin/gradle.properties
+++ b/intellij-plugin/gradle.properties
@@ -2,6 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.apollographql
 pluginName=apollo-intellij-plugin
+pluginId=com.apollographql.ijplugin
 pluginRepositoryUrl=https://github.com/apollographql/apollo-kotlin
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -27,3 +28,6 @@ javaVersion=11
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 # suppress inspection "UnusedProperty"
 kotlin.stdlib.default.dependency=false
+
+# Snapshot version, automatically incremented by the CI
+snapshotVersion=1

--- a/intellij-plugin/snapshots/plugins.xml
+++ b/intellij-plugin/snapshots/plugins.xml
@@ -1,0 +1,9 @@
+<plugins>
+  <plugin
+      id="com.apollographql.ijplugin"
+      url="https://repsy.io/mvn/bod/apollo-intellij-plugin/com/apollographql/apollo-intellij-plugin/4.0.0-SNAPSHOT.1/apollo-intellij-plugin-4.0.0-SNAPSHOT.1.zip"
+      version="4.0.0-SNAPSHOT.1">
+    <idea-version since-build="212" until-build="223.*" />
+    <name>Apollo GraphQL (Snapshot)</name>
+  </plugin>
+</plugins>

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,5 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
-  <id>com.apollographql.ijplugin</id>
   <name>Apollo GraphQL</name>
   <!-- Use the id that is defined for the Organization in the Marketplace -->
   <!-- See https://plugins.jetbrains.com/docs/marketplace/organizations.html#4b3f843d -->

--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -1,0 +1,34 @@
+#!/usr/bin/env kotlin
+import java.io.File
+
+incrementSnapshotVersion()
+runCommand("bash", "-c", "./gradlew :intellij-plugin:updatePluginsXml")
+runCommand("git", "add", "intellij-plugin/gradle.properties")
+runCommand("git", "add", "intellij-plugin/snapshots/plugins.xml")
+runCommand("git", "commit", "-m", "Increment IJ plugin snapshot version")
+
+fun incrementSnapshotVersion() {
+  val ijPropertiesFile = File("intellij-plugin/gradle.properties")
+  val ijPropertiesText = ijPropertiesFile.readText()
+  val updatedIjPropertiesText = ijPropertiesText.replace(Regex("snapshotVersion=(\\d+)")) {
+    val version = it.groupValues[1].toInt()
+    "snapshotVersion=${version + 1}"
+  }
+  ijPropertiesFile.writeText(updatedIjPropertiesText)
+}
+
+fun runCommand(vararg args: String): String {
+  val builder = ProcessBuilder(*args)
+      .redirectError(ProcessBuilder.Redirect.INHERIT)
+
+  val process = builder.start()
+  val ret = process.waitFor()
+
+  val output = process.inputStream.bufferedReader().readText()
+  if (ret != 0) {
+    throw java.lang.Exception("command ${args.joinToString(" ")} failed:\n$output")
+  }
+
+  return output
+}
+

--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -7,6 +7,9 @@ runCommand("git", "add", "intellij-plugin/gradle.properties")
 runCommand("git", "add", "intellij-plugin/snapshots/plugins.xml")
 runCommand("git", "commit", "-m", "Increment IJ plugin snapshot version")
 
+// TODO: commented for now
+// runCommand("git", "push")
+
 fun incrementSnapshotVersion() {
   val ijPropertiesFile = File("intellij-plugin/gradle.properties")
   val ijPropertiesText = ijPropertiesFile.readText()

--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -3,12 +3,9 @@ import java.io.File
 
 incrementSnapshotVersion()
 runCommand("bash", "-c", "./gradlew :intellij-plugin:updatePluginsXml")
-runCommand("git", "add", "intellij-plugin/gradle.properties")
-runCommand("git", "add", "intellij-plugin/snapshots/plugins.xml")
+runCommand("git", "add", "intellij-plugin/gradle.properties", "intellij-plugin/snapshots/plugins.xml")
 runCommand("git", "commit", "-m", "Increment IJ plugin snapshot version")
-
-// TODO: commented for now
-// runCommand("git", "push")
+runCommand("git", "push")
 
 fun incrementSnapshotVersion() {
   val ijPropertiesFile = File("intellij-plugin/gradle.properties")

--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -23,6 +23,7 @@ fun incrementSnapshotVersion() {
 fun runCommand(vararg args: String): String {
   val builder = ProcessBuilder(*args)
       .redirectError(ProcessBuilder.Redirect.INHERIT)
+      .redirectOutput(ProcessBuilder.Redirect.INHERIT)
 
   val process = builder.start()
   val ret = process.waitFor()


### PR DESCRIPTION
Publish the IJ plugin to the Maven central snapshots repository.

This should make it available when adding this custom repository in the plugins settings: `https://s01.oss.sonatype.org/content/repositories/snapshots/com/apollographql/apollo-intellij-plugin/<version>-SNAPSHOT/apollo-intellij-plugin-<version>-SNAPSHOT.xml`.
