### PR TITLE
Fix buildToolsVersion used in android-plugin-max test

### DIFF
--- a/libraries/apollo-gradle-plugin/testProjects/android-plugin-max/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/android-plugin-max/build.gradle.kts
@@ -13,7 +13,7 @@ dependencies {
 android {
   namespace = "com.example"
   compileSdkVersion(libs.versions.android.sdkversion.compile.get().toInt())
-  buildToolsVersion = "34.0.0-rc4"
+  buildToolsVersion = "34.0.0"
 
   defaultConfig {
     minSdkVersion(libs.versions.android.sdkversion.min.get())


### PR DESCRIPTION
34.0.0-rc4 apparently no longer exists