### PR TITLE
apollo-ast: fix column of block strings

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/Lexer.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/Lexer.kt
@@ -332,6 +332,7 @@ internal class Lexer(val src: String) {
   private fun readBlockString(): Token {
     val start = pos - 3 // because of """
     val startLine = line
+    val startColumn = column(start)
     val blockLines = mutableListOf<String>()
     val currentLine = StringBuilder()
 
@@ -383,7 +384,7 @@ internal class Lexer(val src: String) {
 
             return Token.String(
                 startLine,
-                column(start),
+                startColumn,
                 line,
                 column(pos - 1),
                 blockLines.dedentBlockStringLines().joinToString("\n")

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/Parser.kt
@@ -48,10 +48,8 @@ import com.apollographql.apollo3.ast.GQLValue
 import com.apollographql.apollo3.ast.GQLVariableDefinition
 import com.apollographql.apollo3.ast.GQLVariableValue
 import com.apollographql.apollo3.ast.SourceLocation
-import okio.BufferedSource
-import okio.Closeable
 
-internal class Parser(src: String, val withSourceLocation: Boolean, val filePath: String?) {
+internal class Parser(src: String, private val withSourceLocation: Boolean, val filePath: String?) {
   private val lexer = Lexer(src)
   private var token = lexer.nextToken()
   private var lastToken = token
@@ -292,8 +290,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     return expectToken<Token.Name>().value
   }
 
-  private fun parseOperationDefinition(): GQLOperationDefinition {
-    val start = token
+  private fun parseOperationDefinition(start: Token): GQLOperationDefinition {
     val description = expectOptionalToken<Token.String>()?.value
 
     if (peek<Token.LeftBrace>()) {
@@ -384,8 +381,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     )
   }
 
-  private fun parseSchemaDefinition(): GQLSchemaDefinition {
-    val start = token
+  private fun parseSchemaDefinition(start: Token): GQLSchemaDefinition {
     val description = parseDescription()
 
     expectKeyword("schema")
@@ -422,8 +418,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     )
   }
 
-  private fun parseScalarTypeDefinition(): GQLScalarTypeDefinition {
-    val start = token
+  private fun parseScalarTypeDefinition(start: Token): GQLScalarTypeDefinition {
     val description = parseDescription()
     expectKeyword("scalar")
     val name = parseName()
@@ -479,8 +474,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     return parseNonEmptyListOrNull<Token.LeftBrace, Token.RightBrace, GQLFieldDefinition>(::parseFieldDefinition).orEmpty()
   }
 
-  private fun parseObjectTypeDefinition(): GQLTypeDefinition {
-    val start = token
+  private fun parseObjectTypeDefinition(start: Token): GQLTypeDefinition {
     val description = parseDescription()
     this.expectKeyword("type")
     val name = parseName()
@@ -520,8 +514,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     )
   }
 
-  private fun parseInterfaceTypeDefinition(): GQLInterfaceTypeDefinition {
-    val start = token
+  private fun parseInterfaceTypeDefinition(start: Token): GQLInterfaceTypeDefinition {
     val description = parseDescription()
     expectKeyword("interface")
     val name = parseName()
@@ -561,8 +554,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     )
   }
 
-  private fun parseUnionTypeDefinition(): GQLUnionTypeDefinition {
-    val start = token
+  private fun parseUnionTypeDefinition(start: Token): GQLUnionTypeDefinition {
     val description = parseDescription()
     expectKeyword("union")
     val name = parseName()
@@ -606,8 +598,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     }
   }
 
-  private fun parseInputObjectTypeDefinition(): GQLInputObjectTypeDefinition {
-    val start = token
+  private fun parseInputObjectTypeDefinition(start: Token): GQLInputObjectTypeDefinition {
     val description = parseDescription()
     expectKeyword("input")
     val name = parseName()
@@ -647,8 +638,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     return parseNonEmptyListOrNull<Token.LeftBrace, Token.RightBrace, GQLInputValueDefinition>(::parseInputValueDefinition).orEmpty()
   }
 
-  private fun parseEnumTypeDefinition(): GQLEnumTypeDefinition {
-    val start = token
+  private fun parseEnumTypeDefinition(start: Token): GQLEnumTypeDefinition {
     val description = parseDescription()
     expectKeyword("enum")
     val name = parseName()
@@ -717,8 +707,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     return name
   }
 
-  private fun parseDirectiveDefinition(): GQLDirectiveDefinition {
-    val start = token
+  private fun parseDirectiveDefinition(start: Token): GQLDirectiveDefinition {
     val description = parseDescription()
     expectKeyword("directive")
     expectToken<Token.At>()
@@ -758,27 +747,27 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
   }
 
   private fun parseDefinition(): GQLDefinition {
-
+    val start = token
     val hasDescription = peek<Token.String>()
     val t = if (hasDescription) lookaheadToken() else token
 
     return when (t) {
-      is Token.LeftBrace -> parseOperationDefinition()
+      is Token.LeftBrace -> parseOperationDefinition(start)
       is Token.Name -> {
         if (t.value == "extend" && hasDescription) {
           throw ParserException("Type system extensions cannot have a description", t)
         }
         when (t.value) {
-          "schema" -> parseSchemaDefinition()
-          "scalar" -> parseScalarTypeDefinition()
-          "type" -> parseObjectTypeDefinition()
-          "interface" -> parseInterfaceTypeDefinition()
-          "union" -> parseUnionTypeDefinition()
-          "enum" -> parseEnumTypeDefinition()
-          "input" -> parseInputObjectTypeDefinition()
-          "directive" -> parseDirectiveDefinition()
-          "query", "mutation", "subscription" -> parseOperationDefinition()
-          "fragment" -> parseFragmentDefinition()
+          "schema" -> parseSchemaDefinition(start)
+          "scalar" -> parseScalarTypeDefinition(start)
+          "type" -> parseObjectTypeDefinition(start)
+          "interface" -> parseInterfaceTypeDefinition(start)
+          "union" -> parseUnionTypeDefinition(start)
+          "enum" -> parseEnumTypeDefinition(start)
+          "input" -> parseInputObjectTypeDefinition(start)
+          "directive" -> parseDirectiveDefinition(start)
+          "query", "mutation", "subscription" -> parseOperationDefinition(start)
+          "fragment" -> parseFragmentDefinition(start)
           "extend" -> parseTypeSystemExtension()
           else -> unexpected(t)
         }
@@ -788,8 +777,7 @@ internal class Parser(src: String, val withSourceLocation: Boolean, val filePath
     }
   }
 
-  private fun parseFragmentDefinition(): GQLFragmentDefinition {
-    val start = token
+  private fun parseFragmentDefinition(start: Token): GQLFragmentDefinition {
     val description = parseDescription()
     expectKeyword("fragment")
     val name = parseFragmentName()

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/LexerTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/LexerTest.kt
@@ -631,4 +631,23 @@ class LexerTest {
       assertEquals(6, column)
     }
   }
+
+  @Test
+  fun blockStringColumn() {
+    val currentVariantSdl = """
+	""${'"'}
+	Directive description
+	""${'"'}
+	directive @someDirective(
+	    ""${'"'}Argument desedcription""${'"'}
+		arg1: String @deprecated(reason: "directive on argument")
+	) repeatable on ENUM | SCHEMA
+	type Query { fieldA: String }
+""".trimIndent()
+
+    Lexer(currentVariantSdl).apply {
+      nextToken()
+      assertEquals(1, nextToken().column)
+    }
+  }
 }


### PR DESCRIPTION
The first column was computed against the last line of the block string