### PR TITLE
Fix IJ plugin snapshot job

### DIFF
--- a/.github/workflows/publish-ij-plugin-snapshot.yml
+++ b/.github/workflows/publish-ij-plugin-snapshot.yml
@@ -1,10 +1,9 @@
 name: Publish IntelliJ plugin snapshot
 
 on:
-#  pull_request:
-  #    branches: [ '*' ]
   schedule:
     - cron: '0 0 * * 0'
+  workflow_dispatch:
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 

--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -37,7 +37,7 @@ fun runCommand(vararg args: String): String {
 }
 
 fun mergeAndWait(branchName: String) {
-  runCommand("gh", "pr", "merge", branchName, "--squash", "--auto", "--delete-branch")
+  runCommand("gh", "pr", "merge", branchName, "--auto", "--delete-branch")
   println("Waiting for the PR to be merged...")
   while (true) {
     val state = runCommand("gh", "pr", "view", branchName, "--json", "state", "--jq", ".state")


### PR DESCRIPTION
`gh` didn't like `--squash` [apparently](https://github.com/apollographql/apollo-kotlin/actions/runs/4775448756/jobs/8489743024). Also, allow this job to be triggered manually.