### PR TITLE
Add generateInputBuilders

### DIFF
--- a/docs/source/advanced/plugin-configuration.mdx
+++ b/docs/source/advanced/plugin-configuration.mdx
@@ -295,6 +295,9 @@ apollo {
     generateModelBuilders.set(true)
     // Whether to generate fields as primitive types (`int`, `double`, `boolean`) instead of their boxed types (`Integer`, `Double`, etc..)
     generatePrimitiveTypes.set(true)
+    // Opt-in Builders for Operations, Fragments and Input types. Builders are more ergonomic than default arguments when there are a lot of
+    // optional arguments.
+    generateInputBuilders.set(true)
     // The style to use for fields that are nullable in the Java generated code
     nullableFieldStyle.set("apolloOptional")
     // Whether to decapitalize field names in the generated models (for instance `FooBar` -> `fooBar`)

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -127,8 +127,8 @@ public final class com/apollographql/apollo3/compiler/JavaNullable$Companion {
 }
 
 public final class com/apollographql/apollo3/compiler/KotlinCodegenOptions {
-	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/List;ZZLcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;ZLjava/lang/String;Z)V
-	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/List;ZZLcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;ZLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/List;ZZLcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;ZLjava/lang/String;ZZ)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/List;ZZLcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;ZLjava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAddJvmOverloads ()Z
 	public final fun getGenerateAsInternal ()Z
 	public final fun getGenerateFilterNotNull ()Z
