### PR TITLE
[IJ plugin] Contribute introspection URL to GQL plugin

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -232,6 +232,8 @@ class GradleToolingModelService(
             operationPaths = (serviceInfo.graphqlSrcDirs.mapNotNull { it.toProjectLocalPathOrNull() } +
                 dependenciesProjectFiles.flatMap { it.operationPaths })
                 .distinct(),
+            endpointUrl = serviceInfo.endpointUrl,
+            endpointHeaders = serviceInfo.endpointHeaders,
         )
       }
     }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/ApolloGraphQLConfigContributor.kt
@@ -4,6 +4,7 @@ import com.apollographql.ijplugin.gradle.GradleToolingModelService
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.util.logd
 import com.intellij.lang.jsgraphql.ide.config.GraphQLConfigContributor
+import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLConfigKeys
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawConfig
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawProjectConfig
 import com.intellij.lang.jsgraphql.ide.config.loader.GraphQLRawSchemaPointer
@@ -35,5 +36,17 @@ class ApolloGraphQLConfigContributor : GraphQLConfigContributor {
   private fun GraphQLProjectFiles.toGraphQLRawProjectConfig() = GraphQLRawProjectConfig(
       schema = schemaPaths.map { GraphQLRawSchemaPointer(it) },
       include = operationPaths.map { "$it/*.graphql" },
+      extensions = endpointUrl?.let {
+        mapOf(
+            GraphQLConfigKeys.EXTENSION_ENDPOINTS to mapOf(
+                name to buildMap {
+                  put(GraphQLConfigKeys.EXTENSION_ENDPOINT_URL, endpointUrl)
+                  if (endpointHeaders != null) {
+                    put(GraphQLConfigKeys.HEADERS, endpointHeaders)
+                  }
+                }
+            )
+        )
+      }
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLProjectFiles.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/GraphQLProjectFiles.kt
@@ -15,4 +15,6 @@ data class GraphQLProjectFiles(
     val name: String,
     val schemaPaths: List<String>,
     val operationPaths: List<String>,
+    val endpointUrl: String?,
+    val endpointHeaders: Map<String, String>?,
 )

--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -42,6 +42,8 @@ public final class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel
 }
 
 public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$ServiceInfo {
+	public abstract fun getEndpointHeaders ()Ljava/util/Map;
+	public abstract fun getEndpointUrl ()Ljava/lang/String;
 	public abstract fun getGraphqlSrcDirs ()Ljava/util/Set;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getSchemaFiles ()Ljava/util/Set;

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
@@ -13,6 +13,8 @@ interface ApolloGradleToolingModel {
     val schemaFiles: Set<File>
     val graphqlSrcDirs: Set<File>
     val upstreamProjects: Set<String>
+    val endpointUrl: String?
+    val endpointHeaders: Map<String, String>?
   }
 
   companion object {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -62,7 +62,9 @@ abstract class DefaultApolloExtension(
         name = service.name,
         schemaFiles = service.lazySchemaFiles(project),
         graphqlSrcDirs = service.graphqlSourceDirectorySet.srcDirs,
-        upstreamProjects = service.upstreamDependencies.filterIsInstance<ProjectDependency>().map { it.name }.toSet()
+        upstreamProjects = service.upstreamDependencies.filterIsInstance<ProjectDependency>().map { it.name }.toSet(),
+        endpointUrl = service.introspection?.endpointUrl?.orNull,
+        endpointHeaders = service.introspection?.headers?.orNull,
     )
   }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
@@ -16,5 +16,6 @@ internal data class DefaultServiceInfo(
     override val schemaFiles: Set<File>,
     override val graphqlSrcDirs: Set<File>,
     override val upstreamProjects: Set<String>,
-
+    override val endpointUrl: String?,
+    override val endpointHeaders: Map<String, String>?,
 ) : ApolloGradleToolingModel.ServiceInfo, Serializable


### PR DESCRIPTION
When an `introspection` is configured, use that to contribute the URL to the GQL plugin configuration. For instance, with Confetti:

<img width="377" alt="Screenshot 2023-05-02 at 20 18 49" src="https://user-images.githubusercontent.com/372852/235934834-20d39793-eb0e-4bb5-bbdd-f1bd15ec95da.png">
