### PR TITLE
Remove golatac

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -4,9 +4,3 @@ buildscript {
   }
 }
 
-plugins {
-  id("net.mbonnin.golatac") version "0.0.3"
-}
-
-golatac.init(file("../gradle/libraries.toml"))
-

--- a/benchmark/microbenchmark/build.gradle.kts
+++ b/benchmark/microbenchmark/build.gradle.kts
@@ -68,10 +68,10 @@ dependencies {
 
 configure<com.android.build.gradle.LibraryExtension> {
   namespace = "com.apollographql.apollo3.benchmark"
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.min").toInt()
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
     testInstrumentationRunner = "androidx.benchmark.junit4.AndroidBenchmarkRunner"
   }
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.samWithReceiver.gradle.SamWithReceiverGradleSubplugi
 plugins {
   `embedded-kotlin`
   id("java-gradle-plugin")
-  id("net.mbonnin.golatac") version "0.0.3"
 }
 
 plugins.apply(SamWithReceiverGradleSubplugin::class.java)
@@ -14,8 +13,6 @@ extensions.configure(SamWithReceiverExtension::class.java) {
 }
 
 group = "com.apollographql.apollo3.build"
-
-golatac.init(file("../gradle/libraries.toml"))
 
 dependencies {
   compileOnly(gradleApi())

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -16,38 +16,38 @@ group = "com.apollographql.apollo3.build"
 
 dependencies {
   compileOnly(gradleApi())
-  compileOnly(golatac.lib("gegp"))
+  compileOnly(libs.gegp)
 
-  implementation(golatac.lib("okhttp"))
+  implementation(libs.okhttp)
 
-  implementation(golatac.lib("kotlinx.benchmark"))
-  implementation(golatac.lib("dokka.plugin"))
-  implementation(golatac.lib("dokka.base"))
+  implementation(libs.kotlinx.benchmark)
+  implementation(libs.dokka.plugin)
+  implementation(libs.dokka.base)
 
   // We add all the plugins to the classpath here so that they are loaded with proper conflict resolution
   // See https://github.com/gradle/gradle/issues/4741
-  implementation(golatac.lib("android.plugin"))
-  implementation(golatac.lib("gradle.japicmp.plugin"))
-  implementation(golatac.lib("vespene"))
-  implementation(golatac.lib("poet.java"))
-  implementation(golatac.lib("poet.kotlin"))
-  implementation(golatac.lib("intellij.plugin"))
-  implementation(golatac.lib("intellij.changelog"))
+  implementation(libs.android.plugin)
+  implementation(libs.gradle.japicmp.plugin)
+  implementation(libs.vespene)
+  implementation(libs.poet.java)
+  implementation(libs.poet.kotlin)
+  implementation(libs.intellij.plugin)
+  implementation(libs.intellij.changelog)
 
   // We want the KSP plugin to use the version from the classpath and not force a newer version
   // of the Gradle plugin
-  implementation(golatac.lib("kotlin.plugin"))
-  runtimeOnly(golatac.lib("ksp"))
+  implementation(libs.kotlin.plugin)
+  runtimeOnly(libs.ksp)
   // XXX: This is only needed for tests. We could have different build logic for different
   // builds but this seems just overkill for now
-  runtimeOnly(golatac.lib("kotlin.allopen"))
-  runtimeOnly(golatac.lib("kotlinx.serialization.plugin"))
+  runtimeOnly(libs.kotlin.allopen)
+  runtimeOnly(libs.kotlinx.serialization.plugin)
 
-  runtimeOnly(golatac.lib("sqldelight.plugin"))
-  runtimeOnly(golatac.lib("gradle.publish.plugin"))
-  runtimeOnly(golatac.lib("benmanes.versions"))
-  runtimeOnly(golatac.lib("gr8"))
-  runtimeOnly(golatac.lib("kotlinx.binarycompatibilityvalidator"))
+  runtimeOnly(libs.sqldelight.plugin)
+  runtimeOnly(libs.gradle.publish.plugin)
+  runtimeOnly(libs.benmanes.versions)
+  runtimeOnly(libs.gr8)
+  runtimeOnly(libs.kotlinx.binarycompatibilityvalidator)
 }
 
 // Keep in sync with CompilerOptions.kt

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -6,5 +6,13 @@ plugins {
 
 rootProject.name = "build-logic"
 
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libraries.toml"))
+    }
+  }
+}
+
 apply(from = "../gradle/repositories.gradle.kts")
 apply(from = "../gradle/ge.gradle")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,7 @@ import JapiCmp.configureJapiCmp
 
 plugins {
   id("apollo.library") apply false
-  id("net.mbonnin.golatac") version "0.0.3"
 }
-
-golatac.init(file("gradle/libraries.toml"))
 
 apply(plugin = "com.github.ben-manes.versions")
 apply(plugin = "org.jetbrains.kotlinx.binary-compatibility-validator")

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,6 @@ org.gradle.caching=true
 # Enable the configuration cache
 org.gradle.unsafe.configuration-cache=true
 
-kotlin.mpp.androidSourceSetLayoutVersion1.nowarn=true
 org.gradle.parallel=true
 
 # See https://kotlinlang.org/docs/whatsnew-eap.html#preview-of-gradle-composite-builds-support-in-kotlin-multiplatform

