### PR TITLE
Fix normalizing data when using `@include` or `@skip` with default values

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -168,10 +168,13 @@ public abstract class com/apollographql/apollo3/api/BTerm {
 
 public final class com/apollographql/apollo3/api/BVariable : com/apollographql/apollo3/api/BTerm {
 	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/apollographql/apollo3/api/BVariable;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/BVariable;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/BVariable;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/BVariable;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/BVariable;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/BVariable;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/Boolean;
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -286,11 +289,14 @@ public final class com/apollographql/apollo3/api/CompiledArgument$Builder {
 
 public final class com/apollographql/apollo3/api/CompiledCondition {
 	public fun <init> (Ljava/lang/String;Z)V
+	public fun <init> (Ljava/lang/String;ZZ)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Z
-	public final fun copy (Ljava/lang/String;Z)Lcom/apollographql/apollo3/api/CompiledCondition;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/CompiledCondition;Ljava/lang/String;ZILjava/lang/Object;)Lcom/apollographql/apollo3/api/CompiledCondition;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/apollographql/apollo3/api/CompiledCondition;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/api/CompiledCondition;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/api/CompiledCondition;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Z
 	public final fun getInverted ()Z
 	public final fun getName ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/BooleanExpression.kt
@@ -136,7 +136,9 @@ sealed class BTerm
 /**
  * A term that comes from @include/@skip or @defer directives and that needs to be matched against operation variables
  */
-data class BVariable(val name: String) : BTerm()
+data class BVariable(val name: String, val defaultValue: Boolean?) : BTerm() {
+  constructor(name: String): this(name, true)
+}
 
 /**
  * A term that comes from @defer directives and that needs to be matched against label and current JSON path

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -132,8 +132,9 @@ class CompiledFragment internal constructor(
   }
 }
 
-
-data class CompiledCondition(val name: String, val inverted: Boolean)
+data class CompiledCondition(val name: String, val inverted: Boolean, val defaultValue: Boolean) {
+  constructor(name: String, inverted: Boolean): this(name, inverted, true)
+}
 
 sealed class CompiledType {
   @Deprecated("Use rawType instead", ReplaceWith("rawType()"))

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
@@ -119,7 +119,11 @@ internal class CompiledSelectionsBuilder(
 
     check(expression is BooleanExpression.Element)
 
-    return CodeBlock.of("%T(%S,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString())
+    return if (expression.value.defaultValue != null) {
+      CodeBlock.of("%T(%S,·%L,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString(), expression.value.defaultValue.toString())
+    } else {
+      CodeBlock.of("%T(%S,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString())
+    }
   }
 
   private fun IrArgument.codeBlock(): CodeBlock {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -351,7 +351,7 @@ internal class IrOperationsBuilder(
         operationType = operationType.toIrOperationType(schema.rootTypeNameFor(operationType)),
         typeCondition = typeDefinition.name,
         variables = variableDefinitions.map { it.toIr() },
-        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeDefinition.name),
+        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeDefinition.name, variableDefinitions),
         sourceWithFragments = sourceWithFragments,
         filePath = sourceLocation.filePath!!,
         dataProperty = dataProperty,
@@ -388,7 +388,7 @@ internal class IrOperationsBuilder(
         filePath = sourceLocation.filePath!!,
         typeCondition = typeDefinition.name,
         variables = inferredVariables.map { it.toIr() },
-        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeCondition.name),
+        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeCondition.name, emptyList()),
         interfaceModelGroup = interfaceModelGroup,
         dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
@@ -520,10 +520,17 @@ internal class IrOperationsBuilder(
       }
       val forceNonNull = gqlField.directives.findNonnull(schema) || parentTypeDefinition.isFieldNonNull(gqlField.name, schema)
 
+      /**
+       * It's ok to always pass the empty list for variableDefinitions because the parsers do not care about @include and @skip
+       * All they care about is that the model types match what is sent by the server
+       */
+      val variableDefinitions: List<GQLVariableDefinition> = emptyList()
+      val condition = gqlField.directives.toIncludeBooleanExpression(variableDefinitions)
+
       CollectedField(
           name = gqlField.name,
           alias = gqlField.alias,
-          condition = gqlField.directives.toIncludeBooleanExpression(),
+          condition = condition,
           selections = gqlField.selectionSet?.selections ?: emptyList(),
           type = fieldDefinition.type,
           description = fieldDefinition.description,
@@ -648,9 +655,9 @@ internal fun GQLValue.toIrValue(): IrValue {
  * - (!)Variable
  * - (!)Variable & (!)Variable
  */
-internal fun List<GQLDirective>.toIncludeBooleanExpression(): BooleanExpression<BVariable> {
+internal fun List<GQLDirective>.toIncludeBooleanExpression(variableDefinitions: List<GQLVariableDefinition>): BooleanExpression<BVariable> {
   val conditions = mapNotNull {
-    it.toIncludeBooleanExpression()
+    it.toIncludeBooleanExpression(variableDefinitions)
   }
   return if (conditions.isEmpty()) {
     BooleanExpression.True
@@ -665,7 +672,7 @@ internal fun List<GQLDirective>.toIncludeBooleanExpression(): BooleanExpression<
   }
 }
 
-internal fun GQLDirective.toIncludeBooleanExpression(): BooleanExpression<BVariable>? {
+internal fun GQLDirective.toIncludeBooleanExpression(variableDefinitions: List<GQLVariableDefinition>): BooleanExpression<BVariable>? {
   if (setOf("skip", "include").contains(name).not()) {
     // not a condition directive
     return null
@@ -681,7 +688,10 @@ internal fun GQLDirective.toIncludeBooleanExpression(): BooleanExpression<BVaria
       if (value.value) BooleanExpression.True else BooleanExpression.False
     }
 
-    is GQLVariableValue -> BooleanExpression.Element(BVariable(name = value.name))
+    is GQLVariableValue -> {
+      val defaultValue = (variableDefinitions.firstOrNull { it.name == value.name }?.defaultValue as? GQLBooleanValue?)?.value
+      BooleanExpression.Element(BVariable(name = value.name, defaultValue = defaultValue))
+    }
     else -> throw IllegalStateException("Apollo: cannot pass ${value.toUtf8()} to '$name' directive")
   }.let {
     if (name == "skip") not(it) else it
@@ -703,7 +713,7 @@ internal fun List<GQLDirective>.toBooleanExpression(): BooleanExpression<BTerm> 
     }
     deferBooleanConditions.first()
   }
-  return toIncludeBooleanExpression().and(deferBooleanExpression).simplify()
+  return toIncludeBooleanExpression(emptyList()).and(deferBooleanExpression).simplify()
 }
 
 internal fun GQLDirective.toDeferBooleanExpression(): BooleanExpression<BTerm>? {

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/ShouldSkip.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/ShouldSkip.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.api.CompiledField
 
 internal fun CompiledField.shouldSkip(variableValues: Map<String, Any?>): Boolean {
   condition.forEach {
-    var value = (variableValues.get(it.name) as? Boolean) ?: false
+    var value = (variableValues.get(it.name) as? Boolean) ?: it.defaultValue
     if (it.inverted) {
       value = !value
     }

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 dependencies {
   implementation(golatac.lib("apollo.runtime"))
   implementation(golatac.lib("apollo.httpCache"))
+  implementation(golatac.lib("apollo.normalizedcache"))
   implementation(golatac.lib("apollo.mockserver"))
   testImplementation(golatac.lib("kotlin.test.junit"))
   testImplementation(golatac.lib("apollo.testingsupport"))

--- a/tests/include-skip-operation-based/src/main/graphql/operations.graphql
+++ b/tests/include-skip-operation-based/src/main/graphql/operations.graphql
@@ -51,3 +51,13 @@ query GetCatIncludeVariableWithDefault($skipIf: Boolean = true) {
     species @skip(if: $skipIf)
   }
 }
+
+fragment animalFragment on Animal {
+  species @skip(if: $skipIf)
+}
+
+query SkipInFragment($skipIf: Boolean = true) {
+  animal {
+    ...animalFragment
+  }
+}

--- a/tests/include-skip-operation-based/src/main/graphql/operations.graphql
+++ b/tests/include-skip-operation-based/src/main/graphql/operations.graphql
@@ -44,3 +44,10 @@ query GetDogSkipFalse {
 fragment dogFragment on Dog {
   barf
 }
+
+
+query GetCatIncludeVariableWithDefault($skipIf: Boolean = true) {
+  animal {
+    species @skip(if: $skipIf)
+  }
+}

--- a/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
+++ b/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
@@ -3,7 +3,7 @@ type Query {
 }
 
 interface Animal {
-  species: String
+  species: String!
 }
 
 type Cat implements Animal {

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -21,6 +21,7 @@ import com.example.type.buildQuery
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class IncludeTest {
 
@@ -159,6 +160,20 @@ class IncludeTest {
     }
 
     operation.normalize(data, CustomScalarAdapters.Empty, TypePolicyCacheKeyGenerator)
+  }
+
+  @Test
+  fun getCatIncludeVariableWithDefaultQuery2() = runBlocking {
+    val operation = GetCatIncludeVariableWithDefaultQuery()
+
+    val data = GlobalBuilder.buildQuery {
+      animal = buildCat {
+      }
+    }
+
+    val response = operation.parseData(data)
+
+    assertNull(response.dataAssertNoErrors.animal!!.species)
   }
 }
 

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,11 +1,17 @@
+
 import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.GlobalBuilder
 import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.example.GetCatIncludeFalseQuery
 import com.example.GetCatIncludeTrueQuery
 import com.example.GetCatIncludeVariableQuery
+import com.example.GetCatIncludeVariableWithDefaultQuery
 import com.example.GetDogSkipFalseQuery
 import com.example.GetDogSkipTrueQuery
 import com.example.GetDogSkipVariableQuery
@@ -140,6 +146,19 @@ class IncludeTest {
     val response = operation.parseData(data)
 
     assertEquals("ouaf", response.dataAssertNoErrors.animal!!.dogFragment!!.barf)
+  }
+
+  @Test
+  fun getCatIncludeVariableWithDefaultQuery(): Unit = runBlocking {
+    val operation = GetCatIncludeVariableWithDefaultQuery()
+
+    val data = GetCatIncludeVariableWithDefaultQuery.Data {
+      animal = buildCat {
+        this["species"] = Optional.Absent
+      }
+    }
+
+    operation.normalize(data, CustomScalarAdapters.Empty, TypePolicyCacheKeyGenerator)
   }
 }
 


### PR DESCRIPTION
For queries like this:

```graphql
query GetAnimal($skipIf: Boolean = true) {
  animal {
    species @skip(if: $skipIf)
  }
}
```
Because the normalizer didn't know about the default value, it would try to normalize null to the cache and fail because species is of non-nullable type.


Note to myself to add backward compat `copy` functions when backporting this to v3