### PR TITLE
Automatic multipart header

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.Upload
 import com.apollographql.apollo3.api.http.internal.urlEncode
 import com.apollographql.apollo3.api.json.JsonWriter
@@ -42,7 +43,10 @@ class DefaultHttpRequestComposer(
       if (apolloRequest.httpHeaders != null) {
         addAll(apolloRequest.httpHeaders)
       }
-      if (apolloRequest.httpHeaders.orEmpty().none { it.name.lowercase() == HEADER_ACCEPT_NAME.lowercase() }) {
+
+      if (apolloRequest.operation is Subscription<*>) {
+        add(HttpHeader(HEADER_ACCEPT_NAME, HEADER_ACCEPT_VALUE_MULTIPART))
+      } else {
         add(HttpHeader(HEADER_ACCEPT_NAME, HEADER_ACCEPT_VALUE_DEFER))
       }
     }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -40,14 +40,13 @@ class DefaultHttpRequestComposer(
     val requestHeaders = mutableListOf<HttpHeader>().apply {
       add(HttpHeader(HEADER_APOLLO_OPERATION_ID, operation.id()))
       add(HttpHeader(HEADER_APOLLO_OPERATION_NAME, operation.name()))
-      if (apolloRequest.httpHeaders != null) {
-        addAll(apolloRequest.httpHeaders)
-      }
-
       if (apolloRequest.operation is Subscription<*>) {
         add(HttpHeader(HEADER_ACCEPT_NAME, HEADER_ACCEPT_VALUE_MULTIPART))
       } else {
         add(HttpHeader(HEADER_ACCEPT_NAME, HEADER_ACCEPT_VALUE_DEFER))
+      }
+      if (apolloRequest.httpHeaders != null) {
+        addAll(apolloRequest.httpHeaders)
       }
     }
 

--- a/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsRouterTest.kt
+++ b/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsRouterTest.kt
@@ -19,7 +19,6 @@ class MultipartSubscriptionsRouterTest {
         .serverUrl("http://localhost:4040/")
         .subscriptionNetworkTransport(
             HttpNetworkTransport.Builder()
-                .addHttpHeader(DefaultHttpRequestComposer.HEADER_ACCEPT_NAME, DefaultHttpRequestComposer.HEADER_ACCEPT_VALUE_MULTIPART)
                 .serverUrl("http://localhost:4040/")
                 .build()
         )


### PR DESCRIPTION
Add the `Accept:` header automatically if a subscription is sent over HTTP