### PR TITLE
Fix another configuration cache issue with Dokka

### DIFF
--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -52,6 +52,7 @@ fun Project.configureDokka() {
   tasks.withType(DokkaTaskPartial::class.java).configureEach {
     //https://github.com/Kotlin/dokka/issues/1455
     dependsOn("assemble")
+    notCompatibleWithConfigurationCache("See https://github.com/Kotlin/dokka/issues/1217")
   }
 
   tasks.withType(AbstractDokkaTask::class.java).configureEach {


### PR DESCRIPTION
The `deploy` job uses a different Dokka task which also isn't compatible with the configuration cache (https://github.com/apollographql/apollo-kotlin/actions/runs/5517526470/jobs/10060265195#step:5:2993)