### PR TITLE
[IJ plugin] Distinguish Apollo v3 and v4

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/action/ApolloV2ToV3MigrationAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/action/ApolloV2ToV3MigrationAction.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.action
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.ApolloProjectService.ApolloVersion
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.ApolloV2ToV3MigrationProcessor
 import com.apollographql.ijplugin.util.logd
@@ -28,7 +29,7 @@ class ApolloV2ToV3MigrationAction : AnAction() {
   }
 
   override fun update(e: AnActionEvent) {
-    e.presentation.isEnabled = e.project?.apolloProjectService?.isApolloAndroid2Project == true
+    e.presentation.isEnabled = e.project?.apolloProjectService?.apolloVersion == ApolloVersion.V2
     e.presentation.isVisible = !ActionPlaces.isPopupPlace(e.place)
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/action/CompatToOperationBasedCodegenMigrationAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/action/CompatToOperationBasedCodegenMigrationAction.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.action
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.ApolloProjectService.ApolloVersion
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.refactoring.migration.compattooperationbased.CompatToOperationBasedCodegenMigrationProcessor
 import com.apollographql.ijplugin.util.logd
@@ -16,6 +17,7 @@ class CompatToOperationBasedCodegenMigrationAction : AnAction() {
     val okCancelResult = Messages.showOkCancelDialog(
         e.project,
         ApolloBundle.message("action.CompatToOperationBasedCodegenMigrationAction.confirmDialog.message"),
+        @Suppress("DialogTitleCapitalization")
         ApolloBundle.message("action.CompatToOperationBasedCodegenMigrationAction.confirmDialog.title"),
         ApolloBundle.message("action.CompatToOperationBasedCodegenMigrationAction.confirmDialog.ok"),
         ApolloBundle.message("action.CompatToOperationBasedCodegenMigrationAction.confirmDialog.cancel"),
@@ -28,7 +30,7 @@ class CompatToOperationBasedCodegenMigrationAction : AnAction() {
   }
 
   override fun update(e: AnActionEvent) {
-    e.presentation.isEnabled = e.project?.apolloProjectService?.isApolloKotlin3Project == true
+    e.presentation.isEnabled = e.project?.apolloProjectService?.apolloVersion == ApolloVersion.V3
     e.presentation.isVisible = !ActionPlaces.isPopupPlace(e.place)
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/codegen/ApolloCodegenService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/codegen/ApolloCodegenService.kt
@@ -4,6 +4,7 @@ import com.apollographql.ijplugin.gradle.CODEGEN_GRADLE_TASK_NAME
 import com.apollographql.ijplugin.gradle.GradleHasSyncedListener
 import com.apollographql.ijplugin.gradle.getGradleRootPath
 import com.apollographql.ijplugin.project.ApolloProjectListener
+import com.apollographql.ijplugin.project.ApolloProjectService
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.SettingsListener
 import com.apollographql.ijplugin.settings.SettingsState
@@ -69,8 +70,8 @@ class ApolloCodegenService(
   private fun startObserveApolloProject() {
     logd()
     project.messageBus.connect(this).subscribe(ApolloProjectListener.TOPIC, object : ApolloProjectListener {
-      override fun apolloProjectChanged(isApolloAndroid2Project: Boolean, isApolloKotlin3Project: Boolean) {
-        logd("isApolloAndroid2Project=$isApolloAndroid2Project isApolloKotlin3Project=$isApolloKotlin3Project")
+      override fun apolloProjectChanged(apolloVersion: ApolloProjectService.ApolloVersion) {
+        logd("apolloVersion=$apolloVersion")
         startOrStopCodegenObservers()
       }
     })
@@ -86,7 +87,7 @@ class ApolloCodegenService(
     })
   }
 
-  private fun shouldTriggerCodegenAutomatically() = project.apolloProjectService.isApolloKotlin3Project && project.settingsState.automaticCodegenTriggering
+  private fun shouldTriggerCodegenAutomatically() = project.apolloProjectService.apolloVersion.isAtLeastV3 && project.settingsState.automaticCodegenTriggering
 
   private fun startOrStopCodegenObservers() {
     if (shouldTriggerCodegenAutomatically()) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -3,6 +3,7 @@ package com.apollographql.ijplugin.gradle
 import com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.project.ApolloProjectListener
+import com.apollographql.ijplugin.project.ApolloProjectService
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.SettingsListener
 import com.apollographql.ijplugin.settings.SettingsState
@@ -56,15 +57,15 @@ class GradleToolingModelService(
   private fun startObserveApolloProject() {
     logd()
     project.messageBus.connect(this).subscribe(ApolloProjectListener.TOPIC, object : ApolloProjectListener {
-      override fun apolloProjectChanged(isApolloAndroid2Project: Boolean, isApolloKotlin3Project: Boolean) {
-        logd("isApolloAndroid2Project=$isApolloAndroid2Project isApolloKotlin3Project=$isApolloKotlin3Project")
+      override fun apolloProjectChanged(apolloVersion: ApolloProjectService.ApolloVersion) {
+        logd("apolloVersion=$apolloVersion")
         startOrStopObserveGradleHasSynced()
         startOrAbortFetchToolingModels()
       }
     })
   }
 
-  private fun shouldFetchToolingModels() = project.apolloProjectService.isApolloKotlin3Project &&
+  private fun shouldFetchToolingModels() = project.apolloProjectService.apolloVersion.isAtLeastV4 &&
       project.settingsState.contributeConfigurationToGraphqlPlugin
 
   private fun startOrStopObserveGradleHasSynced() {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLCustomUsageSearcher.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLCustomUsageSearcher.kt
@@ -34,7 +34,7 @@ class GraphQLCustomUsageSearcher : CustomUsageSearcher() {
     if (element !is GraphQLElement) return
 
     runReadAction {
-      if (!element.project.apolloProjectService.isApolloKotlin3Project) return@runReadAction
+      if (!element.project.apolloProjectService.apolloVersion.isAtLeastV3) return@runReadAction
 
       var isProperty = false
       val kotlinDefinitions = when (val parent = element.parent) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
@@ -26,7 +26,7 @@ import com.intellij.psi.PsiElement
 class GraphQLGotoDeclarationHandler : GotoDeclarationHandler {
   override fun getGotoDeclarationTargets(sourceElement: PsiElement?, offset: Int, editor: Editor?): Array<PsiElement>? {
     val gqlElement = sourceElement?.parent?.parent as? GraphQLElement ?: return null
-    if (!gqlElement.project.apolloProjectService.isApolloKotlin3Project) return null
+    if (!gqlElement.project.apolloProjectService.apolloVersion.isAtLeastV3) return null
 
     val kotlinDefinitions = when (gqlElement) {
       is GraphQLTypedOperationDefinition -> {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinDefinitionMarkerProvider.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinDefinitionMarkerProvider.kt
@@ -21,7 +21,7 @@ class KotlinDefinitionMarkerProvider : RelatedItemLineMarkerProvider() {
   override fun getIcon() = ApolloIcons.Gutter.GraphQL
 
   override fun collectNavigationMarkers(element: PsiElement, result: MutableCollection<in RelatedItemLineMarkerInfo<*>>) {
-    if (!element.project.apolloProjectService.isApolloKotlin3Project) return
+    if (!element.project.apolloProjectService.apolloVersion.isAtLeastV3) return
 
     val nameReferenceExpression = element as? KtNameReferenceExpression ?: return
     val psiLeaf = PsiTreeUtil.getDeepestFirst(element)

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinGotoDeclarationHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinGotoDeclarationHandler.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 class KotlinGotoDeclarationHandler : GotoDeclarationHandler {
   override fun getGotoDeclarationTargets(sourceElement: PsiElement?, offset: Int, editor: Editor?): Array<PsiElement>? {
     if (sourceElement == null) return null
-    if (!sourceElement.project.apolloProjectService.isApolloKotlin3Project) return null
+    if (!sourceElement.project.apolloProjectService.apolloVersion.isAtLeastV3) return null
 
     val nameReferenceExpression = sourceElement.parent as? KtNameReferenceExpression ?: return null
     val psiLeaf = PsiTreeUtil.getDeepestFirst(sourceElement)

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinTypeDeclarationProvider.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/KotlinTypeDeclarationProvider.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtElement
  */
 class KotlinTypeDeclarationProvider : TypeDeclarationProvider {
   override fun getSymbolTypeDeclarations(symbol: PsiElement): Array<PsiElement>? {
-    if (!symbol.project.apolloProjectService.isApolloKotlin3Project) return null
+    if (!symbol.project.apolloProjectService.apolloVersion.isAtLeastV3) return null
 
     // Only care about Kotlin
     if (symbol !is KtElement) return null

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectListener.kt
@@ -8,5 +8,5 @@ interface ApolloProjectListener {
     val TOPIC: Topic<ApolloProjectListener> = Topic.create("Apollo project", ApolloProjectListener::class.java)
   }
 
-  fun apolloProjectChanged(isApolloAndroid2Project: Boolean, isApolloKotlin3Project: Boolean)
+  fun apolloProjectChanged(apolloVersion: ApolloProjectService.ApolloVersion)
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
@@ -19,7 +19,7 @@ internal class ApolloProjectManagerListener : ProjectManagerListener {
     // Initialize all services on project open.
     // But wait for 'smart mode' to do it.
     DumbService.getInstance(project).runWhenSmart {
-      logd("isApolloKotlin3Project=" + project.apolloProjectService.isApolloKotlin3Project)
+      logd("apolloVersion=" + project.apolloProjectService.apolloVersion)
       project.service<ApolloCodegenService>()
       project.service<GradleToolingModelService>()
       project.service<SettingsService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectService.kt
@@ -5,8 +5,18 @@ import com.intellij.openapi.project.Project
 
 interface ApolloProjectService {
   var isInitialized: Boolean
-  val isApolloAndroid2Project: Boolean
-  val isApolloKotlin3Project: Boolean
+
+  enum class ApolloVersion {
+    NONE,
+    V2,
+    V3,
+    V4,
+    ;
+    val isAtLeastV3 get() = this >= V3
+    val isAtLeastV4 get() = this >= V4
+  }
+
+  val apolloVersion: ApolloVersion
 }
 
 val Project.apolloProjectService get() = service<ApolloProjectService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectServiceImpl.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.apollographql.ijplugin.project
 
-import com.apollographql.ijplugin.util.isApolloAndroid2Project
-import com.apollographql.ijplugin.util.isApolloKotlin3Project
+import com.apollographql.ijplugin.project.ApolloProjectService.ApolloVersion
+import com.apollographql.ijplugin.util.getApolloVersion
 import com.apollographql.ijplugin.util.logd
 import com.intellij.ProjectTopics
 import com.intellij.openapi.Disposable
@@ -13,8 +13,7 @@ class ApolloProjectServiceImpl(
     private val project: Project,
 ) : ApolloProjectService, Disposable {
 
-  override var isApolloAndroid2Project: Boolean = false
-  override var isApolloKotlin3Project: Boolean = false
+  override var apolloVersion: ApolloVersion = ApolloVersion.NONE
   override var isInitialized: Boolean = false
 
   init {
@@ -35,15 +34,13 @@ class ApolloProjectServiceImpl(
 
   private fun onLibrariesChanged() {
     logd()
-    val previousIsApolloAndroid2Project  = isApolloAndroid2Project
-    val previousIsApolloKotlin3Project = isApolloKotlin3Project
+    val previousApolloVersion  = apolloVersion
     synchronized(this) {
-      isApolloAndroid2Project = project.isApolloAndroid2Project()
-      isApolloKotlin3Project = project.isApolloKotlin3Project()
+      apolloVersion = project.getApolloVersion()
     }
-    logd("isApolloAndroid2Project=$isApolloAndroid2Project isApolloKotlin3Project=$isApolloKotlin3Project")
-    if (previousIsApolloAndroid2Project != isApolloAndroid2Project || previousIsApolloKotlin3Project != isApolloKotlin3Project) {
-      project.messageBus.syncPublisher(ApolloProjectListener.TOPIC).apolloProjectChanged(isApolloAndroid2Project = isApolloAndroid2Project, isApolloKotlin3Project = isApolloKotlin3Project)
+    logd("apolloVersion=$apolloVersion")
+    if (previousApolloVersion != apolloVersion) {
+      project.messageBus.syncPublisher(ApolloProjectListener.TOPIC).apolloProjectChanged(apolloVersion = apolloVersion)
     }
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -1,9 +1,12 @@
 package com.apollographql.ijplugin.settings
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.studio.ApiKeyDialog
+import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.ui.AddEditRemovePanel
+import com.intellij.ui.dsl.builder.bindSelected
 import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.dsl.gridLayout.HorizontalAlign
 import javax.swing.JCheckBox
@@ -12,94 +15,92 @@ import javax.swing.JPanel
 
 
 class SettingsComponent(private val project: Project) {
+  private val propertyGraph = PropertyGraph()
+  private val automaticCodegenTriggeringProperty = propertyGraph.property(false)
+  private val contributeConfigurationToGraphqlPluginProperty = propertyGraph.property(false)
+
+  var automaticCodegenTriggering: Boolean by automaticCodegenTriggeringProperty
+  var contributeConfigurationToGraphqlPlugin: Boolean by contributeConfigurationToGraphqlPluginProperty
+  var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
+    get() = addEditRemovePanel?.data?.toList()?: emptyList()
+    set(value) {
+      addEditRemovePanel?.data = value.toMutableList()
+    }
+
   private lateinit var chkAutomaticCodegenTriggering: JCheckBox
-  private lateinit var chkContributeConfigurationToGraphqlPlugin: JCheckBox
-  private lateinit var addEditRemovePanel: AddEditRemovePanel<ApolloKotlinServiceConfiguration>
+  private var addEditRemovePanel: AddEditRemovePanel<ApolloKotlinServiceConfiguration>? = null
 
   val panel: JPanel = panel {
     group(ApolloBundle.message("settings.codegen.title")) {
       row {
         chkAutomaticCodegenTriggering = checkBox(ApolloBundle.message("settings.codegen.automaticCodegenTriggering.text"))
             .comment(ApolloBundle.message("settings.codegen.automaticCodegenTriggering.comment"))
+            .bindSelected(automaticCodegenTriggeringProperty)
             .component
       }
     }
     group(ApolloBundle.message("settings.graphqlPlugin.title")) {
       row {
-        chkContributeConfigurationToGraphqlPlugin = checkBox(ApolloBundle.message("settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.text"))
+        checkBox(ApolloBundle.message("settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.text"))
             .comment(ApolloBundle.message("settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.comment"))
-            .component
+            .bindSelected(contributeConfigurationToGraphqlPluginProperty)
       }
     }
     group(ApolloBundle.message("settings.studio.title")) {
-      row {
-        addEditRemovePanel = object : AddEditRemovePanel<ApolloKotlinServiceConfiguration>(
-            ApiKeysModel(),
-            emptyList(),
-            ApolloBundle.message("settings.studio.apiKeys.text")
-        ) {
-          override fun addItem(): ApolloKotlinServiceConfiguration? {
-            val apiKeyDialog = ApiKeyDialog(project)
-            if (!apiKeyDialog.showAndGet()) return null
-            return ApolloKotlinServiceConfiguration(
-                id = apiKeyDialog.apolloKotlinServiceId,
-                graphOsGraphName = apiKeyDialog.graphOsServiceName,
-            ).apply {
-              graphOsApiKey = apiKeyDialog.graphOsApiKey
+      if (!project.apolloProjectService.apolloVersion.isAtLeastV4) {
+        row { label(ApolloBundle.message("settings.studio.apiKeys.needV4.message")) }
+      } else {
+        row {
+          addEditRemovePanel = object : AddEditRemovePanel<ApolloKotlinServiceConfiguration>(
+              ApiKeysModel(),
+              emptyList(),
+              ApolloBundle.message("settings.studio.apiKeys.text")
+          ) {
+            override fun addItem(): ApolloKotlinServiceConfiguration? {
+              val apiKeyDialog = ApiKeyDialog(project)
+              if (!apiKeyDialog.showAndGet()) return null
+              return ApolloKotlinServiceConfiguration(
+                  id = apiKeyDialog.apolloKotlinServiceId,
+                  graphOsGraphName = apiKeyDialog.graphOsServiceName,
+              ).apply {
+                graphOsApiKey = apiKeyDialog.graphOsApiKey
+              }
             }
+
+            override fun editItem(o: ApolloKotlinServiceConfiguration): ApolloKotlinServiceConfiguration? {
+              val apiKeyDialog = ApiKeyDialog(
+                  project,
+                  apolloKotlinServiceId = o.apolloKotlinServiceId,
+                  graphOsApiKey = o.graphOsApiKey ?: "",
+                  graphOsServiceName = o.graphOsGraphName
+              )
+              if (!apiKeyDialog.showAndGet()) return null
+              return ApolloKotlinServiceConfiguration(
+                  id = apiKeyDialog.apolloKotlinServiceId,
+                  graphOsGraphName = apiKeyDialog.graphOsServiceName,
+              ).apply {
+                graphOsApiKey = apiKeyDialog.graphOsApiKey
+              }
+            }
+
+            override fun removeItem(o: ApolloKotlinServiceConfiguration?): Boolean {
+              return true
+            }
+          }.apply {
+            table.setShowGrid(false)
+            table.setShowColumns(true)
+            emptyText.text = ApolloBundle.message("settings.studio.apiKeys.empty")
           }
 
-          override fun editItem(o: ApolloKotlinServiceConfiguration): ApolloKotlinServiceConfiguration? {
-            val apiKeyDialog = ApiKeyDialog(
-                project,
-                apolloKotlinServiceId = o.apolloKotlinServiceId,
-                graphOsApiKey = o.graphOsApiKey ?: "",
-                graphOsServiceName = o.graphOsGraphName
-            )
-            if (!apiKeyDialog.showAndGet()) return null
-            return ApolloKotlinServiceConfiguration(
-                id = apiKeyDialog.apolloKotlinServiceId,
-                graphOsGraphName = apiKeyDialog.graphOsServiceName,
-            ).apply {
-              graphOsApiKey = apiKeyDialog.graphOsApiKey
-            }
-          }
-
-          override fun removeItem(o: ApolloKotlinServiceConfiguration?): Boolean {
-            return true
-          }
-        }.apply {
-          table.setShowGrid(false)
-          table.setShowColumns(true)
-          emptyText.text = ApolloBundle.message("settings.studio.apiKeys.empty")
+          cell(addEditRemovePanel!!)
+              .horizontalAlign(HorizontalAlign.FILL)
+              .comment(ApolloBundle.message("settings.studio.apiKeys.comment"))
         }
-
-        cell(addEditRemovePanel)
-            .horizontalAlign(HorizontalAlign.FILL)
-            .comment(ApolloBundle.message("settings.studio.apiKeys.comment"))
       }
     }
   }
 
   val preferredFocusedComponent: JComponent = chkAutomaticCodegenTriggering
-
-  var automaticCodegenTriggering: Boolean
-    get() = chkAutomaticCodegenTriggering.isSelected
-    set(value) {
-      chkAutomaticCodegenTriggering.isSelected = value
-    }
-
-  var contributeConfigurationToGraphqlPlugin: Boolean
-    get() = chkContributeConfigurationToGraphqlPlugin.isSelected
-    set(value) {
-      chkContributeConfigurationToGraphqlPlugin.isSelected = value
-    }
-
-  var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
-    get() = addEditRemovePanel.data.toList()
-    set(value) {
-      addEditRemovePanel.data = value.toMutableList()
-    }
 }
 
 class ApiKeysModel : AddEditRemovePanel.TableModel<ApolloKotlinServiceConfiguration>() {

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -54,6 +54,7 @@ settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.text=Contribute co
 settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.comment=Allows the GraphQL plugin to be aware of the location of your GraphQL files. This invokes Gradle once per Apollo module when the project is opened, which may take a while if you have many modules.
 
 settings.studio.title=Apollo GraphOS
+settings.studio.apiKeys.needV4.message=Apollo GraphOS configuration is supported on projects using Apollo Kotlin v4 or later.
 settings.studio.apiKeys.text=API keys
 settings.studio.apiKeys.empty=No API keys
 settings.studio.apiKeys.comment=API keys are used to authenticate with Apollo GraphOS. <a href=\"https://www.apollographql.com/docs/graphos/api-keys/\">Learn more</a>.


### PR DESCRIPTION
- don't try to fetch GradleToolingModel if project isn't using v4
- show a warning in the settings about needing v4 for GraphOS configuration

<img width="1068" alt="Screenshot 2023-06-30 at 16 20 21" src="https://github.com/apollographql/apollo-kotlin/assets/372852/d54c25b8-e1b8-42cf-941b-a197a7c1773f">
