### PR TITLE
integration-tests: better IDE support

### DIFF
--- a/tests/integration-tests/build.gradle.kts
+++ b/tests/integration-tests/build.gradle.kts
@@ -21,8 +21,6 @@ kotlin {
       dependencies {
         implementation(libs.apollo.api)
         implementation(libs.apollo.normalizedcache)
-        implementation(libs.apollo.testingsupport)
-        implementation(libs.apollo.mockserver)
         implementation(libs.apollo.adapters)
         implementation(libs.apollo.runtime)
       }
@@ -30,6 +28,8 @@ kotlin {
 
     findByName("commonTest")?.apply {
       dependencies {
+        implementation(libs.apollo.mockserver)
+        implementation(libs.apollo.testingsupport)
         implementation(libs.kotlinx.coroutines)
         implementation(libs.kotlinx.serialization.json.asProvider())
         implementation(libs.kotlinx.coroutines.test)


### PR DESCRIPTION
This fixes red underlines in integration-tests.