### PR TITLE
JSON: Remove limitation on the JSON nesting

### DIFF
--- a/libraries/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
+++ b/libraries/apollo-api/src/commonTest/kotlin/test/JsonTest.kt
@@ -3,8 +3,12 @@ package test
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.LongAdapter
+import com.apollographql.apollo3.api.json.MapJsonReader
 import com.apollographql.apollo3.api.json.MapJsonWriter
 import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
+import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -26,5 +30,37 @@ class JsonTest {
       AnyAdapter.toJson(this, CustomScalarAdapters.Empty, mapWriter.root()!!)
     }
     assertEquals("9223372036854775807", json)
+  }
+
+  @Test
+  fun canReadAndWriteVeryDeeplyNestedJsonSource() {
+    val json = buildJsonString {
+      val nesting = 1025
+      repeat(nesting) {
+        beginObject()
+        name("child")
+      }
+      value("yooooo")
+      repeat(nesting) {
+        endObject()
+      }
+    }
+
+    Buffer().writeUtf8(json).jsonReader().readAny()
+  }
+
+  @Test
+  fun canReadVeryDeeplyNestedJsonMap() {
+    val root = mutableMapOf<String, Any>()
+    var map = root
+    val nesting = 1025
+
+    repeat(nesting) {
+      val newMap = mutableMapOf<String, Any>()
+      map.put("child", newMap)
+      map = newMap
+    }
+
+    MapJsonReader(root).readAny()
   }
 }

--- a/libraries/apollo-api/src/jsMain/kotlin/com/apollographql/apollo3/api/json/DynamicJsJsonReader.kt
+++ b/libraries/apollo-api/src/jsMain/kotlin/com/apollographql/apollo3/api/json/DynamicJsJsonReader.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.api.json
 
-import com.apollographql.apollo3.api.json.BufferedSourceJsonReader.Companion.MAX_STACK_SIZE
+import com.apollographql.apollo3.api.json.BufferedSourceJsonReader.Companion.INITIAL_STACK_SIZE
 import com.apollographql.apollo3.api.json.MapJsonReader.Companion.buffer
 import com.apollographql.apollo3.api.json.internal.toDoubleExact
 import com.apollographql.apollo3.api.json.internal.toIntExact
@@ -74,14 +74,14 @@ constructor(
    * - a String representing the current key to be read in a Map
    * - null if peekedToken is BEGIN_OBJECT
    */
-  private val path = arrayOfNulls<Any>(MAX_STACK_SIZE)
+  private var path = arrayOfNulls<Any>(INITIAL_STACK_SIZE)
 
   /**
    * The current object memorized in case we need to rewind
    */
-  private var containerStack = arrayOfNulls<Any?>(MAX_STACK_SIZE)
-  private val iteratorStack = arrayOfNulls<IteratorWrapper>(MAX_STACK_SIZE)
-  private val nameIndexStack = IntArray(MAX_STACK_SIZE)
+  private var containerStack = arrayOfNulls<Any?>(INITIAL_STACK_SIZE)
+  private var iteratorStack = arrayOfNulls<IteratorWrapper>(INITIAL_STACK_SIZE)
+  private var nameIndexStack = IntArray(INITIAL_STACK_SIZE)
 
   private var stackSize = 0
 
@@ -143,17 +143,25 @@ constructor(
     }
   }
 
+  private fun increaseStack() {
+    if (stackSize == path.size) {
+      path = path.copyOf(path.size * 2)
+      containerStack = containerStack.copyOf(containerStack.size * 2)
+      nameIndexStack = nameIndexStack.copyOf(nameIndexStack.size * 2)
+      iteratorStack = iteratorStack.copyOf(iteratorStack.size * 2)
+    }
+    stackSize++
+  }
+
+
   override fun beginArray() = apply {
     if (peek() != JsonReader.Token.BEGIN_ARRAY) {
       throw JsonDataException("Expected BEGIN_ARRAY but was ${peek()} at path ${getPathAsString()}")
     }
 
     val currentValue = peekedData as Array<*>
-
-    check(stackSize < MAX_STACK_SIZE) {
-      "Nesting too deep"
-    }
-    stackSize++
+    
+    increaseStack()
 
     path[stackSize - 1] = -1
     iteratorStack[stackSize - 1] = IteratorWrapper.StandardIterator(currentValue.iterator())
@@ -175,10 +183,7 @@ constructor(
       throw JsonDataException("Expected BEGIN_OBJECT but was ${peek()} at path ${getPathAsString()}")
     }
 
-    check(stackSize < MAX_STACK_SIZE) {
-      "Nesting too deep"
-    }
-    stackSize++
+    increaseStack()
     containerStack[stackSize - 1] = peekedData.asDynamic()
 
     rewind()


### PR DESCRIPTION
If the JSON is too nested, an OutOfMemory exception will be thrown.

Closes https://github.com/apollographql/apollo-kotlin/issues/5159