### PR TITLE
Allow changing the serverUrl of WebSocketNetworkTransport

### DIFF
--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -109,6 +109,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun webSocketIdleTimeoutMillis (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketReopenWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketServerUrl (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun wsProtocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
 
@@ -425,7 +426,7 @@ public final class com/apollographql/apollo3/network/ws/WebSocketEngineKt {
 }
 
 public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTransport : com/apollographql/apollo3/network/NetworkTransport {
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lcom/apollographql/apollo3/network/ws/WebSocketEngine;JLcom/apollographql/apollo3/network/ws/WsProtocol$Factory;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Ljava/util/List;Lcom/apollographql/apollo3/network/ws/WebSocketEngine;JLcom/apollographql/apollo3/network/ws/WsProtocol$Factory;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun closeConnection (Ljava/lang/Throwable;)V
 	public fun dispose ()V
 	public fun execute (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -442,6 +443,7 @@ public final class com/apollographql/apollo3/network/ws/WebSocketNetworkTranspor
 	public final fun protocol (Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun reopenWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun serverUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
+	public final fun serverUrl (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/network/ws/WebSocketNetworkTransport$Builder;
 }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -197,6 +197,7 @@ private constructor(
     private var httpExposeErrorBody: Boolean? = null
     private var webSocketEngine: WebSocketEngine? = null
     private var webSocketReopenWhen: (suspend (Throwable, attempt: Long) -> Boolean)? = null
+    private var webSocketReopenServerUrl: (suspend () -> String)? = null
 
     init {
       failOnNativeIfLegacyMemoryManager()
@@ -316,11 +317,26 @@ private constructor(
 
     /**
      * The url of the GraphQL server used for WebSockets
+     * Use this function or webSocketServerUrl((suspend () -> String)) but not both.
      *
      * See also [subscriptionNetworkTransport] for more customization
      */
     fun webSocketServerUrl(webSocketServerUrl: String) = apply {
       this.webSocketServerUrl = webSocketServerUrl
+    }
+
+    /**
+     * Configure dynamically the url of the GraphQL server used for WebSockets.
+     * Use this function or webSocketServerUrl(String) but not both.
+     *
+     * @param webSocketServerUrl a function returning the new server URL.
+     * This function will be called every time a WebSocket is opened. For example, you can use it to update your
+     * auth credentials in case of an unauthorized error.
+     *
+     * It is a suspending function, so it can be used to introduce delay before setting the new server URL.
+     */
+    fun webSocketServerUrl(webSocketServerUrl: (suspend () -> String)) = apply {
+      this.webSocketReopenServerUrl = webSocketServerUrl
     }
 
     /**
@@ -527,6 +543,9 @@ private constructor(
         check(webSocketReopenWhen == null) {
           "Apollo: 'webSocketReopenWhen' has no effect if 'subscriptionNetworkTransport' is set"
         }
+        check(webSocketReopenServerUrl == null) {
+          "Apollo: 'webSocketReopenServerUrl' has no effect if 'subscriptionNetworkTransport' is set"
+        }
         subscriptionNetworkTransport!!
       } else {
         val url = webSocketServerUrl ?: httpServerUrl
@@ -549,6 +568,9 @@ private constructor(
                 }
                 if (webSocketReopenWhen != null) {
                   reopenWhen(webSocketReopenWhen)
+                }
+                if (webSocketReopenServerUrl != null) {
+                  serverUrl(webSocketReopenServerUrl)
                 }
               }
               .build()
@@ -599,6 +621,7 @@ private constructor(
       }
       subscriptionNetworkTransport?.let { builder.subscriptionNetworkTransport(it) }
       webSocketServerUrl?.let { builder.webSocketServerUrl(it) }
+      webSocketReopenServerUrl?.let { builder.webSocketServerUrl(it) }
       webSocketEngine?.let { builder.webSocketEngine(it) }
       webSocketReopenWhen?.let { builder.webSocketReopenWhen(it) }
       webSocketIdleTimeoutMillis?.let { builder.webSocketIdleTimeoutMillis(it) }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -57,12 +57,12 @@ import okio.use
  */
 class WebSocketNetworkTransport
 private constructor(
-    private val serverUrl: String,
+    private val serverUrl: (suspend () -> String),
     private val headers: List<HttpHeader>,
     private val webSocketEngine: WebSocketEngine = DefaultWebSocketEngine(),
     private val idleTimeoutMillis: Long = 60_000,
     private val protocolFactory: WsProtocol.Factory = SubscriptionWsProtocol.Factory(),
-    private val reopenWhen: (suspend (Throwable, attempt: Long) -> Boolean)?,
+    private val reopenWhen: (suspend (Throwable, attempt: Long) -> Boolean)?
 ) : NetworkTransport {
 
   /**
@@ -187,7 +187,7 @@ private constructor(
 
             val webSocketConnection = try {
               webSocketEngine.open(
-                  url = serverUrl,
+                  url = serverUrl(),
                   headers = if (headers.any { it.name == "Sec-WebSocket-Protocol" }) {
                     headers
                   } else {
@@ -347,7 +347,7 @@ private constructor(
   }
 
   class Builder {
-    private var serverUrl: String? = null
+    private var serverUrl: (suspend () -> String)? = null
     private var headers: MutableList<HttpHeader> = mutableListOf()
     private var webSocketEngine: WebSocketEngine? = null
     private var idleTimeoutMillis: Long? = null
@@ -355,6 +355,19 @@ private constructor(
     private var reopenWhen: (suspend (Throwable, attempt: Long) -> Boolean)? = null
 
     fun serverUrl(serverUrl: String) = apply {
+      this.serverUrl = { serverUrl }
+    }
+
+    /**
+     * Configure the server URL dynamically.
+     *
+     * @param serverUrl a function returning the new server URL.
+     * This function will be called every time a WebSocket is opened. For example, you can use it to update your
+     * auth credentials in case of an unauthorized error.
+     *
+     * It is a suspending function, so it can be used to introduce delay before setting the new serverUrl.
+     */
+    fun serverUrl(serverUrl: (suspend () -> String)?) = apply {
       this.serverUrl = serverUrl
     }
 
@@ -398,14 +411,13 @@ private constructor(
     }
 
     fun build(): WebSocketNetworkTransport {
-      @Suppress("DEPRECATION")
       return WebSocketNetworkTransport(
-          serverUrl ?: error("No serverUrl specified"),
-          headers,
-          webSocketEngine ?: DefaultWebSocketEngine(),
-          idleTimeoutMillis ?: 60_000,
-          protocolFactory ?: SubscriptionWsProtocol.Factory(),
-          reopenWhen
+          serverUrl = serverUrl ?: error("No serverUrl specified"),
+          headers = headers,
+          webSocketEngine = webSocketEngine ?: DefaultWebSocketEngine(),
+          idleTimeoutMillis = idleTimeoutMillis ?: 60_000,
+          protocolFactory = protocolFactory ?: SubscriptionWsProtocol.Factory(),
+          reopenWhen = reopenWhen
       )
     }
   }


### PR DESCRIPTION
Related to #4775.

Allow to dynamically set the websocket server URL in case we need to pass a new server URL with a new auth when the socket is reopen.