### PR TITLE
[Build scripts] Bump toolchain to Java 17

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - run: |
           ulimit -c unlimited

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - name: Build with Gradle
         run: |
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 11 # Keep this one on an older JDK version to make sure we can still build with Java11
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - name: Build with Gradle
         run: |
@@ -71,7 +71,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - name: Build with Gradle
         run: |
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       # Set environment variables
       - name: Export Properties

--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
 
       - name: Increment snapshot version
         run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - name: Build with Gradle
         run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
       - name: Publish to Maven Central
         run: |
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b #v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
       - name: Publish to JetBrains marketplace
         run: ./gradlew --no-build-cache :intellij-plugin:publishPlugin
         env:

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverExtension
 import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverGradleSubplugin
 
@@ -50,9 +51,15 @@ dependencies {
   runtimeOnly(golatac.lib("kotlinx.binarycompatibilityvalidator"))
 }
 
+// Keep in sync with CompilerOptions.kt
 java {
-  // Keep in sync with CompilerOptions.kt
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+tasks.withType(JavaCompile::class.java).configureEach {
+  options.release.set(11)
+}
+tasks.withType(KotlinJvmCompile::class.java).configureEach {
+  kotlinOptions.jvmTarget = "11"
 }
 
 gradlePlugin {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -55,7 +55,7 @@ dependencies {
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
-tasks.withType(JavaCompile::class.java).configureEach {
+tasks.withType<JavaCompile>().configureEach {
   options.release.set(11)
 }
 tasks.withType(KotlinJvmCompile::class.java).configureEach {

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
 
 java {
   // Keep in sync with CompilerOptions.kt
-  toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+  toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 gradlePlugin {

--- a/build-logic/src/main/kotlin/CompilerOptions.kt
+++ b/build-logic/src/main/kotlin/CompilerOptions.kt
@@ -1,7 +1,9 @@
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
@@ -56,6 +58,15 @@ fun Project.configureJavaAndKotlinCompilers() {
   }
 
   allWarningsAsErrors(true)
+}
+
+fun Project.configureTests(jvmVersion: Int) {
+  tasks.withType(Test::class.java).configureEach {
+    val javaToolchains = this@configureTests.extensions.getByName("javaToolchains") as JavaToolchainService
+    javaLauncher.set(javaToolchains.launcherFor {
+      languageVersion.set(JavaLanguageVersion.of(jvmVersion))
+    })
+  }
 }
 
 internal fun Project.optIn(vararg annotations: String) {

--- a/build-logic/src/main/kotlin/CompilerOptions.kt
+++ b/build-logic/src/main/kotlin/CompilerOptions.kt
@@ -46,9 +46,8 @@ fun Project.configureJavaAndKotlinCompilers() {
 
   @Suppress("UnstableApiUsage")
   project.extensions.getByType(JavaPluginExtension::class.java).apply {
-    // Compile and run tests with Java11
     // Keep in sync with build-logic/build.gradle.kts
-    toolchain.languageVersion.set(JavaLanguageVersion.of(11))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
   }
   @Suppress("UnstableApiUsage")
   project.tasks.withType(JavaCompile::class.java).configureEach {

--- a/build-logic/src/main/kotlin/com/apollographql/apollo3/buildlogic/plugin/LibraryConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/com/apollographql/apollo3/buildlogic/plugin/LibraryConventionPlugin.kt
@@ -4,6 +4,7 @@ import configureJavaAndKotlinCompilers
 import configureMppDefaults
 import configurePublishing
 import configureTesting
+import configureTests
 import optIn
 import org.gradle.api.Action
 import org.gradle.api.Plugin
@@ -18,7 +19,7 @@ class LibraryConventionPlugin : Plugin<Project> {
       group = property("GROUP")!!
       version = property("VERSION_NAME")!!
 
-      extensions.create("apolloLibrary", Extension::class.java)
+      extensions.create("apolloLibrary", Extension::class.java, project)
 
       configureJavaAndKotlinCompilers()
       optIn(
@@ -57,6 +58,10 @@ class LibraryConventionPlugin : Plugin<Project> {
           attributes(mapOf("Automatic-Module-Name" to javaModuleName))
         }
       }
+    }
+
+    fun runTestsWithJavaVersion(javaVersion: Int) {
+      project.configureTests(javaVersion)
     }
   }
 }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 }
 
 apolloLibrary {
+  // See GradleVersionTests.kt the Gradle runner will choke on more recent versions
+  // Keep in sync with TestUtils.kt
+  runTestsWithJavaVersion(11)
 }
 
 // Configuration for extra jar to pass to R8 to give it more context about what can be relocated

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -66,11 +66,14 @@ object TestUtils {
       appendLine("}")
       appendLine()
 
+      // Keep in sync with apollo-gradle-plugin/build.gradle.kts
+      // https://issuetracker.google.com/issues/260059413
       append("""
-        java {
-          toolchain { 
-            languageVersion.set(JavaLanguageVersion.of(8))
-          }
+        android {
+            compileOptions {
+                sourceCompatibility = 11
+                targetCompatibility = 11
+            }
         }
       """.trimIndent())
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/com/apollographql/apollo3/gradle/util/TestUtils.kt
@@ -66,17 +66,6 @@ object TestUtils {
       appendLine("}")
       appendLine()
 
-      // Keep in sync with apollo-gradle-plugin/build.gradle.kts
-      // https://issuetracker.google.com/issues/260059413
-      append("""
-        android {
-            compileOptions {
-                sourceCompatibility = 11
-                targetCompatibility = 11
-            }
-        }
-      """.trimIndent())
-
       appendLine()
       append("""
         dependencies {
@@ -95,6 +84,13 @@ object TestUtils {
             |android {
             |  compileSdkVersion(libs.versions.android.sdkversion.compile.get().toInteger())
             |  namespace = "com.example"
+            |  
+            |  // Keep in sync with apollo-gradle-plugin/build.gradle.kts
+            |  // https://issuetracker.google.com/issues/260059413  
+            |  compileOptions {
+            |    sourceCompatibility = 11
+            |    targetCompatibility = 11
+            |  }
             |
           """.trimMargin()
         )


### PR DESCRIPTION
Bump toolchain to Java17 except Gradle tests that still run Java11 for testing with older Gradle versions
