### PR TITLE
Remove initRuntimeIfNeeded() from the source code

### DIFF
--- a/libraries/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/appleMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -83,8 +83,6 @@ actual class MockServer(
     val stableRef = StableRef.create(socket!!)
 
     pthread_create(pthreadT.ptr, null, staticCFunction { arg ->
-      initRuntimeIfNeeded()
-
       val ref = arg!!.asStableRef<Socket>()
 
       try {

--- a/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHttpEngine.kt
+++ b/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/NSURLSessionHttpEngine.kt
@@ -41,8 +41,6 @@ actual class DefaultHttpEngine constructor(
   @Suppress("UNCHECKED_CAST")
   override suspend fun execute(request: HttpRequest): HttpResponse = suspendCancellableCoroutine { continuation ->
     val delegate = { httpData: NSData?, nsUrlResponse: NSURLResponse?, error: NSError? ->
-      initRuntimeIfNeeded()
-
       continuation.resumeWith(
           buildHttpResponse(
               data = httpData,


### PR DESCRIPTION
Resolve #4858 

As the issue mentioned, since `initRuntimeIfNeeded` is no longer needed they are removed