### PR TITLE
Fix defer with router tests

### DIFF
--- a/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -50,7 +50,7 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
   }.listen()
 
   override suspend fun url() = url ?: suspendCoroutine { cont ->
-    url = "http://localhost:${server.address().unsafeCast<AddressInfo>().port}/"
+    url = "http://127.0.0.1:${server.address().unsafeCast<AddressInfo>().port}/"
     server.on("listening") { _ ->
       cont.resume(url!!)
     }

--- a/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
@@ -40,7 +40,7 @@ class DeferWithRouterTest {
   private fun setUp() {
     apolloClient = ApolloClient.Builder()
         .httpEngine(getStreamingHttpEngine())
-        .serverUrl("http://localhost:4000/")
+        .serverUrl("http://127.0.0.1:4000/")
         .build()
   }
 


### PR DESCRIPTION
[Sometimes](https://github.com/apollographql/apollo-kotlin/actions/runs/5538687166/jobs/10118285481#step:8:330), but not always, `localhost` can't be resolved by node - I don't know why.
This only happens with a recent version of node (recently changed by [this change](https://github.com/apollographql/apollo-kotlin/pull/5090/files?w=1#diff-131d3dcf6023f5c7633513f53d03510c711d3a4f4e3f44f1a1237554e8f505dfL29)), and I could only reproduce with the defer with router tests, but not with the other tests which also use `localhost` from `MockServer.url()` - but I changed it there too just in case, and to please the nodejs gods.