### PR TITLE
Test: remove flake 

### DIFF
--- a/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
+++ b/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
@@ -25,7 +25,9 @@ class BenchmarksTest {
     repeat(MEASUREMENT_COUNT) {
       durations.add(
           measureTime {
-            repeat(EXECUTION_PER_MEASUREMENT) { test(it) }
+            repeat(EXECUTION_PER_MEASUREMENT) {
+              test(it)
+            }
           }
       )
     }
@@ -83,8 +85,8 @@ class BenchmarksTest {
   )
 
   companion object {
-    private const val EXECUTION_PER_MEASUREMENT = 500
-    private const val MEASUREMENT_COUNT = 10
+    private const val EXECUTION_PER_MEASUREMENT = 100
+    private const val MEASUREMENT_COUNT = 4
 
     val measurements = mutableListOf<Measurement>()
 

--- a/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
+++ b/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
@@ -25,9 +25,7 @@ class BenchmarksTest {
     repeat(MEASUREMENT_COUNT) {
       durations.add(
           measureTime {
-            repeat(EXECUTION_PER_MEASUREMENT) {
-              test(it)
-            }
+            repeat(EXECUTION_PER_MEASUREMENT) { test(it) }
           }
       )
     }
@@ -85,8 +83,8 @@ class BenchmarksTest {
   )
 
   companion object {
-    private const val EXECUTION_PER_MEASUREMENT = 100
-    private const val MEASUREMENT_COUNT = 4
+    private const val EXECUTION_PER_MEASUREMENT = 500
+    private const val MEASUREMENT_COUNT = 10
 
     val measurements = mutableListOf<Measurement>()
 


### PR DESCRIPTION
Using `inexistent.host` created tiemouts instead of DNS error sometimes. Trigger the error by trying to connect to a (hopefully) closed port instead