### PR TITLE
More urlencode tests

### DIFF
--- a/libraries/apollo-api/build.gradle.kts
+++ b/libraries/apollo-api/build.gradle.kts
@@ -17,6 +17,13 @@ kotlin {
         api(project(":apollo-annotations"))
       }
     }
+
+    findByName("commonTest")?.apply {
+      dependencies {
+        //implementation(golatac.lib("kotlin.test.junit"))
+        implementation(golatac.lib("kotlin.test"))
+      }
+    }
   }
 }
 

--- a/libraries/apollo-api/src/jvmTest/kotlin/UrlEncodeTest.kt
+++ b/libraries/apollo-api/src/jvmTest/kotlin/UrlEncodeTest.kt
@@ -1,0 +1,18 @@
+import com.apollographql.apollo3.api.http.internal.urlEncode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UrlEncodeTest {
+
+  @Test
+  fun test() {
+    listOf(
+        "%" to "%25",
+        " " to "%20",
+        "{}" to "%7B%7D",
+        "e30=" to "e30%3D", // {} base64 encoded
+    ).forEach {
+      assertEquals(it.second, it.first.urlEncode())
+    }
+  }
+}


### PR DESCRIPTION
Follow up from https://github.com/apollographql/apollo-kotlin/pull/4804. Maybe it's not worth adding a new dependency just for urlencode but in all cases, we need more unit tests for this. 