### PR TITLE
[IJ/AS plugin] Improve Kotlin -> GraphQL navigation

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
@@ -39,7 +39,7 @@ class GraphQLGotoDeclarationHandler : GotoDeclarationHandler {
       nameReferenceExpression.isApolloModelField() -> {
         return buildList {
           // Add GraphQL field(s)
-          addAll(findGraphQLFields(nameReferenceExpression))
+          addAll(findGraphQLElements(nameReferenceExpression))
 
           // Add the original referred to element
           val resolvedElement = nameReferenceExpression.references.firstIsInstanceOrNull<KtSimpleNameReference>()?.resolve()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/Navigation.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/Navigation.kt
@@ -4,19 +4,18 @@ import com.apollographql.ijplugin.util.findChildrenOfType
 import com.intellij.lang.jsgraphql.GraphQLFileType
 import com.intellij.lang.jsgraphql.psi.GraphQLDefinition
 import com.intellij.lang.jsgraphql.psi.GraphQLElement
-import com.intellij.lang.jsgraphql.psi.GraphQLField
 import com.intellij.lang.jsgraphql.psi.GraphQLFile
 import com.intellij.lang.jsgraphql.psi.GraphQLFragmentDefinition
-import com.intellij.lang.jsgraphql.psi.GraphQLFragmentSpread
-import com.intellij.lang.jsgraphql.psi.GraphQLInlineFragment
 import com.intellij.lang.jsgraphql.psi.GraphQLOperationDefinition
-import com.intellij.lang.jsgraphql.psi.GraphQLTypeCondition
+import com.intellij.lang.jsgraphql.psi.GraphQLSelectionSet
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.FileTypeIndex
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.asJava.toLightClass
+import org.jetbrains.kotlin.idea.base.utils.fqname.fqName
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.nj2k.postProcessing.type
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtElement
@@ -31,7 +30,7 @@ private val APOLLO_OPERATION_TYPES = setOf(
     "com.apollographql.apollo3.api.Subscription",
 )
 
-private val APOLLO_FRAGMENT_TYPE = "com.apollographql.apollo3.api.Fragment.Data"
+private const val APOLLO_FRAGMENT_TYPE = "com.apollographql.apollo3.api.Fragment.Data"
 
 fun KtNameReferenceExpression.isApolloOperationOrFragmentReference(): Boolean {
   val resolvedElement = references.firstIsInstanceOrNull<KtSimpleNameReference>()?.resolve()
@@ -81,35 +80,109 @@ fun findOperationOrFragmentGraphQLDefinitions(project: Project, name: String): L
   return definitions
 }
 
-fun findGraphQLFields(nameReferenceExpression: KtNameReferenceExpression): List<GraphQLElement> {
-  val fields = mutableListOf<GraphQLElement>()
+fun findGraphQLElements(nameReferenceExpression: KtNameReferenceExpression): List<GraphQLElement> {
+  val elements = mutableListOf<GraphQLElement>()
   val project = nameReferenceExpression.project
-  val containingClassName = (nameReferenceExpression.references.firstIsInstanceOrNull<KtSimpleNameReference>()?.resolve() as? KtElement)
-      ?.topMostContainingClass()
-      ?.name
+  val parameter = nameReferenceExpression.references.firstIsInstanceOrNull<KtSimpleNameReference>()?.resolve() as? KtParameter
       ?: return emptyList()
-  val operationOrFragmentDefinitions = findOperationOrFragmentGraphQLDefinitions(project, containingClassName)
+  val operationOrFragmentClass = parameter.topMostContainingClass() ?: return emptyList()
+  val fieldPath = operationOrFragmentClass.parameterPath(parameter)
+  val operationOrFragmentDefinitions = findOperationOrFragmentGraphQLDefinitions(project, operationOrFragmentClass.name!!)
   for (operationOrFragmentDefinition in operationOrFragmentDefinitions) {
-    fields +=
-        // Fields (including aliases)
-        operationOrFragmentDefinition.findChildrenOfType<GraphQLField> { field ->
-          field.name == nameReferenceExpression.text ||
-              field.alias?.identifier?.referenceName == nameReferenceExpression.text
-        } +
-            // Fragment spreads
-            operationOrFragmentDefinition.findChildrenOfType<GraphQLFragmentSpread> { fragmentSpread ->
-              fragmentSpread.name.equals(nameReferenceExpression.text, ignoreCase = true)
-            } +
-            // Inline fragments
-            operationOrFragmentDefinition.findChildrenOfType<GraphQLInlineFragment> { inlineFragment ->
-              inlineFragment.typeCondition?.typeName?.name?.let { "on$it" } == nameReferenceExpression.text
-            }
-                // Only keep the type condition
-                .flatMap { inlineFragment ->
-                  inlineFragment.findChildrenOfType<GraphQLTypeCondition>()
-                }
+    elements += operationOrFragmentDefinition.findElementAtPath(fieldPath) ?: continue
   }
-  return fields
+  return elements
+}
+
+/**
+ * For a given [parameter], return a path for this field in the given operation class.
+ *
+ * For instance if the operation class is:
+ * ```
+ * class MyQuery : Query {
+ *   data class Data(val user: User)
+ *                              ↖
+ *                  data class User(val address: Address)
+ *                                                ↖
+ *                                    data class Address(val street: String)
+ * }
+ * ```
+ *
+ * Then the path for `Address.street` will be `["user", "address", "street"]`.
+ */
+private fun KtClass.parameterPath(parameter: KtParameter): List<String> {
+  var modelClass = parameter.containingClass()!!
+  val parameterPath = mutableListOf(parameter.name!!)
+  constructPath@ while (true) {
+    var found = false
+    findClass@ for (candidateModelClass in findChildrenOfType<KtClass>()) {
+      // Look for the parameter in the constructor
+      for (ctorParameter in candidateModelClass.primaryConstructor?.valueParameters.orEmpty()) {
+        val parameterType = ctorParameter.type()
+        if (parameterType?.fqName == modelClass.fqName ||
+            // For lists
+            parameterType?.arguments?.firstOrNull()?.type?.fqName == modelClass.fqName
+        ) {
+          parameterPath.add(0, ctorParameter.name!!)
+          modelClass = candidateModelClass
+          found = true
+          break@findClass
+        }
+      }
+    }
+    if (!found) break
+  }
+  return parameterPath
+}
+
+/**
+ * Get the element (field, fragment spread, or inline fragment type condition) at the given path.
+ */
+private fun GraphQLDefinition.findElementAtPath(path: List<String>): GraphQLElement? {
+  var element: GraphQLElement? = null
+  var selectionSet = findChildrenOfType<GraphQLSelectionSet>(recursive = false).firstOrNull() ?: return null
+  for (pathElement in path) {
+    var found = false
+    for (selection in selectionSet.selectionList) {
+      if (selection.field != null) {
+        // Field
+        val field = selection.field!!
+        if (field.name == pathElement ||
+            field.alias?.identifier?.referenceName == pathElement) {
+          element = field
+          field.selectionSet?.let { selectionSet = it }
+          found = true
+          break
+        }
+      } else if (selection.fragmentSelection != null) {
+        // Fragment
+        if (selection.fragmentSelection!!.inlineFragment != null) {
+          // Inline
+          val inlineFragment = selection.fragmentSelection!!.inlineFragment!!
+          if (inlineFragment.typeCondition?.typeName?.name?.let { "on$it" } == pathElement) {
+            // Point to the type condition
+            element = inlineFragment.typeCondition
+            inlineFragment.selectionSet?.let { selectionSet = it }
+            found = true
+            break
+          }
+        } else if (selection.fragmentSelection!!.fragmentSpread != null) {
+          // Spread
+          val fragmentSpread = selection.fragmentSelection!!.fragmentSpread!!
+          if (fragmentSpread.name.equals(pathElement, ignoreCase = true)) {
+            element = fragmentSpread
+            found = true
+            break
+          }
+        }
+      }
+    }
+    if (!found) {
+      element = null
+      break
+    }
+  }
+  return element
 }
 
 // Remove "Query", "Mutation", or "Subscription" from the end of the operation name

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -20,13 +20,23 @@ fun PsiElement.addSiblingAfter(element: PsiElement): PsiElement {
 
 inline fun <reified T : PsiElement> PsiElement.findChildrenOfType(
     withSelf: Boolean = false,
+    recursive: Boolean = true,
     noinline predicate: ((T) -> Boolean)? = null,
 ): List<T> {
-  return PsiTreeUtil.findChildrenOfAnyType(this, !withSelf, T::class.java).let {
-    if (predicate == null) {
-      it.toList()
+  return if (recursive) {
+    PsiTreeUtil.findChildrenOfAnyType(this, !withSelf, T::class.java)
+  } else {
+    if (withSelf && this is T) {
+      listOf(this)
     } else {
-      it.filter(predicate)
+      PsiTreeUtil.getChildrenOfTypeAsList(this, T::class.java)
     }
   }
+      .let {
+        if (predicate == null) {
+          it.toList()
+        } else {
+          it.filter(predicate)
+        }
+      }
 }


### PR DESCRIPTION
Related to #4919. 

This makes the field navigation more robust in `operationBased`: will no longer list all descendant fields with a given name, but only the exact one.

For `responseBased`, this can't always work so all matching fields will still be suggested as a fallback.