### PR TITLE
fix: add encodeDefaults to introspection schema serializer

### DIFF
--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/IntrospectionSchema.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/IntrospectionSchema.kt
@@ -190,6 +190,7 @@ private val json: Json by lazy {
     classDiscriminator = "kind"
     @OptIn(ExperimentalSerializationApi::class)
     explicitNulls = false
+    encodeDefaults = true
   }
 }
 


### PR DESCRIPTION
Hey 👋 This is a PR to fix an issue discussed in [this](https://kotlinlang.slack.com/archives/C01A6KM1SBZ/p1686315540433019) thread from the Kotlin slack.  

I do see a bunch of test failures when I run this, but they all seem to be related to the intellij plugin (so, assuming this is just an issue w/ my local setup?).  Was gonna toss it over to the CI and see what happens there :)

If you would like me to add a test for this change, just let me know and point me to a test file you'd like the new test to be placed in

