### PR TITLE
[IJ plugin] v3 -> v4 migration: deprecations/renames

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/Refactoring.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/Refactoring.kt
@@ -68,7 +68,10 @@ fun findMethodReferences(
 
 fun findFieldReferences(project: Project, className: String, fieldName: String): Collection<PsiReference> {
   val psiLookupClass = JavaPsiFacade.getInstance(project).findClass(className, GlobalSearchScope.allScope(project)) ?: return emptyList()
-  val field = psiLookupClass.findFieldByName(fieldName, true) ?: return emptyList()
+  val field = psiLookupClass.findFieldByName(fieldName, true)
+      // Fallback to methods as in Kotlin, properties with getters are compiled as Java methods
+      ?: psiLookupClass.findMethodsByName(fieldName, true).firstOrNull()
+      ?: return emptyList()
   val processor = RenamePsiElementProcessor.forElement(field)
   return processor.findReferences(field, GlobalSearchScope.projectScope(project), false)
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/Refactoring.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/Refactoring.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiMigration
 import com.intellij.psi.PsiPackage
 import com.intellij.psi.PsiReference
@@ -49,16 +50,17 @@ fun findMethodReferences(
     className: String,
     methodName: String,
     extensionTargetClassName: String? = null,
+    methodPredicate: (PsiMethod) -> Boolean = { true },
 ): Collection<PsiReference> {
   val psiLookupClass = JavaPsiFacade.getInstance(project).findClass(className, GlobalSearchScope.allScope(project)) ?: return emptyList()
   val methods = psiLookupClass.findMethodsByName(methodName, false)
       .filter { method ->
-        if (extensionTargetClassName == null) return@filter true
+        if (extensionTargetClassName == null) return@filter methodPredicate(method)
         // In Kotlin extensions, the target is passed to the first parameter
         if (method.parameterList.parametersCount < 1) return@filter false
         val firstParameter = method.parameterList.parameters.first()
         val firstParameterType = (firstParameter.type as? PsiClassType)?.rawType()?.canonicalText
-        firstParameterType == extensionTargetClassName
+        firstParameterType == extensionTargetClassName && methodPredicate(method)
       }
   return methods.flatMap { method ->
     val processor = RenamePsiElementProcessor.forElement(method)
@@ -69,7 +71,7 @@ fun findMethodReferences(
 fun findFieldReferences(project: Project, className: String, fieldName: String): Collection<PsiReference> {
   val psiLookupClass = JavaPsiFacade.getInstance(project).findClass(className, GlobalSearchScope.allScope(project)) ?: return emptyList()
   val field = psiLookupClass.findFieldByName(fieldName, true)
-      // Fallback to methods as in Kotlin, properties with getters are compiled as Java methods
+  // Fallback to methods as in Kotlin, properties with getters are compiled as Java methods
       ?: psiLookupClass.findMethodsByName(fieldName, true).firstOrNull()
       ?: return emptyList()
   val processor = RenamePsiElementProcessor.forElement(field)

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/item/UpdateFieldName.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/item/UpdateFieldName.kt
@@ -9,15 +9,14 @@ import org.jetbrains.kotlin.psi.KtPsiFactory
 class UpdateFieldName(
     private val className: String,
     private val oldFieldName: String,
-    private val newFieldName: String,
-    private val isMethodCall: Boolean = false,
+    private val replacementExpression: String,
 ) : MigrationItem() {
   override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
     return findFieldReferences(project = project, className = className, fieldName = oldFieldName).toMigrationItemUsageInfo()
   }
 
   override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
-    val newFieldReference = KtPsiFactory(project).createExpression(if (isMethodCall) "$newFieldName()" else newFieldName)
+    val newFieldReference = KtPsiFactory(project).createExpression(replacementExpression)
     usage.element.replace(newFieldReference)
   }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/item/UpdateFieldName.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/item/UpdateFieldName.kt
@@ -10,13 +10,14 @@ class UpdateFieldName(
     private val className: String,
     private val oldFieldName: String,
     private val newFieldName: String,
+    private val isMethodCall: Boolean = false,
 ) : MigrationItem() {
   override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
     return findFieldReferences(project = project, className = className, fieldName = oldFieldName).toMigrationItemUsageInfo()
   }
 
   override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
-    val newFieldReference = KtPsiFactory(project).createExpression(newFieldName)
+    val newFieldReference = KtPsiFactory(project).createExpression(if (isMethodCall) "$newFieldName()" else newFieldName)
     usage.element.replace(newFieldReference)
   }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -24,7 +24,9 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
 
   override val migrationItems = listOf(
       // Deprecations / renames
-      UpdateFieldName("$apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow", isMethodCall = true),
+      UpdateFieldName("$apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow()"),
+      UpdateFieldName("$apollo3.exception.ApolloCompositeException", "first", "suppressedExceptions.first()"),
+      UpdateFieldName("$apollo3.exception.ApolloCompositeException", "second", "suppressedExceptions.getOrNull(1)"),
       UpdateMethodName("$apollo3.ast.GQLResult", "valueAssertNoErrors", "getOrThrow"),
       RemoveMethodCall("$apollo3.cache.normalized.NormalizedCache", "emitCacheMisses", extensionTargetClassName = "$apollo3.api.MutableExecutionOptions"),
       RemoveWatchMethodArguments(),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -10,6 +10,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDepende
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradlePluginInBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.ReplaceExecuteCacheAndNetwork
 import com.intellij.openapi.project.Project
 
 private const val apollo4LatestVersion = "4.0.0-alpha.2"
@@ -29,7 +30,8 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateFieldName("$apollo3.exception.ApolloCompositeException", "second", "suppressedExceptions.getOrNull(1)"),
       UpdateMethodName("$apollo3.ast.GQLResult", "valueAssertNoErrors", "getOrThrow"),
       RemoveMethodCall("$apollo3.cache.normalized.NormalizedCache", "emitCacheMisses", extensionTargetClassName = "$apollo3.api.MutableExecutionOptions"),
-      RemoveWatchMethodArguments(),
+      RemoveWatchMethodArguments,
+      ReplaceExecuteCacheAndNetwork,
 
       // Gradle
       UpdateGradlePluginInBuildKts(apollo3, apollo3, apollo4LatestVersion),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -3,10 +3,13 @@ package com.apollographql.ijplugin.refactoring.migration.v3tov4
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.refactoring.migration.ApolloMigrationRefactoringProcessor
 import com.apollographql.ijplugin.refactoring.migration.apollo3
+import com.apollographql.ijplugin.refactoring.migration.item.RemoveMethodCall
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateFieldName
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesInToml
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradlePluginInBuildKts
+import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
 import com.intellij.openapi.project.Project
 
 private const val apollo4LatestVersion = "4.0.0-alpha.2"
@@ -21,8 +24,10 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
 
   override val migrationItems = listOf(
       // Deprecations / renames
-      UpdateFieldName("com.apollographql.apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow", isMethodCall = true),
-
+      UpdateFieldName("$apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow", isMethodCall = true),
+      UpdateMethodName("$apollo3.ast.GQLResult", "valueAssertNoErrors", "getOrThrow"),
+      RemoveMethodCall("$apollo3.cache.normalized.NormalizedCache", "emitCacheMisses", extensionTargetClassName = "$apollo3.api.MutableExecutionOptions"),
+      RemoveWatchMethodArguments(),
 
       // Gradle
       UpdateGradlePluginInBuildKts(apollo3, apollo3, apollo4LatestVersion),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -4,6 +4,7 @@ import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.refactoring.migration.ApolloMigrationRefactoringProcessor
 import com.apollographql.ijplugin.refactoring.migration.apollo3
 import com.apollographql.ijplugin.refactoring.migration.item.RemoveMethodCall
+import com.apollographql.ijplugin.refactoring.migration.item.UpdateClassName
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateFieldName
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesInToml
@@ -28,6 +29,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateFieldName("$apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow()"),
       UpdateFieldName("$apollo3.exception.ApolloCompositeException", "first", "suppressedExceptions.first()"),
       UpdateFieldName("$apollo3.exception.ApolloCompositeException", "second", "suppressedExceptions.getOrNull(1)"),
+      UpdateClassName("$apollo3.exception.ApolloCompositeException", "$apollo3.exception.ApolloException"),
       UpdateMethodName("$apollo3.ast.GQLResult", "valueAssertNoErrors", "getOrThrow"),
       RemoveMethodCall("$apollo3.cache.normalized.NormalizedCache", "emitCacheMisses", extensionTargetClassName = "$apollo3.api.MutableExecutionOptions"),
       RemoveWatchMethodArguments,

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -3,6 +3,7 @@ package com.apollographql.ijplugin.refactoring.migration.v3tov4
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.refactoring.migration.ApolloMigrationRefactoringProcessor
 import com.apollographql.ijplugin.refactoring.migration.apollo3
+import com.apollographql.ijplugin.refactoring.migration.item.UpdateFieldName
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesInToml
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradlePluginInBuildKts
@@ -19,6 +20,10 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
   override val noUsageMessage = ApolloBundle.message("ApolloV3ToV4MigrationProcessor.noUsage")
 
   override val migrationItems = listOf(
+      // Deprecations / renames
+      UpdateFieldName("com.apollographql.apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow", isMethodCall = true),
+
+
       // Gradle
       UpdateGradlePluginInBuildKts(apollo3, apollo3, apollo4LatestVersion),
       UpdateGradleDependenciesInToml(apollo3, apollo3, apollo4LatestVersion),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/RemoveWatchMethodArguments.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/RemoveWatchMethodArguments.kt
@@ -1,0 +1,39 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.ijplugin.refactoring.findMethodReferences
+import com.apollographql.ijplugin.refactoring.migration.apollo3
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.parentOfType
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtImportDirective
+
+open class RemoveWatchMethodArguments : MigrationItem() {
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    return findMethodReferences(
+        project = project,
+        className = "$apollo3.cache.normalized.NormalizedCache",
+        methodName = "watch",
+        extensionTargetClassName = "$apollo3.ApolloCall",
+    ) { method -> method.parameterList.parameters.any { it.name == "fetchThrows" } }
+        .toMigrationItemUsageInfo()
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    val element = usage.element
+    val importDirective = element.parentOfType<KtImportDirective>()
+    if (importDirective != null) {
+      // Reference is an import
+      return
+    }
+    val methodCall = element.parentOfType<KtCallExpression>() ?: return
+    val valueArgumentList = methodCall.valueArgumentList ?: return
+    repeat(valueArgumentList.arguments.size) {
+      valueArgumentList.removeArgument(0)
+    }
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/ReplaceExecuteCacheAndNetwork.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/ReplaceExecuteCacheAndNetwork.kt
@@ -9,31 +9,29 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiMigration
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.parentOfType
-import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtPsiFactory
 
-object RemoveWatchMethodArguments : MigrationItem() {
+object ReplaceExecuteCacheAndNetwork : MigrationItem() {
   override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
     return findMethodReferences(
         project = project,
         className = "$apollo3.cache.normalized.NormalizedCache",
-        methodName = "watch",
-        extensionTargetClassName = "$apollo3.ApolloCall",
-    ) { method -> method.parameterList.parameters.any { it.name == "fetchThrows" } }
-        .toMigrationItemUsageInfo()
+        methodName = "executeCacheAndNetwork",
+        extensionTargetClassName = "$apollo3.ApolloCall"
+    ).toMigrationItemUsageInfo()
   }
 
   override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
-    val element = usage.element
+   val element = usage.element
     val importDirective = element.parentOfType<KtImportDirective>()
     if (importDirective != null) {
       // Reference is an import
       return
     }
-    val methodCall = element.parentOfType<KtCallExpression>() ?: return
-    val valueArgumentList = methodCall.valueArgumentList ?: return
-    repeat(valueArgumentList.arguments.size) {
-      valueArgumentList.removeArgument(0)
-    }
+    element.parentOfType<KtDotQualifiedExpression>()?.selectorExpression?.replace(KtPsiFactory(project).createExpression("fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()"))
   }
+
+  override fun importsToAdd() = setOf("$apollo3.cache.normalized.fetchPolicy", "$apollo3.cache.normalized.FetchPolicy")
 }

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
@@ -11,8 +11,11 @@ import org.junit.runners.JUnit4
 @RunWith(JUnit4::class)
 class ApolloV3ToV4MigrationTest : ApolloTestCase() {
   override val mavenLibraries = listOf(
-      "com.apollographql.apollo3:apollo-api:3.8.2",
-      "com.apollographql.apollo3:apollo-runtime:3.8.2",
+      "com.apollographql.apollo3:apollo-annotations-jvm:3.8.2",
+      "com.apollographql.apollo3:apollo-api-jvm:3.8.2",
+      "com.apollographql.apollo3:apollo-mpp-utils-jvm:3.8.2",
+      "com.apollographql.apollo3:apollo-runtime-jvm:3.8.2",
+      "com.apollographql.apollo3:apollo-normalized-cache-jvm:3.8.2",
   )
 
   override fun getTestDataPath() = "src/test/testData/migration/v3-to-v4"
@@ -25,6 +28,9 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
 
   @Test
   fun testUpdateGradleDependenciesInLibsVersionsToml() = runMigration(extension = "versions.toml", fileNameInProject = "libs.versions.toml")
+
+  @Test
+  fun deprecations() = runMigration()
 
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.emitCacheMisses
 import com.apollographql.apollo3.cache.normalized.watch
+import com.apollographql.apollo3.exception.ApolloCompositeException
 
 suspend fun test() {
   val response: ApolloResponse<*>? = null
@@ -20,4 +21,8 @@ suspend fun test() {
   apolloClient!!.query(query!!).watch(fetchThrows = true, refetchThrows = false)
   apolloClient!!.query(query!!).watch(fetchThrows = true)
   apolloClient!!.query(query!!).watch()
+
+  val compositeException: ApolloCompositeException? = null
+  println(compositeException!!.first)
+  println(compositeException!!.second)
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
@@ -1,0 +1,23 @@
+package com.example.myapplication
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Query
+import com.apollographql.apollo3.cache.normalized.emitCacheMisses
+import com.apollographql.apollo3.cache.normalized.watch
+
+suspend fun test() {
+  val response: ApolloResponse<*>? = null
+  println(response?.dataAssertNoErrors)
+
+  val apolloClient: ApolloClient? = null
+  val query: Query<*>? = null
+
+  apolloClient!!.query(query!!).emitCacheMisses(true).toFlow()
+
+  apolloClient!!.query(query!!).watch(true, false)
+  apolloClient!!.query(query!!).watch(true)
+  apolloClient!!.query(query!!).watch(fetchThrows = true, refetchThrows = false)
+  apolloClient!!.query(query!!).watch(fetchThrows = true)
+  apolloClient!!.query(query!!).watch()
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.emitCacheMisses
+import com.apollographql.apollo3.cache.normalized.executeCacheAndNetwork
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloCompositeException
 
@@ -25,4 +26,6 @@ suspend fun test() {
   val compositeException: ApolloCompositeException? = null
   println(compositeException!!.first)
   println(compositeException!!.second)
+
+  apolloClient!!.query(query!!).executeCacheAndNetwork()
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.watch
-import com.apollographql.apollo3.exception.ApolloCompositeException
+import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 
@@ -23,7 +23,7 @@ suspend fun test() {
   apolloClient!!.query(query!!).watch()
   apolloClient!!.query(query!!).watch()
 
-  val compositeException: ApolloCompositeException? = null
+  val compositeException: ApolloException? = null
   println(compositeException!!.suppressedExceptions.first())
   println(compositeException!!.suppressedExceptions.getOrNull(1))
 

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
@@ -5,6 +5,8 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloCompositeException
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 
 suspend fun test() {
   val response: ApolloResponse<*>? = null
@@ -24,4 +26,6 @@ suspend fun test() {
   val compositeException: ApolloCompositeException? = null
   println(compositeException!!.suppressedExceptions.first())
   println(compositeException!!.suppressedExceptions.getOrNull(1))
+
+  apolloClient!!.query(query!!).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.watch
+import com.apollographql.apollo3.exception.ApolloCompositeException
 
 suspend fun test() {
   val response: ApolloResponse<*>? = null
@@ -19,4 +20,8 @@ suspend fun test() {
   apolloClient!!.query(query!!).watch()
   apolloClient!!.query(query!!).watch()
   apolloClient!!.query(query!!).watch()
+
+  val compositeException: ApolloCompositeException? = null
+  println(compositeException!!.suppressedExceptions.first())
+  println(compositeException!!.suppressedExceptions.getOrNull(1))
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
@@ -1,0 +1,22 @@
+package com.example.myapplication
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Query
+import com.apollographql.apollo3.cache.normalized.watch
+
+suspend fun test() {
+  val response: ApolloResponse<*>? = null
+  println(response?.dataOrThrow())
+
+  val apolloClient: ApolloClient? = null
+  val query: Query<*>? = null
+
+  apolloClient!!.query(query!!).toFlow()
+
+  apolloClient!!.query(query!!).watch()
+  apolloClient!!.query(query!!).watch()
+  apolloClient!!.query(query!!).watch()
+  apolloClient!!.query(query!!).watch()
+  apolloClient!!.query(query!!).watch()
+}


### PR DESCRIPTION
A few symbols that have been renamed or replaced by something else. There may be a few more coming next.