--- a/libraries/apollo-adapters/build.gradle.kts
+++ b/libraries/apollo-adapters/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
     findByName("commonMain")?.apply {
       dependencies {
         api(project(":apollo-api"))
-        api(golatac.lib("kotlinx.datetime"))
+        api(libs.kotlinx.datetime)
       }
     }
     findByName("jsMain")?.apply {

--- a/libraries/apollo-annotations/build.gradle.kts
+++ b/libraries/apollo-annotations/build.gradle.kts
@@ -12,15 +12,15 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(golatac.lib("kotlin.stdlib"))
-        api(golatac.lib("jetbrains.annotations"))
+        api(libs.kotlin.stdlib)
+        api(libs.jetbrains.annotations)
       }
     }
 
     findByName("jsMain")?.apply {
       dependencies {
         // See https://youtrack.jetbrains.com/issue/KT-53471
-        api(golatac.lib("kotlin.stdlib.js"))
+        api(libs.kotlin.stdlib.js)
       }
     }
   }

--- a/libraries/apollo-api-java/build.gradle.kts
+++ b/libraries/apollo-api-java/build.gradle.kts
@@ -9,6 +9,6 @@ apolloLibrary {
 
 dependencies {
   api(project(":apollo-api"))
-  api(golatac.lib("okhttp"))
-  compileOnly(golatac.lib("guava.jre"))
+  api(libs.okhttp)
+  compileOnly(libs.guava.jre)
 }

--- a/libraries/apollo-api/build.gradle.kts
+++ b/libraries/apollo-api/build.gradle.kts
@@ -12,16 +12,17 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        api(golatac.lib("okio"))
-        api(golatac.lib("uuid"))
+        api(libs.okio)
+        api(libs.uuid)
         api(project(":apollo-annotations"))
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        //implementation(golatac.lib("kotlin.test.junit"))
-        implementation(golatac.lib("kotlin.test"))
+        //implementation(libs.kotlin.test.junit)
+        //implementation("org.jetbrains.kotlin:kotlin-test")
+        implementation(libs.kotlin.test.asProvider().get().toString())
       }
     }
   }

--- a/libraries/apollo-ast/build.gradle.kts
+++ b/libraries/apollo-ast/build.gradle.kts
@@ -21,27 +21,27 @@ kotlin {
   sourceSets {
     getByName("commonMain") {
       dependencies {
-        api(golatac.lib("okio"))
+        api(libs.okio)
         api(project(":apollo-annotations"))
-        implementation(golatac.lib("kotlinx.serialization.json"))
+        implementation(libs.kotlinx.serialization.json)
       }
     }
 
     getByName("jsMain") {
       dependencies {
-        implementation(golatac.lib("okio.nodefilesystem"))
+        implementation(libs.okio.nodefilesystem)
       }
     }
     getByName("jvmMain") {
       dependencies {
-        implementation(golatac.lib("antlr.runtime"))
+        implementation(libs.antlr.runtime)
       }
     }
   }
 }
 
 dependencies {
-  antlr(golatac.lib("antlr"))
+  antlr(libs.antlr)
 }
 
 // Only expose the antlr runtime dependency

