### PR TITLE
Fix cacheKeyForObject doc

### DIFF
--- a/docs/source/caching/programmatic-ids.mdx
+++ b/docs/source/caching/programmatic-ids.mdx
@@ -43,7 +43,7 @@ You can get the current object's typename from the `context` object and include 
 ```kotlin
 val cacheKeyGenerator = object : CacheKeyGenerator {
   override fun cacheKeyForObject(obj: Map<String, Any?>, context: CacheKeyGeneratorContext): CacheKey? {
-    val typename = context.field.type.leafType().name
+    val typename = obj["__typename"] as String
     val id = obj["id"] as String
 
     return CacheKey(typename, id)


### PR DESCRIPTION
`leafType()` is deprecated and `rawType().name` might give the name of the interface and not the concrete type

Many thanks @trod-123 for catching this