### PR TITLE
Add a @JsName annotation to Operation.name()

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operation.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operation.kt
@@ -19,6 +19,7 @@ interface Operation<D : Operation.Data> : Executable<D> {
   /**
    * The GraphQL operation name as in the `*.graphql` file.
    */
+  @JsName("operationName")
   fun name(): String
 
   /**

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -43,6 +43,7 @@ if (System.getProperty("idea.sync.active") == null) {
       ":native-benchmarks:compileCommonMainKotlinMetadata",
       ":pagination:compileCommonMainKotlinMetadata",
       ":sqlite:compileCommonMainKotlinMetadata",
-      ":websockets:compileCommonMainKotlinMetadata"
+      ":websockets:compileCommonMainKotlinMetadata",
+      ":js:compileCommonMainKotlinMetadata",
   ))
 }

--- a/tests/js/build.gradle.kts
+++ b/tests/js/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+  id("apollo.test")
+  id("com.apollographql.apollo3")
+}
+
+apolloTest {
+  mpp {
+    withJvm.set(false)
+    appleTargets.set(emptySet())
+  }
+}
+
+kotlin {
+  sourceSets {
+    findByName("commonMain")?.apply {
+      dependencies {
+        implementation(golatac.lib("apollo.runtime"))
+      }
+    }
+
+    findByName("commonTest")?.apply {
+      dependencies {
+        implementation(golatac.lib("apollo.testingsupport"))
+      }
+    }
+  }
+}
+
+apollo {
+  service("service") {
+    packageName.set("js.test")
+  }
+}

--- a/tests/js/src/commonMain/graphql/operations.graphql
+++ b/tests/js/src/commonMain/graphql/operations.graphql
@@ -1,0 +1,3 @@
+mutation CreateCustomer($name: String!, $id: Int!) {
+  createCustomer(input: {customer: {storeId: $id, name: $name}})
+}

--- a/tests/js/src/commonMain/graphql/schema.graphqls
+++ b/tests/js/src/commonMain/graphql/schema.graphqls
@@ -1,0 +1,16 @@
+type Query {
+  a: String
+}
+
+type Mutation {
+  createCustomer(input: CreateCustomerInput!): Boolean
+}
+
+input CreateCustomerInput {
+  customer: CustomerInput!
+}
+
+input CustomerInput {
+  storeId: Int!
+  name: String!
+}

--- a/tests/js/src/jsTest/kotlin/JsTest.kt
+++ b/tests/js/src/jsTest/kotlin/JsTest.kt
@@ -1,0 +1,9 @@
+import js.test.CreateCustomerMutation
+import kotlin.test.Test
+
+class JsTest {
+  @Test
+  fun nameAndIdParametersCompile() {
+    CreateCustomerMutation(name = "a", id = 42)
+  }
+}


### PR DESCRIPTION
A fix for #4640.

I was wondering why nobody had this problem before, especially with `id` (a common argument name) - turns out we've had `@JsName` on `id()` since JS was [introduced](https://github.com/apollographql/apollo-kotlin/pull/3208/files?w=1#diff-3dea12462b10a56e86f12d23dcdb8bcd533f438da4cbabc4248c31a127d2bff6R34).