--- a/libraries/apollo-cli/build.gradle.kts
+++ b/libraries/apollo-cli/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 dependencies {
   implementation(project(":apollo-tooling"))
   implementation(project(":apollo-annotations"))
-  implementation(golatac.lib("kotlinx.serialization.json"))
-  implementation(golatac.lib("clikt"))
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.clikt)
 }
 
 application {

--- a/libraries/apollo-compiler/build.gradle.kts
+++ b/libraries/apollo-compiler/build.gradle.kts
@@ -12,24 +12,24 @@ apolloLibrary {
 
 dependencies {
   implementation(project(":apollo-ast"))
-  api(golatac.lib("poet.kotlin")) {
+  api(libs.poet.kotlin) {
     // We don't use any of the KotlinPoet kotlin-reflect features
     exclude(module = "kotlin-reflect")
   }
-  api(golatac.lib("poet.java"))
+  api(libs.poet.java)
 
-  implementation(golatac.lib("kotlinx.serialization.json"))
-  implementation(golatac.lib("kotlinx.serialization.json.okio"))
+  implementation(libs.kotlinx.serialization.json)
+  implementation(libs.kotlinx.serialization.json.okio)
 
-  testImplementation(golatac.lib("kotlin.compiletesting"))
-  testImplementation(golatac.lib("google.testing.compile"))
-  testImplementation(golatac.lib("truth"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
-  testImplementation(golatac.lib("google.testparameterinjector"))
+  testImplementation(libs.kotlin.compiletesting)
+  testImplementation(libs.google.testing.compile)
+  testImplementation(libs.truth)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.google.testparameterinjector)
   testImplementation(project(":apollo-api-java")) {
     because("Generated Java code references Java and Guava Optionals")
   }
-  testImplementation(golatac.lib("androidx.annotation")) {
+  testImplementation(libs.androidx.annotation) {
     because("Used in the Java generated code")
   }
 }

--- a/libraries/apollo-compose-paging-support/build.gradle.kts
+++ b/libraries/apollo-compose-paging-support/build.gradle.kts
@@ -12,11 +12,11 @@ dependencies {
 }
 
 android {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.compose.paging.support"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.compose.min").toInt()
+    minSdk = libs.versions.android.sdkversion.compose.min.get().toInt()
   }
 
   buildFeatures {
@@ -24,7 +24,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = golatac.version("compose.compiler")
+    kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
   }
 
   // TODO: compiling fails only with the debug variant currently, due to using a version of Kotlin non supported by Compose.

--- a/libraries/apollo-compose-support/build.gradle.kts
+++ b/libraries/apollo-compose-support/build.gradle.kts
@@ -7,17 +7,17 @@ plugins {
 }
 
 dependencies {
-  api(golatac.lib("compose-runtime"))
+  api(libs.compose.runtime)
   api(project(":apollo-runtime"))
   api(project(":apollo-normalized-cache"))
 }
 
 android {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.compose.support"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.compose.min").toInt()
+    minSdk = libs.versions.android.sdkversion.compose.min.get().toInt()
   }
 
   buildFeatures {
@@ -25,7 +25,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = golatac.version("compose.compiler")
+    kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
   }
 }
 

--- a/libraries/apollo-gradle-plugin-external/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin-external/build.gradle.kts
@@ -10,9 +10,9 @@ apolloLibrary {
 }
 
 dependencies {
-  compileOnly(golatac.lib("gradle.api.min"))
-  compileOnly(golatac.lib("kotlin.plugin.min"))
-  compileOnly(golatac.lib("android.plugin.min"))
+  compileOnly(libs.gradle.api.min)
+  compileOnly(libs.kotlin.plugin.min)
+  compileOnly(libs.android.plugin.min)
 
   api(project(":apollo-compiler"))
   implementation(project(":apollo-tooling"))

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -29,11 +29,11 @@ dependencies {
   add("shade", project(":apollo-gradle-plugin-external"))
 
   testImplementation(project(":apollo-ast"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("truth"))
-  testImplementation(golatac.lib("assertj"))
-  testImplementation(golatac.lib("okhttp.mockwebserver"))
-  testImplementation(golatac.lib("okhttp.tls"))
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  testImplementation(libs.assertj)
+  testImplementation(libs.okhttp.mockwebserver)
+  testImplementation(libs.okhttp.tls)
 }
 
 if (relocateJar) {

--- a/libraries/apollo-http-cache/build.gradle.kts
+++ b/libraries/apollo-http-cache/build.gradle.kts
@@ -8,13 +8,13 @@ apolloLibrary {
 }
 
 dependencies {
-  api(golatac.lib("okhttp"))
+  api(libs.okhttp)
   api(project(":apollo-api"))
   api(project(":apollo-runtime"))
-  implementation(golatac.lib("moshi"))
-  implementation(golatac.lib("kotlinx.datetime"))
+  implementation(libs.moshi)
+  implementation(libs.kotlinx.datetime)
 
   testImplementation(project(":apollo-mockserver"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
-  testImplementation(golatac.lib("truth"))
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.truth)
 }

--- a/libraries/apollo-idling-resource/build.gradle.kts
+++ b/libraries/apollo-idling-resource/build.gradle.kts
@@ -5,15 +5,15 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("androidx.espresso.idlingresource"))
+  implementation(libs.androidx.espresso.idlingresource)
   api(project(":apollo-runtime"))
 }
 
 android {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.idling.resource"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.min").toInt()
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
   }
 }

--- a/libraries/apollo-mockserver/build.gradle.kts
+++ b/libraries/apollo-mockserver/build.gradle.kts
@@ -15,17 +15,17 @@ kotlin {
     findByName("commonMain")?.apply {
       dependencies {
         api(project(":apollo-annotations"))
-        api(golatac.lib("okio"))
-        implementation(golatac.lib("atomicfu")) {
+        api(libs.okio)
+        implementation(libs.atomicfu.get().toString()) {
           because("We need locks for native (we don't use the gradle plugin rewrite)")
         }
-        api(golatac.lib("kotlinx.coroutines"))
+        api(libs.kotlinx.coroutines)
       }
     }
 
     findByName("jsMain")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlinx.nodejs"))
+        implementation(libs.kotlinx.nodejs)
       }
     }
 

--- a/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
       dependencies {
         api(project(":apollo-api"))
         api(project(":apollo-mpp-utils"))
-        implementation(golatac.lib("okio"))
-        api(golatac.lib("uuid"))
+        implementation(libs.okio)
+        api(libs.uuid)
       }
     }
   }

--- a/libraries/apollo-normalized-cache-api/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-api/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
       dependencies {
         api(project(":apollo-api"))
         api(project(":apollo-mpp-utils"))
-        implementation(golatac.lib("okio"))
-        api(golatac.lib("uuid"))
+        implementation(libs.okio)
+        api(libs.uuid)
       }
     }
   }

--- a/libraries/apollo-normalized-cache-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-incubating/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
       dependencies {
         api(project(":apollo-runtime"))
         api(project(":apollo-normalized-cache-api-incubating"))
-        api(golatac.lib("kotlinx.coroutines"))
-        implementation(golatac.lib("atomicfu")) {
+        api(libs.kotlinx.coroutines)
+        implementation(libs.atomicfu.get().toString()) {
           because("Use of ReentrantLock in DefaultApolloStore for Apple (we don't use the gradle plugin rewrite)")
         }
       }

--- a/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/build.gradle.kts
@@ -44,39 +44,39 @@ kotlin {
         api(project(":apollo-api"))
         api(project(":apollo-normalized-cache-api-incubating"))
         api(project(":apollo-normalized-cache-incubating"))
-        api(golatac.lib("sqldelight.runtime"))
+        api(libs.sqldelight.runtime)
       }
     }
 
     findByName("jvmMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.jvm"))
