### PR TITLE
GE: remove Built-By attribute in generated jars

### DIFF
--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -117,7 +117,6 @@ private fun Project.configurePublishingInternal() {
   tasks.withType(Jar::class.java) {
     manifest {
       attributes["Built-By"] = findProperty("POM_DEVELOPER_ID") as String?
-      attributes["Build-Jdk"] = "${System.getProperty("java.version")} (${System.getProperty("java.vendor")} ${System.getProperty("java.vm.version")})"
       attributes["Created-By"] = "Gradle ${gradle.gradleVersion}"
       attributes["Implementation-Title"] = findProperty("POM_NAME") as String?
       attributes["Implementation-Version"] = findProperty("VERSION_NAME") as String?


### PR DESCRIPTION
The "Built-By" jar attribute is different depending your machine and creates build cache misses