### PR TITLE
Enable gradle enterprise

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,9 @@ jobs:
           # 'Resolving NPM dependencies using yarn' returns 137
           ./gradlew compileKotlinJs
           ./gradlew --stop
-          ./gradlew ciTestsGradle --scan
+          ./gradlew ciTestsGradle
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
@@ -60,7 +62,9 @@ jobs:
           # 'Resolving NPM dependencies using yarn' returns 137
           ./gradlew compileKotlinJs --stacktrace
           ./gradlew --stop
-          ./gradlew ciTestsNoGradle --stacktrace --scan
+          ./gradlew ciTestsNoGradle --stacktrace
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
@@ -89,7 +93,9 @@ jobs:
           # 'Resolving NPM dependencies using yarn' returns 137
           ./gradlew compileKotlinJs
           ./gradlew --stop
-          ./gradlew -p tests ciBuild --scan
+          ./gradlew -p tests ciBuild
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts
@@ -144,10 +150,12 @@ jobs:
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
 
           ./gradlew :intellij-plugin:listProductsReleases # prepare list of IDEs for Plugin Verifier
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       # Run tests
       - name: Run Tests
-        run: ./gradlew :intellij-plugin:check --scan
+        run: ./gradlew :intellij-plugin:check 
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,11 +26,6 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
-          ulimit -c unlimited
-          # Workaround an issue where kotlinNpmInstall outputs
-          # 'Resolving NPM dependencies using yarn' returns 137
-          ./gradlew compileKotlinJs
-          ./gradlew --stop
           ./gradlew ciTestsGradle
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -57,11 +52,6 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
-          ulimit -c unlimited
-          # Workaround an issue where kotlinNpmInstall outputs
-          # 'Resolving NPM dependencies using yarn' returns 137
-          ./gradlew compileKotlinJs --stacktrace
-          ./gradlew --stop
           ./gradlew ciTestsNoGradle --stacktrace
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
@@ -88,11 +78,6 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
-          ulimit -c unlimited
-          # Workaround an issue where kotlinNpmInstall outputs
-          # 'Resolving NPM dependencies using yarn' returns 137
-          ./gradlew compileKotlinJs
-          ./gradlew --stop
           ./gradlew -p tests ciBuild
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,12 +135,12 @@ jobs:
           echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
 
           ./gradlew :intellij-plugin:listProductsReleases # prepare list of IDEs for Plugin Verifier
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       # Run tests
       - name: Run Tests
-        run: ./gradlew :intellij-plugin:check 
+        run: ./gradlew :intellij-plugin:check
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,8 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise") version "3.12.4"
+  id("com.gradle.enterprise") version "3.12.6"
+  id("com.gradle.common-custom-user-data-gradle-plugin") version "1.10"
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
 }
 
@@ -26,12 +27,19 @@ apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
   server = "https://ge.apollographql.com"
+  allowUntrustedServer = true
 
   buildScan {
+    publishAlways()
+    
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"
 
     val isCiBuild = System.getenv("CI") != null
     isUploadInBackground = !isCiBuild
+
+    capture {
+      this.isTaskInputFiles = true
+    }
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
+
 rootProject.name = "apollo-kotlin"
 
 rootProject.projectDir
@@ -31,10 +33,9 @@ gradleEnterprise {
 
   buildScan {
     publishAlways()
+    this as BuildScanExtensionWithHiddenFeatures
+    publishIfAuthenticated()
     
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
-
     val isCiBuild = System.getenv("CI") != null
     isUploadInBackground = !isCiBuild
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,7 +29,7 @@ apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
   server = "https://ge.apollographql.com"
-  allowUntrustedServer = true
+  allowUntrustedServer = false
 
   buildScan {
     publishAlways()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,8 @@ plugins {
 apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
+  server = "https://ge.apollographql.com"
+
   buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -30,6 +30,8 @@ plugins {
 apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
+  server = "https://ge.apollographql.com"
+
   buildScan {
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -23,7 +23,8 @@ pluginManagement {
 }
 
 plugins {
-  id("com.gradle.enterprise") version "3.12.4"
+  id("com.gradle.enterprise") version "3.12.6"
+  id("com.gradle.common-custom-user-data-gradle-plugin") version "1.10"
   id("org.gradle.toolchains.foojay-resolver-convention") version "0.4.0"
 }
 
@@ -31,13 +32,20 @@ apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
   server = "https://ge.apollographql.com"
+  allowUntrustedServer = true
 
   buildScan {
+    publishAlways()
+
     termsOfServiceUrl = "https://gradle.com/terms-of-service"
     termsOfServiceAgree = "yes"
 
     val isCiBuild = System.getenv("CI") != null
     isUploadInBackground = !isCiBuild
+
+    capture {
+      this.isTaskInputFiles = true
+    }
   }
 }
 

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -34,7 +34,7 @@ apply(from = "./gradle/repositories.gradle.kts")
 
 gradleEnterprise {
   server = "https://ge.apollographql.com"
-  allowUntrustedServer = true
+  allowUntrustedServer = false
 
   buildScan {
     publishAlways()

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -1,3 +1,5 @@
+import com.gradle.enterprise.gradleplugin.internal.extension.BuildScanExtensionWithHiddenFeatures
+
 rootProject.name = "apollo-tests"
 
 // Include all tests
@@ -37,8 +39,8 @@ gradleEnterprise {
   buildScan {
     publishAlways()
 
-    termsOfServiceUrl = "https://gradle.com/terms-of-service"
-    termsOfServiceAgree = "yes"
+    this as BuildScanExtensionWithHiddenFeatures
+    publishIfAuthenticated()
 
     val isCiBuild = System.getenv("CI") != null
     isUploadInBackground = !isCiBuild


### PR DESCRIPTION
Enable ge.apollographql.com.

You'll have to run  `./gradlew provisionGradleEnterpriseAccessKey` to upload builds. 

Builds are available at https://ge.apollographql.com/

