### PR TITLE
Defer tests: ignore locations in error cases

### DIFF
--- a/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
@@ -267,7 +267,7 @@ class DeferWithRouterTest {
   fun handlesErrorsThrownInDeferredFragments() = runTest(before = { setUp() }, after = { tearDown() }) {
     // Expected payloads:
     // {"data":{"computer":{"__typename":"Computer","id":"Computer1"}},"hasNext":true}
-    // {"hasNext":false,"incremental":[{"data":{"errorField":null},"path":["computer"],"errors":[{"message":"Subgraph errors redacted","locations":[{"line":1,"column":104}],"path":["computer","errorField"]}]}]}
+    // {"hasNext":false,"incremental":[{"data":{"errorField":null},"path":["computer"],"errors":[{"message":"Subgraph errors redacted","path":["computer","errorField"]}]}]}
     val query = HandlesErrorsThrownInDeferredFragmentsQuery()
     val uuid = uuid4()
 
@@ -296,7 +296,7 @@ class DeferWithRouterTest {
                 listOf(
                     Error(
                         message = "Subgraph errors redacted",
-                        locations = listOf(Error.Location(1, 104)),
+                        locations = null,
                         path = listOf("computer", "errorField"),
                         extensions = null,
                         nonStandardFields = null,
@@ -360,7 +360,7 @@ class DeferWithRouterTest {
   @Test
   fun handlesNonNullableErrorsThrownOutsideDeferredFragments() = runTest(before = { setUp() }, after = { tearDown() }) {
     // Expected payloads:
-    // {"data":{"computer":null},"errors":[{"message":"Subgraph errors redacted","locations":[{"line":1,"column":117}],"path":["computer","nonNullErrorField"]}],"hasNext":true}
+    // {"data":{"computer":null},"errors":[{"message":"Subgraph errors redacted","path":["computer","nonNullErrorField"]}],"hasNext":true}
     // {"hasNext":false}
     val query = HandlesNonNullableErrorsThrownOutsideDeferredFragmentsQuery()
     val uuid = uuid4()
@@ -377,7 +377,7 @@ class DeferWithRouterTest {
                 listOf(
                     Error(
                         message = "Subgraph errors redacted",
-                        locations = listOf(Error.Location(1, 117)),
+                        locations = null,
                         path = listOf("computer", "nonNullErrorField"),
                         extensions = null,
                         nonStandardFields = null,

--- a/tests/defer/src/commonTest/kotlin/test/TestUtil.kt
+++ b/tests/defer/src/commonTest/kotlin/test/TestUtil.kt
@@ -14,10 +14,6 @@ internal fun assertResponseListEquals(expectedResponseList: List<ApolloResponse<
     assertContentEquals(expectedResponse.errors, actualResponse.errors) { expectedError, actualError ->
       assertEquals(expectedError.message, actualError.message)
       kotlin.test.assertContentEquals(expectedError.path, actualError.path)
-      assertContentEquals(expectedError.locations, actualError.locations) { expectedLocation, actualLocation ->
-        assertEquals(expectedLocation.line, actualLocation.line)
-        assertEquals(expectedLocation.column, actualLocation.column)
-      }
     }
   }
 }


### PR DESCRIPTION
The `locations` started to have different values in recent router versions, but actually, they should be [completely removed](https://github.com/apollographql/router/issues/3022), so ignore them in our tests.