### PR TITLE
Gradle plugin: make generateSourcesDuringGradleSync opt-in now that we have the IJ plugin

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -234,7 +234,7 @@ abstract class DefaultApolloExtension(
     }
 
     codegenOnGradleSyncConfigured = true
-    if (this.generateSourcesDuringGradleSync.getOrElse(true)) {
+    if (this.generateSourcesDuringGradleSync.getOrElse(false)) {
       project.tasks.maybeCreate("prepareKotlinIdeaImport").dependsOn(generateApolloSources)
     }
   }


### PR DESCRIPTION
I've been burned a couple of times where the sync was failing because of bad .graphql files. Feels wrong to have no autocomplete in Gradle files because of some GraphQL files. Plus we have the IJ plugin to do it now.