### PR TITLE
🐛 extending an enum value removes description

### DIFF
--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/TypeExtensionsMergeScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/TypeExtensionsMergeScope.kt
@@ -74,7 +74,7 @@ private fun ValidationScope.mergeEnumValues(
     val existing = result.firstOrNull { it.name == other.name }
     result += if (existing != null) {
       result.remove(existing)
-      other.copy(directives = mergeDirectives(existing.directives, other.directives))
+      existing.copy(directives = mergeDirectives(existing.directives, other.directives))
     } else {
       other
     }


### PR DESCRIPTION
The merging of the enum value extensions is using the extending enum value as a base and merging directives, but this means if the base had a description we lose that. I think switching this to using the existing value as the base which might have the description and copying it while merging in the extending directives gets the expected behaviour.

For example, a schema like this
```
enum Enum {
  "description"
  VALUE
}

extend enum Enum {
  VALUE @directive
}
```

The result is 
```
enum Enum {
   VALUE @directive
}
```

But I believe the result should be 
```
enum Enum {
  "description"
   VALUE @directive
}
```