### PR TITLE
Multipart subscriptions: send an error on critical errors

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -195,6 +195,7 @@ private constructor(
               }
 
               Kind.OTHER -> {
+                // We assume if there's something that is not a payload, it is an error
                 val response = part.jsonReader().readAny()
                 errorResponse(operation, SubscriptionOperationException(operation.name(), response))
               }
@@ -217,7 +218,6 @@ private constructor(
             }
           }
         }.catch {
-          it.printStackTrace()
           emit(errorResponse(operation, it))
         }
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -4,17 +4,20 @@ import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.parseJsonResponse
 import com.apollographql.apollo3.api.withDeferredFragmentIds
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloParseException
+import com.apollographql.apollo3.exception.SubscriptionOperationException
 import com.apollographql.apollo3.internal.DeferredJsonMerger
 import com.apollographql.apollo3.internal.isMultipart
 import com.apollographql.apollo3.internal.multipartBodyFlow
@@ -23,6 +26,7 @@ import com.apollographql.apollo3.network.NetworkTransport
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -156,63 +160,66 @@ private constructor(
 
     return multipartBodyFlow(httpResponse)
         .mapNotNull { part ->
-          try {
-            val what = part.peek().jsonReader().use { reader ->
+          if (operation is Subscription) {
+            val kind = part.peek().jsonReader().use { reader ->
               // detect what kind of payload we have
               reader.beginObject()
               if (!reader.hasNext()) {
-                return@use EMPTY
+                return@use Kind.EMPTY
               }
               val name = reader.nextName()
 
-              if (name == "payload") {
-                return@use PAYLOAD
-              } else {
-                return@use OTHER
+              return@use when (name) {
+                "payload" -> Kind.PAYLOAD
+                else -> Kind.OTHER
               }
             }
-
-            when (what) {
-              EMPTY -> {
-                // nothing to do
+            when (kind) {
+              Kind.EMPTY -> {
+                // nothing to do, maybe it's a ping
                 null
               }
 
-              PAYLOAD -> {
+              Kind.PAYLOAD -> {
                 val reader = part.jsonReader()
                 // advance the reader
                 reader.beginObject()
                 reader.nextName()
+
+                // Do nothing with "done", we just rely on the multipart closing boundary to close the stream gracefully
+                // TODO: make parseJsonResponse not close the jsonReader
                 operation.parseJsonResponse(
                     jsonReader = reader,
                     customScalarAdapters = customScalarAdapters
-                ).newBuilder().build()
+                )
               }
 
-              else -> {
-                if (jsonMerger == null) {
-                  jsonMerger = DeferredJsonMerger()
-                }
-                val merged = jsonMerger!!.merge(part)
-                val deferredFragmentIds = jsonMerger!!.mergedFragmentIds
-                val isLast = !jsonMerger!!.hasNext
-
-                if (jsonMerger!!.isEmptyPayload) {
-                  null
-                } else {
-                  operation.parseJsonResponse(
-                      jsonReader = merged.jsonReader(),
-                      customScalarAdapters = customScalarAdapters.withDeferredFragmentIds(deferredFragmentIds)
-                  ).newBuilder().isLast(isLast).build()
-                }
+              Kind.OTHER -> {
+                val response = part.jsonReader().readAny()
+                errorResponse(operation, SubscriptionOperationException(operation.name(), response))
               }
             }
+          } else {
+            if (jsonMerger == null) {
+              jsonMerger = DeferredJsonMerger()
+            }
+            val merged = jsonMerger!!.merge(part)
+            val deferredFragmentIds = jsonMerger!!.mergedFragmentIds
+            val isLast = !jsonMerger!!.hasNext
 
-          } catch (e: Exception) {
-            errorResponse(operation, e)
+            if (jsonMerger!!.isEmptyPayload) {
+              null
+            } else {
+              operation.parseJsonResponse(
+                  jsonReader = merged.jsonReader(),
+                  customScalarAdapters = customScalarAdapters.withDeferredFragmentIds(deferredFragmentIds)
+              ).newBuilder().isLast(isLast).build()
+            }
           }
+        }.catch {
+          it.printStackTrace()
+          emit(errorResponse(operation, it))
         }
-
   }
 
   private fun <D : Operation.Data> ApolloResponse<D>.withHttpInfo(
@@ -350,8 +357,10 @@ private constructor(
 
 
   private companion object {
-    private const val EMPTY = 0
-    private const val PAYLOAD = 1
-    private const val OTHER = 2
+    enum class Kind {
+      EMPTY,
+      PAYLOAD,
+      OTHER,
+    }
   }
 }

--- a/libraries/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/network/MultipartReaderTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/com/apollographql/apollo3/network/MultipartReaderTest.kt
@@ -1,0 +1,44 @@
+package com.apollographql.apollo3.network
+
+import com.apollographql.apollo3.internal.MultipartReader
+import okio.Buffer
+import okio.use
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MultipartReaderTest {
+  private val response = buildString {
+    append("--graphql\r\n")
+    append("content-type: application/json\r\n")
+    append("\r\n")
+    append("{\"payload\":{\"data\":{\"aReviewWasAdded\":{\"id\":3,\"body\":\"A new review for Apollo Studio\"}}},\"done\":false}")
+
+    append("\r\n--graphql\r\n")
+    append("content-type: application/json\r\n")
+    append("\r\n")
+    append("{\"payload\":{\"data\":{\"aReviewWasAdded\":{\"id\":23,\"body\":\"A new review for Apollo Studio\"}}},\"done\":false}")
+
+    append("\r\n--graphql\r\n")
+    append("content-type: application/json\r\n")
+    append("\r\n")
+    append("{\"errors\":[{\"message\":\"cannot read message from websocket\",\"extensions\":{\"code\":\"WEBSOCKET_MESSAGE_ERROR\"}}],\"done\":true}")
+
+    append("\r\n--graphql--\r\n")
+  }
+
+  @Test
+  fun finishesGraceFully() {
+    var partCount = 0
+    MultipartReader(Buffer().writeUtf8(response), "graphql").use {
+      while (true) {
+        val part = it.nextPart() ?: break
+        //assertTrue(part.body.readUtf8().isNotEmpty())
+        println(part.body.readUtf8())
+        partCount++
+      }
+    }
+
+    assertEquals(3, partCount)
+  }
+}

--- a/tests/multipart/src/commonMain/graphql/router/operations.graphql
+++ b/tests/multipart/src/commonMain/graphql/router/operations.graphql
@@ -7,3 +7,10 @@ subscription Die {
     }
   }
 }
+
+subscription Review {
+  aReviewWasAdded {
+    id
+    body
+  }
+}

--- a/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsFakeTest.kt
+++ b/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsFakeTest.kt
@@ -7,9 +7,15 @@ import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.flow.toList
 import multipart.CounterSubscription
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 
+/**
+ * This is a test from the early days of multipart subscriptions. It's not valid anymore but kept around
+ * as reference. If you come here and wonder what this is, now is probably a good time to remove it.
+ */
+@Ignore
 class MultipartSubscriptionsFakeTest {
   private lateinit var mockServer: MockServer
   private lateinit var apolloClient: ApolloClient

--- a/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsRouterTest.kt
+++ b/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsRouterTest.kt
@@ -1,10 +1,12 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
-import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
+import com.apollographql.apollo3.network.http.LoggingInterceptor
 import com.apollographql.apollo3.testing.internal.runTest
+import okio.use
 import router.DieSubscription
+import router.ReviewSubscription
 import kotlin.test.Ignore
 import kotlin.test.Test
 
@@ -13,34 +15,59 @@ import kotlin.test.Test
  */
 @Ignore
 class MultipartSubscriptionsRouterTest {
-  @Test
-  fun routerTest() = runTest {
-    val apolloClient = ApolloClient.Builder()
-        .serverUrl("http://localhost:4040/")
-        .subscriptionNetworkTransport(
-            HttpNetworkTransport.Builder()
-                .serverUrl("http://localhost:4040/")
-                .build()
-        )
-        .build()
+  private fun client(log: Boolean) = ApolloClient.Builder()
+      .serverUrl("http://localhost:4040/")
+      .subscriptionNetworkTransport(
+          HttpNetworkTransport.Builder()
+              .apply {
+                if (log) {
+                  addInterceptor(
+                      LoggingInterceptor(LoggingInterceptor.Level.BODY) {
+                        println(it.replace("\r", "\\r").replace("\n", "\\n"))
+                      },
+                  )
+                }
+              }
+              .serverUrl("http://localhost:4040/")
+              .build()
+      )
+      .build()
 
-    /**
-     * Should display something like this
-     *
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=3, sides=30, color=red)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=5, sides=31, color=blue)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=11, sides=32, color=red)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=12, sides=33, color=blue)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=21, sides=34, color=red)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=16, sides=35, color=blue)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=22, sides=36, color=red)))
-     * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=11, sides=37, color=blue)))
-     */
-    apolloClient.subscription(DieSubscription()).toFlow().collect {
-      if (it.data != null) {
-        println("${it.data}")
-      } else {
-        it.exception!!.printStackTrace()
+  @Test
+  fun dieTest() = runTest {
+    client(log = true).use { apolloClient ->
+      /**
+       * Should display something like this
+       *
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=3, sides=30, color=red)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=5, sides=31, color=blue)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=11, sides=32, color=red)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=12, sides=33, color=blue)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=21, sides=34, color=red)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=16, sides=35, color=blue)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=22, sides=36, color=red)))
+       * Got Data(aNewDieWasCreated=ANewDieWasCreated(die=Die(roll=11, sides=37, color=blue)))
+       */
+      apolloClient.subscription(DieSubscription()).toFlow().collect {
+        if (it.data != null) {
+          println("${it.data}")
+        } else {
+          it.exception!!.printStackTrace()
+        }
+      }
+    }
+  }
+
+  @Test
+  fun reviewTest() = runTest {
+    client(log = true).use { apolloClient ->
+      apolloClient.subscription(ReviewSubscription()).toFlow().collect {
+        if (it.data != null) {
+          println("${it.data} isLast=${it.isLast}")
+        } else {
+          println("exception: ${it.exception}")
+          it.exception?.printStackTrace()
+        }
       }
     }
   }


### PR DESCRIPTION
If we get an error payload, return an exception to the caller:

```
--graphql
content-type: application/json

{"errors":[{"message":"cannot read message from websocket","extensions":{"code":"WEBSOCKET_MESSAGE_ERROR"}}],"done":true}
```