### PR TITLE
Cache: Fix CacheFirst + emitCacheMisses(true)

### DIFF
--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -62,8 +62,15 @@ val CacheFirstInterceptor = object : ApolloInterceptor {
       }.singleOrNull()
 
       if (cacheResponse != null) {
-        emit(cacheResponse)
-        return@flow
+        if (cacheResponse.cacheInfo?.isCacheHit == true) {
+          // This is a cache hit, stop here
+          emit(cacheResponse)
+          return@flow
+        } else {
+          emit(cacheResponse.newBuilder().isLast(false).build())
+          // The response was a cache miss emitted by emitCacheMisses(true)
+          // We need to continue to the network
+        }
       }
 
       val networkResponses = chain.proceed(

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
           because("OperationOutputTest uses it to check the json and we can't use moshi since it's mpp code")
         }
         implementation(golatac.lib("kotlinx.coroutines.test"))
+        implementation(golatac.lib("turbine"))
       }
     }
 


### PR DESCRIPTION
When using `emitCacheMisses(true)`, the `CacheFirst` fetch policy was never going to the network and therefore could miss some events. This PR adds a test and a fix to continue to the network in case the first response is a cache miss.

A huuuuuuuge THANK YOU to @mateuszkwiecinski for all the investigations and to @lwasyl for locating the source of the issue. You rock!

PS: we're hoping to simplify the error handling in 4.x and remove the number of special cases in the interceptors (see [this PR](https://github.com/apollographql/apollo-kotlin/pull/4685)). Ping @BoD we should do a small RFC before we're committing to this change to gather community feedback. 