### PR TITLE
[apollo-ast] add endLine/endColumn

### DIFF
--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -205,6 +205,8 @@ The AST classes (`GQLNode` and subclasses) as well as `Introspection` classes ar
 
 `SourceLocation.position` is renamed `SourceLocation.column` and is now 1-indexed
 
+`GQLNode.sourceLocation` is now nullable
+
 ## Gradle configuration
 
 * Publishing is no longer configured automatically.

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -924,6 +924,10 @@ public final class com/apollographql/apollo3/ast/SourceLocation$Companion {
 	public final fun getUNKNOWN ()Lcom/apollographql/apollo3/ast/SourceLocation;
 }
 
+public final class com/apollographql/apollo3/ast/SourceLocationKt {
+	public static final fun pretty (Lcom/apollographql/apollo3/ast/SourceLocation;)Ljava/lang/String;
+}
+
 public abstract interface class com/apollographql/apollo3/ast/TransformResult {
 }
 

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -116,14 +116,13 @@ public final class com/apollographql/apollo3/ast/GQLDirectiveLocation : java/lan
 
 public final class com/apollographql/apollo3/ast/GQLDocument : com/apollographql/apollo3/ast/GQLNode {
 	public static final field Companion Lcom/apollographql/apollo3/ast/GQLDocument$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Lcom/apollographql/apollo3/ast/SourceLocation;)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lcom/apollographql/apollo3/ast/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lcom/apollographql/apollo3/ast/GQLDocument;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/GQLDocument;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLDocument;
+	public fun <init> (Ljava/util/List;Lcom/apollographql/apollo3/ast/SourceLocation;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public final fun copy (Ljava/util/List;Lcom/apollographql/apollo3/ast/SourceLocation;)Lcom/apollographql/apollo3/ast/GQLDocument;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/GQLDocument;Ljava/util/List;Lcom/apollographql/apollo3/ast/SourceLocation;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLDocument;
 	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo3/ast/NodeContainer;)Lcom/apollographql/apollo3/ast/GQLNode;
 	public fun getChildren ()Ljava/util/List;
 	public final fun getDefinitions ()Ljava/util/List;
