### PR TITLE
Fix variables in fragments

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
@@ -119,11 +119,7 @@ internal class CompiledSelectionsBuilder(
 
     check(expression is BooleanExpression.Element)
 
-    return if (expression.value.defaultValue != null) {
-      CodeBlock.of("%T(%S,·%L,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString(), expression.value.defaultValue.toString())
-    } else {
-      CodeBlock.of("%T(%S,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString())
-    }
+    return CodeBlock.of("%T(%S,·%L)", KotlinSymbols.CompiledCondition, expression.value.name, inverted.toString())
   }
 
   private fun IrArgument.codeBlock(): CodeBlock {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrBuilder.kt
@@ -444,7 +444,7 @@ internal class IrBuilder(
         operationType = operationType.toIrOperationType(schema.rootTypeNameFor(operationType)),
         typeCondition = typeDefinition.name,
         variables = variableDefinitions.map { it.toIr() },
-        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeDefinition.name, variableDefinitions),
+        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeDefinition.name),
         sourceWithFragments = sourceWithFragments,
         filePath = sourceLocation.filePath!!,
         dataProperty = dataProperty,
@@ -479,7 +479,7 @@ internal class IrBuilder(
         filePath = sourceLocation.filePath!!,
         typeCondition = typeDefinition.name,
         variables = inferredVariables.map { it.toIr() },
-        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeCondition.name, emptyList()),
+        selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selectionSet.selections, typeCondition.name),
         interfaceModelGroup = interfaceModelGroup,
         dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
@@ -646,17 +646,10 @@ internal class IrBuilder(
             }
       }
 
