### PR TITLE
Add default headers when uploading schema

### DIFF
--- a/libraries/apollo-cli/src/main/kotlin/com/apollographql/apollo3/cli/PublishSchemaCommand.kt
+++ b/libraries/apollo-cli/src/main/kotlin/com/apollographql/apollo3/cli/PublishSchemaCommand.kt
@@ -20,7 +20,10 @@ internal class PublishSchemaCommand: CliktCommand() {
         key = key,
         graph = graph,
         variant = graphVariant,
-        sdl = File(schema).readText()
+        sdl = File(schema).readText(),
+        subgraph = subgraph,
+        revision = revision,
+        headers = mapOf("apollographql-client-name" to "apollo-cli")
     )
   }
 }


### PR DESCRIPTION
With the public platform api, the `apollographql-client-name` and `apollographql-client-version` headers are mandatory. They were already added when using the gradle task but not when calling `SchemaUploader` directly.

Related to https://github.com/joreilly/Confetti/pull/478.