### PR TITLE
[IJ Plugin] Don't report redefinitions of built-in types as errors

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/BuiltInRedefinitionErrorFilter.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/graphql/BuiltInRedefinitionErrorFilter.kt
@@ -1,0 +1,50 @@
+package com.apollographql.ijplugin.graphql
+
+import com.intellij.lang.jsgraphql.ide.validation.GraphQLErrorFilter
+import com.intellij.lang.jsgraphql.types.GraphQLError
+import com.intellij.lang.jsgraphql.types.language.DirectiveDefinition
+import com.intellij.lang.jsgraphql.types.language.EnumTypeDefinition
+import com.intellij.lang.jsgraphql.types.language.ObjectTypeDefinition
+import com.intellij.lang.jsgraphql.types.language.ScalarTypeDefinition
+import com.intellij.lang.jsgraphql.types.schema.idl.errors.DirectiveRedefinitionError
+import com.intellij.lang.jsgraphql.types.schema.idl.errors.TypeRedefinitionError
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+
+/**
+ * Suppress redefinition errors for built-in GraphQL types/directives.
+ *
+ * TODO: remove this once https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665 is fixed
+ */
+class BuiltInRedefinitionErrorFilter : GraphQLErrorFilter {
+  private val builtInScalarTypes = listOf("Int", "Float", "String", "Boolean", "ID")
+  private val builtInDirectives = listOf("skip", "include", "deprecated", "defer", "specifiedBy")
+
+  override fun isGraphQLErrorSuppressed(project: Project, error: GraphQLError, element: PsiElement?): Boolean {
+    return when (error) {
+      is TypeRedefinitionError -> {
+        when (val node = error.node) {
+          is ScalarTypeDefinition -> {
+            node.name in builtInScalarTypes
+          }
+
+          is ObjectTypeDefinition -> {
+            node.name.startsWith("__")
+          }
+
+          is EnumTypeDefinition -> {
+            node.name.startsWith("__")
+          }
+
+          else -> false
+        }
+      }
+
+      is DirectiveRedefinitionError -> {
+        (error.node as DirectiveDefinition).name in builtInDirectives
+      }
+
+      else -> false
+    }
+  }
+}

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -133,9 +133,13 @@
 
   </extensions>
 
-  <!-- Contribute configuration to the GraphQL plugin -->
   <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">
+    <!-- Contribute configuration to the GraphQL plugin -->
     <configContributor implementation="com.apollographql.ijplugin.graphql.ApolloGraphQLConfigContributor" />
+
+    <!-- Suppress redefinition errors for built-in GraphQL types/directives. -->
+    <!-- TODO: remove this once https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665 is fixed -->
+    <errorFilter implementation="com.apollographql.ijplugin.graphql.BuiltInRedefinitionErrorFilter" />
   </extensions>
 
   <applicationListeners>


### PR DESCRIPTION
See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
I'll also open a PR to the the GraphQL plugin so hopefully we can remove this from ours.

See also #5126 