-	public final fun getFilePath ()Ljava/lang/String;
 	public fun getSourceLocation ()Lcom/apollographql/apollo3/ast/SourceLocation;
 	public fun writeInternal (Lcom/apollographql/apollo3/ast/SDLWriter;)V
 }

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -116,7 +116,8 @@ public final class com/apollographql/apollo3/ast/GQLDirectiveLocation : java/lan
 
 public final class com/apollographql/apollo3/ast/GQLDocument : com/apollographql/apollo3/ast/GQLNode {
 	public static final field Companion Lcom/apollographql/apollo3/ast/GQLDocument$Companion;
-	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Lcom/apollographql/apollo3/ast/SourceLocation;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Lcom/apollographql/apollo3/ast/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lcom/apollographql/apollo3/ast/GQLDocument;
 	public static synthetic fun copy$default (Lcom/apollographql/apollo3/ast/GQLDocument;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLDocument;
 	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo3/ast/NodeContainer;)Lcom/apollographql/apollo3/ast/GQLNode;
@@ -830,6 +831,20 @@ public abstract interface class com/apollographql/apollo3/ast/NodeTransformer {
 	public abstract fun transform (Lcom/apollographql/apollo3/ast/GQLNode;)Lcom/apollographql/apollo3/ast/TransformResult;
 }
 
+public final class com/apollographql/apollo3/ast/ParserOptions {
+	public static final field Companion Lcom/apollographql/apollo3/ast/ParserOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (ZZZ)V
+	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAllowEmpty ()Z
+	public final fun getUseAntlr ()Z
+	public final fun getWithSourceLocation ()Z
+}
+
+public final class com/apollographql/apollo3/ast/ParserOptions$Companion {
+	public final fun getDefault ()Lcom/apollographql/apollo3/ast/ParserOptions;
+}
+
 public final class com/apollographql/apollo3/ast/QueryDocumentMinifier {
 	public static final field INSTANCE Lcom/apollographql/apollo3/ast/QueryDocumentMinifier;
 	public static final fun minify (Ljava/lang/String;)Ljava/lang/String;
@@ -894,8 +909,10 @@ public final class com/apollographql/apollo3/ast/SourceAwareException$Companion 
 
 public final class com/apollographql/apollo3/ast/SourceLocation {
 	public static final field Companion Lcom/apollographql/apollo3/ast/SourceLocation$Companion;
-	public fun <init> (IILjava/lang/String;)V
+	public fun <init> (IIIILjava/lang/String;)V
 	public final fun getColumn ()I
+	public final fun getEndColumn ()I
+	public final fun getEndLine ()I
 	public final fun getFilePath ()Ljava/lang/String;
 	public final fun getLine ()I
 	public final fun getPosition ()I

--- a/libraries/apollo-ast/src/jmh/kotlin/benchmark/Benchmark.kt
+++ b/libraries/apollo-ast/src/jmh/kotlin/benchmark/Benchmark.kt
@@ -1,5 +1,6 @@
 package benchmark
 
+import com.apollographql.apollo3.ast.ParserOptions
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import okio.buffer
 import okio.source
@@ -31,14 +32,14 @@ open class Benchmark {
   @Benchmark
   fun antlrTest(): Double {
     return testFiles.sumOf {
-      it.source().buffer().parseAsGQLDocument(useAntlr = true).getOrThrow().definitions.size.toDouble()
+      it.source().buffer().parseAsGQLDocument(options = ParserOptions(useAntlr = true)).getOrThrow().definitions.size.toDouble()
     }
   }
 
   @Benchmark
   fun parserTest(): Double {
     return testFiles.sumOf {
-      it.source().buffer().parseAsGQLDocument(useAntlr = false).getOrThrow().definitions.size.toDouble()
+      it.source().buffer().parseAsGQLDocument(options = ParserOptions(useAntlr = true)).getOrThrow().definitions.size.toDouble()
     }
   }
 }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Issue.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Issue.kt
@@ -6,20 +6,20 @@ package com.apollographql.apollo3.ast
  */
 sealed class Issue(
     val message: String,
-    val sourceLocation: SourceLocation,
+    val sourceLocation: SourceLocation?,
     val severity: Severity,
 ) {
   /**
    * A grammar error
    */
-  class ParsingError(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.ERROR)
+  class ParsingError(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.ERROR)
 
   /**
    * A GraphqQL validation error as per the spec
    */
   class ValidationError(
       message: String,
-      sourceLocation: SourceLocation,
+      sourceLocation: SourceLocation?,
       severity: Severity = Severity.ERROR,
       val details: ValidationDetails = ValidationDetails.Other,
   ) : Issue(message, sourceLocation, severity)
@@ -27,17 +27,17 @@ sealed class Issue(
   /**
    * A deprecated field/enum is used
    */
-  class DeprecatedUsage(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.WARNING)
+  class DeprecatedUsage(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.WARNING)
 
   /**
    * A variable is unused
    */
-  class UnusedVariable(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.WARNING)
+  class UnusedVariable(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.WARNING)
 
   /**
    * A fragment has an @include or @skip directive. While this is valid GraphQL, the responseBased codegen does not support that
    */
-  class ConditionalFragment(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.ERROR)
+  class ConditionalFragment(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.ERROR)
 
   /**
    * When models are nested, upper case fields are not supported as Kotlin doesn't allow a property name
@@ -48,20 +48,20 @@ sealed class Issue(
    *
    * This error is an Apollo Kotlin specific error
    */
-  class UpperCaseField(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.ERROR)
+  class UpperCaseField(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.ERROR)
 
   /**
    * The GraphQL spec allows inline fragments without a type condition, but we currently forbid this because we need the type condition
    * to name the models in operation based codegen.
    */
-  class InlineFragmentWithoutTypeCondition(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.ERROR)
+  class InlineFragmentWithoutTypeCondition(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.ERROR)
 
   /**
    * Certain enum value names such as `type` are reserved for Apollo.
    *
    * This error is an Apollo Kotlin specific error
    */
-  class ReservedEnumValueName(message: String, sourceLocation: SourceLocation) : Issue(message, sourceLocation, Severity.ERROR)
+  class ReservedEnumValueName(message: String, sourceLocation: SourceLocation?) : Issue(message, sourceLocation, Severity.ERROR)
 
   enum class Severity {
     WARNING,

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -131,7 +131,7 @@ class Schema internal constructor(
   @ApolloInternal
   fun toMap(): Map<String, Any> {
     return mapOf(
-        "sdl" to GQLDocument(definitions, null).toUtf8(),
+        "sdl" to GQLDocument(definitions, sourceLocation = null).toUtf8(),
         "keyFields" to keyFields.mapValues { it.value.toList().sorted() },
         "foreignNames" to foreignNames,
         "directivesToStrip" to directivesToStrip,

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
@@ -38,3 +38,5 @@ class SourceLocation(
     val UNKNOWN = SourceLocation(-1, -1, -1, -1, null)
   }
 }
+
+fun SourceLocation?.pretty() = this?.pretty() ?: "(unknown location)"

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
@@ -3,13 +3,13 @@ package com.apollographql.apollo3.ast
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 
 /**
- * @param line the line number where the symbol starts, starting at 1
+ * @param line the line where the symbol starts, starting at 1
  *
- * @param column the column in the current line where the symbol starts, starting at 1
+ * @param column the column where the symbol starts, starting at 1
  *
- * @param endLine the line number where the symbol end, inclusive, starting at 1
+ * @param endLine the line where the symbol ends, inclusive, starting at 1
  *
- * @param endColumn the column in the current line where the symbol end, inclusive, starting at 1
+ * @param endColumn the column where the symbol ends, inclusive, starting at 1
  * *
  * @param filePath The path to the document containing the node
  * Might be null if the document origin is not known

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
@@ -3,16 +3,22 @@ package com.apollographql.apollo3.ast
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 
 /**
- * @param line the line number of the source location, starting at 1
+ * @param line the line number where the symbol starts, starting at 1
  *
- * @param column the position in the current line, starting at 1
+ * @param column the column in the current line where the symbol starts, starting at 1
  *
+ * @param endLine the line number where the symbol end, inclusive, starting at 1
+ *
+ * @param endColumn the column in the current line where the symbol end, inclusive, starting at 1
+ * *
  * @param filePath The path to the document containing the node
  * Might be null if the document origin is not known
  */
 class SourceLocation(
     val line: Int,
     val column: Int,
+    val endLine: Int,
+    val endColumn: Int,
     val filePath: String?
 ) {
   @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
@@ -27,6 +33,6 @@ class SourceLocation(
   fun pretty(): String = "$filePath: ($line, $column)"
 
   companion object {
-    val UNKNOWN = SourceLocation(-1, -1, null)
+    val UNKNOWN = SourceLocation(-1, -1, -1, -1, null)
   }
 }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/SourceLocation.kt
@@ -33,6 +33,8 @@ class SourceLocation(
   fun pretty(): String = "$filePath: ($line, $column)"
 
   companion object {
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+    @Deprecated("SourceLocation is now nullable and this is replaced by null", ReplaceWith("null"), level = DeprecationLevel.ERROR)
     val UNKNOWN = SourceLocation(-1, -1, -1, -1, null)
   }
 }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/api.kt
@@ -39,9 +39,9 @@ private fun <T: Any> BufferedSource.parseInternal(filePath: String?, block: Pars
   return try {
     GQLResult(Parser(this, filePath).use(block), emptyList())
   } catch (e: ParserException) {
-    GQLResult(null, listOf(Issue.ParsingError(e.message, SourceLocation(e.token.line, e.token.column, filePath))))
+    GQLResult(null, listOf(Issue.ParsingError(e.message, SourceLocation(e.token.line, e.token.column, -1, -1, filePath))))
   } catch (e: LexerException) {
-    GQLResult(null, listOf(Issue.ParsingError(e.message, SourceLocation(e.line, e.column, filePath))))
+    GQLResult(null, listOf(Issue.ParsingError(e.message, SourceLocation(e.line, e.column, -1, -1, filePath))))
   }
 }
 /**

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/exception.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/exception.kt
@@ -16,7 +16,7 @@ open class SourceAwareException(
       // Idea understands a certain format and makes logs clickable
       // It's not 100% clear where this is specified but it at least works with
       // 2020.3
-      return "e: ${sourceLocation?.pretty()}: $description"
+      return "e: ${sourceLocation.pretty()}: $description"
     }
 
     private fun preview(error: String, sourceLocation: SourceLocation?): String {

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/exception.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/exception.kt
@@ -5,23 +5,23 @@ import java.io.IOException
 
 open class SourceAwareException(
     val error: String,
-    val sourceLocation: SourceLocation,
+    val sourceLocation: SourceLocation?,
 ) : RuntimeException(preview(
     error = error,
     sourceLocation = sourceLocation
 )) {
 
   companion object {
-    private fun formatForIdea(sourceLocation: SourceLocation, description: String): String {
+    private fun formatForIdea(sourceLocation: SourceLocation?, description: String): String {
       // Idea understands a certain format and makes logs clickable
       // It's not 100% clear where this is specified but it at least works with
       // 2020.3
-      return "e: ${sourceLocation.pretty()}: $description"
+      return "e: ${sourceLocation?.pretty()}: $description"
     }
 
-    private fun preview(error: String, sourceLocation: SourceLocation): String {
-      val filePath = sourceLocation.filePath
-      val preview = if (filePath != null && sourceLocation.line >= 1 && sourceLocation.column >= 1) {
+    private fun preview(error: String, sourceLocation: SourceLocation?): String {
+      val preview = if (sourceLocation?.filePath != null && sourceLocation.line >= 1 && sourceLocation.column >= 1) {
+        val filePath = sourceLocation.filePath
         val document = try {
           File(filePath).readText()
         } catch (e: IOException) {
@@ -53,18 +53,18 @@ open class SourceAwareException(
  *
  * This most likely a bug. For an example, an Antlr rule was added to the grammar but the Kotlin code does not handle it
  */
-class UnrecognizedAntlrRule(error: String, sourceLocation: SourceLocation) : SourceAwareException(error, sourceLocation)
+class UnrecognizedAntlrRule(error: String, sourceLocation: SourceLocation?) : SourceAwareException(error, sourceLocation)
 
 /**
  * An exception while converting to/from introspection
  *
  * This most likely means the json/sdl was inconsistent or corrupted
  */
-class ConversionException(error: String, sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(error, sourceLocation)
+class ConversionException(error: String, sourceLocation: SourceLocation? = null) : SourceAwareException(error, sourceLocation)
 
 /**
  * The schema is invalid
  *
  * TODO: transform this into issues
  */
-class SchemaValidationException(error: String, sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : SourceAwareException(error, sourceLocation)
+class SchemaValidationException(error: String, sourceLocation: SourceLocation? = null) : SourceAwareException(error, sourceLocation)

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
@@ -18,7 +18,7 @@ import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
  * Whitespace tokens are not mapped to GQLNodes so some formatting will be lost during modification
  */
 sealed interface GQLNode {
-  val sourceLocation: SourceLocation
+  val sourceLocation: SourceLocation?
 
   /**
    * The children of this node.
@@ -130,7 +130,7 @@ sealed class GQLSelection : GQLNode
 class GQLDocument(
     val definitions: List<GQLDefinition>,
     val filePath: String?,
-    override val sourceLocation: SourceLocation = SourceLocation(0, 0, -1, -1, filePath),
+    override val sourceLocation: SourceLocation? = SourceLocation(0, 0, -1, -1, filePath),
 ) : GQLNode {
   override val children = definitions
 
@@ -159,7 +159,7 @@ class GQLDocument(
 }
 
 class GQLOperationDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val operationType: String,
     val name: String?,
     val variableDefinitions: List<GQLVariableDefinition>,
@@ -173,7 +173,7 @@ class GQLOperationDefinition(
   val selectionSet: GQLSelectionSet
     get() {
       return GQLSelectionSet(
-          sourceLocation = SourceLocation.UNKNOWN,
+          sourceLocation = null,
           selections = selections
       )
     }
@@ -202,7 +202,7 @@ class GQLOperationDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       operationType: String = this.operationType,
       name: String? = this.name,
       variableDefinitions: List<GQLVariableDefinition> = this.variableDefinitions,
@@ -231,7 +231,7 @@ class GQLOperationDefinition(
 }
 
 class GQLFragmentDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val directives: List<GQLDirective>,
     val typeCondition: GQLNamedType,
@@ -244,7 +244,7 @@ class GQLFragmentDefinition(
   val selectionSet: GQLSelectionSet
     get() {
       return GQLSelectionSet(
-          sourceLocation = SourceLocation.UNKNOWN,
+          sourceLocation = null,
           selections = selections
       )
     }
@@ -266,7 +266,7 @@ class GQLFragmentDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
       typeCondition: GQLNamedType = this.typeCondition,
@@ -293,7 +293,7 @@ class GQLFragmentDefinition(
 }
 
 class GQLSchemaDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val description: String?,
     val directives: List<GQLDirective>,
     val rootOperationTypeDefinitions: List<GQLOperationTypeDefinition>,
@@ -318,7 +318,7 @@ class GQLSchemaDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       directives: List<GQLDirective> = this.directives,
       rootOperationTypeDefinitions: List<GQLOperationTypeDefinition> = this.rootOperationTypeDefinitions,
@@ -365,7 +365,7 @@ sealed class GQLTypeDefinition : GQLDefinition, GQLNamed, GQLDescribed, GQLHasDi
 }
 
 class GQLInterfaceTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     val implementsInterfaces: List<String>,
@@ -397,7 +397,7 @@ class GQLInterfaceTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       implementsInterfaces: List<String> = this.implementsInterfaces,
@@ -421,7 +421,7 @@ class GQLInterfaceTypeDefinition(
 }
 
 class GQLObjectTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     val implementsInterfaces: List<String>,
@@ -455,7 +455,7 @@ class GQLObjectTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       implementsInterfaces: List<String> = this.implementsInterfaces,
@@ -481,7 +481,7 @@ class GQLObjectTypeDefinition(
 }
 
 class GQLInputObjectTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     override val directives: List<GQLDirective>,
@@ -510,7 +510,7 @@ class GQLInputObjectTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -534,7 +534,7 @@ class GQLInputObjectTypeDefinition(
 }
 
 class GQLScalarTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     override val directives: List<GQLDirective>,
@@ -555,7 +555,7 @@ class GQLScalarTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -574,7 +574,7 @@ class GQLScalarTypeDefinition(
 }
 
 class GQLEnumTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     override val directives: List<GQLDirective>,
@@ -601,7 +601,7 @@ class GQLEnumTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -623,7 +623,7 @@ class GQLEnumTypeDefinition(
 }
 
 class GQLUnionTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val description: String?,
     override val name: String,
     override val directives: List<GQLDirective>,
@@ -647,7 +647,7 @@ class GQLUnionTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -669,7 +669,7 @@ class GQLUnionTypeDefinition(
 }
 
 class GQLDirectiveDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val description: String?,
     override val name: String,
     val arguments: List<GQLInputValueDefinition>,
@@ -697,7 +697,7 @@ class GQLDirectiveDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       arguments: List<GQLInputValueDefinition> = this.arguments,
@@ -730,7 +730,7 @@ class GQLDirectiveDefinition(
 }
 
 class GQLSchemaExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val directives: List<GQLDirective>,
     val operationTypeDefinitions: List<GQLOperationTypeDefinition>,
 ) : GQLDefinition, GQLTypeSystemExtension {
@@ -755,7 +755,7 @@ class GQLSchemaExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       directives: List<GQLDirective> = this.directives,
       operationTypesDefinition: List<GQLOperationTypeDefinition> = this.operationTypeDefinitions,
   ): GQLSchemaExtension = GQLSchemaExtension(
@@ -773,7 +773,7 @@ class GQLSchemaExtension(
 }
 
 class GQLEnumTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val directives: List<GQLDirective>,
     val enumValues: List<GQLEnumValueDefinition>,
@@ -800,7 +800,7 @@ class GQLEnumTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
       enumValues: List<GQLEnumValueDefinition> = this.enumValues,
@@ -820,7 +820,7 @@ class GQLEnumTypeExtension(
 }
 
 class GQLObjectTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val implementsInterfaces: List<String>,
     val directives: List<GQLDirective>,
@@ -852,7 +852,7 @@ class GQLObjectTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       implementsInterfaces: List<String> = this.implementsInterfaces,
       directives: List<GQLDirective> = this.directives,
@@ -874,7 +874,7 @@ class GQLObjectTypeExtension(
 }
 
 class GQLInputObjectTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val directives: List<GQLDirective>,
     val inputFields: List<GQLInputValueDefinition>,
@@ -901,7 +901,7 @@ class GQLInputObjectTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
       inputFields: List<GQLInputValueDefinition> = this.inputFields,
@@ -921,7 +921,7 @@ class GQLInputObjectTypeExtension(
 }
 
 class GQLScalarTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val directives: List<GQLDirective>,
 ) : GQLDefinition, GQLTypeExtension {
@@ -940,7 +940,7 @@ class GQLScalarTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
   ): GQLScalarTypeExtension = GQLScalarTypeExtension(
@@ -957,7 +957,7 @@ class GQLScalarTypeExtension(
 }
 
 class GQLInterfaceTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val implementsInterfaces: List<String>,
     val directives: List<GQLDirective>,
@@ -989,7 +989,7 @@ class GQLInterfaceTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       implementsInterfaces: List<String> = this.implementsInterfaces,
       directives: List<GQLDirective> = this.directives,
@@ -1010,7 +1010,7 @@ class GQLInterfaceTypeExtension(
 }
 
 class GQLUnionTypeExtension(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val directives: List<GQLDirective>,
     val memberTypes: List<GQLNamedType>,
@@ -1032,7 +1032,7 @@ class GQLUnionTypeExtension(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
       memberTypes: List<GQLNamedType> = this.memberTypes,
@@ -1052,7 +1052,7 @@ class GQLUnionTypeExtension(
 }
 
 class GQLEnumValueDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val description: String?,
     override val name: String,
     val directives: List<GQLDirective>,
@@ -1073,7 +1073,7 @@ class GQLEnumValueDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -1094,7 +1094,7 @@ class GQLEnumValueDefinition(
 }
 
 class GQLFieldDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val description: String?,
     override val name: String,
     val arguments: List<GQLInputValueDefinition>,
@@ -1123,7 +1123,7 @@ class GQLFieldDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       arguments: List<GQLInputValueDefinition> = this.arguments,
@@ -1149,7 +1149,7 @@ class GQLFieldDefinition(
 }
 
 class GQLInputValueDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val description: String?,
     override val name: String,
     val directives: List<GQLDirective>,
@@ -1194,7 +1194,7 @@ class GQLInputValueDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       description: String? = this.description,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
@@ -1223,7 +1223,7 @@ class GQLInputValueDefinition(
  * have a description
  */
 class GQLVariableDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val name: String,
     val type: GQLType,
     val defaultValue: GQLValue?,
@@ -1247,7 +1247,7 @@ class GQLVariableDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       type: GQLType = this.type,
       defaultValue: GQLValue? = this.defaultValue,
@@ -1275,7 +1275,7 @@ class GQLVariableDefinition(
  * @param namedType the name of the root object type, i.e. "Query", ...
  */
 class GQLOperationTypeDefinition(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val operationType: String,
     val namedType: String,
 ) : GQLNode {
@@ -1289,7 +1289,7 @@ class GQLOperationTypeDefinition(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       operationType: String = this.operationType,
       namedType: String = this.namedType,
   ): GQLOperationTypeDefinition {
@@ -1309,7 +1309,7 @@ class GQLOperationTypeDefinition(
  * @param name the name of the directive without the '@'. Example: "include"
  */
 class GQLDirective(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
     val arguments: List<GQLArgument>,
 ) : GQLNode, GQLNamed {
@@ -1326,7 +1326,7 @@ class GQLDirective(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       arguments: List<GQLArgument> = this.arguments,
   ): GQLDirective {
@@ -1345,7 +1345,7 @@ class GQLDirective(
 }
 
 class GQLObjectField(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val name: String,
     val value: GQLValue,
 ) : GQLNode {
@@ -1360,7 +1360,7 @@ class GQLObjectField(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       value: GQLValue = this.value,
   ): GQLObjectField {
@@ -1379,7 +1379,7 @@ class GQLObjectField(
 }
 
 class GQLArgument(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val name: String,
     val value: GQLValue,
 ) : GQLNode {
@@ -1394,7 +1394,7 @@ class GQLArgument(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       value: GQLValue = this.value,
   ): GQLArgument {
@@ -1416,7 +1416,7 @@ class GQLArgument(
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 class GQLSelectionSet(
     val selections: List<GQLSelection>,
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
 ) : GQLNode {
   override val children = selections
 
@@ -1427,7 +1427,7 @@ class GQLSelectionSet(
   @Suppress("DEPRECATION")
   fun copy(
       selections: List<GQLSelection> = this.selections,
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
   ): GQLSelectionSet {
     return GQLSelectionSet(
         selections = selections,
@@ -1446,7 +1446,7 @@ class GQLSelectionSet(
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 class GQLArguments(
     val arguments: List<GQLArgument>,
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
 ) : GQLNode {
   override val children: List<GQLNode> = arguments
 
@@ -1457,7 +1457,7 @@ class GQLArguments(
   @Suppress("DEPRECATION")
   fun copy(
       arguments: List<GQLArgument> = this.arguments,
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
   ): GQLArguments {
     return GQLArguments(
         arguments = arguments,
@@ -1493,7 +1493,7 @@ private fun List<GQLArgument>.writeArguments(writer: SDLWriter) {
 }
 
 class GQLField(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val alias: String?,
     val name: String,
     val arguments: List<GQLArgument>,
@@ -1506,7 +1506,7 @@ class GQLField(
   val selectionSet: GQLSelectionSet
     get() {
       return GQLSelectionSet(
-          sourceLocation = SourceLocation.UNKNOWN,
+          sourceLocation = null,
           selections = selections
       )
     }
@@ -1536,7 +1536,7 @@ class GQLField(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       alias: String? = this.alias,
       name: String = this.name,
       arguments: List<GQLArgument> = this.arguments,
@@ -1561,7 +1561,7 @@ class GQLField(
 }
 
 class GQLInlineFragment(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val typeCondition: GQLNamedType?,
     val directives: List<GQLDirective>,
     val selections: List<GQLSelection>,
@@ -1572,7 +1572,7 @@ class GQLInlineFragment(
   val selectionSet: GQLSelectionSet
     get() {
       return GQLSelectionSet(
-          sourceLocation = SourceLocation.UNKNOWN,
+          sourceLocation = null,
           selections = selections
       )
     }
@@ -1597,7 +1597,7 @@ class GQLInlineFragment(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       typeCondition: GQLNamedType? = this.typeCondition,
       directives: List<GQLDirective> = this.directives,
       selections: List<GQLSelection> = this.selections,
@@ -1618,7 +1618,7 @@ class GQLInlineFragment(
 }
 
 class GQLFragmentSpread(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val name: String,
     val directives: List<GQLDirective>,
 ) : GQLSelection() {
@@ -1637,7 +1637,7 @@ class GQLFragmentSpread(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
       directives: List<GQLDirective> = this.directives,
   ) = GQLFragmentSpread(
@@ -1656,7 +1656,7 @@ class GQLFragmentSpread(
 sealed class GQLType : GQLNode
 
 class GQLNamedType(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     override val name: String,
 ) : GQLType(), GQLNamed {
 
@@ -1669,7 +1669,7 @@ class GQLNamedType(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
   ) = GQLNamedType(
       sourceLocation = sourceLocation,
@@ -1682,7 +1682,7 @@ class GQLNamedType(
 }
 
 class GQLNonNullType(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val type: GQLType,
 ) : GQLType() {
 
@@ -1696,7 +1696,7 @@ class GQLNonNullType(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       type: GQLType = this.type,
   ) = GQLNonNullType(
       sourceLocation = sourceLocation,
@@ -1711,7 +1711,7 @@ class GQLNonNullType(
 }
 
 class GQLListType(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val type: GQLType,
 ) : GQLType() {
 
@@ -1726,7 +1726,7 @@ class GQLListType(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       type: GQLType = this.type,
   ) = GQLListType(
       sourceLocation = sourceLocation,
@@ -1743,7 +1743,7 @@ class GQLListType(
 
 sealed class GQLValue : GQLNode
 class GQLVariableValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val name: String,
 ) : GQLValue() {
 
@@ -1756,7 +1756,7 @@ class GQLVariableValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       name: String = this.name,
   ) = GQLVariableValue(
       sourceLocation = sourceLocation,
@@ -1769,7 +1769,7 @@ class GQLVariableValue(
 }
 
 class GQLIntValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val value: Int,
 ) : GQLValue() {
 
@@ -1782,7 +1782,7 @@ class GQLIntValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       value: Int = this.value,
   ) = GQLIntValue(
       sourceLocation = sourceLocation,
@@ -1795,7 +1795,7 @@ class GQLIntValue(
 }
 
 class GQLFloatValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val value: Double,
 ) : GQLValue() {
 
@@ -1808,7 +1808,7 @@ class GQLFloatValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       value: Double = this.value,
   ) = GQLFloatValue(
       sourceLocation = sourceLocation,
@@ -1821,7 +1821,7 @@ class GQLFloatValue(
 }
 
 class GQLStringValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val value: String,
 ) : GQLValue() {
 
@@ -1834,7 +1834,7 @@ class GQLStringValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       value: String = this.value,
   ) = GQLStringValue(
       sourceLocation = sourceLocation,
@@ -1847,7 +1847,7 @@ class GQLStringValue(
 }
 
 class GQLBooleanValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val value: Boolean,
 ) : GQLValue() {
 
@@ -1860,7 +1860,7 @@ class GQLBooleanValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       value: Boolean = this.value,
   ) = GQLBooleanValue(
       sourceLocation = sourceLocation,
@@ -1873,7 +1873,7 @@ class GQLBooleanValue(
 }
 
 class GQLEnumValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val value: String,
 ) : GQLValue() {
 
@@ -1886,7 +1886,7 @@ class GQLEnumValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       value: String = this.value,
   ) = GQLEnumValue(
       sourceLocation = sourceLocation,
@@ -1899,7 +1899,7 @@ class GQLEnumValue(
 }
 
 class GQLListValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val values: List<GQLValue>,
 ) : GQLValue() {
 
@@ -1914,7 +1914,7 @@ class GQLListValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       values: List<GQLValue> = this.values,
   ) = GQLListValue(
       sourceLocation = sourceLocation,
@@ -1929,7 +1929,7 @@ class GQLListValue(
 }
 
 class GQLObjectValue(
-    override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN,
+    override val sourceLocation: SourceLocation? = null,
     val fields: List<GQLObjectField>,
 ) : GQLValue() {
 
@@ -1946,7 +1946,7 @@ class GQLObjectValue(
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
       fields: List<GQLObjectField> = this.fields,
   ) = GQLObjectValue(
       sourceLocation = sourceLocation,
@@ -1960,7 +1960,7 @@ class GQLObjectValue(
   }
 }
 
-class GQLNullValue(override val sourceLocation: SourceLocation = SourceLocation.UNKNOWN) : GQLValue() {
+class GQLNullValue(override val sourceLocation: SourceLocation? = null) : GQLValue() {
 
   override val children = emptyList<GQLNode>()
 
@@ -1971,7 +1971,7 @@ class GQLNullValue(override val sourceLocation: SourceLocation = SourceLocation.
   }
 
   fun copy(
-      sourceLocation: SourceLocation = this.sourceLocation,
+      sourceLocation: SourceLocation? = this.sourceLocation,
   ) = GQLNullValue(
       sourceLocation = sourceLocation,
   )

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
@@ -129,9 +129,10 @@ sealed class GQLSelection : GQLNode
  */
 class GQLDocument(
     val definitions: List<GQLDefinition>,
-    val filePath: String?,
-    override val sourceLocation: SourceLocation? = SourceLocation(0, 0, -1, -1, filePath),
+    override val sourceLocation: SourceLocation?,
 ) : GQLNode {
+  constructor(definitions: List<GQLDefinition>, filePath: String?): this(definitions, SourceLocation(0, 0, -1, -1, filePath))
+
   override val children = definitions
 
   override fun writeInternal(writer: SDLWriter) {
@@ -140,18 +141,18 @@ class GQLDocument(
 
   fun copy(
       definitions: List<GQLDefinition> = this.definitions,
-      filePath: String? = this.filePath,
+      sourceLocation: SourceLocation? = this.sourceLocation,
   ): GQLDocument {
     return GQLDocument(
         definitions = definitions,
-        filePath = filePath
+        sourceLocation = sourceLocation
     )
   }
 
   override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
     return copy(
         definitions = container.take(),
-        filePath = filePath
+        sourceLocation = sourceLocation
     )
   }
 

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gql.kt
@@ -130,8 +130,8 @@ sealed class GQLSelection : GQLNode
 class GQLDocument(
     val definitions: List<GQLDefinition>,
     val filePath: String?,
+    override val sourceLocation: SourceLocation = SourceLocation(0, 0, -1, -1, filePath),
 ) : GQLNode {
-  override val sourceLocation: SourceLocation = SourceLocation(0, 0, filePath)
   override val children = definitions
 
   override fun writeInternal(writer: SDLWriter) {

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -81,7 +81,7 @@ internal fun combineDefinitions(left: List<GQLDefinition>, right: List<GQLDefini
     if (existingDefinition != null) {
       if (conflictResolution == ConflictResolution.Error) {
         error("Apollo: definition '${builtInTypeDefinition.name}' is already in the schema at " +
-            "'${existingDefinition.sourceLocation.filePath}:${existingDefinition.sourceLocation}'")
+            "'${existingDefinition.sourceLocation?.filePath}:${existingDefinition.sourceLocation}'")
       }
     } else {
       mergedDefinitions.add(builtInTypeDefinition)

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -562,7 +562,7 @@ internal class ExecutableValidationScope(
   }
 
   private fun buildMessage(fieldA: GQLField, fieldB: GQLField, message: String): String {
-    return "`${fieldA.responseName()}` cannot be merged with `${fieldB.responseName()}` (at ${fieldB.sourceLocation?.pretty()}): " +
+    return "`${fieldA.responseName()}` cannot be merged with `${fieldB.responseName()}` (at ${fieldB.sourceLocation.pretty()}): " +
         "$message. Use different aliases on the fields to fetch both if this was intentional."
   }
 

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -66,8 +66,8 @@ internal class ExecutableValidationScope(
    */
   private val variableUsages = mutableListOf<VariableUsage>()
 
-  private val deferDirectiveLabels = mutableMapOf<String, SourceLocation>()
-  private val deferDirectivePathAndLabels = mutableMapOf<String, SourceLocation>()
+  private val deferDirectiveLabels = mutableMapOf<String, SourceLocation?>()
+  private val deferDirectivePathAndLabels = mutableMapOf<String, SourceLocation?>()
 
   fun validate(document: GQLDocument): List<Issue> {
     document.validateExecutable()
@@ -136,13 +136,13 @@ internal class ExecutableValidationScope(
   @Suppress("KotlinConstantConditions")
   private fun GQLType.mergeWith(other: GQLType): GQLType? {
     return if (this is GQLNonNullType && other is GQLNonNullType) {
-      type.mergeWith(other.type)?.let { GQLNonNullType(SourceLocation.UNKNOWN, it) }
+      type.mergeWith(other.type)?.let { GQLNonNullType(null, it) }
     } else if (this is GQLNonNullType && other !is GQLNonNullType) {
-      type.mergeWith(other)?.let { GQLNonNullType(SourceLocation.UNKNOWN, it) }
+      type.mergeWith(other)?.let { GQLNonNullType(null, it) }
     } else if (this !is GQLNonNullType && other is GQLNonNullType) {
-      this.mergeWith(other.type)?.let { GQLNonNullType(SourceLocation.UNKNOWN, it) }
+      this.mergeWith(other.type)?.let { GQLNonNullType(null, it) }
     } else if (this is GQLListType && other is GQLListType) {
-      this.type.mergeWith(other.type)?.let { GQLListType(SourceLocation.UNKNOWN, it) }
+      this.type.mergeWith(other.type)?.let { GQLListType(null, it) }
     } else if (this is GQLListType && other !is GQLListType) {
       null
     } else if (this !is GQLListType && other is GQLListType) {
@@ -448,7 +448,7 @@ internal class ExecutableValidationScope(
       // This will never happen from parsing documents but is kept for reference and to catch bad manual document modifications
       registerIssue(
           message = "Selection of type `${parentTypeDefinition.name}` must have a selection of sub-fields",
-          sourceLocation = SourceLocation.UNKNOWN
+          sourceLocation = null
       )
       return
     }
@@ -562,7 +562,7 @@ internal class ExecutableValidationScope(
   }
 
   private fun buildMessage(fieldA: GQLField, fieldB: GQLField, message: String): String {
-    return "`${fieldA.responseName()}` cannot be merged with `${fieldB.responseName()}` (at ${fieldB.sourceLocation.pretty()}): " +
+    return "`${fieldA.responseName()}` cannot be merged with `${fieldB.responseName()}` (at ${fieldB.sourceLocation?.pretty()}): " +
         "$message. Use different aliases on the fields to fetch both if this was intentional."
   }
 

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
@@ -58,13 +58,15 @@ internal class Parser(source: BufferedSource, val withSourceLocation: Boolean, v
   private var lookaheadToken: Token? = null
 
   fun parseDocument(allowEmpty: Boolean): GQLDocument {
+    val start = token
+    val definitions = if (allowEmpty) {
+      parseList<Token.StartOfFile, Token.EndOfFile, GQLDefinition>(::parseDefinition)
+    } else {
+      parseNonEmptyList<Token.StartOfFile, Token.EndOfFile, GQLDefinition>(::parseDefinition)
+    }
     return GQLDocument(
-        definitions = if (allowEmpty) {
-          parseList<Token.StartOfFile, Token.EndOfFile, GQLDefinition>(::parseDefinition)
-        } else {
-          parseNonEmptyList<Token.StartOfFile, Token.EndOfFile, GQLDefinition>(::parseDefinition)
-        },
-        filePath
+        definitions = definitions,
+        sourceLocation = sourceLocation(start)
     )
   }
 

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
@@ -51,7 +51,7 @@ import com.apollographql.apollo3.ast.SourceLocation
 import okio.BufferedSource
 import okio.Closeable
 
-internal class Parser(source: BufferedSource, val filePath: String?) : Closeable {
+internal class Parser(source: BufferedSource, val withSourceLocation: Boolean, val filePath: String?) : Closeable {
   private val lexer = Lexer(source)
   private var token = lexer.nextToken()
   private var lastToken = token
@@ -271,7 +271,9 @@ internal class Parser(source: BufferedSource, val filePath: String?) : Closeable
     )
   }
 
-  private fun sourceLocation(from: Token): SourceLocation {
+  private fun sourceLocation(from: Token): SourceLocation? {
+    if (!withSourceLocation) return null
+
     return SourceLocation(
         from.line, from.column, lastToken.endLine, lastToken.endColumn, filePath
     )
@@ -901,7 +903,9 @@ internal class Parser(source: BufferedSource, val filePath: String?) : Closeable
     }
   }
 
-  private fun sourceLocation(): SourceLocation {
+  private fun sourceLocation(): SourceLocation? {
+    if (!withSourceLocation) return null
+
     return SourceLocation(
         token.line,
         token.column,

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -27,7 +27,6 @@ import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.Schema.Companion.TYPE_POLICY
-import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.apolloDefinitions
 import com.apollographql.apollo3.ast.builtinDefinitions
 import com.apollographql.apollo3.ast.canHaveKeyFields
@@ -77,7 +76,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
     when (gqlDefinition) {
       is GQLSchemaDefinition -> {
         if (schemaDefinition != null) {
-          issues.add(Issue.ValidationError("schema is already defined. First definition was ${schemaDefinition!!.sourceLocation.pretty()}", gqlDefinition.sourceLocation))
+          issues.add(Issue.ValidationError("schema is already defined. First definition was ${schemaDefinition!!.sourceLocation?.pretty()}", gqlDefinition.sourceLocation))
         } else {
           schemaDefinition = gqlDefinition
         }
@@ -87,7 +86,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
         val existing = directiveDefinitions[gqlDefinition.name]
         if (existing != null) {
           var severity: Issue.Severity = Issue.Severity.ERROR
-          val message = "Directive '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation.pretty()}"
+          val message = "Directive '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation?.pretty()}"
 
           if (gqlDefinition.name in apolloDefinitions.mapNotNull { (it as? GQLDirectiveDefinition)?.name }.toSet()) {
             // We override the definition to stay compatible with previous versions
@@ -108,7 +107,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
       is GQLTypeDefinition -> {
         val existing = typeDefinitions[gqlDefinition.name]
         if (existing != null) {
-          issues.add(Issue.ValidationError("Type '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation.pretty()}", gqlDefinition.sourceLocation))
+          issues.add(Issue.ValidationError("Type '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation?.pretty()}", gqlDefinition.sourceLocation))
         } else {
           typeDefinitions[gqlDefinition.name] = gqlDefinition
         }
@@ -203,7 +202,7 @@ internal fun ValidationScope.syntheticSchemaDefinition(): GQLSchemaDefinition {
     val typeDefinition = typeDefinitions[typeName]
     if (typeDefinition == null) {
       if (it == "query") {
-        registerIssue("No schema definition and not 'Query' type found", sourceLocation = SourceLocation.UNKNOWN)
+        registerIssue("No schema definition and not 'Query' type found", sourceLocation = null)
       }
       return@mapNotNull null
     }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -34,6 +34,7 @@ import com.apollographql.apollo3.ast.combineDefinitions
 import com.apollographql.apollo3.ast.containsError
 import com.apollographql.apollo3.ast.linkDefinitions
 import com.apollographql.apollo3.ast.parseAsGQLSelections
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.rawType
 import com.apollographql.apollo3.ast.transform2
 
@@ -76,7 +77,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
     when (gqlDefinition) {
       is GQLSchemaDefinition -> {
         if (schemaDefinition != null) {
-          issues.add(Issue.ValidationError("schema is already defined. First definition was ${schemaDefinition!!.sourceLocation?.pretty()}", gqlDefinition.sourceLocation))
+          issues.add(Issue.ValidationError("schema is already defined. First definition was ${schemaDefinition!!.sourceLocation.pretty()}", gqlDefinition.sourceLocation))
         } else {
           schemaDefinition = gqlDefinition
         }
@@ -86,7 +87,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
         val existing = directiveDefinitions[gqlDefinition.name]
         if (existing != null) {
           var severity: Issue.Severity = Issue.Severity.ERROR
-          val message = "Directive '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation?.pretty()}"
+          val message = "Directive '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation.pretty()}"
 
           if (gqlDefinition.name in apolloDefinitions.mapNotNull { (it as? GQLDirectiveDefinition)?.name }.toSet()) {
             // We override the definition to stay compatible with previous versions
@@ -107,7 +108,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
       is GQLTypeDefinition -> {
         val existing = typeDefinitions[gqlDefinition.name]
         if (existing != null) {
-          issues.add(Issue.ValidationError("Type '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation?.pretty()}", gqlDefinition.sourceLocation))
+          issues.add(Issue.ValidationError("Type '${gqlDefinition.name}' is defined multiple times. First definition is: ${existing.sourceLocation.pretty()}", gqlDefinition.sourceLocation))
         } else {
           typeDefinitions[gqlDefinition.name] = gqlDefinition
         }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Token.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/Token.kt
@@ -1,82 +1,83 @@
 package com.apollographql.apollo3.ast.internal
 
-internal sealed class Token(val line: kotlin.Int, val column: kotlin.Int) {
-    object StartOfFile : Token(1, 0) {
-        override fun toString() = "SOF"
-    }
+internal sealed class Token(val line: kotlin.Int, val column: kotlin.Int, val endLine: kotlin.Int, val endColumn: kotlin.Int) {
+  object StartOfFile : Token(1, 1, 1, 1) {
+    override fun toString() = "SOF"
+  }
 
-    class EndOfFile(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "EOF"
-    }
-    class ExclamationPoint(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "!"
-    }
+  class EndOfFile(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "EOF"
+  }
 
-    class Dollar(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "$"
-    }
+  class ExclamationPoint(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "!"
+  }
 
-    class Ampersand(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "&"
-    }
+  class Dollar(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "$"
+  }
 
-    class LeftParenthesis(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "("
-    }
+  class Ampersand(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "&"
+  }
 
-    class RightParenthesis(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = ")"
-    }
+  class LeftParenthesis(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "("
+  }
 
-    class Spread(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "..."
-    }
+  class RightParenthesis(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = ")"
+  }
 
-    class Colon(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = ":"
-    }
+  class Spread(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column + 3) {
+    override fun toString() = "..."
+  }
 
-    class Equals(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "="
-    }
+  class Colon(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = ":"
+  }
 
-    class At(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "@"
-    }
+  class Equals(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "="
+  }
 
-    class LeftBracket(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "["
-    }
+  class At(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "@"
+  }
 
-    class RightBracket(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "]"
-    }
+  class LeftBracket(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "["
+  }
 
-    class LeftBrace(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "{"
-    }
+  class RightBracket(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "]"
+  }
 
-    class RightBrace(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "}"
-    }
+  class LeftBrace(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "{"
+  }
 
-    class Pipe(line: kotlin.Int, column: kotlin.Int) : Token(line, column) {
-        override fun toString() = "|"
-    }
+  class RightBrace(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "}"
+  }
 
-    class Name(line: kotlin.Int, column: kotlin.Int, val value: kotlin.String) : Token(line, column) {
-        override fun toString() = "name: $value"
-    }
+  class Pipe(line: kotlin.Int, column: kotlin.Int) : Token(line, column, line, column) {
+    override fun toString() = "|"
+  }
 
-    class Int(line: kotlin.Int, column: kotlin.Int, val value: kotlin.Int) : Token(line, column) {
-        override fun toString() = "int: $value"
-    }
+  class Name(line: kotlin.Int, column: kotlin.Int, endColumn: kotlin.Int, val value: kotlin.String) : Token(line, column, line, endColumn) {
+    override fun toString() = "name: $value"
+  }
 
-    class Float(line: kotlin.Int, column: kotlin.Int, val value: Double) : Token(line, column) {
-        override fun toString() = "float: $value"
-    }
+  class Int(line: kotlin.Int, column: kotlin.Int, endColumn: kotlin.Int, val value: kotlin.Int) : Token(line, column, line, endColumn) {
+    override fun toString() = "int: $value"
+  }
 
-    class String(line: kotlin.Int, column: kotlin.Int, val value: kotlin.String) : Token(line, column) {
-        override fun toString() = "string: \"$value\""
-    }
+  class Float(line: kotlin.Int, column: kotlin.Int, endColumn: kotlin.Int, val value: Double) : Token(line, column, line, endColumn) {
+    override fun toString() = "float: $value"
+  }
+
+  class String(line: kotlin.Int, column: kotlin.Int, endLine: kotlin.Int, endColumn: kotlin.Int, val value: kotlin.String) : Token(line, column, endLine, endColumn) {
+    override fun toString() = "string: \"$value\""
+  }
 }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/TypeExtensionsMergeScope.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/TypeExtensionsMergeScope.kt
@@ -211,7 +211,7 @@ private inline fun <reified T> IssuesScope.mergeUniquesOrThrow(
 private fun IssuesScope.mergeUniqueInterfacesOrThrow(
     list: List<String>,
     others: List<String>,
-    sourceLocation: SourceLocation,
+    sourceLocation: SourceLocation?,
 ): List<String> = with(list) {
   return (this + others).apply {
     groupBy { it }.entries.firstOrNull { it.value.size > 1 }?.let {

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
@@ -66,7 +66,7 @@ internal interface ValidationScope : IssuesScope {
 
   fun registerIssue(
       message: String,
-      sourceLocation: SourceLocation,
+      sourceLocation: SourceLocation?,
       severity: Issue.Severity = Issue.Severity.ERROR,
       details: ValidationDetails = ValidationDetails.Other,
   ) {
@@ -249,7 +249,7 @@ private fun ValidationScope.validateArgument(
  */
 internal fun ValidationScope.validateArguments(
     arguments: List<GQLArgument>,
-    sourceLocation: SourceLocation,
+    sourceLocation: SourceLocation?,
     inputValueDefinitions: List<GQLInputValueDefinition>,
     debug: String,
     registerVariableUsage: (VariableUsage) -> Unit,

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/antlrParse.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/antlrParse.kt
@@ -26,7 +26,7 @@ import com.apollographql.apollo3.generated.antlr.GraphQLParser as AntlrGraphQLPa
  *
  * @param startRule returns the start rule and consumes the stream. It is expected that startRule
  * consumes the whole source
- * @param convert converts startRule to something else, most of the times a GQLNode. Not called if there are
+ * @param convert converts startRule to something else, most of the time a GQLNode. Not called if there are
  * any parsing issues
  */
 internal fun <T : RuleContext, R: Any> antlrParse(
@@ -60,7 +60,7 @@ internal fun <T : RuleContext, R: Any> antlrParse(
           ) {
             issues.add(Issue.ParsingError(
                 message = "Unsupported token `${(offendingSymbol as? Token)?.text ?: offendingSymbol.toString()}`",
-                sourceLocation = SourceLocation(line, position, filePath)
+                sourceLocation = SourceLocation(line, position, -1, -1, filePath)
             ))
           }
         }
@@ -74,7 +74,7 @@ internal fun <T : RuleContext, R: Any> antlrParse(
     issues.add(
         Issue.ParsingError(
             "Extra token at end of file `${currentToken.text}`",
-            SourceLocation(currentToken.line, currentToken.charPositionInLine, filePath)
+            SourceLocation(currentToken.line, currentToken.charPositionInLine, -1, -1, filePath)
         )
     )
   }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/antlr_to_gql.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/internal/antlr_to_gql.kt
@@ -20,6 +20,8 @@ private class AntlrToGQLScope(val filePath: String?) {
   private fun sourceLocation(token: Token) = SourceLocation(
       line = token.line,
       column = token.charPositionInLine + 1,
+      endLine = -1,
+      endColumn = -1,
       filePath = filePath
   )
 

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.kt
@@ -44,7 +44,9 @@ private class GQLDocumentBuilder(private val introspectionSchema: IntrospectionS
   private val sourceLocation = SourceLocation(
       filePath = filePath,
       line = -1,
-      column = -1
+      column = -1,
+      endLine = -1,
+      endColumn = -1,
   )
 
   fun toGQLDocument(): GQLDocument {

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/locations.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/locations.kt
@@ -26,100 +26,100 @@ internal fun GQLDefinition.removeLocation(): GQLDefinition = when(this) {
 }
 
 internal fun GQLEnumTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     enumValues = enumValues.map { it.removeLocation() }
 )
 internal fun GQLInputObjectTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     inputFields = inputFields.map { it.removeLocation() }
 )
 internal fun GQLInterfaceTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     fields = fields.map { it.removeLocation() }
 )
 internal fun GQLObjectTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     fields =  fields.map { it.removeLocation() }
 )
 internal fun GQLScalarTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
 )
 internal fun GQLUnionTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     memberTypes = memberTypes.map { it.removeLocation() }
 )
 internal fun GQLUnionTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     memberTypes = memberTypes.map { it.removeLocation() }
 )
 
 internal fun GQLFieldDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     arguments = arguments.map { it.removeLocation() },
     type = type.removeLocation()
 )
 internal fun GQLScalarTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
 )
 
 internal fun GQLSchemaDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     rootOperationTypeDefinitions = rootOperationTypeDefinitions.map { it.removeLocation() },
 )
 
 internal fun GQLOperationTypeDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
 )
 internal fun GQLSchemaExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     operationTypesDefinition =operationTypeDefinitions.map { it.removeLocation() },
 )
 
 internal fun GQLInterfaceTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     fields = fields.map { it.removeLocation() },
 )
 
 internal fun GQLInputObjectTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     inputFields = inputFields.map { it.removeLocation() },
 )
 
 internal fun GQLObjectTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     fields = fields.map { it.removeLocation() },
 )
 
 internal fun GQLOperationDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     selections = selections.removeSelectionsLocation(),
     variableDefinitions = variableDefinitions.map { it.removeLocation() }
 )
 
 internal fun GQLVariableDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     type = type.removeLocation(),
     defaultValue = defaultValue?.removeLocation(),
     directives = directives.map { it.removeLocation() }
 )
 
 internal fun GQLFragmentDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     typeCondition = typeCondition.removeLocation(),
     selections = selections.removeSelectionsLocation()
@@ -131,18 +131,18 @@ private fun List<GQLArgument>.removeArgumentsLocation() = map { it.removeLocatio
 
 internal fun GQLSelection.removeLocation(): GQLSelection = when(this) {
   is GQLField -> copy(
-      sourceLocation = SourceLocation.UNKNOWN,
+      sourceLocation = null,
       arguments = arguments.removeArgumentsLocation(),
       selections = selections.removeSelectionsLocation(),
       directives = directives.map { it.removeLocation() }
   )
 
   is GQLFragmentSpread -> copy(
-      sourceLocation = SourceLocation.UNKNOWN,
+      sourceLocation = null,
       directives = directives.map { it.removeLocation() }
   )
   is GQLInlineFragment -> copy(
-      sourceLocation = SourceLocation.UNKNOWN,
+      sourceLocation = null,
       typeCondition = typeCondition?.removeLocation(),
       directives = directives.map { it.removeLocation() },
       selections = selections.removeSelectionsLocation()
@@ -150,57 +150,57 @@ internal fun GQLSelection.removeLocation(): GQLSelection = when(this) {
 }
 
 internal fun GQLEnumTypeExtension.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
     enumValues = enumValues.map { it.removeLocation() },
 )
 
 internal fun GQLEnumValueDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     directives = directives.map { it.removeLocation() },
 )
 
 internal fun GQLEnumValue.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
 )
 
 internal fun GQLDirective.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     arguments = arguments.removeArgumentsLocation()
 )
 
 internal fun GQLArgument.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     value = value.removeLocation()
 )
 internal fun GQLDirectiveDefinition.removeLocation(): GQLDirectiveDefinition = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     arguments = arguments.map { it.removeLocation() },
 )
 
 
 private fun GQLInputValueDefinition.removeLocation() = copy(
-    sourceLocation = SourceLocation.UNKNOWN,
+    sourceLocation = null,
     type = type.removeLocation(),
     defaultValue = defaultValue?.removeLocation(),
 )
 
 internal fun GQLType.removeLocation() = when(this) {
-  is GQLNonNullType -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLListType -> copy(sourceLocation = SourceLocation.UNKNOWN)
+  is GQLNonNullType -> copy(sourceLocation = null)
+  is GQLListType -> copy(sourceLocation = null)
   is GQLNamedType -> removeLocation()
 }
 
-internal fun GQLNamedType.removeLocation() = copy(sourceLocation = SourceLocation.UNKNOWN)
+internal fun GQLNamedType.removeLocation() = copy(sourceLocation = null)
 
 internal fun GQLValue.removeLocation() = when (this) {
-  is GQLBooleanValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
+  is GQLBooleanValue -> copy(sourceLocation = null)
   is GQLEnumValue -> removeLocation()
-  is GQLFloatValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLIntValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLListValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLNullValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLObjectValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLStringValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
-  is GQLVariableValue -> copy(sourceLocation = SourceLocation.UNKNOWN)
+  is GQLFloatValue -> copy(sourceLocation = null)
+  is GQLIntValue -> copy(sourceLocation = null)
+  is GQLListValue -> copy(sourceLocation = null)
+  is GQLNullValue -> copy(sourceLocation = null)
+  is GQLObjectValue -> copy(sourceLocation = null)
+  is GQLStringValue -> copy(sourceLocation = null)
+  is GQLVariableValue -> copy(sourceLocation = null)
 }

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/locations.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/locations.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.ast
 
 internal fun GQLDocument.removeLocation(): GQLDocument = copy(
     definitions = definitions.map { it.removeLocation() },
-    filePath = null
+    sourceLocation = null
 )
 
 internal fun GQLDefinition.removeLocation(): GQLDefinition = when(this) {

--- a/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/add_required_fields.kt
+++ b/libraries/apollo-ast/src/main/kotlin/com/apollographql/apollo3/ast/transformation/add_required_fields.kt
@@ -162,7 +162,7 @@ private fun buildField(name: String): GQLField {
       name = name,
       arguments = emptyList(),
       selections = emptyList(),
-      sourceLocation = SourceLocation.UNKNOWN,
+      sourceLocation = null,
       directives = emptyList(),
       alias = null
   )

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
@@ -20,7 +20,7 @@ class ParserTest {
       ab bc
       """.trimIndent()
           .buffer()
-          .parseAsGQLDocument(useAntlr = false)
+          .parseAsGQLDocument()
           .getOrThrow()
       fail("An exception was expected")
     } catch (e: Exception) {
@@ -74,7 +74,7 @@ query Test {
       """
     string.trimIndent()
         .buffer()
-        .parseAsGQLDocument(useAntlr = false)
+        .parseAsGQLDocument()
         .getOrThrow()
         .definitions
         .first()
@@ -82,7 +82,7 @@ query Test {
         .selections
         .first()
         .cast<GQLField>()
-        .sourceLocation
+        .sourceLocation!!
         .apply {
           assertEquals(4, line)
           assertEquals(6, endLine)

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
@@ -1,8 +1,12 @@
 package com.apollographql.apollo3.graphql.ast.test
 
 import com.apollographql.apollo3.ast.GQLField
+import com.apollographql.apollo3.ast.GQLFieldDefinition
+import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
 import com.apollographql.apollo3.ast.GQLOperationDefinition
 import com.apollographql.apollo3.ast.GQLStringValue
+import com.apollographql.apollo3.ast.GQLTypeDefinition
+import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.parseAsGQLValue
@@ -63,7 +67,7 @@ class ParserTest {
 
   @Test
   fun endLineAndColumn() {
-    val string = """
+    """
       # comment before
 query Test {
   # comment here
@@ -71,8 +75,7 @@ query Test {
     first: 100
     )
 }
-      """
-    string.trimIndent()
+      """.trimIndent()
         .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
@@ -88,6 +91,31 @@ query Test {
           assertEquals(6, endLine)
           assertEquals(3, column)
           assertEquals(5, endColumn)
+        }
+  }
+
+  @Test
+  fun endLineAndColumn2() {
+    """
+      type Something { 
+        fieldA: String
+      }
+    """.trimIndent()
+        .buffer()
+        .parseAsGQLDocument()
+        .getOrThrow()
+        .definitions
+        .first()
+        .cast<GQLObjectTypeDefinition>()
+        .fields
+        .first()
+        .cast<GQLFieldDefinition>()
+        .sourceLocation!!
+        .apply {
+          assertEquals(2, line)
+          assertEquals(2, endLine)
+          assertEquals(3, column)
+          assertEquals(16, endColumn)
         }
   }
 }

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/KeyFieldsTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/KeyFieldsTest.kt
@@ -69,7 +69,7 @@ class KeyFieldsTest {
         .let { issue ->
           assertContains(issue.message, "Type 'Foo' cannot have key fields since it implements")
           assertContains(issue.message, "Node")
-          assertEquals(13, issue.sourceLocation.line)
+          assertEquals(13, issue.sourceLocation?.line)
         }
   }
 
@@ -89,7 +89,7 @@ class KeyFieldsTest {
         """.trimIndent(),
               issue.message
           )
-          assertEquals(15, issue.sourceLocation.line)
+          assertEquals(15, issue.sourceLocation?.line)
         }
   }
 

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
@@ -22,6 +22,6 @@ class OperationValidationTest {
     val operationIssues = operations.validateAsExecutable(schema).issues
     assertEquals(1, operationIssues.size)
     assertEquals("Use of deprecated input field `deprecatedParameter`", operationIssues[0].message)
-    assertEquals(SourceLocation(12, 41, null).pretty(), operationIssues[0].sourceLocation.pretty())
+    assertEquals(SourceLocation(12, 41, -1, -1, null).pretty(), operationIssues[0].sourceLocation.pretty())
   }
 }

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
@@ -22,6 +22,6 @@ class OperationValidationTest {
     val operationIssues = operations.validateAsExecutable(schema).issues
     assertEquals(1, operationIssues.size)
     assertEquals("Use of deprecated input field `deprecatedParameter`", operationIssues[0].message)
-    assertEquals(SourceLocation(12, 41, -1, -1, null).pretty(), operationIssues[0].sourceLocation.pretty())
+    assertEquals(SourceLocation(12, 41, -1, -1, null).pretty(), operationIssues[0].sourceLocation?.pretty())
   }
 }

--- a/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
+++ b/libraries/apollo-ast/src/test/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
@@ -3,6 +3,7 @@ package com.apollographql.apollo3.graphql.ast.test.validation
 import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.introspection.toSchema
 import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.validateAsExecutable
 import okio.buffer
 import okio.source
@@ -22,6 +23,6 @@ class OperationValidationTest {
     val operationIssues = operations.validateAsExecutable(schema).issues
     assertEquals(1, operationIssues.size)
     assertEquals("Use of deprecated input field `deprecatedParameter`", operationIssues[0].message)
-    assertEquals(SourceLocation(12, 41, -1, -1, null).pretty(), operationIssues[0].sourceLocation?.pretty())
+    assertEquals(SourceLocation(12, 41, -1, -1, null).pretty(), operationIssues[0].sourceLocation.pretty())
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.ast.GQLScalarTypeDefinition
 import com.apollographql.apollo3.ast.GQLSchemaDefinition
 import com.apollographql.apollo3.ast.GQLTypeDefinition
 import com.apollographql.apollo3.ast.Issue
+import com.apollographql.apollo3.ast.ParserOptions
 import com.apollographql.apollo3.ast.QueryDocumentMinifier
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.checkKeyFields
@@ -86,7 +87,7 @@ object ApolloCompiler {
 
     result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      logger.warning("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
+      logger.warning("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
     }
 
     val schema = result.getOrThrow()
@@ -109,7 +110,7 @@ object ApolloCompiler {
     val definitions = mutableListOf<GQLDefinition>()
     val parseIssues = mutableListOf<Issue>()
     map { file ->
-      val parseResult = file.source().buffer().parseAsGQLDocument(filePath = file.path, useAntlr = useAntlr)
+      val parseResult = file.source().buffer().parseAsGQLDocument(filePath = file.path, options = ParserOptions(useAntlr = useAntlr))
       if (parseResult.issues.isNotEmpty()) {
         parseIssues.addAll(parseResult.issues)
       } else {
@@ -167,7 +168,7 @@ object ApolloCompiler {
 
     warnings.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      options.logger.warning("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
+      options.logger.warning("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
     }
     if (options.failOnWarnings && warnings.isNotEmpty()) {
       throw IllegalStateException("Apollo: Warnings found and 'failOnWarnings' is true, aborting.")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -67,7 +67,7 @@ object ApolloCompiler {
     }
 
     if (mainSchemaDocuments.size > 1) {
-      error("Multiple schemas found:\n${mainSchemaDocuments.map { it.filePath }.joinToString("\n")}\n" +
+      error("Multiple schemas found:\n${mainSchemaDocuments.map { it.sourceLocation?.filePath }.joinToString("\n")}\n" +
           "Use different services for different schemas")
     } else if (mainSchemaDocuments.isEmpty()) {
       error("Schema(s) found:\n${schemaFiles.map { it.absolutePath }.joinToString("\n")}\n" +
@@ -96,7 +96,7 @@ object ApolloCompiler {
     checkScalars(schema, scalarMapping)
     return CodegenSchema(
         schema = schema,
-        packageName = packageNameGenerator.packageName(mainSchemaDocument.filePath!!),
+        packageName = packageNameGenerator.packageName(mainSchemaDocument.sourceLocation?.filePath!!),
         codegenModels = codegenModels,
         scalarMapping = scalarMapping,
         targetLanguage = targetLanguage,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -16,6 +16,7 @@ import com.apollographql.apollo3.ast.checkKeyFields
 import com.apollographql.apollo3.ast.checkNoErrors
 import com.apollographql.apollo3.ast.introspection.toSchemaGQLDocument
 import com.apollographql.apollo3.ast.parseAsGQLDocument
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.transformation.addRequiredFields
 import com.apollographql.apollo3.ast.validateAsExecutable
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
@@ -87,7 +88,7 @@ object ApolloCompiler {
 
     result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      logger.warning("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
+      logger.warning("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
     }
 
     val schema = result.getOrThrow()
@@ -168,7 +169,7 @@ object ApolloCompiler {
 
     warnings.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      options.logger.warning("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
+      options.logger.warning("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
     }
     if (options.failOnWarnings && warnings.isNotEmpty()) {
       throw IllegalStateException("Apollo: Warnings found and 'failOnWarnings' is true, aborting.")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
@@ -56,7 +56,7 @@ class IncomingOptions(
 
       result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
         // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-        println("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
+        println("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
       }
       return result.getOrThrow() to mainSchemaDocument.filePath!!
     }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ast.GQLTypeDefinition
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.introspection.toSchemaGQLDocument
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import java.io.File
 
@@ -56,7 +57,7 @@ class IncomingOptions(
 
       result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
         // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-        println("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
+        println("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
       }
       return result.getOrThrow() to mainSchemaDocument.filePath!!
     }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/IncomingOptions.kt
@@ -36,7 +36,7 @@ class IncomingOptions(
       }
 
       if (mainSchemaDocuments.size > 1) {
-        error("Multiple schemas found:\n${mainSchemaDocuments.map { it.filePath }.joinToString("\n")}\n" +
+        error("Multiple schemas found:\n${mainSchemaDocuments.map { it.sourceLocation?.filePath }.joinToString("\n")}\n" +
             "Use different services for different schemas")
       } else if (mainSchemaDocuments.isEmpty()) {
         error("Schema(s) found:\n${schemaFiles.map { it.absolutePath }.joinToString("\n")}\n" +
@@ -59,7 +59,7 @@ class IncomingOptions(
         // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
         println("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
       }
-      return result.getOrThrow() to mainSchemaDocument.filePath!!
+      return result.getOrThrow() to mainSchemaDocument.sourceLocation?.filePath!!
     }
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkApolloTargetNameClashes.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkApolloTargetNameClashes.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ast.GQLTypeDefinition
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.findTargetName
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout
 
 /**
@@ -36,7 +37,7 @@ internal fun checkApolloTargetNameClashes(schema: Schema): List<Issue> {
       val typeForUsedName = usedNames[name]!!
       issues.add(
           Issue.ReservedEnumValueName(
-              message = "'${targetName}' cannot be used as a target name for '${type.name}' because it clashes with '${typeForUsedName.name}' defined at ${typeForUsedName.sourceLocation?.pretty()}",
+              message = "'${targetName}' cannot be used as a target name for '${type.name}' because it clashes with '${typeForUsedName.name}' defined at ${typeForUsedName.sourceLocation.pretty()}",
               sourceLocation = type.sourceLocation
           )
       )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkApolloTargetNameClashes.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/checkApolloTargetNameClashes.kt
@@ -36,7 +36,7 @@ internal fun checkApolloTargetNameClashes(schema: Schema): List<Issue> {
       val typeForUsedName = usedNames[name]!!
       issues.add(
           Issue.ReservedEnumValueName(
-              message = "'${targetName}' cannot be used as a target name for '${type.name}' because it clashes with '${typeForUsedName.name}' defined at ${typeForUsedName.sourceLocation.pretty()}",
+              message = "'${targetName}' cannot be used as a target name for '${type.name}' because it clashes with '${typeForUsedName.name}' defined at ${typeForUsedName.sourceLocation?.pretty()}",
               sourceLocation = type.sourceLocation
           )
       )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -293,7 +293,7 @@ internal class IrOperationsBuilder(
         variables = variableDefinitions.map { it.toIr() },
         selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selections, typeDefinition.name),
         sourceWithFragments = sourceWithFragments,
-        filePath = sourceLocation.filePath!!,
+        filePath = sourceLocation!!.filePath!!,
         dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
         responseBasedDataModelGroup = responseBasedModelGroup
@@ -325,7 +325,7 @@ internal class IrOperationsBuilder(
     return IrFragmentDefinition(
         name = name,
         description = description,
-        filePath = sourceLocation.filePath!!,
+        filePath = sourceLocation!!.filePath!!,
         typeCondition = typeDefinition.name,
         variables = inferredVariables.map { it.toIr() },
         selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selections, typeCondition.name),

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TestUtils.kt
@@ -117,7 +117,7 @@ internal object TestUtils {
   }
 
   fun List<Issue>.serialize() = joinToString(separator) {
-    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation.line}:${it.sourceLocation.column})\n${it.message}"
+    "${it.severity}: ${it.javaClass.simpleName} (${it.sourceLocation?.line}:${it.sourceLocation?.column})\n${it.message}"
   }
 }
 

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -20,7 +20,7 @@ class ValidationTest(name: String, private val graphQLFile: File) {
   @Test
   fun testValidation() = checkExpected(graphQLFile) { schema ->
     // Don't use absolute path for filePath because it depends on the machine where the test is run
-    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name, useAntlr = false)
+    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
 
     val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
       if (parseResult.issues.isNotEmpty()) {

--- a/libraries/apollo-compiler/src/test/validation/schema/executable-definition.expected
+++ b/libraries/apollo-compiler/src/test/validation/schema/executable-definition.expected
@@ -1,5 +1,5 @@
 ERROR: ValidationError (1:1)
 Found an executable definition. Schemas should only contain type system definitions.
 ------------
-ERROR: ValidationError (-1:-1)
+ERROR: ValidationError (null:null)
 No schema definition and not 'Query' type found

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaExtensions.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaExtensions.kt
@@ -24,7 +24,7 @@ internal fun Iterable<File>.toSchema(logger: Logger): Schema {
 
     result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      logger.warn("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
+      logger.warn("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
     }
 
     result.getOrThrow()

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaExtensions.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/SchemaExtensions.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.ast.GQLDocument
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.introspection.toSchemaGQLDocument
+import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import org.gradle.api.logging.Logger
 import java.io.File
@@ -24,7 +25,7 @@ internal fun Iterable<File>.toSchema(logger: Logger): Schema {
 
     result.issues.filter { it.severity == Issue.Severity.WARNING }.forEach {
       // Using this format, IntelliJ will parse the warning and display it in the 'run' panel
-      logger.warn("w: ${it.sourceLocation?.pretty()}: Apollo: ${it.message}")
+      logger.warn("w: ${it.sourceLocation.pretty()}: Apollo: ${it.message}")
     }
 
     result.getOrThrow()


### PR DESCRIPTION
This PR adds `GQLNode.endLine` and `GQLNode.endColumn`. Also because `SourceLocation` adds some overhead, there is now an option to skip it if it's not going to be used. This means `sourceLocation` became nullable in the whole codebase but this was actually more or less the case because we had `SourceLocation.UNKNOWN` in a bunch of places already

The `endLine`/`endColumn` is inclusive. For this GraphQL document:

```graphql
{
  countries(first: 100) {
    code
  }
}
```

The 'countries" `GQLField` will have (including the selections):

* `line = 2`
* `column = 3`
* `endLine = 4`
* `endColumn = 3`

@mayakoneval would that fit your use case?
