### PR TITLE
Remove deprecation on connectToAndroidSourceSet because alternative have issues too

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -729,11 +729,6 @@ interface Service {
      * @param name: the name of the source set. For an example, "main", "test" or "androidTest"
      * You can also use more qualified source sets like "demo", "debug" or "demoDebug"
      */
-    @Deprecated(
-        "This method doesn't mark the sources as \"generated\". This confuses some tools like lint that might do extra work on the generated files",
-        ReplaceWith("connectToAndroidVariant(variant)")
-    )
-    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_6_3)
     fun connectToAndroidSourceSet(name: String)
 
     /**

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -529,13 +529,8 @@ abstract class DefaultApolloExtension(
       }
 
       project.androidExtension != null -> {
-        if (hasExplicitService) {
-          // The default service is created from `afterEvaluate` and it looks like it's too late to register new sources
-          @Suppress("DEPRECATION")
-          connection.connectToAndroidSourceSet("main")
-        } else {
-          connection.connectToAllAndroidVariants()
-        }
+        // The default service is created from `afterEvaluate` and it looks like it's too late to register new sources
+        connection.connectToAndroidSourceSet("main")
       }
 
       project.kotlinProjectExtension != null -> {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultDirectoryConnection.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultDirectoryConnection.kt
@@ -30,7 +30,6 @@ internal class DefaultDirectoryConnection(
     connectToAndroidVariant(project, variant, outputDir, task)
   }
 
-  @Deprecated("This method doesn't mark the sources as generated. This confuses some tools like lint that might do extra work on the generated files", replaceWith = ReplaceWith("connectToAndroidVariant(variant)"))
   override fun connectToAndroidSourceSet(name: String) {
     connectToAndroidSourceSet(project, name, outputDir, task)
   }


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/issues/4669

* `registerJavaGeneratingTask` fails on incremental build in unit tests.
* `connectToAndroidSourceSet` fails to mark generated files as "generated" for lint purposes

Between both issues, it feels better to have something that compiles. This can be overriden from Gradle files if needed.