### PR TITLE
Fix IJ plugin snapshot in GH action

### DIFF
--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -7,7 +7,7 @@ val branchName = "release-increment-ij-plugin-snapshot"
 runCommand("git", "checkout", "-b", branchName)
 runCommand("git", "add", "intellij-plugin/gradle.properties", "intellij-plugin/snapshots/plugins.xml")
 runCommand("git", "commit", "-m", "Increment IJ plugin snapshot version")
-runCommand("git", "push")
+runCommand("git", "push", "origin", branchName)
 runCommand("gh", "pr", "create", "--fill")
 mergeAndWait(branchName)
 


### PR DESCRIPTION
Fix [missing](https://github.com/apollographql/apollo-kotlin/actions/runs/4521878458/jobs/7963902886#step:4:89) remote and branch name in git push command.