+        implementation(libs.sqldelight.jvm)
       }
     }
 
     findByName("appleMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.native"))
+        implementation(libs.sqldelight.native)
       }
     }
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("truth"))
+        implementation(libs.truth)
       }
     }
 
     findByName("androidMain")?.apply {
       dependencies {
-        api(golatac.lib("androidx.sqlite"))
-        implementation(golatac.lib("sqldelight.android"))
-        implementation(golatac.lib("androidx.sqlite.framework"))
-        implementation(golatac.lib("androidx.startup.runtime"))
+        api(libs.androidx.sqlite)
+        implementation(libs.sqldelight.android)
+        implementation(libs.androidx.sqlite.framework)
+        implementation(libs.androidx.startup.runtime)
       }
     }
     findByName("androidTest")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlin.test.junit"))
+        implementation(libs.kotlin.test.junit)
       }
     }
     findByName("commonTest")?.apply {
@@ -88,11 +88,11 @@ kotlin {
 }
 
 configure<com.android.build.gradle.LibraryExtension> {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.cache.normalized.sql"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.min").toInt()
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
   }
 }
 

--- a/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-sqlite/build.gradle.kts
@@ -36,34 +36,34 @@ kotlin {
 
     findByName("jvmMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.jvm"))
+        implementation(libs.sqldelight.jvm)
       }
     }
 
     findByName("appleMain")?.apply {
       dependencies {
-        implementation(golatac.lib("sqldelight.native"))
+        implementation(libs.sqldelight.native)
       }
     }
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("truth"))
+        implementation(libs.truth)
       }
     }
 
     findByName("androidMain")?.apply {
       dependencies {
-        api(golatac.lib("androidx.sqlite"))
-        implementation(golatac.lib("sqldelight.android"))
-        implementation(golatac.lib("androidx.sqlite.framework"))
-        implementation(golatac.lib("androidx.startup.runtime"))
+        api(libs.androidx.sqlite)
+        implementation(libs.sqldelight.android)
+        implementation(libs.androidx.sqlite.framework)
+        implementation(libs.androidx.startup.runtime)
       }
     }
 
     findByName("androidTest")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlin.test.junit"))
+        implementation(libs.kotlin.test.junit)
       }
     }
 
@@ -76,11 +76,11 @@ kotlin {
 }
 
 configure<com.android.build.gradle.LibraryExtension> {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.cache.normalized.sql"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.min").toInt()
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
   }
 }
 

--- a/libraries/apollo-normalized-cache/build.gradle.kts
+++ b/libraries/apollo-normalized-cache/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
       dependencies {
         api(project(":apollo-runtime"))
         api(project(":apollo-normalized-cache-api"))
-        api(golatac.lib("kotlinx.coroutines"))
-        implementation(golatac.lib("atomicfu")) {
+        api(libs.kotlinx.coroutines)
+        implementation(libs.atomicfu.get().toString()) {
           because("Use of ReentrantLock in DefaultApolloStore for Apple (we don't use the gradle plugin rewrite)")
         }
       }

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -16,9 +16,9 @@ kotlin {
       dependencies {
         api(project(":apollo-api"))
         api(project(":apollo-mpp-utils"))
-        api(golatac.lib("okio"))
-        api(golatac.lib("uuid"))
-        api(golatac.lib("kotlinx.coroutines"))
+        api(libs.okio)
+        api(libs.uuid)
+        api(libs.kotlinx.coroutines)
       }
     }
 
@@ -38,13 +38,13 @@ kotlin {
 
     findByName("jvmMain")?.apply {
       dependencies {
-        api(golatac.lib("okhttp"))
+        api(libs.okhttp)
       }
     }
 
     findByName("jsMain")?.apply {
       dependencies {
-        api(golatac.lib("ktor.client.js"))
+        api(libs.ktor.client.js)
       }
     }
 
@@ -55,9 +55,9 @@ kotlin {
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlin.test.junit"))
-        implementation(golatac.lib("truth"))
-        implementation(golatac.lib("okhttp"))
+        implementation(libs.kotlin.test.junit)
+        implementation(libs.truth)
+        implementation(libs.okhttp)
       }
     }
   }

--- a/libraries/apollo-rx2-support-java/build.gradle.kts
+++ b/libraries/apollo-rx2-support-java/build.gradle.kts
@@ -8,6 +8,6 @@ apolloLibrary {
 }
 
 dependencies {
-  api(golatac.lib("rx.java2"))
+  api(libs.rx.java2)
   api(project(":apollo-runtime-java"))
 }

