### PR TITLE
Bump sqldelight to 1.5.5

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -31,7 +31,7 @@ okhttp = "4.9.3"
 rx-android = "2.0.1"
 rx-java2 = "2.2.21"
 rx-java3 = "3.1.3"
-sqldelight = "1.5.6"
+sqldelight = "1.5.5"
 truth = "1.1.3"
 
 [libraries]
@@ -130,10 +130,10 @@ poet-java = { group = "com.squareup", name = "javapoet", version.ref = "javaPoet
 poet-kotlin = { group = "com.squareup", name = "kotlinpoet", version = "1.12.0" }
 rx-java2 = { group = "io.reactivex.rxjava2", name = "rxjava", version.ref = "rx-java2" }
 rx-java3 = { group = "io.reactivex.rxjava3", name = "rxjava", version.ref = "rx-java3" }
-sqldelight-android = { group = "net.mbonnin.sqldelight", name = "android-driver", version.ref = "sqldelight" }
-sqldelight-jvm = { group = "net.mbonnin.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
-sqldelight-native = { group = "net.mbonnin.sqldelight", name = "native-driver", version.ref = "sqldelight" }
-sqldelight-plugin = { group = "net.mbonnin.sqldelight", name = "gradle-plugin", version.ref = "sqldelight" }
+sqldelight-android = { group = "com.squareup.sqldelight", name = "android-driver", version.ref = "sqldelight" }
+sqldelight-jvm = { group = "com.squareup.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
+sqldelight-native = { group = "com.squareup.sqldelight", name = "native-driver", version.ref = "sqldelight" }
+sqldelight-plugin = { group = "com.squareup.sqldelight", name = "gradle-plugin", version.ref = "sqldelight" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "0.7.0" }
 uuid = { group = "com.benasher44", name = "uuid", version = "0.3.1" }

--- a/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 apply(plugin = "com.android.library")
-apply(plugin = "net.mbonnin.sqldelight")
+apply(plugin = "com.squareup.sqldelight")
 
 apolloLibrary {
   javaModuleName("com.apollographql.apollo3.cache.normalized.sql")

--- a/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 apply(plugin = "com.android.library")
-apply(plugin = "net.mbonnin.sqldelight")
+apply(plugin = "com.squareup.sqldelight")
 
 apolloLibrary {
   javaModuleName("com.apollographql.apollo3.cache.normalized.sql")


### PR DESCRIPTION
See https://github.com/cashapp/sqldelight/releases/tag/1.5.5, no need to fork anymore