### PR TITLE
[Runtime] throw ApolloNetworkException instead of ApolloParseException on IOException

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -23,10 +23,9 @@ class DefaultApolloException(message: String? = null, cause: Throwable? = null):
  * A network error happened: socket closed, DNS issue, TLS problem, etc...
  *
  * @param message a message indicating what the error was.
- * @param platformCause the underlying cause. Might be null. When not null, it can be cast to:
- * - a [Throwable] on JVM platforms.
- * - a [NSError] on Darwin platforms.
- * to get more details about what went wrong.
+ * @param platformCause the underlying cause to get more details about what went wrong. Might be null. When not null, it can either be:
+ * - a [Throwable].
+ * - or a [NSError] on Darwin platforms.
  */
 class ApolloNetworkException(
     message: String? = null,
@@ -96,6 +95,9 @@ class JsonDataException(message: String) : ApolloException(message)
  */
 class ApolloParseException(message: String? = null, cause: Throwable? = null) : ApolloException(message = message, cause = cause)
 
+/**
+ * The response was successfully parsed but contained errors and partial data was explicitly disabled
+ */
 class ApolloGraphQLException(val errors: List<Error>): ApolloException("GraphQL error(s)")
 
 /**

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
+import okio.EOFException
 import okio.IOException
 import okio.use
 
@@ -106,6 +107,13 @@ private constructor(
       is ApolloException -> {
         // This happens for malformed JSON
         throwable
+      }
+      is EOFException -> {
+        // This happens for premature end of file
+        ApolloParseException(
+            message = "EOFException while parsing the HTTP network response",
+            cause = throwable
+        )
       }
       is IOException -> {
         // This happens when JsonReader returns an IO error

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -110,7 +110,7 @@ private constructor(
       is IOException -> {
         // This happens when JsonReader returns an IO error
         ApolloNetworkException(
-            message = "IOError while parsing the HTTP network response",
+            message = "IOException while parsing the HTTP network response",
             platformCause = throwable
         )
       }


### PR DESCRIPTION
Low hanging fruit, closes https://github.com/apollographql/apollo-kotlin/issues/2783. 