### PR TITLE
Fix gh command for IJ plugin snapshots

### DIFF
--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -37,7 +37,7 @@ fun runCommand(vararg args: String): String {
 }
 
 fun mergeAndWait(branchName: String) {
-  runCommand("gh", "pr", "merge", branchName, "--auto", "--delete-branch")
+  runCommand("gh", "pr", "merge", branchName, "--squash", "--auto", "--delete-branch")
   println("Waiting for the PR to be merged...")
   while (true) {
     val state = runCommand("gh", "pr", "view", branchName, "--json", "state", "--jq", ".state")


### PR DESCRIPTION
`--squash` [is needed](https://github.com/apollographql/apollo-kotlin/actions/runs/4859822679/jobs/8662911874) when not using merge queues.