### PR TITLE
Revert "Share Gradle Tests Home with the main build (#4900)"

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -113,32 +113,6 @@ configure<PublishingExtension> {
   }
 }
 
-tasks.register("wrapInitScripts") {
-  doLast {
-    val initDir = File(System.getenv("HOME")).resolve(".gradle/init.d/")
-
-    val buildCapture = initDir.resolve("build-result-capture.init.gradle")
-    if (!buildCapture.exists()) {
-      // Running on a local machine or wrapping is already done
-      println("~/.gradle/init.d/build-result-capture.init.gradle not found")
-      return@doLast
-    }
-    println("wrapping init scrips")
-
-    // Rename the script
-    buildCapture.renameTo(initDir.resolve("build-result-capture"))
-
-    initDir.resolve("wrapper.init.gradle.kts").writeText("""
-      if (System.getProperty("skipBuildCollection") == null) {
-          println("Init scripts: capturing builds")
-          apply(from = "build-result-capture")
-      } else {
-          println("Init scripts: skipping build capture")
-      }
-    """.trimIndent())
-  }
-}
-
 tasks.register("cleanStaleTestProjects") {
   doFirst {
     /**
@@ -162,11 +136,6 @@ tasks.withType<Test> {
   dependsOn(":apollo-gradle-plugin-external:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-tooling:publishAllPublicationsToPluginTestRepository")
   dependsOn("publishAllPublicationsToPluginTestRepository")
-  if (System.getenv("CI") != null) {
-    dependsOn("wrapInitScripts")
-  }
-  // Because we run the GradleRunner in process, this gets forwarded to invocation
-  systemProperty("skipBuildCollection", "true")
 
   dependsOn("cleanStaleTestProjects")
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
@@ -176,15 +176,8 @@ object TestUtils {
         .forwardStdOutput(output)
         .forwardStdError(error)
         .withProjectDir(projectDir)
-        // Runs in-process, saves a bit of time
         .withDebug(true)
-        .withArguments(
-            "-g",
-            // Reuse the main build home directory
-            File(System.getenv("HOME")).resolve(".gradle").absolutePath,
-            "--stacktrace",
-            *args
-        )
+        .withArguments("--stacktrace", *args)
         .apply {
           if (gradleVersion != null) {
             withGradleVersion(gradleVersion)
@@ -204,8 +197,8 @@ object TestUtils {
 
   fun fixturesDirectory() = File(System.getProperty("user.dir"), "testFiles")
 
-  fun executeTaskAndAssertSuccess(task: String, dir: File, vararg args: String) {
-    val result = executeTask(task, dir, *args)
+  fun executeTaskAndAssertSuccess(task: String, dir: File) {
+    val result = executeTask(task, dir)
     Assert.assertEquals(TaskOutcome.SUCCESS, result.task(task)?.outcome)
   }
 }


### PR DESCRIPTION
This reverts commit 8b0b1363d29683bafb196e28be87833970d18ceb.

Link to the failing CI run: https://github.com/apollographql/apollo-kotlin/actions/runs/5046653706/jobs/9052472100#step:5:4707
