### PR TITLE
Try to decrease test flakiness

### DIFF
--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 
 @ApolloExperimental
-suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 500) = withTimeout(timeoutMillis) {
+suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 1000) = withTimeout(timeoutMillis) {
   receive()
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/batching/QueryBatchingTest.kt
@@ -63,7 +63,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpBatching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 1000)
         .build()
 
     val result1 = async {
@@ -124,7 +124,7 @@ class QueryBatchingTest {
     mockServer.enqueue("""[{"data":{"launch":{"id":"84"}}}]""")
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpBatching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 1000)
         .build()
 
     val result1 = async {
@@ -156,7 +156,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpBatching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 1000)
         // Opt out by default
         .canBeBatched(false)
         .build()
@@ -203,7 +203,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpBatching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 1000)
         .httpHeaders(
             listOf(
                 HttpHeader("client0", "0"),
@@ -240,7 +240,7 @@ class QueryBatchingTest {
     mockServer.enqueue(response)
     apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .httpBatching(batchIntervalMillis = 300)
+        .httpBatching(batchIntervalMillis = 1000)
         .build()
 
     val result1 = async {


### PR DESCRIPTION
This tries to address fails seen here, which are all timing/timeout issues:
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7857176942#step:5:2701
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7858513403#step:5:2725
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7860330104#step:5:2696
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7861965094#step:5:2955
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7867443325#step:5:2583
- https://github.com/apollographql/apollo-kotlin/actions/runs/4471811442/jobs/7868194585#step:5:2654