### PR TITLE
Add Gradle tooling model

### DIFF
--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -28,6 +28,25 @@ public abstract interface class com/apollographql/apollo3/gradle/api/ApolloExten
 	public abstract fun service (Ljava/lang/String;Lorg/gradle/api/Action;)V
 }
 
+public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel {
+	public static final field Companion Lcom/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$Companion;
+	public static final field VERSION I
+	public abstract fun getMetadataProjectDependencies ()Ljava/util/List;
+	public abstract fun getProjectName ()Ljava/lang/String;
+	public abstract fun getServiceInfos ()Ljava/util/List;
+	public abstract fun getVersion ()I
+}
+
+public final class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$Companion {
+	public static final field VERSION I
+}
+
+public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$ServiceInfo {
+	public abstract fun getGraphqlSrcDirs ()Ljava/util/Set;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getSchemaFiles ()Ljava/util/Set;
+}
+
 public abstract interface class com/apollographql/apollo3/gradle/api/Introspection {
 	public abstract fun getEndpointUrl ()Lorg/gradle/api/provider/Property;
 	public abstract fun getHeaders ()Lorg/gradle/api/provider/MapProperty;

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
@@ -1,0 +1,26 @@
+package com.apollographql.apollo3.gradle.api
+
+import java.io.File
+
+interface ApolloGradleToolingModel {
+  val version: Int
+
+  val projectName: String
+  val serviceInfos: List<ServiceInfo>
+  val metadataProjectDependencies: List<String>
+
+  interface ServiceInfo {
+    val name: String
+    val schemaFiles: Set<File>
+    val graphqlSrcDirs: Set<File>
+  }
+
+  companion object {
+    /**
+     * Current version of the tooling model.
+     * Increment this value when the model changes in breaking ways.
+     * Adding properties / functions is never breaking, whereas deleting, renaming, changing types or signatures is breaking.
+     */
+    const val VERSION = 1
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
@@ -1,0 +1,19 @@
+package com.apollographql.apollo3.gradle.internal
+
+import com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel
+import java.io.File
+import java.io.Serializable
+
+internal data class DefaultApolloGradleToolingModel(
+    override val projectName: String,
+    override val serviceInfos: List<ApolloGradleToolingModel.ServiceInfo>,
+    override val metadataProjectDependencies: List<String>,
+) : ApolloGradleToolingModel, Serializable {
+  override val version: Int = ApolloGradleToolingModel.VERSION
+}
+
+internal data class DefaultServiceInfo(
+    override val name: String,
+    override val schemaFiles: Set<File>,
+    override val graphqlSrcDirs: Set<File>,
+) : ApolloGradleToolingModel.ServiceInfo, Serializable

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleToolingTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/GradleToolingTests.kt
@@ -1,0 +1,78 @@
+package com.apollographql.apollo3.gradle.test
+
+import com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel
+import com.apollographql.apollo3.gradle.util.TestUtils
+import org.gradle.tooling.GradleConnector
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+
+class GradleToolingTests {
+  private fun withMultipleServicesProject(apolloConfiguration: String, block: (File) -> Unit) {
+    TestUtils.withProject(
+        usesKotlinDsl = false,
+        plugins = listOf(TestUtils.kotlinJvmPlugin, TestUtils.apolloPlugin),
+        apolloConfiguration = apolloConfiguration
+    ) { dir ->
+      val source = TestUtils.fixturesDirectory()
+
+      val target = File(dir, "src/main/graphql/githunt")
+      File(source, "githunt").copyRecursively(target = target, overwrite = true)
+
+      File(dir, "src/main/graphql/com").copyRecursively(target = File(dir, "src/main/graphql/starwars"), overwrite = true)
+      File(dir, "src/main/graphql/com").deleteRecursively()
+
+      block(dir)
+    }
+  }
+
+  @Test
+  fun `tooling model exposes all service infos`() {
+    val apolloConfiguration = """
+      apollo {
+        service("starwars") {
+          packageName.set("starwars")
+          srcDir("src/main/graphql/starwars")
+        }
+        service("githunt") {
+          packageName.set("githunt")
+          srcDir("src/main/graphql/githunt")
+        }
+      }
+    """.trimIndent()
+    withMultipleServicesProject(apolloConfiguration) { dir ->
+      val toolingModel = GradleConnector.newConnector()
+          .forProjectDirectory(dir)
+          .connect()
+          .use { connection ->
+            connection.getModel(ApolloGradleToolingModel::class.java)
+          }
+      Assert.assertEquals(ApolloGradleToolingModel.VERSION, toolingModel.version)
+      Assert.assertEquals(emptyList<String>(), toolingModel.metadataProjectDependencies)
+
+      val serviceInfo0 = toolingModel.serviceInfos[0]
+      Assert.assertEquals("starwars", serviceInfo0.name)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars")), serviceInfo0.graphqlSrcDirs)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/starwars/example/schema.json")), serviceInfo0.schemaFiles)
+
+      val serviceInfo1 = toolingModel.serviceInfos[1]
+      Assert.assertEquals("githunt", serviceInfo1.name)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt")), serviceInfo1.graphqlSrcDirs)
+      Assert.assertEquals(setOf(File(dir, "src/main/graphql/githunt/schema.json")), serviceInfo1.schemaFiles)
+    }
+  }
+
+  @Test
+  fun `tooling model exposes apollo metadata dependencies`() {
+    TestUtils.withTestProject("multi-modules-diamond") { dir ->
+      val toolingModel = GradleConnector.newConnector()
+          .forProjectDirectory(File(dir, "leaf"))
+          .connect()
+          .use { connection ->
+            connection.getModel(ApolloGradleToolingModel::class.java)
+          }
+      Assert.assertEquals(ApolloGradleToolingModel.VERSION, toolingModel.version)
+      Assert.assertEquals(listOf("node1", "node2"), toolingModel.metadataProjectDependencies)
+    }
+  }
+}


### PR DESCRIPTION
Starting point to expose information that can then be used in the IJ plugin. For now, information about where to expect operation/schema files.