### PR TITLE
[IJ plugin] v3 -> v4 migration: Gradle conf

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v2tov3/ApolloV2ToV3MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v2tov3/ApolloV2ToV3MigrationProcessor.kt
@@ -14,7 +14,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdatePackageName
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.AddUseVersion2Compat
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.RemoveDependenciesInBuildKts
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.UpdateAddCustomTypeAdapter
-import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.UpdateCustomTypeMappingInBuildKts
+import com.apollographql.ijplugin.refactoring.migration.item.UpdateCustomTypeMappingInBuildKts
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.UpdateEnumValueUpperCase
 import com.apollographql.ijplugin.refactoring.migration.v2tov3.item.UpdateFileUpload
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesBuildKts

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -14,6 +14,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodCall
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.EncloseInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateFieldNameInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateWebSocketReconnectWhen
 import com.intellij.openapi.project.Project
 
@@ -75,6 +76,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateGradleDependenciesInToml(apollo3, apollo3, apollo4LatestVersion),
       UpdateGradleDependenciesBuildKts(apollo3, apollo3),
 
+      UpdateFieldNameInService("generateModelBuilder", "generateModelBuilders"),
       EncloseInService,
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -78,6 +78,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateGradleDependenciesBuildKts(apollo3, apollo3),
 
       UpdateFieldNameInService("generateModelBuilder", "generateModelBuilders"),
+      UpdateFieldNameInService("generateTestBuilders", "generateDataBuilders"),
       UpdateCustomTypeMappingInBuildKts,
       EncloseInService,
   )

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -12,6 +12,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDepende
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradlePluginInBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodCall
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.EncloseInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateWebSocketReconnectWhen
 import com.intellij.openapi.project.Project
@@ -73,5 +74,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateGradlePluginInBuildKts(apollo3, apollo3, apollo4LatestVersion),
       UpdateGradleDependenciesInToml(apollo3, apollo3, apollo4LatestVersion),
       UpdateGradleDependenciesBuildKts(apollo3, apollo3),
+
+      EncloseInService,
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -6,6 +6,7 @@ import com.apollographql.ijplugin.refactoring.migration.apollo3
 import com.apollographql.ijplugin.refactoring.migration.item.ConstructorInsteadOfBuilder
 import com.apollographql.ijplugin.refactoring.migration.item.RemoveMethodCall
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateClassName
+import com.apollographql.ijplugin.refactoring.migration.item.UpdateCustomTypeMappingInBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateFieldName
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesBuildKts
 import com.apollographql.ijplugin.refactoring.migration.item.UpdateGradleDependenciesInToml
@@ -77,6 +78,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateGradleDependenciesBuildKts(apollo3, apollo3),
 
       UpdateFieldNameInService("generateModelBuilder", "generateModelBuilders"),
+      UpdateCustomTypeMappingInBuildKts,
       EncloseInService,
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -16,6 +16,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.EncloseInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateFieldNameInService
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateMultiModuleConfiguration
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateWebSocketReconnectWhen
 import com.intellij.openapi.project.Project
 
@@ -80,6 +81,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateFieldNameInService("generateModelBuilder", "generateModelBuilders"),
       UpdateFieldNameInService("generateTestBuilders", "generateDataBuilders"),
       UpdateCustomTypeMappingInBuildKts,
