### PR TITLE
Introduce a dynamic JSON parser for JS

### DIFF
--- a/tests/js/src/commonMain/graphql/operations.graphql
+++ b/tests/js/src/commonMain/graphql/operations.graphql
@@ -1,3 +1,11 @@
 mutation CreateCustomer($name: String!, $id: Int!) {
   createCustomer(input: {customer: {storeId: $id, name: $name}})
 }
+
+query GetSalesPeople {
+  getSalesPeople {
+    __typename
+    name
+    favoriteNumbers
+  }
+}

--- a/tests/js/src/commonMain/graphql/schema.graphqls
+++ b/tests/js/src/commonMain/graphql/schema.graphqls
@@ -1,9 +1,15 @@
 type Query {
   a: String
+  getSalesPeople: [SalesPerson]
 }
 
 type Mutation {
   createCustomer(input: CreateCustomerInput!): Boolean
+}
+
+type SalesPerson {
+  name: String
+  favoriteNumbers: [Int]
 }
 
 input CreateCustomerInput {

--- a/tests/js/src/jsTest/kotlin/JsTest.kt
+++ b/tests/js/src/jsTest/kotlin/JsTest.kt
@@ -1,9 +1,45 @@
+import com.apollographql.apollo3.api.json.DynamicJsJsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
 import js.test.CreateCustomerMutation
+import js.test.GetSalesPeopleQuery
 import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class JsTest {
   @Test
   fun nameAndIdParametersCompile() {
     CreateCustomerMutation(name = "a", id = 42)
+  }
+
+  @Test
+  fun dynamicJsonReaderCanParseIntoAdapter() {
+    val dynamicResponse = JSON.parse("""
+          {
+            "data": {
+              "getSalesPeople": [
+                {
+                  "__typename": "foo",
+                  "favoriteNumbers": [1, 2, 3],
+                  "name": "bob"
+                }
+              ]
+            }
+          }
+        """.trimIndent()) as dynamic
+    val query = GetSalesPeopleQuery()
+    val jsonReader = DynamicJsJsonReader(dynamicResponse)
+    val response = query.parseJsonResponse(jsonReader)
+    assertEquals(
+        GetSalesPeopleQuery.Data(
+            getSalesPeople = listOf(
+                GetSalesPeopleQuery.GetSalesPeople(
+                    __typename = "foo",
+                    favoriteNumbers = listOf(1, 2, 3),
+                    name = "bob"
+                )
+            )
+        ),
+        response.data
+    )
   }
 }


### PR DESCRIPTION
This change introduces a new `HttpEngine` that uses the browser's `fetch` and `json()` calls directly so that all of the JSON parsing happens in native code. The resulting `dynamic` is then passed to a new `DynamicJsJsonReader` for use by the adapters.

Of note, I also tried a version of this where I modified the existing ktor engine to call `JSON.parse()` directly with the byte buffer in the response. I found that approach to be roughly 1/2 as fast as using the native `json()` api.

I put the new http engine behind a flag, so it shouldn't break any existing behavior.

There are still performance issues with the `Call` creation, but this change speeds up the response parsing by ~4-5x.

See https://github.com/apollographql/apollo-kotlin/issues/4732