### PR TITLE
Allow custom SqlDriver

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -132,6 +132,7 @@ sqldelight-android = { group = "com.squareup.sqldelight", name = "android-driver
 sqldelight-jvm = { group = "com.squareup.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
 sqldelight-native = { group = "com.squareup.sqldelight", name = "native-driver", version.ref = "sqldelight" }
 sqldelight-plugin = { group = "com.squareup.sqldelight", name = "gradle-plugin", version.ref = "sqldelight" }
+sqldelight-runtime = { group = "com.squareup.sqldelight", name = "runtime", version.ref = "sqldelight" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "0.7.0" }
 uuid = { group = "com.benasher44", name = "uuid", version = "0.3.1" }

--- a/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
@@ -49,13 +49,13 @@ kotlin {
 
     findByName("jvmMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.jvm"))
+        api(golatac.lib("sqldelight.jvm"))
       }
     }
 
     findByName("appleMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.native"))
+        api(golatac.lib("sqldelight.native"))
       }
     }
 
@@ -68,7 +68,7 @@ kotlin {
     findByName("androidMain")?.apply {
       dependencies {
         api(golatac.lib("androidx.sqlite"))
-        implementation(golatac.lib("sqldelight.android"))
+        api(golatac.lib("sqldelight.android"))
         implementation(golatac.lib("androidx.sqlite.framework"))
         implementation(golatac.lib("androidx.startup.runtime"))
       }
@@ -88,7 +88,7 @@ kotlin {
 
 configure<com.android.build.gradle.LibraryExtension> {
   compileSdk = golatac.version("android.sdkversion.compile").toInt()
-  namespace ="com.apollographql.apollo3.cache.normalized.sql"
+  namespace = "com.apollographql.apollo3.cache.normalized.sql"
 
   defaultConfig {
     minSdk = golatac.version("android.sdkversion.min").toInt()

--- a/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
@@ -44,18 +44,19 @@ kotlin {
         api(project(":apollo-api"))
         api(project(":apollo-normalized-cache-api-incubating"))
         api(project(":apollo-normalized-cache-incubating"))
+        api(golatac.lib("sqldelight.runtime"))
       }
     }
 
     findByName("jvmMain")?.apply {
       dependencies {
-        api(golatac.lib("sqldelight.jvm"))
+        implementation(golatac.lib("sqldelight.jvm"))
       }
     }
 
     findByName("appleMain")?.apply {
       dependencies {
-        api(golatac.lib("sqldelight.native"))
+        implementation(golatac.lib("sqldelight.native"))
       }
     }
 
@@ -68,7 +69,7 @@ kotlin {
     findByName("androidMain")?.apply {
       dependencies {
         api(golatac.lib("androidx.sqlite"))
-        api(golatac.lib("sqldelight.android"))
+        implementation(golatac.lib("sqldelight.android"))
         implementation(golatac.lib("androidx.sqlite.framework"))
         implementation(golatac.lib("androidx.startup.runtime"))
       }

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.cache.normalized.sql.internal.getSchema
 import com.squareup.sqldelight.android.AndroidSqliteDriver
 import com.squareup.sqldelight.db.SqlDriver
 
-actual class SqlNormalizedCacheFactory internal constructor(
+actual class SqlNormalizedCacheFactory actual constructor(
     private val driver: SqlDriver,
     private val withDates: Boolean,
 ) : NormalizedCacheFactory() {

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo3.cache.normalized.sql.internal.getSchema
 import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.drivers.native.NativeSqliteDriver
 
-actual class SqlNormalizedCacheFactory internal constructor(
+actual class SqlNormalizedCacheFactory actual constructor(
     private val driver: SqlDriver,
     private val withDates: Boolean,
 ) : NormalizedCacheFactory() {

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.cache.normalized.sql
 
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
+import com.squareup.sqldelight.db.SqlDriver
 
 /**
  * Creates a new [NormalizedCacheFactory] that uses a persistent cache based on Sqlite
@@ -16,5 +17,7 @@ import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
  * Once a database is created, this parameter cannot change
  * Default: false
  */
-expect class SqlNormalizedCacheFactory(name: String? = "apollo.db", withDates: Boolean = false) : NormalizedCacheFactory
+expect class SqlNormalizedCacheFactory(name: String? = "apollo.db", withDates: Boolean = false) : NormalizedCacheFactory {
+  constructor(driver: SqlDriver, withDates: Boolean = false)
+}
 

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/sql/OpenDbTest.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/commonTest/kotlin/com/apollographql/apollo3/cache/normalized/sql/OpenDbTest.kt
@@ -1,8 +1,6 @@
 package com.apollographql.apollo3.cache.normalized.sql
 
-import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.testing.HostFileSystem
-import okio.FileSystem
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertTrue

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactoryJvm.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactoryJvm.kt
@@ -8,7 +8,7 @@ import com.squareup.sqldelight.db.SqlDriver
 import com.squareup.sqldelight.sqlite.driver.JdbcSqliteDriver
 import java.util.Properties
 
-actual class SqlNormalizedCacheFactory internal constructor(
+actual class SqlNormalizedCacheFactory actual constructor(
     private val driver: SqlDriver,
     private val withDates: Boolean,
 ) : NormalizedCacheFactory() {


### PR DESCRIPTION
Implementation for discussion at https://github.com/apollographql/apollo-kotlin/issues/4504

Publicly exposes `SqlNormalizedCacheFactory` constructors which take a `SqlDriver` argument.