### PR TITLE
Add minVersion

### DIFF
--- a/docs/source/fetching/defer.mdx
+++ b/docs/source/fetching/defer.mdx
@@ -1,6 +1,7 @@
 ---
 title: 'Using the @defer directive in Apollo Kotlin'
 description: 'Fetch slower schema fields asynchronously'
+minVersion: 3.6.0
 ---
 
 > ⚠️ **The `@defer` directive is currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin and enabled for use by default.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-android/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md&title=[Defer%20Support]) or in the [Kotlin Slack community](https://slack.kotl.in/).


### PR DESCRIPTION
This PR replaces uses of "available in version ..." with the new [<MinVersion> component](https://apollograph.slack.com/archives/C0721M2F6/p1690243600979049?thread_ts=1690218529.773819&cid=C0721M2F6).

It's likely not comprehensive but at least replaces previous mentions of versions. (Searched for "available", "version", and "<=" in .mdx files.)