--- a/libraries/apollo-rx2-support/build.gradle.kts
+++ b/libraries/apollo-rx2-support/build.gradle.kts
@@ -9,8 +9,8 @@ apolloLibrary {
 
 dependencies {
   implementation(project(":apollo-api"))
-  api(golatac.lib("rx.java2"))
-  api(golatac.lib("kotlinx.coroutines.rx2"))
+  api(libs.rx.java2)
+  api(libs.kotlinx.coroutines.rx2)
 
   api(project(":apollo-runtime"))
   api(project(":apollo-normalized-cache"))

--- a/libraries/apollo-rx3-support-java/build.gradle.kts
+++ b/libraries/apollo-rx3-support-java/build.gradle.kts
@@ -11,6 +11,6 @@ apolloLibrary {
 }
 
 dependencies {
-  api(golatac.lib("rx.java3"))
+  api(libs.rx.java3)
   api(project(":apollo-runtime-java"))
 }

--- a/libraries/apollo-rx3-support/build.gradle.kts
+++ b/libraries/apollo-rx3-support/build.gradle.kts
@@ -12,8 +12,8 @@ apolloLibrary {
 
 dependencies {
   implementation(project(":apollo-api"))
-  api(golatac.lib("rx.java3"))
-  api(golatac.lib("kotlinx.coroutines.rx3"))
+  api(libs.rx.java3)
+  api(libs.kotlinx.coroutines.rx3)
 
   api(project(":apollo-runtime"))
   api(project(":apollo-normalized-cache"))

--- a/libraries/apollo-testing-support/build.gradle.kts
+++ b/libraries/apollo-testing-support/build.gradle.kts
@@ -16,30 +16,30 @@ kotlin {
         api(project(":apollo-api"))
         api(project(":apollo-runtime"))
         api(project(":apollo-mockserver"))
-        api(golatac.lib("kotlinx.coroutines"))
-        implementation(golatac.lib("atomicfu")) {
+        api(libs.kotlinx.coroutines)
+        implementation(libs.atomicfu.get().toString()) {
           because("We need locks in TestNetworkTransportHandler (we don't use the gradle plugin rewrite)")
         }
-        implementation(golatac.lib("kotlinx.coroutines.test"))
+        implementation(libs.kotlinx.coroutines.test)
       }
     }
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("truth"))
+        implementation(libs.truth)
       }
     }
 
     findByName("jsMain")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlinx.nodejs"))
-        implementation(golatac.lib("kotlin.test.js"))
-        api(golatac.lib("okio.nodefilesystem"))
+        implementation(libs.kotlinx.nodejs)
+        implementation(libs.kotlin.test.js)
+        api(libs.okio.nodefilesystem)
       }
     }
     findByName("jsTest")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlin.test.js"))
+        implementation(libs.kotlin.test.js)
       }
     }
   }

--- a/libraries/apollo-tooling/build.gradle.kts
+++ b/libraries/apollo-tooling/build.gradle.kts
@@ -14,14 +14,14 @@ dependencies {
   }
 
   implementation(project(":apollo-ast"))
-  implementation(golatac.lib("apollo-runtime-published"))
-  implementation(golatac.lib("okhttp"))
-  implementation(golatac.lib("kotlinx.serialization.json"))
+  implementation(libs.apollo.runtime.published)
+  implementation(libs.okhttp)
+  implementation(libs.kotlinx.serialization.json)
 
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("truth"))
-  testImplementation(golatac.lib("apollo-mockserver-published"))
-  testImplementation(golatac.lib("apollo-testingsupport-published"))
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
+  testImplementation(libs.apollo.mockserver.published)
+  testImplementation(libs.apollo.testingsupport.published)
 }
 
 apollo {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,13 @@ rootProject.projectDir
 
 include(":intellij-plugin")
 
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("gradle/libraries.toml"))
+    }
+  }
+}
 
 apply(from = "./gradle/repositories.gradle.kts")
 apply(from = "./gradle/ge.gradle")

--- a/tests/ast-benchmark/build.gradle.kts
+++ b/tests/ast-benchmark/build.gradle.kts
@@ -14,9 +14,9 @@ benchmark {
 
 dependencies {
   implementation("com.apollographql.apollo3:apollo-ast")
-  implementation(golatac.lib("graphql.java"))
+  implementation(libs.graphql.java)
   implementation("org.jetbrains.kotlin:kotlin-test")
 
-  add("jmhImplementation", golatac.lib("kotlinx.benchmark.runtime"))
+  add("jmhImplementation", libs.kotlinx.benchmark.runtime)
   add("jmhImplementation", sourceSets.main.get().output + sourceSets.main.get().runtimeClasspath)
 }

--- a/tests/browser-tests/build.gradle.kts
+++ b/tests/browser-tests/build.gradle.kts
@@ -16,8 +16,8 @@ kotlin {
   sourceSets {
     val commonTest by getting {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("kotlinx.coroutines.test"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.kotlinx.coroutines.test)
       }
     }
   }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,9 +1,7 @@
 plugins {
   id("apollo.test") apply false
-  id("net.mbonnin.golatac") version "0.0.3"
 }
 
-golatac.init(file("../gradle/libraries.toml"))
 
 rootProject.configureNode()
 

--- a/tests/compiler-hooks/build.gradle.kts
+++ b/tests/compiler-hooks/build.gradle.kts
@@ -22,10 +22,10 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("kotlin.reflect"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.kotlin.reflect)
 }
 
 apollo {

--- a/tests/data-builders-java/build.gradle.kts
+++ b/tests/data-builders-java/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation("com.apollographql.apollo3:apollo-runtime")
-  testImplementation(golatac.lib("junit"))
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/defer/build.gradle.kts
+++ b/tests/defer/build.gradle.kts
@@ -19,15 +19,15 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("apollo.normalizedcache"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.apollo.normalizedcache)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.mockserver"))
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.mockserver)
+        implementation(libs.apollo.testingsupport)
       }
     }
 
