### PR TITLE
Publishing: fix Gradle portal publishing and apollo-gradle-plugin-external

### DIFF
--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -162,10 +162,9 @@ private fun Project.configurePublishingInternal() {
            * java-gradle-plugin creates 2 publications (one marker and one regular) but without source/javadoc.
            */
           withType(MavenPublication::class.java) {
-            artifact(javadocJarTaskProvider)
-            // Only add sources for the main publication
-            // XXX: is there a nicer way to do this?
+            // Only add sources and javadoc for the main publication
             if (!name.lowercase().contains("marker")) {
+              artifact(javadocJarTaskProvider)
               artifact(createJavaSourcesTask())
             }
           }
@@ -249,7 +248,6 @@ private fun Project.configurePublishingInternal() {
   }
 
   // See https://youtrack.jetbrains.com/issue/KT-46466/Kotlin-MPP-publishing-Gradle-7-disables-optimizations-because-of-task-dependencies#focus=Comments-27-7102038.0-0
-
   val signingTasks = tasks.withType(Sign::class.java)
   tasks.withType(AbstractPublishToMaven::class.java).configureEach {
     this.dependsOn(signingTasks)

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -152,12 +152,23 @@ private fun Project.configurePublishingInternal() {
             }
           }
         }
-
+        plugins.hasPlugin("com.gradle.plugin-publish") -> {
+          /**
+           * com.gradle.plugin-publish creates all publications
+           */
+        }
         plugins.hasPlugin("java-gradle-plugin") -> {
           /**
            * java-gradle-plugin creates 2 publications (one marker and one regular) but without source/javadoc.
-           * the new publish plugin creates everything
            */
+          withType(MavenPublication::class.java) {
+            artifact(javadocJarTaskProvider)
+            // Only add sources for the main publication
+            // XXX: is there a nicer way to do this?
+            if (!name.lowercase().contains("marker")) {
+              artifact(createJavaSourcesTask())
+            }
+          }
         }
 
         extensions.findByName("android") != null -> {

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -83,6 +83,9 @@ if (relocateJar) {
 
 
 gradlePlugin {
+  website.set("https://github.com/apollographql/apollo-kotlin")
+  vcsUrl.set("https://github.com/apollographql/apollo-kotlin")
+
   plugins {
     create("apolloGradlePlugin") {
       id = "com.apollographql.apollo3"

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("java-gradle-plugin")
-  id("apollo.library")
   id("com.gradle.plugin-publish")
+  id("apollo.library")
   id("com.gradleup.gr8")
 }
 


### PR DESCRIPTION
* Gradle portal publishing requires a websiteUrl
* `apollo-gradle-plugin-external` requires javadoc & source (which is not the case for `apollo-gradle-plugin` because the portal publishing plugin does it.