### PR TITLE
Doc: Switch to Dokkatoo

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,16 +23,11 @@ jobs:
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
+        # Dokka is very memory hungry and running it in parallel will exhaust the runners memory
         run: |
-          ulimit -c unlimited
-          # Workaround an issue where kotlinNpmInstall outputs
-          # 'Resolving NPM dependencies using yarn' returns 137
-          ./gradlew --no-build-cache compileKotlinJs
-          ./gradlew --stop
           ./gradlew --no-build-cache ciBuild
-          ./gradlew --stop
-          ./gradlew --no-build-cache -p tests ciBuild
-          ./gradlew --no-build-cache dokkaHtmlMultiModule
+          ./gradlew --no-build-cache -p tests ciBuild    
+          ./gradlew --no-build-cache dokkatooGeneratePublicationHtml --max-workers 4 
           ./gradlew --no-build-cache ciPublishSnapshot
         env:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
@@ -50,4 +45,4 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@ba1486788b0490a235422264426c45848eac35c6 #v4.4.1
         with:
           branch: gh-pages # The branch the action should deploy to.
-          folder: build/dokkaHtml # The folder the action should deploy.
+          folder: build/dokka/html # The folder the action should deploy.

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -23,8 +23,7 @@ dependencies {
 
   implementation(golatac.lib("okhttp"))
 
-  implementation(golatac.lib("dokka.plugin"))
-  implementation(golatac.lib("dokka.base"))
+  implementation(golatac.lib("dokkatoo"))
 
   // We add all the plugins to the classpath here so that they are loaded with proper conflict resolution
   // See https://github.com/gradle/gradle/issues/4741

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -54,7 +54,7 @@ val Project.dokkatooExtension: DokkatooExtension
   get() = extensions.getByName("dokkatoo") as DokkatooExtension
 
 val DokkatooExtension.versions: DokkatooExtension.Versions
-  get() = extensions.getByName("version") as DokkatooExtension.Versions
+  get() = extensions.getByName("versions") as DokkatooExtension.Versions
 
 fun Project.setDokkaStyle() {
   dokkatooExtension.apply {

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -50,9 +50,14 @@ fun Project.configurePublishing() {
   configurePublishingInternal()
 }
 
+val Project.dokkatooExtension: DokkatooExtension
+  get() = extensions.getByName("dokkatoo") as DokkatooExtension
+
+val DokkatooExtension.versions: DokkatooExtension.Versions
+  get() = extensions.getByName("version") as DokkatooExtension.Versions
+
 fun Project.setDokkaStyle() {
-  extensions.getByName("dokkatoo").apply {
-    this as DokkatooExtension
+  dokkatooExtension.apply {
     pluginsConfiguration.named("html", DokkaHtmlPluginParameters::class.java) {
       customStyleSheets.from(
           listOf("style.css", "prism.css", "logo-styles.css").map { rootProject.file("dokka/$it") }
@@ -71,8 +76,7 @@ private fun Project.configureDokka() {
 
   setDokkaStyle()
 
-  extensions.getByName("dokkatoo").apply {
-    this as DokkatooExtension
+  dokkatooExtension.apply {
     dokkatooSourceSets.configureEach {
       documentedVisibilities(
         VisibilityModifier.PUBLIC,
@@ -87,7 +91,6 @@ private fun Project.configureDokka() {
 
     dokkatooPublications.configureEach {
       suppressObviousFunctions.set(true)
-      suppressObviousFunctions.set(false)
     }
   }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import JapiCmp.configureJapiCmp
+import dev.adamko.dokkatoo.DokkatooExtension
 
 plugins {
   id("apollo.library") apply false
@@ -8,7 +9,7 @@ plugins {
 golatac.init(file("gradle/libraries.toml"))
 
 apply(plugin = "com.github.ben-manes.versions")
-apply(plugin = "org.jetbrains.dokka")
+apply(plugin = "dev.adamko.dokkatoo-html")
 apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")
 
 version = property("VERSION_NAME")!!
@@ -100,11 +101,6 @@ tasks.register("ciBuild") {
   dependsOn(subprojectTasks("build"))
 }
 
-tasks.named("dokkaHtmlMultiModule").configure {
-  this as org.jetbrains.dokka.gradle.DokkaMultiModuleTask
-  outputDirectory.set(buildDir.resolve("dokkaHtml/kdoc"))
-}
-
 tasks.named("dependencyUpdates").configure {
   (this as com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask)
   rejectVersionIf {
@@ -159,4 +155,9 @@ tasks.register("rmbuild") {
       }
     }.count()
   }
+}
+
+setDokkaStyle()
+dependencies {
+  add("dokkatooPluginHtml", "org.jetbrains.dokka:all-modules-page-plugin:1.7.20")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,5 +159,5 @@ tasks.register("rmbuild") {
 
 setDokkaStyle()
 dependencies {
-  add("dokkatooPluginHtml", "org.jetbrains.dokka:all-modules-page-plugin:1.7.20")
+  add("dokkatooPluginHtml", "org.jetbrains.dokka:all-modules-page-plugin:${org.jetbrains.dokka.DokkaVersion.version}")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,5 +159,9 @@ tasks.register("rmbuild") {
 
 setDokkaStyle()
 dependencies {
-  add("dokkatooPluginHtml", "org.jetbrains.dokka:all-modules-page-plugin:${org.jetbrains.dokka.DokkaVersion.version}")
+  add("dokkatooPluginHtml",
+      dokkatooExtension.versions.jetbrainsDokka.map { dokkaVersion ->
+        "org.jetbrains.dokka:all-modules-page-plugin:$dokkaVersion"
+      }
+  )
 }

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -14,7 +14,6 @@ apollo-published = "3.8.0"
 cache = "2.0.2"
 # See https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 compose-compiler = "1.4.3"
-dokka = "1.8.10"
 guava = "31.1-jre"
 javaPoet = "1.13.0"
 jetbrains-annotations = "24.0.1"
@@ -73,8 +72,7 @@ atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version = "0.20
 benmanes-versions = { group = "com.github.ben-manes", name = "gradle-versions-plugin", version = "0.33.0" }
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version = "3.5.2" }
 compose-runtime = { group = "androidx.compose.runtime", name = "runtime", version = "1.3.3" }
-dokka-base = { group = "org.jetbrains.dokka", name = "dokka-base", version.ref = "dokka" }
-dokka-plugin = { group = "org.jetbrains.dokka", name = "dokka-gradle-plugin", version.ref = "dokka" }
+dokkatoo = "dev.adamko.dokkatoo:dokkatoo-plugin:1.3.0"
 gegp = "com.gradle:gradle-enterprise-gradle-plugin:3.13" # // sync with settings.gradle.kts
 # Not updating because it fails in apollo-compiler Java tests with
 # annotation @org.jetbrains.annotations.Nullable not applicable in this type context

--- a/gradle/repositories.gradle.kts
+++ b/gradle/repositories.gradle.kts
@@ -31,6 +31,8 @@ listOf(pluginManagement.repositories, dependencyResolutionManagement.repositorie
         // For org.jetbrains.changelog
         includeModule("org.jetbrains.changelog", "org.jetbrains.changelog.gradle.plugin")
         includeModule("org.jetbrains.intellij.plugins", "gradle-changelog-plugin")
+
+        includeModule("dev.adamko.dokkatoo", "dokkatoo-plugin")
       }
     }
 

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -18,7 +18,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -18,7 +18,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**


### PR DESCRIPTION
Use https://github.com/adamko-dev/dokkatoo that is configuration cache compatible and cache relocatable

The workers use *a lot* of memory so depending the machine, we can't run too many in parallel. I set the number of parallel workers to 4 for now. 🤞 that it works on GA runners...