@@ -45,7 +45,7 @@ kotlin {
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.httpCache"))
+        implementation(libs.apollo.httpCache)
       }
     }
   }

--- a/tests/deprecated-requires-opt-in/build.gradle.kts
+++ b/tests/deprecated-requires-opt-in/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 /**

--- a/tests/enums/build.gradle.kts
+++ b/tests/enums/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/escaping/build.gradle.kts
+++ b/tests/escaping/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/filesystem-sensitivity/build.gradle.kts
+++ b/tests/filesystem-sensitivity/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  implementation(libs.apollo.api)
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/gzip/build.gradle.kts
+++ b/tests/gzip/build.gradle.kts
@@ -14,13 +14,13 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
   }

--- a/tests/http-cache/build.gradle.kts
+++ b/tests/http-cache/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.httpCache"))
-  implementation(golatac.lib("apollo.mockserver"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.httpCache)
+  implementation(libs.apollo.mockserver)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.apollo.testingsupport)
 }
 
 apollo {

--- a/tests/idling-resource/build.gradle.kts
+++ b/tests/idling-resource/build.gradle.kts
@@ -6,20 +6,20 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("androidx.espresso.idlingresource"))
-  implementation(golatac.lib("apollo.idlingresource"))
-  testImplementation(golatac.lib("apollo.mockserver"))
-  testImplementation(golatac.lib("android.support.annotations"))
-  testImplementation(golatac.lib("android.test.runner"))
+  implementation(libs.androidx.espresso.idlingresource)
+  implementation(libs.apollo.idlingresource)
+  testImplementation(libs.apollo.mockserver)
+  testImplementation(libs.android.support.annotations)
+  testImplementation(libs.android.test.runner)
 }
 
 android {
-  compileSdk = golatac.version("android.sdkversion.compile").toInt()
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
   namespace = "com.apollographql.apollo3.idling.resource.test"
 
   defaultConfig {
-    minSdk = golatac.version("android.sdkversion.min").toInt()
-    targetSdk = golatac.version("android.sdkversion.target").toInt()
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
+    targetSdk = libs.versions.android.sdkversion.target.get().toInt()
   }
 }
 

--- a/tests/include-skip-operation-based/build.gradle.kts
+++ b/tests/include-skip-operation-based/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.httpCache"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  implementation(golatac.lib("apollo.mockserver"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.httpCache)
+  implementation(libs.apollo.normalizedcache)
+  implementation(libs.apollo.mockserver)
+  testImplementation(libs.kotlin.test.junit)
+  testImplementation(libs.apollo.testingsupport)
 }
 
 apollo {

--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -19,36 +19,34 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.api"))
-        implementation(golatac.lib("apollo.normalizedcache"))
-        implementation(golatac.lib("apollo.testingsupport"))
-        implementation(golatac.lib("apollo.mockserver"))
-        implementation(golatac.lib("apollo.adapters"))
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.api)
+        implementation(libs.apollo.normalizedcache)
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.mockserver)
+        implementation(libs.apollo.adapters)
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("kotlinx.coroutines"))
-        implementation(golatac.lib("kotlinx.serialization.json").toString()) {
-          because("OperationOutputTest uses it to check the json and we can't use moshi since it's mpp code")
-        }
-        implementation(golatac.lib("kotlinx.coroutines.test"))
-        implementation(golatac.lib("turbine"))
+        implementation(libs.kotlinx.coroutines)
+        implementation(libs.kotlinx.serialization.json.asProvider())
+        implementation(libs.kotlinx.coroutines.test)
+        implementation(libs.turbine)
       }
     }
 
     findByName("javaCodegenTest")?.apply {
       dependencies {
         // Add test-junit manually because configureMppTestsDefaults did not do it for us
-        implementation(golatac.lib("kotlin.test.junit"))
+        implementation(libs.kotlin.test.junit)
       }
     }
 
     findByName("jvmTest")?.apply {
       dependencies {
-        implementation(golatac.lib("okhttp.logging"))
+        implementation(libs.okhttp.logging)
       }
     }
   }

--- a/tests/ios-test/build.gradle.kts
+++ b/tests/ios-test/build.gradle.kts
@@ -16,14 +16,14 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("apollo.mockserver"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.apollo.mockserver)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
   }

--- a/tests/java-client/build.gradle.kts
+++ b/tests/java-client/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime.java"))
-  implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("apollo.rx3.java"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("truth"))
+  implementation(libs.apollo.runtime.java)
+  implementation(libs.apollo.mockserver)
+  implementation(libs.apollo.rx3.java)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
   testImplementation(project(":sample-server"))
 }
 

--- a/tests/java-nullability/build.gradle.kts
+++ b/tests/java-nullability/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api.java"))
-  implementation(golatac.lib("guava.jre"))
-  implementation(golatac.lib("androidx.annotation"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.api.java)
+  implementation(libs.guava.jre)
+  implementation(libs.androidx.annotation)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/java-tests/build.gradle.kts
+++ b/tests/java-tests/build.gradle.kts
@@ -5,14 +5,14 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.httpCache"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  implementation(golatac.lib("apollo.normalizedcache.sqlite"))
-  implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("apollo.rx2"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("truth"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.httpCache)
+  implementation(libs.apollo.normalizedcache)
+  implementation(libs.apollo.normalizedcache.sqlite)
+  implementation(libs.apollo.mockserver)
+  implementation(libs.apollo.rx2)
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }
 
 apollo {

--- a/tests/jpms/build.gradle.kts
+++ b/tests/jpms/build.gradle.kts
@@ -6,10 +6,10 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.rx2"))
-  implementation(golatac.lib("apollo.normalizedcache.sqlite"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.rx2)
+  implementation(libs.apollo.normalizedcache.sqlite)
+  testImplementation(libs.junit)
 }
 
 application {

--- a/tests/js/build.gradle.kts
+++ b/tests/js/build.gradle.kts
@@ -15,13 +15,13 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
   }

--- a/tests/jsexport/build.gradle.kts
+++ b/tests/jsexport/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin {
 
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 

--- a/tests/jvmoverloads/build.gradle.kts
+++ b/tests/jvmoverloads/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/kotlin-codegen/build.gradle.kts
+++ b/tests/kotlin-codegen/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  implementation(libs.apollo.api)
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/model-builders-java/build.gradle.kts
+++ b/tests/model-builders-java/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   implementation("com.apollographql.apollo3:apollo-runtime")
-  testImplementation(golatac.lib("junit"))
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/models-operation-based-with-interfaces/build.gradle.kts
+++ b/tests/models-operation-based-with-interfaces/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.normalizedcache"))
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.adapters"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
+  implementation(libs.apollo.normalizedcache)
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.adapters)
+  testImplementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/models-operation-based/build.gradle.kts
+++ b/tests/models-operation-based/build.gradle.kts
@@ -21,22 +21,22 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("apollo.normalizedcache"))
-        implementation(golatac.lib("apollo.adapters"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.apollo.normalizedcache)
+        implementation(libs.apollo.adapters)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
 
     findByName("javaCodegenTest")?.apply {
       dependencies {
         // Add test-junit manually because configureMppTestsDefaults did not do it for us
-        implementation(golatac.lib("kotlin.test.junit"))
+        implementation(libs.kotlin.test.junit)
       }
     }
   }

--- a/tests/models-response-based/build.gradle.kts
+++ b/tests/models-response-based/build.gradle.kts
@@ -12,15 +12,15 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("apollo.normalizedcache"))
-        implementation(golatac.lib("apollo.adapters"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.apollo.normalizedcache)
+        implementation(libs.apollo.adapters)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
   }

--- a/tests/multi-module-1/child/build.gradle.kts
+++ b/tests/multi-module-1/child/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
   implementation(project(":multi-module-1:root"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/multi-module-1/file-path/build.gradle.kts
+++ b/tests/multi-module-1/file-path/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
   implementation(project(":multi-module-1:root"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/multi-module-1/root/build.gradle.kts
+++ b/tests/multi-module-1/root/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
 }
 
 apollo {

--- a/tests/multi-module-2/child/build.gradle.kts
+++ b/tests/multi-module-2/child/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
   implementation(project(":multi-module-2:root"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/multi-module-2/root/build.gradle.kts
+++ b/tests/multi-module-2/root/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api"))
+  implementation(libs.apollo.api)
 }
 
 apollo {

--- a/tests/multi-module-3/child/build.gradle.kts
+++ b/tests/multi-module-3/child/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
   implementation(project(":multi-module-3:root"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/multi-module-3/root/build.gradle.kts
+++ b/tests/multi-module-3/root/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api"))
+  implementation(libs.apollo.api)
 }
 
 apollo {

--- a/tests/multipart/build.gradle.kts
+++ b/tests/multipart/build.gradle.kts
@@ -12,13 +12,13 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
+        implementation(libs.apollo.testingsupport)
       }
     }
   }

--- a/tests/native-benchmarks/build.gradle.kts
+++ b/tests/native-benchmarks/build.gradle.kts
@@ -15,16 +15,16 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
-        implementation(golatac.lib("apollo.normalizedcache"))
+        implementation(libs.apollo.runtime)
+        implementation(libs.apollo.normalizedcache)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
-        implementation(golatac.lib("apollo.mockserver"))
-        implementation(golatac.lib("apollo.mpputils"))
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.mockserver)
+        implementation(libs.apollo.mpputils)
       }
     }
   }

--- a/tests/no-query-document/build.gradle.kts
+++ b/tests/no-query-document/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.mockserver)
+  implementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/no-runtime/build.gradle.kts
+++ b/tests/no-runtime/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.api"))
+  implementation(libs.apollo.api)
   implementation(project(":sample-server"))
-  implementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("okhttp"))
+  implementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.okhttp)
 }
 
 apollo {

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  implementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.mockserver)
+  implementation(libs.apollo.normalizedcache)
+  implementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/optimistic-data/build.gradle.kts
+++ b/tests/optimistic-data/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("turbine"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.normalizedcache)
+  testImplementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.turbine)
 }
 
 apollo {

--- a/tests/optional-variables/build.gradle.kts
+++ b/tests/optional-variables/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/outofbounds/build.gradle.kts
+++ b/tests/outofbounds/build.gradle.kts
@@ -5,9 +5,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/pagination/build.gradle.kts
+++ b/tests/pagination/build.gradle.kts
@@ -14,16 +14,16 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("atomicfu"))
-        implementation(golatac.lib("apollo.testingsupport"))
-        implementation(golatac.lib("apollo.normalizedcache.incubating"))
-        implementation(golatac.lib("apollo.normalizedcache.sqlite.incubating"))
+        implementation(libs.atomicfu)
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.normalizedcache.incubating)
+        implementation(libs.apollo.normalizedcache.sqlite.incubating)
       }
     }
   }

--- a/tests/runtime/build.gradle.kts
+++ b/tests/runtime/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
+  implementation(libs.apollo.runtime)
   implementation(project(":sample-server"))
-  implementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("okhttp"))
+  implementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.okhttp)
 }
 
 apollo {

--- a/tests/rxjava/build.gradle.kts
+++ b/tests/rxjava/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  implementation(golatac.lib("apollo.mockserver"))
-  implementation(golatac.lib("apollo.rx2"))
-  testImplementation(golatac.lib("kotlin.test.junit"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.normalizedcache)
+  implementation(libs.apollo.mockserver)
+  implementation(libs.apollo.rx2)
+  testImplementation(libs.kotlin.test.junit)
 }
 
 apollo {

--- a/tests/sample-server/build.gradle.kts
+++ b/tests/sample-server/build.gradle.kts
@@ -6,15 +6,15 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("graphqlkotlin"))
-  implementation(golatac.lib("kotlin.reflect")) {
+  implementation(libs.graphqlkotlin)
+  implementation(libs.kotlin.reflect) {
     because("graphqlKotlin pull kotlin-reflect and that triggers a warning like" +
         "Runtime JAR files in the classpath should have the same version.")
   }
-  implementation(golatac.lib("kotlinx.coroutines.reactor")) {
+  implementation(libs.kotlinx.coroutines.reactor) {
     because("reactor must have the same version as the coroutines version")
   }
-  compileOnly(golatac.lib("apollo.annotations")) {
+  compileOnly(libs.apollo.annotations) {
     because("""
       We unconditionally opt-in ApolloExperimental in all the tests and we need the symbol in the 
       classpath to prevent a warning

--- a/tests/scalar-adapters/build.gradle.kts
+++ b/tests/scalar-adapters/build.gradle.kts
@@ -5,10 +5,10 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.adapters"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.adapters)
+  testImplementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/schema-changes/build.gradle.kts
+++ b/tests/schema-changes/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.normalizedcache"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("turbine"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.normalizedcache)
+  testImplementation(libs.apollo.testingsupport)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.turbine)
 }
 
 apollo {

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -28,8 +28,13 @@ includeBuild("../") {
   name = "apollo-kotlin"
 }
 
-
-
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("../gradle/libraries.toml"))
+    }
+  }
+}
 
 apply(from = "./gradle/repositories.gradle.kts")
 apply(from = "./gradle/ge.gradle")

--- a/tests/sqlite/build.gradle.kts
+++ b/tests/sqlite/build.gradle.kts
@@ -14,15 +14,15 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
-        implementation(golatac.lib("apollo.normalizedcache.incubating"))
-        implementation(golatac.lib("apollo.normalizedcache.sqlite.incubating"))
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.normalizedcache.incubating)
+        implementation(libs.apollo.normalizedcache.sqlite.incubating)
       }
     }
   }

--- a/tests/termination/build.gradle.kts
+++ b/tests/termination/build.gradle.kts
@@ -6,9 +6,9 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
+  implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
 }
 
 apollo {

--- a/tests/test-network-transport/build.gradle.kts
+++ b/tests/test-network-transport/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-  implementation(golatac.lib("apollo.runtime"))
-  implementation(golatac.lib("apollo.mockserver"))
-  testImplementation(golatac.lib("kotlin.test"))
-  testImplementation(golatac.lib("junit"))
-  testImplementation(golatac.lib("turbine"))
-  testImplementation(golatac.lib("apollo.testingsupport"))
+  implementation(libs.apollo.runtime)
+  implementation(libs.apollo.mockserver)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.turbine)
+  testImplementation(libs.apollo.testingsupport)
 }
 
 apollo {

--- a/tests/websockets/build.gradle.kts
+++ b/tests/websockets/build.gradle.kts
@@ -12,15 +12,15 @@ kotlin {
   sourceSets {
     findByName("commonMain")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.runtime"))
+        implementation(libs.apollo.runtime)
       }
     }
 
     findByName("commonTest")?.apply {
       dependencies {
-        implementation(golatac.lib("apollo.testingsupport"))
-        implementation(golatac.lib("apollo.normalizedcache"))
-        implementation(golatac.lib("turbine"))
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.normalizedcache)
+        implementation(libs.turbine)
       }
     }
 


### PR DESCRIPTION
Now that we have an optimized build, re-enable version catalog accessors, see if we still have those out-of-date issues in the composite builds.

