### PR TITLE
Enable gradle-home-cache-cleanup

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,6 +17,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - run: |
           ulimit -c unlimited
           # Workaround an issue where kotlinNpmInstall outputs

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,6 +21,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
           ulimit -c unlimited
@@ -47,6 +49,8 @@ jobs:
           distribution: 'temurin'
           java-version: 11 # Keep this one on an older JDK version to make sure we can still build with Java11
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
           ulimit -c unlimited
@@ -73,6 +77,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
           ulimit -c unlimited

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
           ulimit -c unlimited

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,6 +17,8 @@ jobs:
           distribution: 'temurin'
           java-version: 17
       - uses: gradle/gradle-build-action@3fbe033aaae657f011f88f29be9e65ed26bd29ef #v2.3.3
+        with:
+          gradle-home-cache-cleanup: true
       - name: Publish to Maven Central
         run: |
           ./gradlew --no-build-cache ciPublishRelease -Pgradle.publish.key="${{ secrets.GRADLE_PUBLISH_KEY }}" -Pgradle.publish.secret="${{ secrets.GRADLE_PUBLISH_SECRET }}"


### PR DESCRIPTION
To reduce cache sizes and on CI.

https://github.com/gradle/gradle-build-action/blob/main/README.md#removing-unused-files-from-gradle-user-home-before-saving-to-cache