@@ -185,6 +185,7 @@ public final class com/apollographql/apollo3/compiler/OptionsKt {
 	public static final field defaultGenerateDataBuilders Z
 	public static final field defaultGenerateFilterNotNull Z
 	public static final field defaultGenerateFragmentImplementations Z
+	public static final field defaultGenerateInputBuilders Z
 	public static final field defaultGenerateModelBuilders Z
 	public static final field defaultGenerateOptionalOperationVariables Z
 	public static final field defaultGeneratePrimitiveTypes Z

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -394,6 +394,7 @@ object ApolloCompiler {
       addJvmOverloads: Boolean = defaultAddJvmOverloads,
       requiresOptInAnnotation: String = defaultRequiresOptInAnnotation,
       compilerKotlinHooks: ApolloCompilerKotlinHooks = defaultCompilerKotlinHooks,
+      generateInputBuilders: Boolean = false
   ): CodegenMetadata {
     /**
      * Inject all built-in scalars
@@ -484,7 +485,8 @@ object ApolloCompiler {
             addJvmOverloads = addJvmOverloads,
             requiresOptInAnnotation = requiresOptInAnnotation,
             compilerKotlinHooks = compilerKotlinHooks,
-            languageVersion = targetLanguage
+            languageVersion = targetLanguage,
+            generateInputBuilders = generateInputBuilders
         )
         writeKotlin(
             commonCodegenOptions = commonCodegenOptions,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -247,6 +247,7 @@ class KotlinCodegenOptions(
      */
     val addJvmOverloads: Boolean = false,
     val requiresOptInAnnotation: String?,
+
     /**
      * Whether to add the [JsExport] annotation to generated models. This is useful to be able to cast JSON parsed
      * responses into Kotlin classes using [unsafeCast].
@@ -255,6 +256,16 @@ class KotlinCodegenOptions(
      */
     @ApolloExperimental
     val jsExport: Boolean = false,
+
+    /**
+     * Whether to generate builders in addition to constructors for operations and input types.
+     * Constructors are more concise but require passing an instance of `Optional` always, making them more verbose
+     * for the cases where there are a lot of optional input parameters.
+     *
+     * Default: false
+     */
+    @ApolloExperimental
+    val generateInputBuilders: Boolean = false
 )
 
 class JavaCodegenOptions(
@@ -369,6 +380,7 @@ const val defaultAddJvmOverloads = false
 const val defaultFieldsOnDisjointTypesMustMerge = true
 const val defaultGeneratePrimitiveTypes = false
 const val defaultJsExport = false
+const val defaultGenerateInputBuilders = false
 val defaultNullableFieldStyle = JavaNullable.NONE
 const val defaultDecapitalizeFields = false
 val defaultCompilerKotlinHooks = ApolloCompilerKotlinHooks.Identity

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -72,6 +72,7 @@ internal object KotlinCodeGen {
     val hooks = kotlinCodegenOptions.compilerKotlinHooks
     val generateSchema = commonCodegenOptions.generateSchema || generateDataBuilders
     val outputDir = commonCodegenOptions.outputDir
+    val generateInputBuilders = kotlinCodegenOptions.generateInputBuilders
 
     val upstreamResolver = resolverInfos.fold(null as KotlinResolver?) { acc, resolverInfo ->
       KotlinResolver(resolverInfo.entries, acc, scalarMapping, requiresOptInAnnotation, hooks)
@@ -108,7 +109,7 @@ internal object KotlinCodeGen {
         builders.add(EnumResponseAdapterBuilder(context, irEnum))
       }
       irSchema.irInputObjects.forEach { irInputObject ->
-        builders.add(InputObjectBuilder(context, irInputObject))
+        builders.add(InputObjectBuilder(context, irInputObject, generateInputBuilders))
         builders.add(InputObjectAdapterBuilder(context, irInputObject))
       }
       irSchema.irUnions.forEach {irUnion ->
@@ -156,7 +157,8 @@ internal object KotlinCodeGen {
                     fragment,
                     flatten,
                     addJvmOverloads,
-                    generateDataBuilders
+                    generateDataBuilders,
+                    generateInputBuilders,
                 )
             )
             if (fragment.variables.isNotEmpty()) {
@@ -184,6 +186,7 @@ internal object KotlinCodeGen {
                   flatten,
                   addJvmOverloads,
                   generateDataBuilders,
+                  generateInputBuilders
               )
           )
         }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -61,6 +61,7 @@ internal object KotlinSymbols {
   val MapBuilder = ClassNames.MapBuilder.toKotlinPoetClassName()
   val StubbedProperty = ClassNames.StubbedProperty.toKotlinPoetClassName()
   val MandatoryTypenameProperty = ClassNames.MandatoryTypenameProperty.toKotlinPoetClassName()
+  val Builder = ClassName("", "Builder")
 
   /**
    * Kotlin class names

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InputObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InputObjectBuilder.kt
@@ -1,22 +1,33 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
+import com.apollographql.apollo3.compiler.codegen.Identifier
+import com.apollographql.apollo3.compiler.codegen.Identifier.Builder
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.NamedType
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.makeDataClass
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toNamedType
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toParameterSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toPropertySpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toSetterFunSpec
 import com.apollographql.apollo3.compiler.ir.IrInputObject
+import com.apollographql.apollo3.compiler.ir.IrNonNullType
+import com.apollographql.apollo3.compiler.ir.IrOptionalType
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class InputObjectBuilder(
     val context: KotlinContext,
     val inputObject: IrInputObject,
+    val generateInputBuilders: Boolean,
 ) : CgFileBuilder {
   private val packageName = context.layout.typePackageName()
   private val simpleName = context.layout.inputObjectName(inputObject.name)
+  private val className = ClassName(packageName, simpleName)
 
   override fun build(): CgFile {
     return CgFile(
@@ -29,16 +40,60 @@ internal class InputObjectBuilder(
   override fun prepare() {
     context.resolver.registerSchemaType(
         inputObject.name,
-        ClassName(packageName, simpleName)
+        className
     )
   }
 
-  private fun IrInputObject.typeSpec() =
-      TypeSpec
-          .classBuilder(simpleName)
-          .maybeAddDescription(description)
-          .makeDataClass(fields.map {
-            it.toNamedType().toParameterSpec(context)
-          })
-          .build()
+  private fun IrInputObject.typeSpec(): TypeSpec {
+    val namedTypes = fields.map {
+      it.toNamedType()
+    }
+    return TypeSpec
+        .classBuilder(simpleName)
+        .maybeAddDescription(description)
+        .makeDataClass(namedTypes.map { it.toParameterSpec(context) })
+        .apply {
+          if (namedTypes.isNotEmpty() && generateInputBuilders) {
+            addType(namedTypes.builderTypeSpec(context, className))
+          }
+        }
+        .build()
+  }
+}
+
+
+internal fun List<NamedType>.builderTypeSpec(context: KotlinContext, returnedClassName: ClassName): TypeSpec {
+  return TypeSpec.classBuilder(Builder)
+      .apply {
+        forEach {
+          addProperty(it.toPropertySpec(context))
+          addFunction(it.toSetterFunSpec(context))
+        }
+      }
+      .addFunction(toBuildFunSpec(context, returnedClassName))
+      .build()
+}
+
+private fun List<NamedType>.toBuildFunSpec(context: KotlinContext, returnedClassName: ClassName): FunSpec {
+  return FunSpec.builder(Identifier.build)
+      .returns(returnedClassName)
+      .addCode(
+          CodeBlock.builder()
+              .add("return·%T(\n", returnedClassName)
+              .indent()
+              .apply {
+                forEach {
+                  val propertyName = context.layout.propertyName(it.graphQlName)
+                  add("%L·=·%L", propertyName, propertyName)
+                  if (it.type is IrNonNullType && it.type.ofType !is IrOptionalType) {
+                    add("·?:·error(\"missing·value·for·$propertyName\")")
+                  }
+                  add(",\n")
+                }
+              }
+              .unindent()
+              .add(")")
+              .build()
+      )
+      .build()
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/KDoc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/KDoc.kt
@@ -36,6 +36,14 @@ internal fun ParameterSpec.Builder.maybeAddDescription(description: String?): Pa
   return addKdoc("%L", description)
 }
 
+internal fun FunSpec.Builder.maybeAddDescription(description: String?): FunSpec.Builder {
+  if (description.isNullOrBlank()) {
+    return this
+  }
+
+  return addKdoc("%L", description)
+}
+
 
 internal fun TypeSpec.Builder.maybeAddDeprecation(deprecationReason: String?): TypeSpec.Builder {
   if (deprecationReason.isNullOrBlank()) {
@@ -54,6 +62,14 @@ internal fun PropertySpec.Builder.maybeAddDeprecation(deprecationReason: String?
 }
 
 internal fun ParameterSpec.Builder.maybeAddDeprecation(deprecationReason: String?): ParameterSpec.Builder {
+  if (deprecationReason.isNullOrBlank()) {
+    return this
+  }
+
+  return addAnnotation(deprecatedAnnotation(deprecationReason))
+}
+
+internal fun FunSpec.Builder.maybeAddDeprecation(deprecationReason: String?): FunSpec.Builder {
   if (deprecationReason.isNullOrBlank()) {
     return this
   }
@@ -80,6 +96,15 @@ internal fun PropertySpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver
 }
 
 internal fun ParameterSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): ParameterSpec.Builder {
+  if (optInFeature.isNullOrBlank()) {
+    return this
+  }
+
+  val annotation = resolver.resolveRequiresOptInAnnotation() ?: return this
+  return addAnnotation(AnnotationSpec.builder(annotation).build())
+}
+
+internal fun FunSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): FunSpec.Builder {
   if (optInFeature.isNullOrBlank()) {
     return this
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/NamedType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/NamedType.kt
@@ -4,11 +4,17 @@ import com.apollographql.apollo3.compiler.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrInputField
+import com.apollographql.apollo3.compiler.ir.IrNonNullType
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.IrValue
 import com.apollographql.apollo3.compiler.ir.IrVariable
 import com.apollographql.apollo3.compiler.ir.isOptional
+import com.apollographql.apollo3.compiler.ir.makeNonOptional
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
 
 internal class NamedType(
     val graphQlName: String,
@@ -31,6 +37,51 @@ internal fun NamedType.toParameterSpec(context: KotlinContext): ParameterSpec {
       .maybeAddDeprecation(deprecationReason)
       .maybeAddRequiresOptIn(context.resolver, optInFeature)
       .applyIf(type.isOptional()) { defaultValue("%T", KotlinSymbols.Absent) }
+      .build()
+}
+
+internal fun NamedType.toPropertySpec(context: KotlinContext): PropertySpec {
+  val initializer = CodeBlock.builder()
+  val actualType: IrType
+  if (type.isOptional()) {
+    initializer.add("%T", KotlinSymbols.Absent)
+    actualType = type
+  } else {
+    initializer.add("null")
+    actualType = (type as? IrNonNullType)?.ofType ?: type
+  }
+  return PropertySpec
+      .builder(
+          // we use property for parameters as these are ultimately data classes
+          name = context.layout.propertyName(graphQlName),
+          type = context.resolver.resolveIrType(actualType, context.jsExport)
+      )
+      .mutable(true)
+      .addModifiers(KModifier.PRIVATE, )
+      .initializer(initializer.build())
+      .build()
+}
+
+internal fun NamedType.toSetterFunSpec(context: KotlinContext): FunSpec {
+  val propertyName = context.layout.propertyName(graphQlName)
+  val body = CodeBlock.builder()
+  val parameterType: IrType
+  if (type.isOptional()) {
+    body.add("this.%L·=·%T(%L)\n", propertyName, KotlinSymbols.Present, propertyName)
+    parameterType = type.makeNonOptional()
+  } else {
+    body.add("this.%L·=·%L\n", propertyName,propertyName)
+    parameterType = type
+  }
+  body.add("return this")
+  return FunSpec
+      .builder(name = propertyName)
+      .returns(KotlinSymbols.Builder)
+      .maybeAddDescription(description)
+      .maybeAddDeprecation(deprecationReason)
+      .maybeAddRequiresOptIn(context.resolver, optInFeature)
+      .addParameter(ParameterSpec(propertyName, context.resolver.resolveIrType(parameterType, context.jsExport)))
+      .addCode(body.build())
       .build()
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
@@ -136,7 +136,8 @@ internal data class IrEnum(
  *
  * Note: [IrInputField], and [IrVariable] are all very similar since they all share
  * the [com.apollographql.apollo3.ast.GQLInputValueDefinition] type, but [IrVariable]
- * so they are modeled differently in the [IrOperations]
+ * misses description, deprecation and optIn so they are modeled differently in
+ * [IrOperations]
  */
 internal data class IrInputField(
     val name: String,

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/TestQuery.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/TestQuery.kt.expected
@@ -50,6 +50,27 @@ public data class TestQuery(
   .selections(selections = TestQuerySelections.__root)
   .build()
 
+  public class Builder {
+    private var ep: Episode? = null
+
+    private var review: ReviewInput? = null
+
+    public fun ep(ep: Episode): Builder {
+      this.ep = ep
+      return this
+    }
+
+    public fun review(review: ReviewInput): Builder {
+      this.review = review
+      return this
+    }
+
+    public fun build(): TestQuery = TestQuery(
+      ep = ep ?: error("missing value for ep"),
+      review = review ?: error("missing value for review"),
+    )
+  }
+
   @ApolloAdaptableWith(TestQuery_ResponseAdapter.Data::class)
   public data class Data(
     public val createReview: CreateReview?,

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ColorInput.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ColorInput.kt.expected
@@ -33,4 +33,64 @@ public data class ColorInput(
    * Circle ref to review input
    */
   public val reviewRefInput: Optional<ReviewRefInput?> = Optional.Absent,
-)
+) {
+  public class Builder {
+    private var red: Optional<Int> = Optional.Absent
+
+    private var green: Optional<Double?> = Optional.Absent
+
+    private var blue: Optional<Double> = Optional.Absent
+
+    private var enumWithDefaultValue: Optional<Episode?> = Optional.Absent
+
+    private var reviewRefInput: Optional<ReviewRefInput?> = Optional.Absent
+
+    /**
+     * A description with a dollar sign: $10
+     */
+    public fun red(red: Int): Builder {
+      this.red = Optional.Present(red)
+      return this
+    }
+
+    /**
+     * Green color
+     */
+    public fun green(green: Double?): Builder {
+      this.green = Optional.Present(green)
+      return this
+    }
+
+    /**
+     * Blue color
+     */
+    public fun blue(blue: Double): Builder {
+      this.blue = Optional.Present(blue)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun enumWithDefaultValue(enumWithDefaultValue: Episode?): Builder {
+      this.enumWithDefaultValue = Optional.Present(enumWithDefaultValue)
+      return this
+    }
+
+    /**
+     * Circle ref to review input
+     */
+    public fun reviewRefInput(reviewRefInput: ReviewRefInput?): Builder {
+      this.reviewRefInput = Optional.Present(reviewRefInput)
+      return this
+    }
+
+    public fun build(): ColorInput = ColorInput(
+      red = red,
+      green = green,
+      blue = blue,
+      enumWithDefaultValue = enumWithDefaultValue,
+      reviewRefInput = reviewRefInput,
+    )
+  }
+}

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewInput.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewInput.kt.expected
@@ -104,4 +104,251 @@ public data class ReviewInput(
    * for test purpose only
    */
   public val CapitalizedInt: Optional<Int?> = Optional.Absent,
-)
+) {
+  public class Builder {
+    private var stars: Int? = null
+
+    private var nullableIntFieldWithDefaultValue: Optional<Int?> = Optional.Absent
+
+    private var commentary: Optional<String?> = Optional.Absent
+
+    private var favoriteColor: ColorInput? = null
+
+    private var enumWithDefaultValue: Optional<Episode?> = Optional.Absent
+
+    private var nonNullableEnumWithDefaultValue: Optional<Episode> = Optional.Absent
+
+    private var nullableEnum: Optional<Episode?> = Optional.Absent
+
+    private var listOfCustomScalar: Optional<List<Date?>?> = Optional.Absent
+
+    private var customScalar: Optional<Date?> = Optional.Absent
+
+    private var listOfEnums: Optional<List<Episode?>?> = Optional.Absent
+
+    private var listOfInt: Optional<List<Int?>?> = Optional.Absent
+
+    private var listOfString: Optional<List<String?>?> = Optional.Absent
+
+    private var listOfStringNonOptional: List<String?>? = null
+
+    private var listOfInputTypes: Optional<List<ColorInput?>?> = Optional.Absent
+
+    private var booleanWithDefaultValue: Optional<Boolean?> = Optional.Absent
+
+    private var booleanNonOptional: Optional<Boolean?> = Optional.Absent
+
+    private var listOfListOfString: Optional<List<List<String>>?> = Optional.Absent
+
+    private var listOfListOfEnum: Optional<List<List<Episode>>?> = Optional.Absent
+
+    private var listOfListOfCustom: Optional<List<List<Date>>?> = Optional.Absent
+
+    private var listOfListOfObject: Optional<List<List<ColorInput>>?> = Optional.Absent
+
+    private var CapitalizedField: Optional<String?> = Optional.Absent
+
+    private var CapitalizedInt: Optional<Int?> = Optional.Absent
+
+    /**
+     * 0-5 stars
+     */
+    public fun stars(stars: Int): Builder {
+      this.stars = stars
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun nullableIntFieldWithDefaultValue(nullableIntFieldWithDefaultValue: Int?): Builder {
+      this.nullableIntFieldWithDefaultValue = Optional.Present(nullableIntFieldWithDefaultValue)
+      return this
+    }
+
+    /**
+     * Comment about the movie, optional
+     */
+    public fun commentary(commentary: String?): Builder {
+      this.commentary = Optional.Present(commentary)
+      return this
+    }
+
+    /**
+     * Favorite color, optional
+     */
+    public fun favoriteColor(favoriteColor: ColorInput): Builder {
+      this.favoriteColor = favoriteColor
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun enumWithDefaultValue(enumWithDefaultValue: Episode?): Builder {
+      this.enumWithDefaultValue = Optional.Present(enumWithDefaultValue)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun nonNullableEnumWithDefaultValue(nonNullableEnumWithDefaultValue: Episode): Builder {
+      this.nonNullableEnumWithDefaultValue = Optional.Present(nonNullableEnumWithDefaultValue)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun nullableEnum(nullableEnum: Episode?): Builder {
+      this.nullableEnum = Optional.Present(nullableEnum)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfCustomScalar(listOfCustomScalar: List<Date?>?): Builder {
+      this.listOfCustomScalar = Optional.Present(listOfCustomScalar)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun customScalar(customScalar: Date?): Builder {
+      this.customScalar = Optional.Present(customScalar)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfEnums(listOfEnums: List<Episode?>?): Builder {
+      this.listOfEnums = Optional.Present(listOfEnums)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfInt(listOfInt: List<Int?>?): Builder {
+      this.listOfInt = Optional.Present(listOfInt)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfString(listOfString: List<String?>?): Builder {
+      this.listOfString = Optional.Present(listOfString)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfStringNonOptional(listOfStringNonOptional: List<String?>): Builder {
+      this.listOfStringNonOptional = listOfStringNonOptional
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfInputTypes(listOfInputTypes: List<ColorInput?>?): Builder {
+      this.listOfInputTypes = Optional.Present(listOfInputTypes)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun booleanWithDefaultValue(booleanWithDefaultValue: Boolean?): Builder {
+      this.booleanWithDefaultValue = Optional.Present(booleanWithDefaultValue)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun booleanNonOptional(booleanNonOptional: Boolean?): Builder {
+      this.booleanNonOptional = Optional.Present(booleanNonOptional)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfListOfString(listOfListOfString: List<List<String>>?): Builder {
+      this.listOfListOfString = Optional.Present(listOfListOfString)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfListOfEnum(listOfListOfEnum: List<List<Episode>>?): Builder {
+      this.listOfListOfEnum = Optional.Present(listOfListOfEnum)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfListOfCustom(listOfListOfCustom: List<List<Date>>?): Builder {
+      this.listOfListOfCustom = Optional.Present(listOfListOfCustom)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun listOfListOfObject(listOfListOfObject: List<List<ColorInput>>?): Builder {
+      this.listOfListOfObject = Optional.Present(listOfListOfObject)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun CapitalizedField(CapitalizedField: String?): Builder {
+      this.CapitalizedField = Optional.Present(CapitalizedField)
+      return this
+    }
+
+    /**
+     * for test purpose only
+     */
+    public fun CapitalizedInt(CapitalizedInt: Int?): Builder {
+      this.CapitalizedInt = Optional.Present(CapitalizedInt)
+      return this
+    }
+
+    public fun build(): ReviewInput = ReviewInput(
+      stars = stars ?: error("missing value for stars"),
+      nullableIntFieldWithDefaultValue = nullableIntFieldWithDefaultValue,
+      commentary = commentary,
+      favoriteColor = favoriteColor ?: error("missing value for favoriteColor"),
+      enumWithDefaultValue = enumWithDefaultValue,
+      nonNullableEnumWithDefaultValue = nonNullableEnumWithDefaultValue,
+      nullableEnum = nullableEnum,
+      listOfCustomScalar = listOfCustomScalar,
+      customScalar = customScalar,
+      listOfEnums = listOfEnums,
+      listOfInt = listOfInt,
+      listOfString = listOfString,
+      listOfStringNonOptional = listOfStringNonOptional ?: error("missing value for listOfStringNonOptional"),
+      listOfInputTypes = listOfInputTypes,
+      booleanWithDefaultValue = booleanWithDefaultValue,
+      booleanNonOptional = booleanNonOptional,
+      listOfListOfString = listOfListOfString,
+      listOfListOfEnum = listOfListOfEnum,
+      listOfListOfCustom = listOfListOfCustom,
+      listOfListOfObject = listOfListOfObject,
+      CapitalizedField = CapitalizedField,
+      CapitalizedInt = CapitalizedInt,
+    )
+  }
+}

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewRefInput.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/ReviewRefInput.kt.expected
@@ -12,4 +12,17 @@ import com.apollographql.apollo3.api.Optional
  */
 public data class ReviewRefInput(
   public val reviewInput: Optional<ReviewInput?> = Optional.Absent,
-)
+) {
+  public class Builder {
+    private var reviewInput: Optional<ReviewInput?> = Optional.Absent
+
+    public fun reviewInput(reviewInput: ReviewInput?): Builder {
+      this.reviewInput = Optional.Present(reviewInput)
+      return this
+    }
+
+    public fun build(): ReviewRefInput = ReviewRefInput(
+      reviewInput = reviewInput,
+    )
+  }
+}

--- a/libraries/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,8 +2,8 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  191026
-aggregate-kotlin-responseBased                                                                  60021
+aggregate-all                                                                                  191367
+aggregate-kotlin-responseBased                                                                  60362
 aggregate-kotlin-operationBased                                                                 40413
 aggregate-kotlin-compat                                                                             0
 aggregate-java-operationBased                                                                   90592
@@ -37,6 +37,7 @@ java-operationBased-multiple_fragments                                          
 kotlin-operationBased-fragment_with_inline_fragment                                              1255
 java-operationBased-nested_field_with_multiple_fieldsets                                         1255
 kotlin-responseBased-root_query_fragment_with_nested_fragments                                   1249
+kotlin-responseBased-input_object_type                                                           1230
 kotlin-operationBased-nested_named_fragments                                                     1229
 java-operationBased-two_heroes_with_friends                                                      1212
 java-operationBased-inline_fragment_merge_fields                                                 1209
@@ -82,7 +83,6 @@ java-operationBased-fieldset_with_multiple_super                                
 java-operationBased-simple_inline_fragment                                                        901
 java-operationBased-inline_fragment_with_include_directive                                        898
 java-operationBased-introspection_query                                                           890
-kotlin-responseBased-input_object_type                                                            889
 kotlin-operationBased-nested_conditional_inline                                                   886
 kotlin-operationBased-named_fragment_with_variables                                               880
 kotlin-responseBased-mutation_create_review_semantic_naming                                       874

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -303,6 +303,8 @@ class CodegenTest {
 
       val generateSchema = folder.name == "__schema"
 
+      val generateInputBuilders = folder.name == "input_object_type"
+
       val schemaFile = folder.listFiles()!!.find { it.isFile && (it.name == "schema.sdl" || it.name == "schema.json" || it.name == "schema.graphqls") }
           ?: File("src/test/graphql/schema.sdl")
 
@@ -404,7 +406,8 @@ class CodegenTest {
           requiresOptInAnnotation = requiresOptInAnnotation,
           compilerKotlinHooks = compilerKotlinHooks,
           generatePrimitiveTypes = generatePrimitiveTypes,
-          generateFilterNotNull = true
+          generateFilterNotNull = true,
+          generateInputBuilders = generateInputBuilders,
       )
       return outputDir
     }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -643,6 +643,16 @@ interface Service {
   val generatePrimitiveTypes: Property<Boolean>
 
   /**
+   * Whether to generate builders in addition to constructors for operations and input types.
+   * Constructors are more concise but require passing an instance of `Optional` always, making them more verbose
+   * for the cases where there are a lot of optional input parameters.
+   *
+   * Default: false
+   */
+  @ApolloExperimental
+  val generateInputBuilders: Property<Boolean>
+
+  /**
    * The style to use for fields that are nullable in the Java generated code.
    *
    * Only valid when [generateKotlinModels] is `false`.

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBase.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBase.kt
@@ -16,6 +16,7 @@ import com.apollographql.apollo3.compiler.defaultAddJvmOverloads
 import com.apollographql.apollo3.compiler.defaultClassesForEnumsMatching
 import com.apollographql.apollo3.compiler.defaultGenerateFilterNotNull
 import com.apollographql.apollo3.compiler.defaultGenerateFragmentImplementations
+import com.apollographql.apollo3.compiler.defaultGenerateInputBuilders
 import com.apollographql.apollo3.compiler.defaultGenerateModelBuilders
 import com.apollographql.apollo3.compiler.defaultGeneratePrimitiveTypes
 import com.apollographql.apollo3.compiler.defaultGenerateQueryDocument
@@ -94,6 +95,10 @@ abstract class ApolloGenerateSourcesBase : DefaultTask() {
   @get:Input
   @get:Optional
   abstract val generateFilterNotNull: Property<Boolean>
+
+  @get:Input
+  @get:Optional
+  abstract val generateInputBuilders: Property<Boolean>
 
   @get:Input
   @get:Optional
@@ -206,7 +211,8 @@ abstract class ApolloGenerateSourcesBase : DefaultTask() {
             requiresOptInAnnotation = requiresOptInAnnotation.getOrElse(defaultRequiresOptInAnnotation),
             compilerKotlinHooks = compilerKotlinHooks,
             languageVersion = codegenSchema.targetLanguage,
-            jsExport = jsExport.getOrElse(defaultJsExport)
+            jsExport = jsExport.getOrElse(defaultJsExport),
+            generateInputBuilders = generateInputBuilders.getOrElse(defaultGenerateInputBuilders)
         )
         ApolloCompiler.writeKotlin(
             commonCodegenOptions = commonCodegenOptions,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -654,6 +654,7 @@ abstract class DefaultApolloExtension(
     task.generateOptionalOperationVariables.set(service.generateOptionalOperationVariables)
     task.requiresOptInAnnotation.set(service.requiresOptInAnnotation)
     task.generatePrimitiveTypes.set(service.generatePrimitiveTypes)
+    task.generateInputBuilders.set(service.generateInputBuilders)
     val nullableFieldStyle: String? = service.nullableFieldStyle.orNull
     task.nullableFieldStyle.set(
         project.provider {

--- a/tests/input/build.gradle.kts
+++ b/tests/input/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("apollo.test")
+  id("com.apollographql.apollo3")
+}
+
+dependencies {
+  implementation(libs.apollo.api)
+  testImplementation(libs.kotlin.test)
+  testImplementation(libs.junit)
+  testImplementation(libs.okhttp)
+}
+
+apollo {
+  service("service") {
+    packageName.set("com.example")
+    generateOptionalOperationVariables.set(false)
+    generateInputBuilders.set(true)
+  }
+}

--- a/tests/input/src/main/graphql/operation.graphql
+++ b/tests/input/src/main/graphql/operation.graphql
@@ -1,0 +1,7 @@
+query GetUser($input: UserInput!) {
+  user(input: $input)
+}
+
+query GetUser2($input: UserInput) {
+  user(input: $input)
+}

--- a/tests/input/src/main/graphql/schema.graphqls
+++ b/tests/input/src/main/graphql/schema.graphqls
@@ -1,0 +1,8 @@
+type Query {
+  user(input: UserInput): Int
+}
+
+input UserInput {
+  name: String!
+  email: String
+}

--- a/tests/input/src/test/kotlin/test/InputTest.kt
+++ b/tests/input/src/test/kotlin/test/InputTest.kt
@@ -1,0 +1,31 @@
+package test
+
+import com.apollographql.apollo3.api.Optional
+import com.example.GetUser2Query
+import com.example.GetUserQuery
+import com.example.type.UserInput
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class InputTest {
+  @Test
+  fun simple() {
+    val input = UserInput.Builder()
+        .name("Test User")
+        .email("test@example.com")
+        .build()
+
+    assertEquals("Test User", input.name)
+    assertEquals(Optional.present("test@example.com"), input.email)
+
+    val query1 = GetUserQuery.Builder()
+        .input(input)
+        .build()
+    assertEquals("Test User", query1.input.name)
+
+    val query2 = GetUser2Query.Builder()
+        .input(input)
+        .build()
+    assertEquals("Test User", query2.input?.name)
+  }
+}


### PR DESCRIPTION
Kotlin constructors with default params are nice but when compared to `Builders`, they lack the ability to represent the "absent" case. Builders allow 3 cases:

```kotlin
// present
Builder()
  .param(42)
  .build()

// null
Builder()
  .param(null)
  .build()

// absent
Builder()
  .build()
```

The same code in Kotlin requires wrapping the parameters in `Optional` which is more verbose when there are a lot of parameters (See https://github.com/apollographql/apollo-kotlin/issues/4747):

```kotlin
// present
SomeClass(param = Optional.Present(42))

// null
SomeClass(param = Optional.Present(null))

// absent (default)
SomeClass()
```

This PR brings back builders for those cases