-      /**
-       * It's ok to always pass the empty list for variableDefinitions because the parsers do not care about @include and @skip
-       * All they care about is that the model types match what is sent by the server
-       */
-      val variableDefinitions: List<GQLVariableDefinition> = emptyList()
-      val condition = gqlField.directives.toIncludeBooleanExpression(variableDefinitions)
-
       CollectedField(
           name = gqlField.name,
           alias = gqlField.alias,
-          condition = condition,
+          condition = gqlField.directives.toIncludeBooleanExpression(),
           selections = gqlField.selectionSet?.selections ?: emptyList(),
           type = fieldDefinition.type,
           description = fieldDefinition.description,
@@ -768,9 +761,9 @@ internal fun GQLValue.toIrValue(): IrValue {
  * - (!)Variable
  * - (!)Variable & (!)Variable
  */
-internal fun List<GQLDirective>.toIncludeBooleanExpression(variableDefinitions: List<GQLVariableDefinition>): BooleanExpression<BVariable> {
+internal fun List<GQLDirective>.toIncludeBooleanExpression(): BooleanExpression<BVariable> {
   val conditions = mapNotNull {
-    it.toIncludeBooleanExpression(variableDefinitions)
+    it.toIncludeBooleanExpression()
   }
   return if (conditions.isEmpty()) {
     BooleanExpression.True
@@ -785,7 +778,7 @@ internal fun List<GQLDirective>.toIncludeBooleanExpression(variableDefinitions: 
   }
 }
 
-internal fun GQLDirective.toIncludeBooleanExpression(variableDefinitions: List<GQLVariableDefinition>): BooleanExpression<BVariable>? {
+internal fun GQLDirective.toIncludeBooleanExpression(): BooleanExpression<BVariable>? {
   if (setOf("skip", "include").contains(name).not()) {
     // not a condition directive
     return null
@@ -801,10 +794,7 @@ internal fun GQLDirective.toIncludeBooleanExpression(variableDefinitions: List<G
       if (value.value) BooleanExpression.True else BooleanExpression.False
     }
 
-    is GQLVariableValue -> {
-      val defaultValue = (variableDefinitions.firstOrNull { it.name == value.name }?.defaultValue as? GQLBooleanValue?)?.value
-      BooleanExpression.Element(BVariable(name = value.name, defaultValue = defaultValue))
-    }
+    is GQLVariableValue -> BooleanExpression.Element(BVariable(name = value.name))
     else -> throw IllegalStateException("Apollo: cannot pass ${value.toUtf8()} to '$name' directive")
   }.let {
     if (name == "skip") not(it) else it
@@ -826,7 +816,7 @@ internal fun List<GQLDirective>.toBooleanExpression(): BooleanExpression<BTerm> 
     }
     deferBooleanConditions.first()
   }
-  return toIncludeBooleanExpression(emptyList()).and(deferBooleanExpression).simplify()
+  return toIncludeBooleanExpression().and(deferBooleanExpression).simplify()
 }
 
 internal fun GQLDirective.toDeferBooleanExpression(): BooleanExpression<BTerm>? {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/SelectionSetsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/SelectionSetsBuilder.kt
@@ -11,7 +11,6 @@ import com.apollographql.apollo3.ast.GQLNamedType
 import com.apollographql.apollo3.ast.GQLNonNullType
 import com.apollographql.apollo3.ast.GQLSelection
 import com.apollographql.apollo3.ast.GQLType
-import com.apollographql.apollo3.ast.GQLVariableDefinition
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.definitionFromScope
 import com.apollographql.apollo3.ast.rawType
@@ -36,8 +35,8 @@ internal class SelectionSetsBuilder(
     return name
   }
 
-  fun build(gqlSelections: List<GQLSelection>, parentType: String, variableDefinitions: List<GQLVariableDefinition>): List<IrSelectionSet> {
-    return gqlSelections.walk("root", true, parentType, variableDefinitions)
+  fun build(gqlSelections: List<GQLSelection>, parentType: String): List<IrSelectionSet> {
+    return gqlSelections.walk("root", true, parentType)
   }
 
   private class WalkResult(val self: IrSelection, val nested: List<IrSelectionSet>)
@@ -45,8 +44,8 @@ internal class SelectionSetsBuilder(
   /**
    * @param name the name to use for this [IrSelectionSet]. Must be unique for a given operation/fragment definition
    */
-  private fun List<GQLSelection>.walk(name: String, isRoot: Boolean, parentType: String, variableDefinitions: List<GQLVariableDefinition>): List<IrSelectionSet> {
-    val results = mapNotNull { it.walk(parentType, variableDefinitions) }
+  private fun List<GQLSelection>.walk(name: String, isRoot: Boolean, parentType: String): List<IrSelectionSet> {
+    val results = mapNotNull { it.walk(parentType) }
 
     /**
      * Order is important. The selection set will ultimately reference nested selection sets, so the nested need to come first
@@ -55,11 +54,11 @@ internal class SelectionSetsBuilder(
     return results.flatMap { it.nested } + IrSelectionSet(name, isRoot, results.map { it.self })
   }
 
-  private fun GQLSelection.walk(parentType: String, variableDefinitions: List<GQLVariableDefinition>): WalkResult? {
+  private fun GQLSelection.walk(parentType: String): WalkResult? {
     return when (this) {
-      is GQLField -> walk(parentType, variableDefinitions)
-      is GQLInlineFragment -> walk(variableDefinitions)
-      is GQLFragmentSpread -> walk(variableDefinitions)
+      is GQLField -> walk(parentType)
+      is GQLInlineFragment -> walk()
+      is GQLFragmentSpread -> walk()
     }
   }
 
@@ -72,8 +71,8 @@ internal class SelectionSetsBuilder(
     )
   }
 
-  private fun GQLField.walk(parentType: String, variableDefinitions: List<GQLVariableDefinition>): WalkResult? {
-    val expression = directives.toIncludeBooleanExpression(variableDefinitions)
+  private fun GQLField.walk(parentType: String): WalkResult? {
+    val expression = directives.toIncludeBooleanExpression()
     if (expression == BooleanExpression.False) {
       return null
     }
@@ -97,7 +96,7 @@ internal class SelectionSetsBuilder(
             condition = expression,
             selectionSetName = if (selectionSet != null) selectionSetName else null
         ),
-        nested = selectionSet?.selections?.walk(selectionSetName, false, fieldDefinition.type.rawType().name, variableDefinitions).orEmpty()
+        nested = selectionSet?.selections?.walk(selectionSetName, false, fieldDefinition.type.rawType().name).orEmpty()
     )
   }
 
@@ -110,8 +109,8 @@ internal class SelectionSetsBuilder(
     is GQLNamedType -> IrNamedTypeRef(name)
   }
 
-  private fun GQLInlineFragment.walk(variableDefinitions: List<GQLVariableDefinition>): WalkResult? {
-    val expression = directives.toIncludeBooleanExpression(variableDefinitions)
+  private fun GQLInlineFragment.walk(): WalkResult? {
+    val expression = directives.toIncludeBooleanExpression()
     if (expression == BooleanExpression.False) {
       return null
     }
@@ -127,12 +126,12 @@ internal class SelectionSetsBuilder(
             selectionSetName = selectionSetName,
             name = null
         ),
-        nested = selectionSet.selections.walk(selectionSetName, false, typeCondition.name, variableDefinitions)
+        nested = selectionSet.selections.walk(selectionSetName, false, typeCondition.name)
     )
   }
 
-  private fun GQLFragmentSpread.walk(variableDefinitions: List<GQLVariableDefinition>): WalkResult? {
-    val expression = directives.toIncludeBooleanExpression(variableDefinitions)
+  private fun GQLFragmentSpread.walk(): WalkResult? {
+    val expression = directives.toIncludeBooleanExpression()
     if (expression == BooleanExpression.False) {
       return null
     }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/compat/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/compat/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
@@ -48,13 +48,13 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", true, true)))
+        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", true)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", false, true)))
+        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", false)))
         .selections(OtherDroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
@@ -48,13 +48,13 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", true, true)))
+        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", true)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", false, true)))
+        ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", false)))
         .selections(OtherDroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -36,7 +36,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
-  val variables = variables(customScalarAdapters, withDefaultBooleanValues = false)
+  val variables = variables(customScalarAdapters, withDefaultBooleanValues = true)
   return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
@@ -52,7 +52,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
-  val variables = variables(customScalarAdapters, withDefaultBooleanValues = false)
+  val variables = variables(customScalarAdapters, withDefaultBooleanValues = true)
   return Normalizer(variables, rootKey, cacheKeyGenerator, metadataGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
@@ -126,7 +126,7 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
       cache = cache,
       cacheHeaders = cacheHeaders,
       cacheResolver = cacheResolver,
-      variables = variables(customScalarAdapters, withDefaultBooleanValues = false),
+      variables = variables(customScalarAdapters, withDefaultBooleanValues = true),
       rootKey = cacheKey.key,
       rootSelections = rootField().selections,
       rootTypename = rootField().type.rawType().name

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -26,7 +26,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
-  val variables = variables(customScalarAdapters, withDefaultBooleanValues = false)
+  val variables = variables(customScalarAdapters, withDefaultBooleanValues = true)
   return Normalizer(variables, rootKey, cacheKeyGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType().name)
 }
@@ -69,7 +69,7 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
       cache = cache,
       cacheHeaders = cacheHeaders,
       cacheResolver = cacheResolver,
-      variables = variables(customScalarAdapters, withDefaultBooleanValues = false),
+      variables = variables(customScalarAdapters, withDefaultBooleanValues = true),
       rootKey = cacheKey.key,
       rootSelections = rootField().selections,
       rootTypename = rootField().type.rawType().name

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/ShouldSkip.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/ShouldSkip.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.api.CompiledField
 
 internal fun CompiledField.shouldSkip(variableValues: Map<String, Any?>): Boolean {
   condition.forEach {
-    var value = (variableValues.get(it.name) as? Boolean) ?: it.defaultValue
+    var value = (variableValues.get(it.name) as? Boolean) ?: false
     if (it.inverted) {
       value = !value
     }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -23,26 +23,35 @@ tasks.register("ciBuild") {
  * See https://youtrack.jetbrains.com/issue/KT-51970
  * See https://youtrack.jetbrains.com/issue/KT-52172
  */
-gradle.startParameter.setExcludedTaskNames(listOf(
-    ":coroutines-mt:compileAppleMainKotlinMetadata",
-    ":coroutines-mt:compileCommonMainKotlinMetadata",
-    ":defer:compileAppleMainKotlinMetadata",
-    ":defer:compileCommonMainKotlinMetadata",
-    ":gzip:compileCommonMainKotlinMetadata",
-    ":integration-tests:compileAppleMainKotlinMetadata",
-    ":integration-tests:compileCommonMainKotlinMetadata",
-    ":ios-test:compileCommonMainKotlinMetadata",
-    ":legacy-memory-model:compileCommonMainKotlinMetadata",
-    ":models-operation-based:compileAppleMainKotlinMetadata",
-    ":models-operation-based:compileCommonMainKotlinMetadata",
-    ":models-response-based:compileAppleMainKotlinMetadata",
-    ":models-response-based:compileCommonMainKotlinMetadata",
-    ":models-compat:compileAppleMainKotlinMetadata",
-    ":models-compat:compileCommonMainKotlinMetadata",
-    ":multipart:compileCommonMainKotlinMetadata",
-    ":native-benchmarks:compileAppleMainKotlinMetadata",
-    ":native-benchmarks:compileCommonMainKotlinMetadata",
-    ":pagination:compileCommonMainKotlinMetadata",
-    ":sqlite:compileCommonMainKotlinMetadata",
-    ":websockets:compileCommonMainKotlinMetadata"
-))
+val excludedTasks = mutableListOf<String>(
+
+)
+if (System.getProperty("idea.sync.active") == null) {
+  excludedTasks.addAll(
+      listOf(
+          ":coroutines-mt:compileAppleMainKotlinMetadata",
+          ":coroutines-mt:compileCommonMainKotlinMetadata",
+          ":defer:compileAppleMainKotlinMetadata",
+          ":defer:compileCommonMainKotlinMetadata",
+          ":gzip:compileCommonMainKotlinMetadata",
+          ":integration-tests:compileAppleMainKotlinMetadata",
+          ":integration-tests:compileCommonMainKotlinMetadata",
+          ":ios-test:compileCommonMainKotlinMetadata",
+          ":legacy-memory-model:compileCommonMainKotlinMetadata",
+          ":models-operation-based:compileAppleMainKotlinMetadata",
+          ":models-operation-based:compileCommonMainKotlinMetadata",
+          ":models-response-based:compileAppleMainKotlinMetadata",
+          ":models-response-based:compileCommonMainKotlinMetadata",
+          ":models-compat:compileAppleMainKotlinMetadata",
+          ":models-compat:compileCommonMainKotlinMetadata",
+          ":multipart:compileCommonMainKotlinMetadata",
+          ":native-benchmarks:compileAppleMainKotlinMetadata",
+          ":native-benchmarks:compileCommonMainKotlinMetadata",
+          ":pagination:compileCommonMainKotlinMetadata",
+          ":sqlite:compileCommonMainKotlinMetadata",
+          ":websockets:compileCommonMainKotlinMetadata")
+  )
+}
+
+gradle.startParameter.setExcludedTaskNames(excludedTasks)
+

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 dependencies {
   implementation(golatac.lib("apollo.runtime"))
   implementation(golatac.lib("apollo.httpCache"))
-  implementation(golatac.lib("apollo.normalizedcache"))
   implementation(golatac.lib("apollo.mockserver"))
   testImplementation(golatac.lib("kotlin.test.junit"))
   testImplementation(golatac.lib("apollo.testingsupport"))

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
   implementation(golatac.lib("apollo.runtime"))
+  implementation(golatac.lib("apollo.normalizedcache"))
   implementation(golatac.lib("apollo.httpCache"))
   implementation(golatac.lib("apollo.mockserver"))
   testImplementation(golatac.lib("kotlin.test.junit"))

--- a/tests/include-skip-operation-based/src/main/graphql/operations.graphql
+++ b/tests/include-skip-operation-based/src/main/graphql/operations.graphql
@@ -73,3 +73,11 @@ query GetAnimalByIdWithDefaultValue($id: ID = 0) {
     species
   }
 }
+
+query GetQuery($foo: Boolean = false) {
+  ...queryFragment
+}
+
+fragment queryFragment on Query {
+  field @include(if: $foo)
+}

--- a/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
+++ b/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
@@ -5,7 +5,7 @@ type Query {
 }
 
 interface Animal {
-  species: String!
+  species: String
 }
 
 type Cat implements Animal {

--- a/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
+++ b/tests/include-skip-operation-based/src/main/graphql/schema.graphqls
@@ -1,6 +1,7 @@
 type Query {
   animal: Animal
   animalById(id: ID!): Animal
+  field: Int!
 }
 
 interface Animal {

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,17 +1,17 @@
 import com.apollographql.apollo3.api.ApolloResponse
-import com.apollographql.apollo3.api.CustomScalarAdapters
-import com.apollographql.apollo3.api.GlobalBuilder
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+<<<<<<< HEAD
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.example.GetAnimalByIdWithDefaultValueQuery
+=======
+import com.apollographql.apollo3.api.GlobalBuilder
+>>>>>>> parent of a7eebea03 (Fix normalizing data when using `@include` or `@skip` with default values (#4700))
 import com.example.GetCatIncludeFalseQuery
 import com.example.GetCatIncludeTrueQuery
 import com.example.GetCatIncludeVariableQuery
-import com.example.GetCatIncludeVariableWithDefaultQuery
 import com.example.GetDogSkipFalseQuery
 import com.example.GetDogSkipTrueQuery
 import com.example.GetDogSkipVariableQuery
@@ -231,5 +231,4 @@ class IncludeTest {
     val records = operation.normalize(data, CustomScalarAdapters.Empty, TypePolicyCacheKeyGenerator)
     assertTrue(records.containsKey("""animalById({"id":"0"})"""))
   }
-
 }

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -15,7 +15,9 @@ import com.example.GetCatIncludeVariableWithDefaultQuery
 import com.example.GetDogSkipFalseQuery
 import com.example.GetDogSkipTrueQuery
 import com.example.GetDogSkipVariableQuery
+import com.example.GetQuery
 import com.example.SkipFragmentWithDefaultToFalseQuery
+import com.example.fragment.QueryFragment
 import com.example.type.buildCat
 import com.example.type.buildDog
 import com.example.type.buildQuery
@@ -192,6 +194,14 @@ class IncludeTest {
     val response = operation.parseData(data)
 
     assertNotNull(response.dataAssertNoErrors.animal!!.dogFragment)
+  }
+
+  @Test
+  fun includeInFragment(): Unit = runBlocking {
+    val operation = GetQuery()
+
+    operation.normalize(GetQuery.Data("Query", queryFragment = QueryFragment(null)), CustomScalarAdapters.Empty, TypePolicyCacheKeyGenerator)
+
   }
 
   @Test

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,17 +1,17 @@
 import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
-<<<<<<< HEAD
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.example.GetAnimalByIdWithDefaultValueQuery
-=======
 import com.apollographql.apollo3.api.GlobalBuilder
->>>>>>> parent of a7eebea03 (Fix normalizing data when using `@include` or `@skip` with default values (#4700))
+import com.apollographql.apollo3.api.Optional
 import com.example.GetCatIncludeFalseQuery
 import com.example.GetCatIncludeTrueQuery
 import com.example.GetCatIncludeVariableQuery
+import com.example.GetCatIncludeVariableWithDefaultQuery
 import com.example.GetDogSkipFalseQuery
 import com.example.GetDogSkipTrueQuery
 import com.example.GetDogSkipVariableQuery


### PR DESCRIPTION
Because fragments do not have variables, we can't get their default value. Fixes #4818 

This also mirrors the logic from https://github.com/apollographql/apollo-kotlin/pull/4785