### PR TITLE
Disable Kdoc on 4.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
           ./gradlew --no-build-cache ciBuild
           ./gradlew --stop
           ./gradlew --no-build-cache -p tests ciBuild
-          ./gradlew --no-build-cache dokkaHtmlMultiModule
+#          ./gradlew --no-build-cache dokkaHtmlMultiModule
           ./gradlew --no-build-cache ciPublishSnapshot
         env:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
@@ -42,8 +42,8 @@ jobs:
         with:
           name: push.zip
           path: push.zip
-      - name: Deploy Kdoc to github pages
-        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 #v4.4.1
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: build/dokkaHtml # The folder the action should deploy.
+#      - name: Deploy Kdoc to github pages
+#        uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 #v4.4.1
+#        with:
+#          branch: gh-pages # The branch the action should deploy to.
+#          folder: build/dokkaHtml # The folder the action should deploy.


### PR DESCRIPTION
Dokka is currently not compatible with Gradle 8 ([issue](https://github.com/Kotlin/dokka/issues/2796)).

I've added an item to https://github.com/apollographql/apollo-kotlin/issues/4171 so that we remember to check this before going stable. Hopefully dokka 1.8.0 will be out by then