### PR TITLE
[IJ plugin] Add a Download Schema action

### DIFF
--- a/docs/source/advanced/plugin-configuration.mdx
+++ b/docs/source/advanced/plugin-configuration.mdx
@@ -203,6 +203,8 @@ apollo {
 This will create a task named `download<ServiceName>ApolloSchemaFromRegistry` (`downloadServiceApolloSchemaFromRegistry`
 by default).
 
+With the [Android Studio plugin](../testing/android-studio-plugin), you can also go to <kbd>Tools</kbd> | <kbd>Apollo</kbd> | <kbd>Download schema</kbd> which acts as a shortcut to these tasks.
+
 ## All options
 
 Below is a summary of the Gradle options in a single code block. For more details, take a look at the [ApolloExtension KDoc](https://www.apollographql.com/docs/kotlin/kdoc/apollo-gradle-plugin-external/com.apollographql.apollo3.gradle.api/-apollo-extension/index.html)

--- a/docs/source/testing/android-studio-plugin.mdx
+++ b/docs/source/testing/android-studio-plugin.mdx
@@ -58,6 +58,12 @@ In the <kbd>Refactor</kbd> | <kbd>Apollo</kbd> menu, you can find helpers to mig
 Note: while these helpers will automatically update your code when possible, there are some cases where this isn't possible and manual changes are required.
 Please refer to the migration guides ([3.x](../migration/3.0/), [4.x](../migration/4.0/)) when upgrading.
 
+### Download schema
+
+Download the latest version of your schema(s) by going to <kbd>Tools</kbd> | <kbd>Apollo</kbd> | <kbd>Download schema</kbd>.
+
+This uses the Introspection endpoint or the Registry that you can [configure](../advanced/plugin-configuration#downloading-a-schema) on your Apollo service. 
+
 ### Open in Apollo Sandbox
 
 You can open a GraphQL file in [Apollo Sandbox](https://studio.apollographql.com/sandbox/explorer) with right click | <kbd>Open in</kbd> | <kbd>Apollo Sandbox</kbd>.

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
@@ -1,0 +1,132 @@
+package com.apollographql.ijplugin.gradle
+
+import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.apolloProjectService
+import com.apollographql.ijplugin.util.logd
+import com.apollographql.ijplugin.util.logw
+import com.apollographql.ijplugin.util.showNotification
+import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListenerAdapter
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import org.gradle.tooling.events.FailureResult
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.StartEvent
+import org.gradle.tooling.events.SuccessResult
+import org.gradle.tooling.model.GradleProject
+import org.jetbrains.kotlin.idea.configuration.GRADLE_SYSTEM_ID
+import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings
+import org.jetbrains.plugins.gradle.util.GradleConstants
+
+class DownloadSchemaAction : AnAction() {
+  override fun actionPerformed(e: AnActionEvent) {
+    logd()
+    val project = e.project ?: return
+    DownloadSchemaTask(project).queue()
+  }
+
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabled = e.project?.apolloProjectService?.apolloVersion?.isAtLeastV3 == true && e.project?.getGradleRootPath() != null
+  }
+
+  override fun getActionUpdateThread() = ActionUpdateThread.BGT
+}
+
+private val DOWNLOAD_SCHEMA_TASK_REGEX = Regex("download.+ApolloSchemaFrom(Introspection|Registry)")
+private const val SCHEMA_CONFIGURATION_DOC_URL = "https://www.apollographql.com/docs/kotlin/advanced/plugin-configuration#downloading-a-schema"
+
+private class DownloadSchemaTask(project: Project) : Task.Backgroundable(
+    project,
+    ApolloBundle.message("action.DownloadSchemaAction.progress"),
+    false,
+) {
+  override fun run(indicator: ProgressIndicator) {
+    val rootProjectPath = project.getGradleRootPath() ?: return
+    val gradleExecutionHelper = GradleExecutionHelperCompat()
+    val executionSettings = ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, rootProjectPath, GradleConstants.SYSTEM_ID)
+    val rootGradleProject = gradleExecutionHelper.execute(rootProjectPath, executionSettings) { connection ->
+      logd("Fetch Gradle project model")
+      return@execute try {
+        val id = ExternalSystemTaskId.create(GRADLE_SYSTEM_ID, ExternalSystemTaskType.RESOLVE_PROJECT, project)
+        gradleExecutionHelper.getModelBuilder(GradleProject::class.java, connection, id, executionSettings, ExternalSystemTaskNotificationListenerAdapter.NULL_OBJECT)
+            .get()
+      } catch (t: Throwable) {
+        logw(t, "Couldn't fetch Gradle project model")
+        null
+      }
+    } ?: return
+
+    val allDownloadSchemaTasks: List<String> = (rootGradleProject.children + rootGradleProject)
+        .flatMap { gradleProject -> gradleProject.tasks.filter { task -> task.name.matches(DOWNLOAD_SCHEMA_TASK_REGEX) } }
+        .map { it.name }
+        .distinct()
+    logd("allDownloadSchemaTasks=$allDownloadSchemaTasks")
+    if (allDownloadSchemaTasks.isEmpty()) {
+      showNotification(
+          project = project,
+          title = ApolloBundle.message("action.DownloadSchemaAction.noTasksFound.title"),
+          content = ApolloBundle.message("action.DownloadSchemaAction.noTasksFound.content"),
+          type = NotificationType.WARNING,
+          object : AnAction(ApolloBundle.message("action.DownloadSchemaAction.openDocumentation")) {
+            override fun actionPerformed(e: AnActionEvent) {
+              BrowserUtil.browse(SCHEMA_CONFIGURATION_DOC_URL, project)
+            }
+          }
+      )
+      return
+    }
+
+    gradleExecutionHelper.execute(rootProjectPath, executionSettings) { connection ->
+      try {
+        val id = ExternalSystemTaskId.create(GRADLE_SYSTEM_ID, ExternalSystemTaskType.EXECUTE_TASK, project)
+        gradleExecutionHelper.getBuildLauncher(connection, id, allDownloadSchemaTasks, executionSettings, ExternalSystemTaskNotificationListenerAdapter.NULL_OBJECT)
+            .forTasks(*allDownloadSchemaTasks.toTypedArray())
+            .addProgressListener(ProgressListener { event ->
+              when {
+                event is StartEvent && event.descriptor.name == "Run build" -> {
+                  logd("Gradle build started")
+                }
+
+                event is FinishEvent && event.descriptor.name == "Run build" -> {
+                  when (val result = event.result) {
+                    is FailureResult -> {
+                      logd("Gradle build failed: ${result.failures.map { it.message }}")
+                      showNotification(
+                          project = project,
+                          title = ApolloBundle.message("action.DownloadSchemaAction.buildFail.title"),
+                          content = ApolloBundle.message("action.DownloadSchemaAction.buildFail.content", result.failures.firstOrNull()?.message
+                              ?: "(no message)", allDownloadSchemaTasks.joinToString(" ")),
+                          type = NotificationType.WARNING
+                      )
+                    }
+
+                    is SuccessResult -> {
+                      logd("Gradle build success")
+                      val schemas = if (allDownloadSchemaTasks.size > 1) ApolloBundle.message("action.DownloadSchemaAction.schema.plural") else ApolloBundle.message("action.DownloadSchemaAction.schema.singular")
+                      showNotification(
+                          project = project,
+                          content = ApolloBundle.message("action.DownloadSchemaAction.buildSuccess.content", schemas),
+                          type = NotificationType.INFORMATION
+                      )
+                    }
+                  }
+                }
+              }
+            })
+            .run()
+        logd("Gradle execution finished")
+      } catch (t: Throwable) {
+        logd(t, "Gradle execution failed")
+      }
+    }
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/SimpleProgressListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/SimpleProgressListener.kt
@@ -1,0 +1,38 @@
+package com.apollographql.ijplugin.gradle
+
+import com.apollographql.ijplugin.util.logd
+import org.gradle.tooling.Failure
+import org.gradle.tooling.events.FailureResult
+import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.ProgressEvent
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.StartEvent
+import org.gradle.tooling.events.SuccessResult
+
+open class SimpleProgressListener : ProgressListener {
+  override fun statusChanged(event: ProgressEvent) {
+    when {
+      event is StartEvent && event.descriptor.name == "Run build" -> onStart()
+
+      event is FinishEvent && event.descriptor.name == "Run build" -> {
+        when (val result = event.result) {
+          is FailureResult -> onFailure(result.failures)
+
+          is SuccessResult -> onSuccess()
+        }
+      }
+    }
+  }
+
+  open fun onStart() {
+    logd("Gradle build started")
+  }
+
+  open fun onFailure(failures: List<Failure>) {
+    logd("Gradle build failed: ${failures.map { it.message }}")
+  }
+
+  open fun onSuccess() {
+    logd("Gradle build success")
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/fieldinsights/RefreshFieldInsightsAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/fieldinsights/RefreshFieldInsightsAction.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.studio.fieldinsights
 
 import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.SettingsConfigurable
 import com.apollographql.ijplugin.settings.settingsState
 import com.apollographql.ijplugin.util.logd
@@ -32,6 +33,10 @@ class RefreshFieldInsightsAction : AnAction() {
     }
 
     project.fieldInsightsService.fetchLatencies()
+  }
+
+  override fun update(e: AnActionEvent) {
+    e.presentation.isEnabled = e.project?.apolloProjectService?.apolloVersion?.isAtLeastV3 == true
   }
 
   override fun getActionUpdateThread() = ActionUpdateThread.BGT

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
@@ -1,0 +1,37 @@
+package com.apollographql.ijplugin.util
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.NlsContexts
+
+@Suppress("UnstableApiUsage")
+fun createNotification(
+    @NlsContexts.NotificationTitle title: String = "",
+    @NlsContexts.NotificationContent content: String,
+    type: NotificationType,
+    vararg actions: AnAction,
+): Notification = NotificationGroupManager.getInstance()
+    .getNotificationGroup("Apollo")
+    .createNotification(title, content, type)
+    .apply {
+      for (action in actions) {
+        addAction(action)
+      }
+    }
+
+@Suppress("UnstableApiUsage")
+fun showNotification(
+    project: Project,
+    @NlsContexts.NotificationTitle title: String = "",
+    @NlsContexts.NotificationContent content: String,
+    type: NotificationType,
+    vararg actions: AnAction,
+) = createNotification(
+    title = title,
+    content = content,
+    type = type,
+    actions = actions,
+).notify(project)

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
@@ -5,12 +5,13 @@ import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.NlsContexts
+import com.intellij.openapi.util.NlsContexts.NotificationContent
+import com.intellij.openapi.util.NlsContexts.NotificationTitle
 
 @Suppress("UnstableApiUsage")
 fun createNotification(
-    @NlsContexts.NotificationTitle title: String = "",
-    @NlsContexts.NotificationContent content: String,
+    @NotificationTitle title: String = "",
+    @NotificationContent content: String,
     type: NotificationType,
     vararg actions: AnAction,
 ): Notification = NotificationGroupManager.getInstance()
@@ -25,8 +26,8 @@ fun createNotification(
 @Suppress("UnstableApiUsage")
 fun showNotification(
     project: Project,
-    @NlsContexts.NotificationTitle title: String = "",
-    @NlsContexts.NotificationContent content: String,
+    @NotificationTitle title: String = "",
+    @NotificationContent content: String,
     type: NotificationType,
     vararg actions: AnAction,
 ) = createNotification(

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -146,6 +146,13 @@
         serviceImplementation="com.apollographql.ijplugin.studio.fieldinsights.FieldInsightsServiceImpl"
     />
 
+    <!-- Notifications -->
+    <notificationGroup
+        id="Apollo"
+        displayType="BALLOON"
+        key="notification.group.apollo"
+    />
+
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">
@@ -233,6 +240,14 @@
     <action
         id="RefreshFieldInsightsAction"
         class="com.apollographql.ijplugin.studio.fieldinsights.RefreshFieldInsightsAction"
+    >
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Tools / Apollo / Download schema -->
+    <action
+        id="DownloadSchemaAction"
+        class="com.apollographql.ijplugin.gradle.DownloadSchemaAction"
     >
       <add-to-group group-id="ApolloToolsActionGroup" />
     </action>

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -46,6 +46,18 @@ action.RefreshFieldInsightsAction.mustConfigureDialog.title=Apollo GraphOS Not C
 action.RefreshFieldInsightsAction.mustConfigureDialog.ok=Open Settings
 action.RefreshFieldInsightsAction.mustConfigureDialog.cancel=Cancel
 
+action.DownloadSchemaAction.text=Download Schema
+action.DownloadSchemaAction.description=Download the latest schema(s) from introspection or registry as configured in the Apollo Gradle configuration
+action.DownloadSchemaAction.progress=Downloading schema
+action.DownloadSchemaAction.noTasksFound.title=Could not download schema
+action.DownloadSchemaAction.noTasksFound.content=No download schema tasks were found. Please configure an <code>introspection</code> or <code>registry</code> in the Apollo Gradle configuration.
+action.DownloadSchemaAction.openDocumentation=Open Documentation
+action.DownloadSchemaAction.buildFail.title=Could not download schema
+action.DownloadSchemaAction.buildFail.content=Gradle task execution failed: ''{0}''.<br>Try on the command line with <code>./gradlew {1}</code> for more information.
+action.DownloadSchemaAction.buildSuccess.content={0} downloaded successfully
+action.DownloadSchemaAction.schema.singular=Schema
+action.DownloadSchemaAction.schema.plural=Schemas
+
 ApolloMigrationRefactoringProcessor.codeReferences=Items to be migrated
 
 ApolloV2ToV3MigrationProcessor.title=Migrate to Apollo Kotlin 3
@@ -109,3 +121,5 @@ inspection.unusedField.quickFix=Delete field
 inspection.apollo4Available.displayName=Apollo Kotlin 4 is available
 inspection.apollo4Available.reportText=Apollo Kotlin 4 is available
 inspection.apollo4Available.quickFix=Migrate to Apollo Kotlin 4
+
+notification.group.apollo=Apollo


### PR DESCRIPTION
Adds a "Download Schema" menu inside Tools | Apollo.

<img width="571" alt="Screenshot 2023-08-02 at 10 40 37" src="https://github.com/apollographql/apollo-kotlin/assets/372852/3a15f587-b057-4df5-82c0-2e0b0247c203">

<br>
<br>

This is a shortcut to execute all `downloadXyzApolloSchemaFromIntrospection` and `downloadXyzApolloSchemaFromRegistry` gradle tasks found in the project. If no such tasks are found an error bubble is displayed suggesting to add the introspection/registry configuration + a link to the documentation. 



<img width="386" alt="Screenshot 2023-08-02 at 10 43 12" src="https://github.com/apollographql/apollo-kotlin/assets/372852/57c228b5-18bf-48b4-847a-f02d224cc694">

<br>
<br>

<img width="388" alt="Screenshot 2023-08-02 at 10 40 55" src="https://github.com/apollographql/apollo-kotlin/assets/372852/a408fab0-a4b4-4890-832a-25c82a3b05f3">



