### PR TITLE
More Apollo AST APIs

### DIFF
--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -1,4 +1,28 @@
 public final class com/apollographql/apollo3/ast/ApolloParser {
+	public static final fun parseAsGQLDocument (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLDocument (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLDocument (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLDocument$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLDocument$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLDocument$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLSelections (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLSelections (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLSelections (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLSelections$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLSelections$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLSelections$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLType (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLType (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLType (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLType$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLType$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLType$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLValue (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLValue (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun parseAsGQLValue (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLValue$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLValue$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static synthetic fun parseAsGQLValue$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 }
 
 public final class com/apollographql/apollo3/ast/Check_key_fieldsKt {

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -5,24 +5,13 @@ public final class com/apollographql/apollo3/ast/ApolloParser {
 	public static synthetic fun parseAsGQLDocument$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static synthetic fun parseAsGQLDocument$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static synthetic fun parseAsGQLDocument$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLSelections (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static final fun parseAsGQLSelections (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLSelections (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLSelections$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static synthetic fun parseAsGQLSelections$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLSelections$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLType (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static final fun parseAsGQLType (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLType (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLType$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static synthetic fun parseAsGQLType$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLType$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLValue (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static final fun parseAsGQLValue (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static final fun parseAsGQLValue (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLValue$default (Ljava/io/File;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
 	public static synthetic fun parseAsGQLValue$default (Ljava/lang/String;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
-	public static synthetic fun parseAsGQLValue$default (Lokio/Path;Lcom/apollographql/apollo3/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo3/ast/GQLResult;
+	public static final fun toSchema (Ljava/lang/String;)Lcom/apollographql/apollo3/ast/Schema;
 }
 
 public final class com/apollographql/apollo3/ast/Check_key_fieldsKt {

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -217,7 +217,7 @@ class Schema internal constructor(
     @ApolloInternal
     fun fromMap(map: Map<String, Any>): Schema {
       return Schema(
-          definitions = Buffer().writeUtf8(map["sdl"] as String).parseAsGQLDocument().getOrThrow().definitions,
+          definitions = (map["sdl"] as String).parseAsGQLDocument().getOrThrow().definitions,
           keyFields = (map["keyFields"]!! as Map<String, Collection<String>>).mapValues { it.value.toSet() },
           foreignNames = map["foreignNames"]!! as Map<String, String>,
           directivesToStrip = map["directivesToStrip"]!! as List<String>,

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/api.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/api.kt
@@ -27,7 +27,6 @@ import kotlin.jvm.JvmName
 @ApolloExperimental
 fun BufferedSource.toSchema(filePath: String? = null): Schema = parseAsGQLDocument(filePath).getOrThrow().validateAsSchema().getOrThrow()
 
-@ApolloExperimental
 fun String.toSchema(): Schema = parseAsGQLDocument().getOrThrow().validateAsSchema().getOrThrow()
 
 /**
@@ -139,15 +138,6 @@ fun String.parseAsGQLSelections(options: ParserOptions = ParserOptions.Default):
 
 fun Path.parseAsGQLDocument(options: ParserOptions = ParserOptions.Default): GQLResult<GQLDocument> {
   return HOST_FILESYSTEM.source(this).buffer().parseAsGQLDocument(filePath = toString(), options = options)
-}
-fun Path.parseAsGQLValue(options: ParserOptions = ParserOptions.Default): GQLResult<GQLValue> {
-  return HOST_FILESYSTEM.source(this).buffer().parseAsGQLValue(filePath = toString(), options = options)
-}
-fun Path.parseAsGQLType(options: ParserOptions = ParserOptions.Default): GQLResult<GQLType> {
-  return HOST_FILESYSTEM.source(this).buffer().parseAsGQLType(filePath = toString(), options = options)
-}
-fun Path.parseAsGQLSelections(options: ParserOptions = ParserOptions.Default): GQLResult<List<GQLSelection>> {
-  return HOST_FILESYSTEM.source(this).buffer().parseAsGQLSelections(filePath = toString(), options = options)
 }
 
 /**

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -43,8 +43,8 @@ fun apolloDefinitions(version: String): List<GQLDefinition> {
 }
 
 private fun definitionsFromString(string: String): List<GQLDefinition> {
-  return Buffer().writeUtf8(string)
-      .parseAsGQLDocument(null)
+  return string
+      .parseAsGQLDocument()
       .getOrThrow()
       .definitions
 }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqltypedefinition.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqltypedefinition.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.ast
 
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.ast.Schema.Companion.NONNULL
-import com.apollographql.apollo3.ast.internal.buffer
 
 // 5.5.2.3 Fragment spread is possible
 internal fun GQLTypeDefinition.sharesPossibleTypesWith(other: GQLTypeDefinition, schema: Schema): Boolean {
@@ -27,7 +26,7 @@ fun GQLTypeDefinition.isFieldNonNull(fieldName: String, schema: Schema? = null):
 
   val stringValue = (directive.arguments.first().value as GQLStringValue).value
 
-  val selections = stringValue.buffer().parseAsGQLSelections().getOrThrow()
+  val selections = stringValue.parseAsGQLSelections().getOrThrow()
 
   return selections.filterIsInstance<GQLField>()
       .map { it.name }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -502,7 +502,7 @@ private fun List<GQLDirective>.extractFields(argumentName: String): Set<String> 
 
     val selectionSet = (value as? GQLStringValue)?.value ?: return@flatMap emptyList()
 
-    selectionSet.buffer().parseAsGQLSelections().getOrThrow().map { gqlSelection ->
+    selectionSet.parseAsGQLSelections().getOrThrow().map { gqlSelection ->
       // No need to check here, this should be done during validation
       (gqlSelection as GQLField).name
     }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
@@ -37,7 +37,6 @@ import com.apollographql.apollo3.ast.findDeprecationReason
 import com.apollographql.apollo3.ast.isVariableUsageAllowed
 import com.apollographql.apollo3.ast.parseAsGQLSelections
 import com.apollographql.apollo3.ast.pretty
-import okio.Buffer
 
 interface IssuesScope {
   val issues: MutableList<Issue>
@@ -186,7 +185,7 @@ internal fun ValidationScope.extraValidateNonNullDirective(directive: GQLDirecti
     )
     val stringValue = (directive.arguments.first().value as GQLStringValue).value
 
-    val selections = stringValue.buffer().parseAsGQLSelections().getOrThrow()
+    val selections = stringValue.parseAsGQLSelections().getOrThrow()
 
     val badSelection = selections.firstOrNull { it !is GQLField }
     check(badSelection == null) {
@@ -207,7 +206,7 @@ internal fun ValidationScope.extraValidateNonNullDirective(directive: GQLDirecti
  * Extra Apollo-specific validation for @typePolicy
  */
 internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDirective) {
-  (directive.arguments.first().value as GQLStringValue).value.buffer().parseAsGQLSelections().getOrThrow().forEach {
+  (directive.arguments.first().value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach {
     if (it !is GQLField) {
       registerIssue("Fragments are not supported in @$TYPE_POLICY directives", it.sourceLocation)
     } else if (it.selections.isNotEmpty()) {
@@ -215,8 +214,6 @@ internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDire
     }
   }
 }
-
-internal fun String.buffer() = Buffer().writeUtf8(this)
 
 private fun ValidationScope.validateArgument(
     argument: GQLArgument,

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.kt
@@ -32,16 +32,13 @@ import com.apollographql.apollo3.ast.GQLStringValue
 import com.apollographql.apollo3.ast.GQLType
 import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.GQLValue
-import com.apollographql.apollo3.ast.HOST_FILESYSTEM
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.SourceLocation
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.parseAsGQLValue
-import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.validateAsSchema
 import okio.Buffer
 import okio.Path
-import okio.buffer
 import kotlin.jvm.JvmMultifileClass
 import kotlin.jvm.JvmName
 
@@ -344,7 +341,7 @@ fun Path.toSchemaGQLDocument(): GQLDocument {
   return if (name.endsWith("json")) {
     toIntrospectionSchema().toGQLDocument(filePath = name)
   } else {
-    HOST_FILESYSTEM.source(this).buffer().parseAsGQLDocument(this.toString()).getOrThrow()
+    parseAsGQLDocument().getOrThrow()
   }
 }
 

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
@@ -5,9 +5,6 @@ import com.apollographql.apollo3.ast.GQLFieldDefinition
 import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
 import com.apollographql.apollo3.ast.GQLOperationDefinition
 import com.apollographql.apollo3.ast.GQLStringValue
-import com.apollographql.apollo3.ast.GQLTypeDefinition
-import com.apollographql.apollo3.ast.SourceLocation
-import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.parseAsGQLValue
 import kotlin.test.Test
@@ -23,7 +20,6 @@ class ParserTest {
       query Test { field }
       ab bc
       """.trimIndent()
-          .buffer()
           .parseAsGQLDocument()
           .getOrThrow()
       fail("An exception was expected")
@@ -39,14 +35,13 @@ class ParserTest {
       query Test { field }
       # comment after
       """.trimIndent()
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
   }
 
   @Test
   fun blockString() {
-    val value = "\"\"\" \\\"\"\" \"\"\"".buffer().parseAsGQLValue().getOrThrow()
+    val value = "\"\"\" \\\"\"\" \"\"\"".parseAsGQLValue().getOrThrow()
 
     assertEquals(" \"\"\" ", (value as GQLStringValue).value)
   }
@@ -58,7 +53,7 @@ class ParserTest {
         "   \n" +
         "  second line\n" +
         "   \n" +
-        "\"\"\"").buffer().parseAsGQLValue().getOrThrow()
+        "\"\"\"").parseAsGQLValue().getOrThrow()
 
     assertEquals("first line\n \nsecond line", (value as GQLStringValue).value)
   }
@@ -76,7 +71,6 @@ query Test {
     )
 }
       """.trimIndent()
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .definitions
@@ -101,7 +95,6 @@ query Test {
         fieldA: String
       }
     """.trimIndent()
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .definitions

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.graphql.ast.test
 
 import com.apollographql.apollo3.ast.SDLWriter
 import com.apollographql.apollo3.ast.Schema
-import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.toUtf8
@@ -44,7 +43,7 @@ class SDLWriterTest {
 
     """.trimIndent()
 
-    val schema: Schema = schemaString.buffer().toSchema()
+    val schema: Schema = schemaString.toSchema()
     val writerBuffer = Buffer()
     val sdlWriter = SDLWriter(writerBuffer, "    ")
     sdlWriter.write(schema.toGQLDocument())
@@ -107,11 +106,11 @@ class SDLWriterTest {
       
     """.trimIndent()
 
-    val expected = Buffer().writeUtf8(schemaString).parseAsGQLDocument().getOrThrow()
+    val expected = schemaString.parseAsGQLDocument().getOrThrow()
 
     val serialized = expected.toUtf8()
 
-    Buffer().writeUtf8(serialized).parseAsGQLDocument().getOrThrow()
+    serialized.parseAsGQLDocument().getOrThrow()
     // Enable when we have hashCode and equals on GQLNode
     //assertEquals(expected.removeLocation(), actual.removeLocation())
   }

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SchemaTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SchemaTest.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.graphql.ast.test
 
-import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.toSchema
 import kotlin.test.Test
 
@@ -19,6 +18,6 @@ class SchemaTest {
       }
     """.trimIndent()
 
-    schemaString.buffer().toSchema()
+    schemaString.toSchema()
   }
 }

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/TransformTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/TransformTest.kt
@@ -3,7 +3,6 @@ package com.apollographql.apollo3.graphql.ast.test
 import com.apollographql.apollo3.ast.GQLField
 import com.apollographql.apollo3.ast.GQLIntValue
 import com.apollographql.apollo3.ast.TransformResult
-import com.apollographql.apollo3.ast.internal.buffer
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toUtf8
 import com.apollographql.apollo3.ast.transform
@@ -23,7 +22,7 @@ class TransformTest {
 
   @Test
   fun stripFieldsWithDirective() {
-    val document = query.buffer().parseAsGQLDocument().getOrThrow()
+    val document = query.parseAsGQLDocument().getOrThrow()
 
     val currentVersion = 4
     val transformed = document.transform {
@@ -78,7 +77,7 @@ class TransformTest {
       }
     """.trimIndent()
 
-    val transformed = query.buffer().parseAsGQLDocument().getOrThrow().transform {
+    val transformed = query.parseAsGQLDocument().getOrThrow().transform {
       if (it is GQLField && it.name == "objectType") {
         val newField = GQLField(
             alias = null,

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/KeyFieldsTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/KeyFieldsTest.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.graphql.ast.test.keyfields
 
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLOperationDefinition
-import com.apollographql.apollo3.ast.HOST_FILESYSTEM
 import com.apollographql.apollo3.ast.checkKeyFields
 import com.apollographql.apollo3.ast.introspection.toSchema
 import com.apollographql.apollo3.ast.parseAsGQLDocument
@@ -10,7 +9,6 @@ import com.apollographql.apollo3.ast.transformation.addRequiredFields
 import com.apollographql.apollo3.ast.validateAsSchema
 import com.apollographql.apollo3.graphql.ast.test.CWD
 import okio.Path.Companion.toPath
-import okio.buffer
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
@@ -23,8 +21,6 @@ class KeyFieldsTest {
     val schema = "${CWD}/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/schema.graphqls".toPath().toSchema()
 
     val definitions = "${CWD}/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/operations.graphql".toPath()
-        .let { HOST_FILESYSTEM.source(it) }
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .definitions
@@ -63,8 +59,6 @@ class KeyFieldsTest {
   fun testObjectWithTypePolicyAndInterfaceTypePolicyErrors() {
     "${CWD}/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/objectAndInterfaceTypePolicySchema.graphqls"
         .toPath()
-        .let { HOST_FILESYSTEM.source(it) }
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .validateAsSchema()
@@ -81,8 +75,6 @@ class KeyFieldsTest {
   fun testObjectInheritingTwoInterfacesWithDifferentKeyFields() {
     "${CWD}/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/objectInheritingTwoInterfaces.graphqls"
         .toPath()
-        .let { HOST_FILESYSTEM.source(it) }
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .validateAsSchema()
@@ -105,8 +97,6 @@ class KeyFieldsTest {
   fun testInterfacesWithoutKeyFields() {
     "${CWD}/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/keyfields/interfacesWithoutKeyFields.graphqls"
         .toPath()
-        .let { HOST_FILESYSTEM.source(it) }
-        .buffer()
         .parseAsGQLDocument()
         .getOrThrow()
         .validateAsSchema()

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo3/graphql/ast/test/validation/OperationValidationTest.kt
@@ -20,7 +20,7 @@ class OperationValidationTest {
         .toPath()
         .let { HOST_FILESYSTEM.source(it) }
         .buffer()
-        .parseAsGQLDocument()
+        .parseAsGQLDocument(null) // Use filePath = null to remove the absolute path above
         .getOrThrow()
     val operationIssues = operations.validateAsExecutable(schema).issues
     assertEquals(1, operationIssues.size)

--- a/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/api.jvm.kt
+++ b/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/api.jvm.kt
@@ -1,0 +1,21 @@
+@file:JvmMultifileClass
+@file:JvmName("ApolloParser")
+package com.apollographql.apollo3.ast
+
+import okio.buffer
+import okio.source
+import java.io.File
+
+fun File.parseAsGQLDocument(options: ParserOptions = ParserOptions.Default): GQLResult<GQLDocument> {
+  return this.source().buffer().parseAsGQLDocument(filePath = path, options = options)
+}
+fun File.parseAsGQLValue(options: ParserOptions = ParserOptions.Default): GQLResult<GQLValue> {
+  return this.source().buffer().parseAsGQLValue(filePath = path, options = options)
+}
+fun File.parseAsGQLType(options: ParserOptions = ParserOptions.Default): GQLResult<GQLType> {
+  return this.source().buffer().parseAsGQLType(filePath = path, options = options)
+}
+fun File.parseAsGQLSelections(options: ParserOptions = ParserOptions.Default): GQLResult<List<GQLSelection>> {
+  return this.source().buffer().parseAsGQLSelections(filePath = path, options = options)
+}
+

--- a/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/api.jvm.kt
+++ b/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/api.jvm.kt
@@ -9,13 +9,4 @@ import java.io.File
 fun File.parseAsGQLDocument(options: ParserOptions = ParserOptions.Default): GQLResult<GQLDocument> {
   return this.source().buffer().parseAsGQLDocument(filePath = path, options = options)
 }
-fun File.parseAsGQLValue(options: ParserOptions = ParserOptions.Default): GQLResult<GQLValue> {
-  return this.source().buffer().parseAsGQLValue(filePath = path, options = options)
-}
-fun File.parseAsGQLType(options: ParserOptions = ParserOptions.Default): GQLResult<GQLType> {
-  return this.source().buffer().parseAsGQLType(filePath = path, options = options)
-}
-fun File.parseAsGQLSelections(options: ParserOptions = ParserOptions.Default): GQLResult<List<GQLSelection>> {
-  return this.source().buffer().parseAsGQLSelections(filePath = path, options = options)
-}
 

--- a/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.jvm.kt
+++ b/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo3/ast/introspection/introspection_to_schema.jvm.kt
@@ -7,8 +7,6 @@ import com.apollographql.apollo3.ast.GQLDocument
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.validateAsSchema
-import okio.buffer
-import okio.source
 import java.io.File
 
 /**
@@ -19,7 +17,7 @@ fun File.toSchemaGQLDocument(): GQLDocument {
   return if (extension == "json") {
     toIntrospectionSchema().toGQLDocument(filePath = path)
   } else {
-    source().buffer().parseAsGQLDocument(filePath = path).getOrThrow()
+    parseAsGQLDocument().getOrThrow()
   }
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -35,8 +35,6 @@ import com.apollographql.apollo3.compiler.operationoutput.OperationOutput
 import com.apollographql.apollo3.compiler.operationoutput.writeTo
 import com.apollographql.apollo3.compiler.pqm.toPersistedQueryManifest
 import com.apollographql.apollo3.compiler.pqm.writeTo
-import okio.buffer
-import okio.source
 import java.io.File
 
 @ApolloExperimental
@@ -111,7 +109,7 @@ object ApolloCompiler {
     val definitions = mutableListOf<GQLDefinition>()
     val parseIssues = mutableListOf<Issue>()
     map { file ->
-      val parseResult = file.source().buffer().parseAsGQLDocument(filePath = file.path, options = ParserOptions(useAntlr = useAntlr))
+      val parseResult = file.parseAsGQLDocument(options = ParserOptions(useAntlr = useAntlr))
       if (parseResult.issues.isNotEmpty()) {
         parseIssues.addAll(parseResult.issues)
       } else {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
@@ -41,5 +41,3 @@ fun String.decapitalizeFirstLetter(): String {
   }
   return builder.toString()
 }
-
-internal fun String.buffer() = Buffer().writeUtf8(this)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/serialization.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/serialization.kt
@@ -99,7 +99,7 @@ internal object GQLTypeSerializer : KSerializer<GQLType> {
   override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("GQLFragmentDefinition", PrimitiveKind.STRING)
 
   override fun deserialize(decoder: Decoder): GQLType {
-    return decoder.decodeString().buffer().parseAsGQLType().getOrThrow()
+    return decoder.decodeString().parseAsGQLType().getOrThrow()
   }
 
   override fun serialize(encoder: Encoder, value: GQLType) {
@@ -111,7 +111,7 @@ internal object GQLFragmentDefinitionSerializer : KSerializer<GQLFragmentDefinit
   override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("GQLFragmentDefinition", PrimitiveKind.STRING)
 
   override fun deserialize(decoder: Decoder): GQLFragmentDefinition {
-    return decoder.decodeString().buffer().parseAsGQLDocument().getOrThrow().definitions.first() as GQLFragmentDefinition
+    return decoder.decodeString().parseAsGQLDocument().getOrThrow().definitions.first() as GQLFragmentDefinition
   }
 
   override fun serialize(encoder: Encoder, value: GQLFragmentDefinition) {

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -162,7 +162,7 @@ class CodegenTest {
             check(queryFile != null) {
               "Cannot find query file in ${file.absolutePath}"
             }
-            val hasFragments = queryFile.source().buffer().parseAsGQLDocument().getOrThrow().hasFragments()
+            val hasFragments = queryFile.parseAsGQLDocument().getOrThrow().hasFragments()
 
             when {
               file.name == "companion" -> listOf(Parameters(file, MODELS_OPERATION_BASED, true))

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/FieldsOnDisjointTypesMustMergeTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/FieldsOnDisjointTypesMustMergeTest.kt
@@ -16,7 +16,10 @@ class FieldsOnDisjointTypesMustMergeTest {
 
   @Test
   fun testEnableFieldsOnDisjointTypesMustMerge() = checkExpected(graphQLFile) { schema ->
-    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+    val parseResult = graphQLFile
+        .source()
+        .buffer()
+        .parseAsGQLDocument(graphQLFile.name) // strip parts of the path
     val issues = parseResult.getOrThrow().validateAsExecutable(schema = schema!!, fieldsOnDisjointTypesMustMerge = true).issues
     issues.serialize()
   }
@@ -24,7 +27,7 @@ class FieldsOnDisjointTypesMustMergeTest {
   @Test
   fun testDisableFieldsOnDisjointTypesMustMerge() {
     val schema = findSchema(graphQLFile.parentFile)!!
-    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+    val parseResult = graphQLFile.parseAsGQLDocument()
 
     val issues = parseResult.getOrThrow().validateAsExecutable(schema = schema, fieldsOnDisjointTypesMustMerge = false).issues
 

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -19,8 +19,8 @@ class ValidationTest(name: String, private val graphQLFile: File) {
 
   @Test
   fun testValidation() = checkExpected(graphQLFile) { schema ->
-    // Don't use absolute path for filePath because it depends on the machine where the test is run
-    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(filePath = graphQLFile.name)
+    // We just pass graphQLFile.name here to keep the issues shorter
+    val parseResult = graphQLFile.source().buffer().parseAsGQLDocument(graphQLFile.name)
 
     val issues = if (graphQLFile.parentFile.name == "operation" || graphQLFile.parentFile.parentFile.name == "operation") {
       if (parseResult.issues.isNotEmpty()) {

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/RegisterOperations.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/RegisterOperations.kt
@@ -169,7 +169,7 @@ private fun GQLNode.sort(): GQLNode {
 @ApolloExperimental
 object RegisterOperations {
   private fun String.normalize(): String {
-    val gqlDocument = Buffer().writeUtf8(this).parseAsGQLDocument().getOrThrow()
+    val gqlDocument = parseAsGQLDocument().getOrThrow()
 
     // From https://github.com/apollographql/apollo-tooling/blob/6d69f226c2e2c54b4fc0de6394d813bddfb54694/packages/apollo-graphql/src/operationId.ts#L84
 


### PR DESCRIPTION
Add:
* `String.paseAsGQLDocument(ParserOptions)` because there's no need writing everything to utf-8 just to read it back to utf-16 (same for  `parseAsGQLValue`, `parseAsGQLType`, `parseAsGQLSelections`)
* `File.parseAsGQLDocument(ParserOptions)` because it can populate the `filePath` automatically 
* `Path.parseAsGQLDocument(ParserOptions)` because it can populate the `filePath` automatically 

I didn't add `File.parseAsGQLValue(ParserOptions)` and the likes because I don't think it makes much sense to have a file that only contains a value. And it's always easier to add than remove if we need.

These APIs are introduced as Stable. The `BufferedSource` equivalent are still experimental because I'm not sure how much we want to commit on `BufferedSource` (vs kotlinx-io or maybe just exposing String APIs)
