### PR TITLE
[IJ plugin] Add an "enclose in @defer fragment" quick fix for slow field inspection

### DIFF
--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloFieldInsights.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloFieldInsights.html
@@ -1,9 +1,12 @@
 <html>
 <body>
-Reports fields that are particularly expensive to resolve.
+Reports fields that have a high latency.
 <p>
     Field metrics are gathered from Apollo GraphOS.<br>
     See the <a href="https://www.apollographql.com/docs/graphos/metrics/field-usage">GraphOS documentation</a> for more information about field insights.
+</p>
+<p>
+    Configure the threshold to use in the options below.
 </p>
 <!-- tooltip end -->
 <p>To retrieve the data, configure your GraphOS API keys in <a href="settings://com.apollographql.ijplugin.settings.SettingsConfigurable">Languages&nbsp;&amp;&nbsp;Frameworks | GraphQL | Apollo&nbsp;Kotlin</a>

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -61,7 +61,7 @@ settings.studio.apiKeys.comment=API keys are used to authenticate with Apollo Gr
 settings.studio.apiKeys.table.columnGradleProjectName=Gradle Project
 settings.studio.apiKeys.table.columnApolloKotlinServiceName=Gradle Service
 settings.studio.apiKeys.table.columnGraphOsApiKey=GraphOS API Key
-settings.studio.apiKeys.table.columnGraphOsGraphName=GraphOS Graph
+settings.studio.apiKeys.table.columnGraphOsGraphName=GraphOS Graph ID
 
 settings.studio.apiKeyDialog.title.add=Add API Key
 settings.studio.apiKeyDialog.title.edit=API Key
@@ -70,7 +70,7 @@ settings.studio.apiKeyDialog.apolloKotlinServiceName.label=Gradle service:
 settings.studio.apiKeyDialog.graphOsApiKey.label=GraphOS API key:
 settings.studio.apiKeyDialog.graphOsApiKey.emptyText=service:graph:key
 settings.studio.apiKeyDialog.graphOsApiKey.invalid=API key should look like <code>service:graph:key</code> or <code>user:id:key</code>
-settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph name:
+settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph ID:
 
 GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration
 
@@ -82,8 +82,8 @@ SandboxService.OpenInSandboxAction.text=Open in Apollo Sandbox
 inspection.group.graphql=GraphQL
 inspection.group.graphql.studio=Apollo GraphOS
 inspection.group.graphql.apolloKotlin=Apollo Kotlin
-inspection.fieldInsights.displayName=Expensive field
-inspection.fieldInsights.reportText=<html><b><tt>{0}</tt></b> is expensive to resolve: <b>{1}</b>
+inspection.fieldInsights.displayName=High latency field
+inspection.fieldInsights.reportText=<html><b><tt>{0}</tt></b> has a high latency: <b>{1}</b>
 inspection.fieldInsights.settings.threshold=Threshold (ms)
 inspection.fieldInsights.quickFix=Enclose in @defer fragment
 inspection.schemaInGraphqlFile.displayName=Schema in .graphql file

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -85,6 +85,7 @@ inspection.group.graphql.apolloKotlin=Apollo Kotlin
 inspection.fieldInsights.displayName=Expensive field
 inspection.fieldInsights.reportText=<html><b><tt>{0}</tt></b> is expensive to resolve: <b>{1}</b>
 inspection.fieldInsights.settings.threshold=Threshold (ms)
+inspection.fieldInsights.quickFix=Enclose in @defer fragment
 inspection.schemaInGraphqlFile.displayName=Schema in .graphql file
 inspection.schemaInGraphqlFile.reportText=<html>The Apollo Kotlin compiler requires type definitions to reside in a <tt>.graphqls</tt> file
 inspection.schemaInGraphqlFile.quickFix=Rename file to {0}


### PR DESCRIPTION
See #5057

https://github.com/apollographql/apollo-kotlin/assets/372852/96c361f9-7db7-45c0-a18e-5e717189b706



Also, tweak wording according to feedback