### PR TITLE
Add % to reserved characters to encode in URL

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/internal/UrlEncode.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/internal/UrlEncode.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.api.http.internal
 import kotlin.native.concurrent.SharedImmutable
 
 @SharedImmutable
-private val RESERVED_CHARS = "!#\$&'\"()*+,/:;=?@[]{} "
+private val RESERVED_CHARS = "!#\$&'\"()*+,/:;=?@[]{}% "
 
 /**
  * A very simple urlEncode.

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
@@ -43,7 +43,7 @@ class HttpGetTest {
     fun encodeReservedCharactersTest() = mockServerTest {
         // Response not needed, just testing generated url
         mockServer.enqueueData(data = emptyMap())
-        val response = apolloClient.query(SearchHeroQuery("!#\$&'\"()*+,/:;=?@[]{}% "))
+        apolloClient.query(SearchHeroQuery("!#\$&'\"()*+,/:;=?@[]{}% "))
                 .httpMethod(HttpMethod.Get)
                 .execute()
         assertEquals(

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
@@ -38,17 +38,16 @@ class HttpGetTest {
         mockServer.takeRequest().path
     )
   }
-
-    @Test
-    fun encodeReservedCharactersTest() = mockServerTest {
-        // Response not needed, just testing generated url
-        mockServer.enqueueData(data = emptyMap())
-        apolloClient.query(SearchHeroQuery("!#\$&'\"()*+,/:;=?@[]{}% "))
-                .httpMethod(HttpMethod.Get)
-                .execute()
-        assertEquals(
-                "/?operationName=SearchHero&variables=%7B%22text%22%3A%22%21%23%24%26%27%5C%22%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%7B%7D%25%20%22%7D&query=query%20SearchHero%28%24text%3A%20String%29%20%7B%20search%28text%3A%20%24text%29%20%7B%20__typename%20...%20on%20Character%20%7B%20__typename%20name%20...%20on%20Human%20%7B%20homePlanet%20%7D%20...%20on%20Droid%20%7B%20primaryFunction%20%7D%20%7D%20%7D%20%7D",
-                mockServer.takeRequest().path
-        )
-    }
+  @Test
+  fun encodeReservedCharactersTest() = mockServerTest {
+    // Response not needed, just testing generated url
+    mockServer.enqueueData(data = emptyMap())
+    apolloClient.query(SearchHeroQuery("!#$&'()*+,/:;=?@[]{}% "))
+            .httpMethod(HttpMethod.Get)
+            .execute()
+    assertEquals(
+            "/?operationName=SearchHero&variables=%7B%22text%22%3A%22%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%7B%7D%25%20%22%7D&query=query%20SearchHero%28%24text%3A%20String%29%20%7B%20search%28text%3A%20%24text%29%20%7B%20__typename%20...%20on%20Character%20%7B%20__typename%20name%20...%20on%20Human%20%7B%20homePlanet%20%7D%20...%20on%20Droid%20%7B%20primaryFunction%20%7D%20%7D%20%7D%20%7D",
+            mockServer.takeRequest().path
+    )
+  }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
@@ -2,15 +2,17 @@ package test
 
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery
+import com.apollographql.apollo3.integration.normalizer.SearchHeroQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.enqueue
+import com.apollographql.apollo3.testing.enqueueData
 import com.apollographql.apollo3.testing.mockServerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class HttpGetTest {
   @Test
-  fun gzipTest() = mockServerTest {
+  fun getTest() = mockServerTest {
     mockServer.enqueue("""
       {
         "data": {
@@ -36,4 +38,17 @@ class HttpGetTest {
         mockServer.takeRequest().path
     )
   }
+
+    @Test
+    fun encodeReservedCharactersTest() = mockServerTest {
+        // Response not needed, just testing generated url
+        mockServer.enqueueData(data = emptyMap())
+        val response = apolloClient.query(SearchHeroQuery("!#\$&'\"()*+,/:;=?@[]{}% "))
+                .httpMethod(HttpMethod.Get)
+                .execute()
+        assertEquals(
+                "/?operationName=SearchHero&variables=%7B%22text%22%3A%22%21%23%24%26%27%5C%22%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%7B%7D%25%20%22%7D&query=query%20SearchHero%28%24text%3A%20String%29%20%7B%20search%28text%3A%20%24text%29%20%7B%20__typename%20...%20on%20Character%20%7B%20__typename%20name%20...%20on%20Human%20%7B%20homePlanet%20%7D%20...%20on%20Droid%20%7B%20primaryFunction%20%7D%20%7D%20%7D%20%7D",
+                mockServer.takeRequest().path
+        )
+    }
 }

--- a/tests/integration-tests/src/main/graphql/com/apollographql/apollo3/integration/normalizer/SearchHero.graphql
+++ b/tests/integration-tests/src/main/graphql/com/apollographql/apollo3/integration/normalizer/SearchHero.graphql
@@ -1,0 +1,15 @@
+query SearchHero($text: String) {
+    search(text: $text) {
+        __typename
+        ... on Character {
+            __typename
+            name
+            ... on Human {
+                homePlanet
+            }
+            ... on Droid {
+                primaryFunction
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently the library is not encoding the '%' character in GET parameters, i.e if I send a parameter string of '80%' this isn't parsed properly since it needs to be encoded to '%25'

This is a bug in UrlEncode.kt where it looks like it was introduced here in this [PR](https://github.com/apollographql/apollo-kotlin/commit/aa17db584e0b7d6f273a3894237882fd2770d04a#diff-c07ae4e7ec62cfe5701f2fbaf63b5122f0505d001d01671b8a0a60f6c0600184) which was originally encoding every character.