### PR TITLE
stay on AGP 7.4.0-beta02 or IJ sync fails

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -1,5 +1,5 @@
 [versions]
-android-plugin = "7.4.0"
+android-plugin = "7.4.0-beta02"
 android-plugin-min = "3.4.2"
 android-sdkversion-compile = "31"
 android-sdkversion-min = "15"


### PR DESCRIPTION
A more recent AGP was needed to support Gradle 8 ([see this PR](https://github.com/apollographql/apollo-kotlin/pull/4644)) but 7.4.0 is a bit too much for IJ