### PR TITLE
Update gradle plugin configuration doc

### DIFF
--- a/docs/source/advanced/plugin-configuration.mdx
+++ b/docs/source/advanced/plugin-configuration.mdx
@@ -46,7 +46,7 @@ If you expand your schema in a separate file, you can instruct Apollo Kotlin to 
 ```kotlin
 apollo {
   service("service") {
-    schemaFiles.set(setOf(file("shared/graphql/schema.graphqls"), file("shared/graphql/extra.graphqls")))
+    schemaFiles.setFrom("shared/graphql/schema.graphqls", "shared/graphql/extra.graphqls")
   }
 }
 ```


### PR DESCRIPTION
The existing configuration results in a gradle error with a cryptic message. After diffing around I realized that `schemaFiles` is not a property but rather a `ConfigurableFileCollection` so we should use a `setFrom` method instead and provide the list of paths