### PR TITLE
Enable build scans again

### DIFF
--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -6,6 +6,7 @@ gradleEnterprise {
   allowUntrustedServer = false
 
   buildScan {
+    publishAlways()
     publishIfAuthenticated()
 
     uploadInBackground = !isCI


### PR DESCRIPTION
Sorry I got confused about the wording but turns out both are required. 

1. is a Build Scan only and determines whether to publish or not
2. is Gradle Enterprise only and adds another condition on top of 1.

This reverts commit 775c1d869f4a85f9e4cd62cfbde4a663a4acc7e6.
