### PR TITLE
Pass token to GH in env var for IJ plugin snapshots

### DIFF
--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -25,6 +25,7 @@ jobs:
           ./scripts/increment-ij-plugin-snapshot.main.kts
         env:
           COM_APOLLOGRAPHQL_IJ_PLUGIN_SNAPSHOT: true
+          GH_TOKEN: ${{ github.token }}
 
       - name: Publish snapshot to Repsy
         run: ./gradlew --no-build-cache :intellij-plugin:publishAllPublicationsToRepsyIjPluginSnapshots


### PR DESCRIPTION
It was [missing](https://github.com/apollographql/apollo-kotlin/actions/runs/4585930478/jobs/8098380651).