### PR TITLE
SchemaDownlader: Update to download deprecated input fields

### DIFF
--- a/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
@@ -86,6 +86,29 @@ class DownloadSchemaTests {
               "ofType": null
             }
           ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "DeprecatedInput",
+          "description": null,
+          "fields": null,
+          "inputFields": [
+            {
+              "name": "deprecatedField",
+              "description": "deprecatedField",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": true,
+              "deprecationReason": "DeprecatedForTesting"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "possibleTypes": null
         }
       ]
     }

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
@@ -199,7 +199,7 @@ object SchemaDownloader {
         isDeprecated
         deprecationReason
       }
-      inputFields(includeDeprecated: true {
+      inputFields(includeDeprecated: true) {
         ...InputValue
       }
       interfaces {
@@ -221,6 +221,8 @@ object SchemaDownloader {
       description
       type { ...TypeRef }
       defaultValue
+      isDeprecated
+      deprecationReason
     }
 
     fragment TypeRef on __Type {

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
@@ -199,7 +199,7 @@ object SchemaDownloader {
         isDeprecated
         deprecationReason
       }
-      inputFields {
+      inputFields(includeDeprecated: true {
         ...InputValue
       }
       interfaces {


### PR DESCRIPTION
Added `(includeDeprecated: true)` as a params to `inputFields` in the `fragment` portion of the GraphQL query to download a schema.

### Current Behavior

When the `downloadApolloSchema` Gradle task is run, input fields with the `@deprecated` tag **ARE NOT** downloaded.

### Expected Change in Behavior

When the `downloadApolloSchema` Gradle task is run, input fields with the `@deprecated` tag **ARE** downloaded.