### PR TITLE
Fix plugin configuration doc

### DIFF
--- a/docs/source/advanced/plugin-configuration.mdx
+++ b/docs/source/advanced/plugin-configuration.mdx
@@ -46,7 +46,7 @@ If you expand your schema in a separate file, you can instruct Apollo Kotlin to 
 ```kotlin
 apollo {
   service("service") {
-    schemaFiles.set(setOf(file("shared/graphql/schema.graphqls"), file("shared/graphql/extra.graphqls")))
+    schemaFiles.setFrom("shared/graphql/schema.graphqls", "shared/graphql/extra.graphqls")
   }
 }
 ```


### PR DESCRIPTION
`schemaFiles` is not a property and doesn't have a `set` method. Since it's a `ConfigurableFileCollection` we could use a `setFrom` and provide a list of paths