### PR TITLE
Fix sensitivity of test tasks

### DIFF
--- a/build-logic/src/main/kotlin/Testing.kt
+++ b/build-logic/src/main/kotlin/Testing.kt
@@ -1,5 +1,6 @@
 import com.gradle.enterprise.gradleplugin.testretry.retry
 import org.gradle.api.Project
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.testing.AbstractTestTask
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
@@ -32,4 +33,9 @@ fun Project.configureTesting() {
       showStandardStreams = true
     }
   }
+}
+
+// See https://github.com/gradle/gradle/issues/23456
+fun Test.addRelativeInput(name: String, dirPath: Any) {
+  this.inputs.dir(dirPath).withPropertyName(name).withPathSensitivity(PathSensitivity.RELATIVE)
 }

--- a/libraries/apollo-compiler/build.gradle.kts
+++ b/libraries/apollo-compiler/build.gradle.kts
@@ -70,9 +70,9 @@ tasks.withType(KotlinCompile::class.java) {
 
 // since test/graphql is not an input to Test tasks, they're not run with the changes made in there.
 tasks.withType<Test>().configureEach {
-  inputs.dir("src/test/graphql")
-  inputs.dir("src/test/sdl")
-  inputs.dir("src/test/typename")
-  inputs.dir("src/test/usedtypes")
-  inputs.dir("src/test/validation")
+  addRelativeInput("graphqlDir", "src/test/graphql")
+  addRelativeInput("sdlDir", "src/test/sdl")
+  addRelativeInput("typenameDir", "src/test/typename")
+  addRelativeInput("usedtypesDir","src/test/usedtypes")
+  addRelativeInput("validationDir", "src/test/validation")
 }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -127,8 +127,8 @@ tasks.withType<Test> {
   dependsOn(":apollo-tooling:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")
 
-  inputs.dir("src/test/files")
-  inputs.dir("testProjects")
+  addRelativeInput("testFiles", "src/test/files")
+  addRelativeInput("testProjects", "testProjects")
 
   maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).takeIf { it > 0 } ?: 1
 


### PR DESCRIPTION
programmatically created input are "absolute" by default, make them "relative" instead