### PR TITLE
Add a special comment to disable the GraphQL intelliJ plugin inspection

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gql.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gql.kt
@@ -727,6 +727,7 @@ class GQLDirectiveDefinition(
         "include",
         "skip",
         "deprecated",
+        "specifiedBy"
     )
   }
 }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -135,10 +135,6 @@ fun GQLDocument.toSDL(indent: String = "  "): String {
   val buffer = Buffer()
   val writer = SDLWriter(buffer, indent)
 
-  definitions.filter {
-    it !is GQLScalarTypeDefinition || it.name !in GQLTypeDefinition.builtInTypes
-  }
-
   definitions.forEachIndexed { index, definition ->
     when {
       definition is GQLScalarTypeDefinition && definition.name in GQLTypeDefinition.builtInTypes -> {

--- a/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
+++ b/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/ParserTest.kt
@@ -14,7 +14,7 @@ class ParserTest {
   @Test
   fun parserProducesExpectedValues(@TestParameter(valuesProvider = ParametersProvider::class) graphqlFile: File) {
     checkExpected(graphqlFile) {
-      graphqlFile.parseAsGQLDocument()
+      it.parseAsGQLDocument()
           .issues
           .serialize()
     }
@@ -29,28 +29,6 @@ class ParserTest {
           .filter {
             testFilterMatches(it.name)
           }
-    }
-  }
-
-  /**
-   * run the block and checks the result against the .expected file. Will overwrite the result if required
-   *
-   * @param block the callback to produce the result.
-   */
-  fun checkExpected(graphQLFile: File, block: () -> String) {
-    val actual = block()
-
-    val expectedFile = File(graphQLFile.parent, graphQLFile.nameWithoutExtension + ".expected")
-    val expected = try {
-      expectedFile.readText()
-    } catch (e: Exception) {
-      null
-    }
-
-    if (shouldUpdateTestFixtures()) {
-      expectedFile.writeText(actual)
-    } else {
-      assertEquals(expected, actual)
     }
   }
 
@@ -76,6 +54,28 @@ class ParserTest {
       val testFilter = System.getenv("testFilter") ?: System.getProperty("testFilter") ?: return true
 
       return Regex(testFilter).containsMatchIn(value)
+    }
+
+    /**
+     * run the block and checks the result against the .expected file. Will overwrite the result if required
+     *
+     * @param block the callback to produce the result.
+     */
+    fun checkExpected(graphQLFile: File, block: (File) -> String) {
+      val actual = block(graphQLFile)
+
+      val expectedFile = File(graphQLFile.parent, graphQLFile.nameWithoutExtension + ".expected")
+      val expected = try {
+        expectedFile.readText()
+      } catch (e: Exception) {
+        null
+      }
+
+      if (shouldUpdateTestFixtures()) {
+        expectedFile.writeText(actual)
+      } else {
+        assertEquals(expected, actual)
+      }
     }
   }
 }

--- a/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
+++ b/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/SDLWriterTest.kt
@@ -1,48 +1,39 @@
 package com.apollographql.apollo3.graphql.ast.test
 
-import com.apollographql.apollo3.ast.GQLDocument
+import com.apollographql.apollo3.ast.introspection.toSchema
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toSDL
+import com.apollographql.apollo3.ast.withBuiltinDefinitions
+import com.apollographql.apollo3.graphql.ast.test.ParserTest.Companion.checkExpected
+import java.io.File
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 class SDLWriterTest {
   @Test
   fun simpleTest() {
-    val schemaString = """
-      schema {
-          query: Query
-      }
-      
-      type Query {
-          foo: Int
-      }
-      
-      interface A {
-          a: String
-      }
-      
-      interface B {
-          b: String
-      }
-      
-      type C implements A & B {
-          a: String
-      
-          b: String
-      }
-      
-      interface D implements A & B {
-          a: String
-      
-          b: String
-      }
+    val sdlSchema = File("${CWD}/test-fixtures/sdl/simple.graphqls")
 
-    """.trimIndent()
+    checkExpected(sdlSchema) {
+      it.parseAsGQLDocument().getOrThrow().toSDL("    ")
+    }
+  }
 
-    val schema: GQLDocument = schemaString.parseAsGQLDocument().getOrThrow()
-    val sdl = schema.toSDL("    ")
-    assertEquals(schemaString, sdl)
+  @Test
+  fun typeRedefinitionInspectionIsIgnored() {
+    val sdlSchema = File("${CWD}/test-fixtures/sdl/type_redefinitions.graphqls")
+
+    checkExpected(sdlSchema) {
+      it.parseAsGQLDocument().getOrThrow().withBuiltinDefinitions().toSDL("    ")
+    }
+  }
+
+  @Test
+  fun introspectionSchema() {
+    val sdlSchema = File("${CWD}/test-fixtures/sdl/introspection.json")
+
+    checkExpected(sdlSchema) {
+      it.toSchema().toGQLDocument().toSDL("    ")
+    }
   }
 
   @Test

--- a/libraries/apollo-ast/test-fixtures/sdl/introspection.expected
+++ b/libraries/apollo-ast/test-fixtures/sdl/introspection.expected
@@ -1,0 +1,197 @@
+schema {
+    query: Query
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true
+"""
+directive @include ("Included when true." if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
+directive @skip ("Skipped when true." if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+"""
+Marks the field, argument, input field or enum value as deprecated
+"""
+directive @deprecated ("The reason for the deprecation" reason: String = "No longer supported") on FIELD_DEFINITION|ARGUMENT_DEFINITION|ENUM_VALUE|INPUT_FIELD_DEFINITION
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+"""
+Exposes a URL that specifies the behaviour of this scalar.
+"""
+directive @specifiedBy ("The URL that specifies the behaviour of this scalar." url: String!) on SCALAR
+
+directive @defer (label: String, if: Boolean! = true) on FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+type Query {
+    foo: Int
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Schema {
+    description: String
+
+    types: [__Type!]!
+
+    queryType: __Type!
+
+    mutationType: __Type
+
+    subscriptionType: __Type
+
+    directives: [__Directive!]!
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Type {
+    kind: __TypeKind!
+
+    name: String
+
+    description: String
+
+    fields(includeDeprecated: Boolean = false): [__Field!]
+
+    interfaces: [__Type!]
+
+    possibleTypes: [__Type!]
+
+    enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+
+    inputFields(includeDeprecated: Boolean = false): [__InputValue!]
+
+    ofType: __Type
+
+    specifiedByURL: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+enum __TypeKind {
+    SCALAR
+
+    OBJECT
+
+    INTERFACE
+
+    UNION
+
+    ENUM
+
+    INPUT_OBJECT
+
+    LIST
+
+    NON_NULL
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Field {
+    name: String!
+
+    description: String
+
+    args(includeDeprecated: Boolean = false): [__InputValue!]!
+
+    type: __Type!
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __InputValue {
+    name: String!
+
+    description: String
+
+    type: __Type!
+
+    defaultValue: String
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __EnumValue {
+    name: String!
+
+    description: String
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Directive {
+    name: String!
+
+    description: String
+
+    locations: [__DirectiveLocation!]!
+
+    args(includeDeprecated: Boolean = false): [__InputValue!]!
+
+    isRepeatable: Boolean!
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+enum __DirectiveLocation {
+    QUERY
+
+    MUTATION
+
+    SUBSCRIPTION
+
+    FIELD
+
+    FRAGMENT_DEFINITION
+
+    FRAGMENT_SPREAD
+
+    INLINE_FRAGMENT
+
+    VARIABLE_DEFINITION
+
+    SCHEMA
+
+    SCALAR
+
+    OBJECT
+
+    FIELD_DEFINITION
+
+    ARGUMENT_DEFINITION
+
+    INTERFACE
+
+    UNION
+
+    ENUM
+
+    ENUM_VALUE
+
+    INPUT_OBJECT
+
+    INPUT_FIELD_DEFINITION
+}

--- a/libraries/apollo-ast/test-fixtures/sdl/introspection.json
+++ b/libraries/apollo-ast/test-fixtures/sdl/introspection.json
@@ -1,0 +1,138 @@
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "Query",
+          "description": null,
+          "fields": [
+            {
+              "name": "foo",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "possibleTypes": null,
+          "specifiedByURL": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "isRepeatable": false
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "isRepeatable": false
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks the field, argument, input field or enum value as deprecated",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ARGUMENT_DEFINITION",
+            "ENUM_VALUE",
+            "INPUT_FIELD_DEFINITION"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "The reason for the deprecation",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\""
+            }
+          ],
+          "isRepeatable": false
+        },
+        {
+          "name": "specifiedBy",
+          "description": "Exposes a URL that specifies the behaviour of this scalar.",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "The URL that specifies the behaviour of this scalar.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null
+            }
+          ],
+          "isRepeatable": false
+        }
+      ]
+    }
+  }
+}

--- a/libraries/apollo-ast/test-fixtures/sdl/simple.expected
+++ b/libraries/apollo-ast/test-fixtures/sdl/simple.expected
@@ -1,0 +1,27 @@
+schema {
+    query: Query
+}
+
+type Query {
+    foo: Int
+}
+
+interface A {
+    a: String
+}
+
+interface B {
+    b: String
+}
+
+type C implements A & B {
+    a: String
+
+    b: String
+}
+
+interface D implements A & B {
+    a: String
+
+    b: String
+}

--- a/libraries/apollo-ast/test-fixtures/sdl/simple.graphqls
+++ b/libraries/apollo-ast/test-fixtures/sdl/simple.graphqls
@@ -1,0 +1,27 @@
+schema {
+  query: Query
+}
+
+type Query {
+  foo: Int
+}
+
+interface A {
+  a: String
+}
+
+interface B {
+  b: String
+}
+
+type C implements A & B {
+  a: String
+
+  b: String
+}
+
+interface D implements A & B {
+  a: String
+
+  b: String
+}

--- a/libraries/apollo-ast/test-fixtures/sdl/type_redefinitions.expected
+++ b/libraries/apollo-ast/test-fixtures/sdl/type_redefinitions.expected
@@ -1,0 +1,181 @@
+type Query {
+    foo: Int
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Schema {
+    description: String
+
+    types: [__Type!]!
+
+    queryType: __Type!
+
+    mutationType: __Type
+
+    subscriptionType: __Type
+
+    directives: [__Directive!]!
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Type {
+    kind: __TypeKind!
+
+    name: String
+
+    description: String
+
+    fields(includeDeprecated: Boolean = false): [__Field!]
+
+    interfaces: [__Type!]
+
+    possibleTypes: [__Type!]
+
+    enumValues(includeDeprecated: Boolean = false): [__EnumValue!]
+
+    inputFields(includeDeprecated: Boolean = false): [__InputValue!]
+
+    ofType: __Type
+
+    specifiedByURL: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+enum __TypeKind {
+    SCALAR
+
+    OBJECT
+
+    INTERFACE
+
+    UNION
+
+    ENUM
+
+    INPUT_OBJECT
+
+    LIST
+
+    NON_NULL
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Field {
+    name: String!
+
+    description: String
+
+    args(includeDeprecated: Boolean = false): [__InputValue!]!
+
+    type: __Type!
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __InputValue {
+    name: String!
+
+    description: String
+
+    type: __Type!
+
+    defaultValue: String
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __EnumValue {
+    name: String!
+
+    description: String
+
+    isDeprecated: Boolean!
+
+    deprecationReason: String
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+type __Directive {
+    name: String!
+
+    description: String
+
+    locations: [__DirectiveLocation!]!
+
+    args(includeDeprecated: Boolean = false): [__InputValue!]!
+
+    isRepeatable: Boolean!
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+enum __DirectiveLocation {
+    QUERY
+
+    MUTATION
+
+    SUBSCRIPTION
+
+    FIELD
+
+    FRAGMENT_DEFINITION
+
+    FRAGMENT_SPREAD
+
+    INLINE_FRAGMENT
+
+    VARIABLE_DEFINITION
+
+    SCHEMA
+
+    SCALAR
+
+    OBJECT
+
+    FIELD_DEFINITION
+
+    ARGUMENT_DEFINITION
+
+    INTERFACE
+
+    UNION
+
+    ENUM
+
+    ENUM_VALUE
+
+    INPUT_OBJECT
+
+    INPUT_FIELD_DEFINITION
+}
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+directive @skip (if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+directive @include (if: Boolean!) on FIELD|FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+directive @deprecated (reason: String = "No longer supported") on FIELD_DEFINITION|ARGUMENT_DEFINITION|INPUT_FIELD_DEFINITION|ENUM_VALUE
+
+directive @defer (label: String, if: Boolean! = true) on FRAGMENT_SPREAD|INLINE_FRAGMENT
+
+# See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665
+# noinspection GraphQLTypeRedefinition
+directive @specifiedBy (url: String!) on SCALAR

--- a/libraries/apollo-ast/test-fixtures/sdl/type_redefinitions.graphqls
+++ b/libraries/apollo-ast/test-fixtures/sdl/type_redefinitions.graphqls
@@ -1,0 +1,4 @@
+type Query {
+  foo: Int
+}
+


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/issues/5126
See https://github.com/JetBrains/js-graphql-intellij-plugin/issues/665

Add a special GraphQL comment to ignore type redefinition errors:

```graphql
# Ignores IntelliJ plugin errors
# noinspection GraphQLTypeRedefinition
scalar Int
```