+      UpdateMultiModuleConfiguration,
       EncloseInService,
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
@@ -1,0 +1,87 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.apollo3.gradle.api.Service
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.apollographql.ijplugin.util.cast
+import com.apollographql.ijplugin.util.decapitalizeFirstLetter
+import com.apollographql.ijplugin.util.findPsiFilesByName
+import com.apollographql.ijplugin.util.getMethodName
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+object EncloseInService : MigrationItem() {
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    val usages = mutableListOf<MigrationItemUsageInfo>()
+    val buildGradleKtsFiles: List<KtFile> = project.findPsiFilesByName("build.gradle.kts", searchScope).filterIsInstance<KtFile>()
+    for (file in buildGradleKtsFiles) {
+      file.accept(object : KtTreeVisitorVoid() {
+        override fun visitCallExpression(expression: KtCallExpression) {
+          super.visitCallExpression(expression)
+          if (expression.getMethodName() == "apollo") {
+            val blockExpression = expression.valueArguments.firstOrNull()?.cast<KtLambdaArgument>()?.getLambdaExpression()?.bodyExpression
+                ?: return
+            val statements = blockExpression.statements
+            // If there's already a service call, we can't automatically refactor
+            if (statements.none { it is KtCallExpression && it.getMethodName() == "service" }) {
+              usages.add(blockExpression.toMigrationItemUsageInfo())
+            }
+          }
+        }
+      })
+    }
+    return usages
+  }
+
+  private val apolloServiceSymbols: Set<String> by lazy {
+    Service::class.java.declaredMethods.map { it.name.withoutGetter() }.toSet()
+  }
+
+  private fun String.withoutGetter() = if (startsWith("get")) {
+    substring(3).decapitalizeFirstLetter()
+  } else {
+    this
+  }
+
+  private fun KtExpression.isApolloServiceExpression(): Boolean {
+    val referenceExpression = when (this) {
+      // e.g. srcDir("xxx")
+      is KtCallExpression -> calleeExpression
+
+      // e.g. packageName.set("xxx")
+      is KtDotQualifiedExpression -> receiverExpression
+
+      else -> return false
+    } as? KtNameReferenceExpression ?: return false
+    return referenceExpression.getReferencedName() in apolloServiceSymbols
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    val blockExpression = usage.element as KtBlockExpression
+    val nonServiceStatements = blockExpression.statements.filter { !it.isApolloServiceExpression() }
+    val nonServiceStatementsText = nonServiceStatements.map { it.text }
+    nonServiceStatements.forEach { it.delete() }
+    val ktFactory = KtPsiFactory(project)
+    val newBlockExpression = ktFactory.createEmptyBody()
+    for (statement in nonServiceStatementsText) {
+      newBlockExpression.add(ktFactory.createNewLine())
+      newBlockExpression.add(ktFactory.createExpression(statement))
+    }
+    newBlockExpression.add(ktFactory.createNewLine())
+    newBlockExpression.add(ktFactory.createExpression("service(\"service\") {\n${blockExpression.text}\n}"))
+    newBlockExpression.lBrace?.delete()
+    newBlockExpression.rBrace?.delete()
+    blockExpression.replace(newBlockExpression)
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
@@ -4,10 +4,10 @@ import com.apollographql.apollo3.gradle.api.Service
 import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
 import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
 import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
-import com.apollographql.ijplugin.util.cast
 import com.apollographql.ijplugin.util.decapitalizeFirstLetter
 import com.apollographql.ijplugin.util.findPsiFilesByName
 import com.apollographql.ijplugin.util.getMethodName
+import com.apollographql.ijplugin.util.lambdaBlockExpression
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiMigration
 import com.intellij.psi.search.GlobalSearchScope
@@ -16,7 +16,6 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
@@ -30,8 +29,7 @@ object EncloseInService : MigrationItem() {
         override fun visitCallExpression(expression: KtCallExpression) {
           super.visitCallExpression(expression)
           if (expression.getMethodName() == "apollo") {
-            val blockExpression = expression.valueArguments.firstOrNull()?.cast<KtLambdaArgument>()?.getLambdaExpression()?.bodyExpression
-                ?: return
+            val blockExpression = expression.lambdaBlockExpression() ?: return
             val statements = blockExpression.statements
             // If there's already a service call, we can't automatically refactor
             if (statements.none { it is KtCallExpression && it.getMethodName() == "service" }) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
@@ -45,7 +45,10 @@ object EncloseInService : MigrationItem() {
   }
 
   private val apolloServiceSymbols: Set<String> by lazy {
-    Service::class.java.declaredMethods.map { it.name.withoutGetter() }.toSet()
+    Service::class.java.declaredMethods.map { it.name.withoutGetter() }.toMutableSet().apply {
+      // Include the fields that existed in v3, otherwise they'll be removed from the service block
+      add("generateModelBuilder")
+    }
   }
 
   private fun String.withoutGetter() = if (startsWith("get")) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/EncloseInService.kt
@@ -48,6 +48,7 @@ object EncloseInService : MigrationItem() {
     Service::class.java.declaredMethods.map { it.name.withoutGetter() }.toMutableSet().apply {
       // Include the fields that existed in v3, otherwise they'll be removed from the service block
       add("generateModelBuilder")
+      add("customScalarsMapping")
     }
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateFieldNameInService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateFieldNameInService.kt
@@ -1,0 +1,50 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.apollographql.ijplugin.util.cast
+import com.apollographql.ijplugin.util.findPsiFilesByName
+import com.apollographql.ijplugin.util.getMethodName
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+class UpdateFieldNameInService(
+    val oldName:String,
+    val newName:String,
+) : MigrationItem() {
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    val usages = mutableListOf<MigrationItemUsageInfo>()
+    val buildGradleKtsFiles: List<KtFile> = project.findPsiFilesByName("build.gradle.kts", searchScope).filterIsInstance<KtFile>()
+    for (file in buildGradleKtsFiles) {
+      file.accept(object : KtTreeVisitorVoid() {
+        override fun visitCallExpression(expression: KtCallExpression) {
+          super.visitCallExpression(expression)
+          if (expression.getMethodName() == "apollo") {
+            expression.accept(object : KtTreeVisitorVoid() {
+              override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+                super.visitDotQualifiedExpression(expression)
+                if (expression.receiverExpression.cast<KtNameReferenceExpression>()?.getReferencedName() == oldName) {
+                  usages.add(expression.receiverExpression.toMigrationItemUsageInfo())
+                }
+              }
+            })
+          }
+        }
+      })
+    }
+    return usages
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    val element = usage.element
+    element.replace(KtPsiFactory(project).createExpression(newName))
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateMultiModuleConfiguration.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateMultiModuleConfiguration.kt
@@ -1,0 +1,62 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.apollographql.ijplugin.util.containingKtFile
+import com.apollographql.ijplugin.util.findPsiFilesByName
+import com.apollographql.ijplugin.util.getMethodName
+import com.apollographql.ijplugin.util.lambdaBlockExpression
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+
+object UpdateMultiModuleConfiguration : MigrationItem() {
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    val usages = mutableListOf<MigrationItemUsageInfo>()
+    val buildGradleKtsFiles: List<KtFile> = project.findPsiFilesByName("build.gradle.kts", searchScope).filterIsInstance<KtFile>()
+    for (file in buildGradleKtsFiles) {
+      file.accept(object : KtTreeVisitorVoid() {
+        override fun visitCallExpression(expression: KtCallExpression) {
+          super.visitCallExpression(expression)
+          if (expression.getMethodName() == "apolloMetadata") {
+            val argumentText = expression.valueArguments.firstOrNull()?.text ?: return
+            usages.add(expression.toMigrationItemUsageInfo(argumentText))
+          }
+        }
+      })
+    }
+    return usages
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    val file = usage.element.containingKtFile() ?: return
+    usage.element.delete()
+    val ktFactory = KtPsiFactory(project)
+
+    file.accept(object : KtTreeVisitorVoid() {
+      override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        var serviceFound= false
+        if (expression.getMethodName() == "apollo") {
+          val apolloBlockExpression = expression.lambdaBlockExpression() ?: return
+          val apolloStatements = apolloBlockExpression.statements
+          apolloStatements.filter { it is KtCallExpression && it.getMethodName() == "service" }.forEach { serviceCallExpression ->
+            val serviceBlockExpression = (serviceCallExpression as KtCallExpression).lambdaBlockExpression() ?: return@forEach
+            serviceBlockExpression.add(ktFactory.createNewLine())
+            serviceBlockExpression.add(ktFactory.createExpression("dependsOn(${usage.attachedData<String>()})"))
+            serviceFound = true
+          }
+          if (!serviceFound) {
+            apolloBlockExpression.add(ktFactory.createNewLine())
+            apolloBlockExpression.add(ktFactory.createExpression("dependsOn(${usage.attachedData<String>()})"))
+          }
+        }
+      }
+    })
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -4,11 +4,13 @@ import com.intellij.openapi.diagnostic.ControlFlowException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtLambdaArgument
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -62,3 +64,5 @@ fun PsiElement.asKtClass(): KtClass? = cast<KtClass>() ?: cast<KtConstructor<*>>
 fun PsiElement.originalClassName(): String? = resolveKtName()?.asKtClass()?.name
 
 fun KtCallExpression.getMethodName(): String? = calleeExpression.cast<KtNameReferenceExpression>()?.getReferencedName()
+
+fun KtCallExpression.lambdaBlockExpression(): KtBlockExpression? = valueArguments.firstIsInstanceOrNull<KtLambdaArgument>()?.getLambdaExpression()?.bodyExpression

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -4,10 +4,12 @@ import com.intellij.openapi.diagnostic.ControlFlowException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
@@ -58,3 +60,5 @@ fun PsiElement.resolveKtName(): PsiElement? = runCatching {
 fun PsiElement.asKtClass(): KtClass? = cast<KtClass>() ?: cast<KtConstructor<*>>()?.containingClass()
 
 fun PsiElement.originalClassName(): String? = resolveKtName()?.asKtClass()?.name
+
+fun KtCallExpression.getMethodName(): String? = calleeExpression.cast<KtNameReferenceExpression>()?.getReferencedName()

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -146,6 +146,7 @@
     />
   </applicationListeners>
 
+
   <actions>
     <!-- Refactor / Apollo -->
     <!--suppress PluginXmlCapitalization -->
@@ -157,32 +158,6 @@
       <add-to-group group-id="RefactoringMenu" anchor="last" />
     </group>
 
-    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 3 -->
-    <action
-        id="ApolloV2ToV3MigrationAction"
-        class="com.apollographql.ijplugin.action.ApolloV2ToV3MigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-    </action>
-
-    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 4 -->
-    <action
-        id="ApolloV3ToV4MigrationAction"
-        class="com.apollographql.ijplugin.action.ApolloV3ToV4MigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-    </action>
-
-    <!-- Refactor / Apollo / Migrate to operationBased Codegen -->
-    <!--suppress PluginXmlCapitalization -->
-    <action
-        id="CompatToOperationBasedCodegenMigrationAction"
-        class="com.apollographql.ijplugin.action.CompatToOperationBasedCodegenMigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-    </action>
-
-
     <!-- Tools / Apollo -->
     <!--suppress PluginXmlCapitalization -->
     <group
@@ -193,6 +168,34 @@
     >
       <add-to-group group-id="ToolsMenu" anchor="last" />
     </group>
+
+    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 3 (also in Tools / Apollo) -->
+    <action
+        id="ApolloV2ToV3MigrationAction"
+        class="com.apollographql.ijplugin.action.ApolloV2ToV3MigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 4 (also in Tools / Apollo) -->
+    <action
+        id="ApolloV3ToV4MigrationAction"
+        class="com.apollographql.ijplugin.action.ApolloV3ToV4MigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Refactor / Apollo / Migrate to operationBased Codegen (also in Tools / Apollo) -->
+    <!--suppress PluginXmlCapitalization -->
+    <action
+        id="CompatToOperationBasedCodegenMigrationAction"
+        class="com.apollographql.ijplugin.action.CompatToOperationBasedCodegenMigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
 
     <!-- Tools / Apollo / Open in Apollo Sandbox -->
     <action

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
@@ -36,6 +36,9 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
   @Test
   fun testEncloseInService() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
 
+  @Test
+  fun testGradleDeprecations() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
+
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)
     if (fileNameInProject != null) {

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
@@ -42,6 +42,9 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
   @Test
   fun testUpdateCustomScalarsMapping() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
 
+  @Test
+  fun testMultiModule() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
+
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)
     if (fileNameInProject != null) {

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
@@ -39,6 +39,9 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
   @Test
   fun testGradleDeprecations() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
 
+  @Test
+  fun testUpdateCustomScalarsMapping() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
+
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)
     if (fileNameInProject != null) {

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/ApolloV3ToV4MigrationTest.kt
@@ -33,6 +33,9 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
   @Test
   fun deprecations() = runMigration()
 
+  @Test
+  fun testEncloseInService() = runMigration(extension = "gradle.kts", fileNameInProject = "build.gradle.kts")
+
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)
     if (fileNameInProject != null) {

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/encloseInService.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/encloseInService.gradle.kts
@@ -1,0 +1,18 @@
+dependencies {
+  implementation("org.example:somelibrary:1.0.0")
+}
+
+apollo {
+  packageName.set("com.example")
+  // Some comment
+  codegenModels.set("operationBased")
+  linkSqlite.set(true)
+  srcDir("src/main/graphql")
+}
+
+apollo {
+  service("zgluteks") {
+    packageName.set("com.example")
+    codegenModels.set("responseBased")
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/encloseInService_after.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/encloseInService_after.gradle.kts
@@ -1,0 +1,20 @@
+dependencies {
+  implementation("org.example:somelibrary:1.0.0")
+}
+
+apollo {
+  linkSqlite.set(true)
+  service("service") {
+    packageName.set("com.example")
+    // Some comment
+    codegenModels.set("operationBased")
+    srcDir("src/main/graphql")
+  }
+}
+
+apollo {
+  service("zgluteks") {
+    packageName.set("com.example")
+    codegenModels.set("responseBased")
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations.gradle.kts
@@ -1,0 +1,13 @@
+dependencies {
+  implementation("org.example:somelibrary:1.0.0")
+}
+
+apollo {
+  generateModelBuilder.set(true)
+}
+
+apollo {
+  service("xxx") {
+    generateModelBuilder.set(true)
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations.gradle.kts
@@ -4,10 +4,12 @@ dependencies {
 
 apollo {
   generateModelBuilder.set(true)
+  generateTestBuilders.set(true)
 }
 
 apollo {
   service("xxx") {
     generateModelBuilder.set(true)
+    generateTestBuilders.set(true)
   }
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations_after.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations_after.gradle.kts
@@ -5,11 +5,13 @@ dependencies {
 apollo {
   service("service") {
     generateModelBuilders.set(true)
+    generateDataBuilders.set(true)
   }
 }
 
 apollo {
   service("xxx") {
     generateModelBuilders.set(true)
+    generateDataBuilders.set(true)
   }
 }

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations_after.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/gradleDeprecations_after.gradle.kts
@@ -1,0 +1,15 @@
+dependencies {
+  implementation("org.example:somelibrary:1.0.0")
+}
+
+apollo {
+  service("service") {
+    generateModelBuilders.set(true)
+  }
+}
+
+apollo {
+  service("xxx") {
+    generateModelBuilders.set(true)
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/multiModule.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/multiModule.gradle.kts
@@ -1,0 +1,19 @@
+dependencies {
+  apolloMetadata(project(":schema"))
+  implementation(project(":schema"))
+}
+
+apollo {
+  service("service1") {
+    packageName.set("com.example.service1")
+  }
+
+  service("service2") {
+    packageName.set("com.example.service2")
+  }
+}
+
+
+apollo {
+  packageName.set("com.example.service1")
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/multiModule_after.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/multiModule_after.gradle.kts
@@ -1,0 +1,23 @@
+dependencies {
+  implementation(project(":schema"))
+}
+
+apollo {
+  service("service1") {
+    packageName.set("com.example.service1")
+    dependsOn(project(":schema"))
+  }
+
+  service("service2") {
+    packageName.set("com.example.service2")
+    dependsOn(project(":schema"))
+  }
+}
+
+
+apollo {
+  service("service") {
+    packageName.set("com.example.service1")
+    dependsOn(project(":schema"))
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/updateCustomScalarsMapping.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/updateCustomScalarsMapping.gradle.kts
@@ -1,0 +1,55 @@
+apollo {
+  customScalarsMapping.put("URL", "kotlin.String")
+  customScalarsMapping.put("LocalDate", "java.time.LocalDate")
+  customScalarsMapping.put("Upload", "com.apollographql.apollo.api.FileUpload")
+  customScalarsMapping.put(
+      "PaymentMethodsResponse",
+      "com.adyen.checkout.components.model.PaymentMethodsApiResponse"
+  )
+  customScalarsMapping.put("CheckoutPaymentsAction", "kotlin.String")
+  customScalarsMapping.put("CheckoutPaymentAction", "kotlin.String")
+  customScalarsMapping.put("JSONString", "org.json.JSONObject")
+  customScalarsMapping.put("Instant", "java.time.Instant")
+
+  customScalarsMapping.set(
+      mapOf(
+          "URL" to "kotlin.String",
+          "LocalDate" to "java.time.LocalDate",
+          "Upload" to "com.apollographql.apollo.api.FileUpload",
+          "PaymentMethodsResponse" to "com.adyen.checkout.components.model.PaymentMethodsApiResponse",
+          "CheckoutPaymentsAction" to "kotlin.String",
+          "CheckoutPaymentAction" to "kotlin.String",
+          "JSONString" to "org.json.JSONObject",
+          "Instant" to "java.time.Instant",
+      )
+  )
+}
+
+apollo {
+  service("main") {
+    customTypeMapping.put("URL", "kotlin.String")
+    customTypeMapping.put("LocalDate", "java.time.LocalDate")
+    customTypeMapping.put("Upload", "com.apollographql.apollo.api.FileUpload")
+    customTypeMapping.put(
+        "PaymentMethodsResponse",
+        "com.adyen.checkout.components.model.PaymentMethodsApiResponse"
+    )
+    customTypeMapping.put("CheckoutPaymentsAction", "kotlin.String")
+    customTypeMapping.put("CheckoutPaymentAction", "kotlin.String")
+    customTypeMapping.put("JSONString", "org.json.JSONObject")
+    customTypeMapping.put("Instant", "java.time.Instant")
+
+    customTypeMapping.set(
+        mapOf(
+            "URL" to "kotlin.String",
+            "LocalDate" to "java.time.LocalDate",
+            "Upload" to "com.apollographql.apollo.api.FileUpload",
+            "PaymentMethodsResponse" to "com.adyen.checkout.components.model.PaymentMethodsApiResponse",
+            "CheckoutPaymentsAction" to "kotlin.String",
+            "CheckoutPaymentAction" to "kotlin.String",
+            "JSONString" to "org.json.JSONObject",
+            "Instant" to "java.time.Instant",
+        )
+    )
+  }
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/updateCustomScalarsMapping_after.gradle.kts
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/updateCustomScalarsMapping_after.gradle.kts
@@ -1,0 +1,43 @@
+apollo {
+  service("service") {
+    mapScalarToKotlinString("URL")
+    mapScalar("LocalDate", "java.time.LocalDate")
+    mapScalarToUpload("Upload")
+    mapScalar("PaymentMethodsResponse", "com.adyen.checkout.components.model.PaymentMethodsApiResponse")
+    mapScalarToKotlinString("CheckoutPaymentsAction")
+    mapScalarToKotlinString("CheckoutPaymentAction")
+    mapScalar("JSONString", "org.json.JSONObject")
+    mapScalar("Instant", "java.time.Instant")
+
+    mapScalarToKotlinString("URL")
+    mapScalar("LocalDate", "java.time.LocalDate")
+    mapScalarToUpload("Upload")
+    mapScalar("PaymentMethodsResponse", "com.adyen.checkout.components.model.PaymentMethodsApiResponse")
+    mapScalarToKotlinString("CheckoutPaymentsAction")
+    mapScalarToKotlinString("CheckoutPaymentAction")
+    mapScalar("JSONString", "org.json.JSONObject")
+    mapScalar("Instant", "java.time.Instant")
+  }
+}
+
+apollo {
+  service("main") {
+    mapScalarToKotlinString("URL")
+    mapScalar("LocalDate", "java.time.LocalDate")
+    mapScalarToUpload("Upload")
+    mapScalar("PaymentMethodsResponse", "com.adyen.checkout.components.model.PaymentMethodsApiResponse")
+    mapScalarToKotlinString("CheckoutPaymentsAction")
+    mapScalarToKotlinString("CheckoutPaymentAction")
+    mapScalar("JSONString", "org.json.JSONObject")
+    mapScalar("Instant", "java.time.Instant")
+
+    mapScalarToKotlinString("URL")
+    mapScalar("LocalDate", "java.time.LocalDate")
+    mapScalarToUpload("Upload")
+    mapScalar("PaymentMethodsResponse", "com.adyen.checkout.components.model.PaymentMethodsApiResponse")
+    mapScalarToKotlinString("CheckoutPaymentsAction")
+    mapScalarToKotlinString("CheckoutPaymentAction")
+    mapScalar("JSONString", "org.json.JSONObject")
+    mapScalar("Instant", "java.time.Instant")
+  }
+}


### PR DESCRIPTION
- enclose service configuration in a `service("service") {}` block
- `mapScalar` instead of `customScalarsMapping.set` / `.put`
- multi module: `apollo`/`service`/`dependsOn` instead of `dependencies`/`apolloMetadata`
- and a few renames

Also add the Migrate actions to Tools / Apollo (in addition to Refactor / Apollo) for increased visibility