### PR TITLE
Fix renovate syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,9 @@
 {
-  "fileMatch": [
-    ".*settings\\.gradle\\.kts$"
-  ],
+  "gradle": {
+    "fileMatch": [
+      ".*settings\\.gradle\\.kts$"
+    ]
+  },
   "timeout": 600,
-  "versioning": "gradle",
   "extends": ["config:base"]
 }


### PR DESCRIPTION
Sorry for the noise, turns out `fileMatch` needed to be in a "gradle" object