### PR TITLE
Persisted queries doc

### DIFF
--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -31,7 +31,7 @@ Persisted queries is currently in [preview](/resources/product-launch-stages#pre
 - [Apollo Router](/router) (v1.25.0+)
 - [GraphOS Enterprise plan](/graphos/enterprise/)
 
-### 1. Generate the operation manifest
+### 1. Generate operation manifest
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
@@ -69,7 +69,7 @@ The operation manifest is generated in `build/generated/manifest/apollo/$service
 }
 ```
 
-### 2. Publish operation manifests
+### 2. Publish operation manifest
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -36,7 +36,6 @@ Persisted queries is currently in [preview](/resources/product-launch-stages#pre
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
 The operation manifest acts as a safelist of trusted operations the [Apollo Router](/router/) can check incoming requests against. 
-
 To generate the operation manifest, set `operationManifestFormat` to `"persistedQueryManifest"` in your Gradle script:
 
 ```kotlin
@@ -51,7 +50,7 @@ apollo {
 }
 ```
 
-The operation manifest is generated during code generation. This will happen automatically every time you build your project or you can trigger it manually by executing the `generateApolloSources` Gradle task. 
+The operation manifest is generated during code generation. This happens automatically every time you build your project or you can trigger it manually by executing the `generateApolloSources` Gradle task. 
 
 The operation manifest is generated in `build/generated/manifest/apollo/$serviceName/persistedQueryManifest.json`, where `$serviceName` is `"api"` here. The resulting operation manifest looks something like this:
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -39,15 +39,15 @@ Both persisted queries and APQs require you to configure your client makes reque
 
 We recommend you follow this order while implementing:
 
-1. **For persisted queries only**: Generate operation manifests
-1. **For persisted queries only**: Publish operation manifests
+1. **For persisted queries only**: Generate the operation manifest
+1. **For persisted queries only**: Publish the operation manifest
 1. **For both persisted queries and APQs**: Enable persisted queries on `ApolloClient`
 
 The rest of this article details these steps.
 
 Persisted queries also requires you to create and link a PQL, and to configure your router. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
 
-### 1. Generate operation manifests
+### 1. Generate the operation manifest
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -39,34 +39,15 @@ Both persisted queries and APQs require you to configure your client makes reque
 
 We recommend you follow this order while implementing:
 
-1. **For both persisted queries and APQs**: Enable persisted queries on `ApolloClient`
 1. **For persisted queries only**: Generate operation manifests
 1. **For persisted queries only**: Publish operation manifests
+1. **For both persisted queries and APQs**: Enable persisted queries on `ApolloClient`
 
 The rest of this article details these steps.
 
 Persisted queries also requires you to create and link a PQL, and to configure your router. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
 
-### 1. Enable persisted queries on `ApolloClient`
-
-Once you've configured your code generation to include operation IDs, you can update your client to query by operation ID rather than the full operation string. This configuration is the same whether you're using APQs or persisted queries. Call `autoPersistedQueries()` on your `ApolloClient.Builder`:
-
-```kotlin
-val apolloClient = ApolloClient.Builder()
-  .serverUrl("https://...")
-  .autoPersistedQueries()
-  .build()
-```
-
-Once APQs are enabled on your ApolloClient, hashed queries are sent by default.
-
-You may want to disable persisted queries for certain queries, for instance to avoid any caching when the data is updated often. In order to do that, set `enableAutoPersistedQueries` to false on the `ApolloCall`:
-
-```kotlin
-apolloClient.query(myQuery).enableAutoPersistedQueries(false).toFlow()
-```
-
-### 2. Generate operation manifests
+### 1. Generate operation manifests
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
@@ -90,7 +71,7 @@ The operation manifest is generated during code generation. This will happen aut
 
 The operation manifest will be generated in `build/generated/manifest/apollo/$serviceName/persistedQueryManifest.json`, where `$serviceName` is `"api"` here.
 
-### 3. Publish operation manifests
+### 2. Publish operation manifests
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
@@ -121,6 +102,25 @@ rover persisted-queries publish my-graph@my-variant \
 2. It updates any _other_ variants that the PQL is applied to so that routers associated with those variants can fetch their updated PQL.
 
 As with manifest generation, you can execute this command in your CI/CD pipeline to publish new operations as part of your app release process.
+
+### 3. Enable persisted queries on `ApolloClient`
+
+Once you've configured your code generation to include operation IDs, you can update your client to query by operation ID rather than the full operation string. This configuration is the same whether you're using APQs or persisted queries. Call `autoPersistedQueries()` on your `ApolloClient.Builder`:
+
+```kotlin
+val apolloClient = ApolloClient.Builder()
+  .serverUrl("https://...")
+  .autoPersistedQueries()
+  .build()
+```
+
+Once APQs are enabled on your ApolloClient, hashed queries are sent by default.
+
+You may want to disable persisted queries for certain queries, for instance to avoid any caching when the data is updated often. In order to do that, set `enableAutoPersistedQueries` to false on the `ApolloCall`:
+
+```kotlin
+apolloClient.query(myQuery).enableAutoPersistedQueries(false).toFlow()
+```
 
 ## Custom ID for Persisted Queries 
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -3,21 +3,13 @@ title: Persisted queries
 description: Secure your graph while minimizing request latency
 ---
 
-Apollo supports two separate but related features called **automatic persisted queries** (APQs) and **persisted queries**.
-With both features, clients can execute a GraphQL operation by sending an operation's ID instead of the entire operation string. An operation's ID is a hash of the full query string. 
+<ClientPQIntro />
 
-Querying by ID can significantly reduce latency and bandwidth usage. Hashed queries are also sent by default using HTTP `GET` instead of the default `POST`, making them easier to cache in your edge network.
+Hashed queries are also sent by default using HTTP `GET` instead of the default `POST`, making them easier to cache in your edge network.
 
 ## Differences between persisted queries and APQs
 
-With APQs, if the server can't find the operation ID the client provides, the server returns an error indicating that it needs the full operation string. If the Apollo Kotlin client receives this error, it automatically retries the operation with the full operation string.
-
-The persisted queries feature requires operations to be preregistered in a **persisted query list** (**PQL**).
-This allows the PQL to act as a safelist of trusted operations made by your first-party apps. As such, persisted queries is a security feature as much as a performance one.
-
-If you _only_ want to improve request latency and bandwidth usage, APQs addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister trusted operations in a PQL.
-
-For more details on differences between persisted queries and APQs, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries#differences-from-automatic-persisted).
+<ClientPQDifferences />
 
 ## Requirements
 
@@ -90,33 +82,7 @@ The operation manifest is generated in `build/generated/manifest/apollo/$service
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
-<blockquote>
-
-Ensure your Rover CLI version is `0.17.2` or later. Previous versions of Rover don't support publishing operations to a PQL.
-[Download the latest version.](/rover/getting-started/)
-
-</blockquote>
-
-If you want to preregister your manifest as a safelist of trusted operations, you need to publish it to a PQL using the [Rover CLI](/rover/):
-
-```bash title="Example command"
-rover persisted-queries publish my-graph@my-variant \
-  --manifest app/build/generated/manifest/apollo/api/persistedQueryManifest.json
-```
-
-- Replace `my-graph@my-variant` with the **graph ref** of _any_ variant your PQL is [linked to](/graphos/operations/persisted-queries#12-link-the-pql-to-variants). Your platform team can provide this for you.
-    - Graph refs have the format `graph-id@variant-name`.
-- For the `--manifest` option, provide the path to the manifest you want to publish.
-
-**The above command does the following:**
-
-1. It publishes all operations in the provided manifest file to the PQL linked to the specified variant.
-    - Publishing a manifest to a PQL is additive. Any _existing_ entries in the PQL remain.
-    - If you publish an operation with the same `id` but different details from an existing entry in the PQL, the entire publish command fails with an error.
-
-2. It updates any _other_ variants that the PQL is applied to so that routers associated with those variants can fetch their updated PQL.
-
-As with manifest generation, you can execute this command in your CI/CD pipeline to publish new operations as part of your app release process.
+<PublishPQMs />
 
 ### 3. Enable persisted queries on `ApolloClient`
 
@@ -131,15 +97,15 @@ val apolloClient = ApolloClient.Builder()
 
 Once APQs are enabled on your ApolloClient, hashed queries are sent by default.
 
-You may want to disable persisted queries for certain queries, for instance to avoid any caching when the data is updated often. In order to do that, set `enableAutoPersistedQueries` to false on the `ApolloCall`:
+You may want to disable automatic persisted queries for certain queries, for instance to avoid any caching when the data is updated often. To do that, set `enableAutoPersistedQueries` to false on the `ApolloCall`:
 
 ```kotlin
 apolloClient.query(myQuery).enableAutoPersistedQueries(false).toFlow()
 ```
 
-## Custom ID for Persisted Queries 
+## Generating custom IDs for persisted queries
 
-By default, Apollo uses `Sha256` hashing algorithm to generate an ID for the query. To provide custom ID generation logic, use the option - `operationIdGenerator` which accepts an `instance` that implements the `OperationIdGenerator` interface (`com.apollographql.apollo3.compiler.OperationIdGenerator`) as the input. This option can be used to either specify a different hashing algorithm or to fetch the persisted query ID from a different place - e.g. a service or a CLI.
+By default, Apollo uses `Sha256` hashing algorithm to generate an ID for the query. To provide custom ID generation logic, use the `operationIdGenerator` option. It accepts an `instance` that implements the `OperationIdGenerator` interface (`com.apollographql.apollo3.compiler.OperationIdGenerator`) as the input. You can use this option to either specify a different hashing algorithm or to fetch the persisted query ID from a different location, for example, from a service or a CLI.
 
 Example Md5 hash generator:
 
@@ -181,6 +147,6 @@ apollo {
 
 </MultiCodeBlock>
 
-### Versioning Id Generator
+### ID generator versioning
 
 The result of the ID generator is cached. The cache is not updated when the implementation of the ID Generator changes. To indicate an update to the implementation of the ID Generator, change the `version` override as shown in the above example.

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -19,7 +19,7 @@ If you _only_ want to improve request latency and bandwidth usage, APQs addresse
 
 For more details on differences between persisted queries and APQs, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries#differences-from-automatic-persisted).
 
-### Requirements
+## Requirements
 
 You can use APQs with the following versions of Apollo Kotlin, Apollo Server, and Apollo Router:
 - Apollo Kotlin (v1.0.0+)

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -35,7 +35,7 @@ Persisted queries is currently in [preview](/resources/product-launch-stages#pre
 
 ## Implementation steps
 
-Both persisted queries and APQs require you to configure your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate the operations manifest.
+Both persisted queries and APQs require you to configure how your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate the operations manifest.
 
 We recommend you follow this order while implementing:
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -1,12 +1,55 @@
 ---
-title: Persisted queries in Apollo Kotlin
+title: Persisted queries 
+description: Secure your graph while minimizing request latency
 ---
 
-## Automatic persisted queries
+Apollo supports two separate but related features called **automatic persisted queries** (APQs) and **persisted queries**.
+With both features, clients can execute a GraphQL operation by sending an operation's ID instead of the entire operation string. An operation's ID is a hash of the full query string. 
 
-Apollo Kotlin supports [Automatic Persisted Queries](https://www.apollographql.com/docs/apollo-server/performance/apq/) (APQ). To take advantage of it, your GraphQL server _also_ needs to support APQ (Apollo Server supports it out of the box).
+Querying by ID can significantly reduce latency and bandwidth usage. Hashed queries are also sent by default using HTTP `GET` instead of the default `POST`, making them easier to cache in your edge network.
 
-Enable the feature when you initialize your `ApolloClient` instance, like so:
+## Differences between persisted queries and APQs
+
+With APQs, if the server can't find the operation ID the client provides, the server returns an error indicating that it needs the full operation string. If the Apollo Kotlin client receives this error, it automatically retries the operation with the full operation string.
+
+The persisted queries feature requires operations to be preregistered in a **persisted query list** (**PQL**).
+This allows the PQL to act as a safelist of trusted operations made by your first-party apps. As such, persisted queries is a security feature as much as a performance one.
+
+If you _only_ want to improve request latency and bandwidth usage, APQs addresses your use case. If you _also_ want to secure your supergraph with operation safelisting, you should preregister trusted operations in a PQL.
+
+For more details on differences between persisted queries and APQs, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries#differences-from-automatic-persisted).
+
+### Requirements
+
+You can use APQs with the following versions of Apollo Kotlin, Apollo Server, and Apollo Router:
+- Apollo Kotlin (v1.0.0+)
+- [Apollo Server](/apollo-server/) (v1.0.0+)
+- [Apollo Router](/router) (v0.1.0+)
+
+Persisted queries is currently in [preview](/resources/product-launch-stages#preview) and has the following requirements:
+- Apollo Kotlin (v3.8.2+)
+- [Apollo Router](/router) (v1.25.0+)
+- [GraphOS Enterprise plan](/graphos/enterprise/)
+
+> **Note:** You can use _either_ Apollo Server _or_ Apollo Router for APQs. They don't need to be used together.
+
+## Implementation steps
+
+Both persisted queries and APQs require you to configure your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate an operations manifest.
+
+We recommend you follow this order while implementing:
+
+1. **For both persisted queries and APQs**: Enable persisted queries on `ApolloClient`
+1. **For persisted queries only**: Generate operation manifests
+1. **For persisted queries only**: Publish operation manifests
+
+The rest of this article details these steps.
+
+Persisted queries also requires you to create and link a PQL, and to configure your router. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
+
+### 1. Enable persisted queries on `ApolloClient`
+
+Once you've configured your code generation to include operation IDs, you can update your client to query by operation ID rather than the full operation string. This configuration is the same whether you're using APQs or persisted queries. Call `autoPersistedQueries()` on your `ApolloClient.Builder`:
 
 ```kotlin
 val apolloClient = ApolloClient.Builder()
@@ -15,42 +58,71 @@ val apolloClient = ApolloClient.Builder()
   .build()
 ```
 
-You can optionally configure the HTTP methods to use. Using `GET` may take advantage of HTTP caching for instance when using a CDN:
-```kotlin
-val apolloClient = ApolloClient.Builder()
-    .serverUrl("https://...")
-    .autoPersistedQueries(
-        // For the initial hashed query that does not send the actual Graphql document
-        httpMethodForHashedQueries = HttpMethod.Get,
-        
-        // For the follow-up query that sends the full document if the initial hashed query was not found
-        httpMethodForDocumentQueries = HttpMethod.Get
-    )
-    .build()
-```
-
-Note that mutations will always be sent as `POST` requests, regardless of these settings, as to avoid hitting caches.
-
-## Disable persisted queries for certain queries
+Once APQs are enabled on your ApolloClient, hashed queries are sent by default.
 
 You may want to disable persisted queries for certain queries, for instance to avoid any caching when the data is updated often. In order to do that, set `enableAutoPersistedQueries` to false on the `ApolloCall`:
+
 ```kotlin
 apolloClient.query(myQuery).enableAutoPersistedQueries(false).toFlow()
 ```
 
-## operationOutput.json
+### 2. Generate operation manifests
 
-If your backend uses custom persisted queries, Apollo Kotlin can generate an OperationOutput json from your .graphql queries. They will match what the client is sending exactly so you can persist them on your server.
+> This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
+
+An operation manifest acts as a safelist of trusted operations the [Apollo Router](/router/) can check incoming requests against. 
+
+To generate an operation manifest, set `operationManifestFormat` to `"persistedQueryManifest"` in your Gradle script:
 
 ```kotlin
+// build.gradle.kts
 apollo {
-  service("service") {
-    generateOperationOutput.set(true)
+  service("api") {
+    packageName.set("com.example")
+    
+    // Enable generation of the operation manifest
+    operationManifestFormat.set("persistedQueryManifest") // highlight-line 
   }
 }
 ```
 
-## Custom ID for Persisted Queries
+The operation manifest is generated during code generation. This will happen automatically every time you build your project or you can trigger it manually by executing the `generateApolloSources` Gradle task. 
+
+The operation manifest will be generated in `build/generated/manifest/apollo/$serviceName/persistedQueryManifest.json`, where `$serviceName` is `"api"` here.
+
+### 3. Publish operation manifests
+
+> This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
+
+<blockquote>
+
+Ensure your Rover CLI version is `0.17.2` or later. Previous versions of Rover don't support publishing operations to a PQL.
+[Download the latest version.](/rover/getting-started/)
+
+</blockquote>
+
+If you want to preregister your manifest as a safelist of trusted operations, you need to publish it to a PQL using the [Rover CLI](/rover/):
+
+```bash title="Example command"
+rover persisted-queries publish my-graph@my-variant \
+  --manifest ./persistedQueryManifest.json
+```
+
+- Replace `my-graph@my-variant` with the **graph ref** of _any_ variant your PQL is [linked to](/graphos/operations/persisted-queries#12-link-the-pql-to-variants). Your platform team can provide this for you.
+    - Graph refs have the format `graph-id@variant-name`.
+- For the `--manifest` option, provide the path to the manifest you want to publish.
+
+**The above command does the following:**
+
+1. It publishes all operations in the provided manifest file to the PQL linked to the specified variant.
+    - Publishing a manifest to a PQL is additive. Any _existing_ entries in the PQL remain.
+    - If you publish an operation with the same `id` but different details from an existing entry in the PQL, the entire publish command fails with an error.
+
+2. It updates any _other_ variants that the PQL is applied to so that routers associated with those variants can fetch their updated PQL.
+
+As with manifest generation, you can execute this command in your CI/CD pipeline to publish new operations as part of your app release process.
+
+## Custom ID for Persisted Queries 
 
 By default, Apollo uses `Sha256` hashing algorithm to generate an ID for the query. To provide custom ID generation logic, use the option - `operationIdGenerator` which accepts an `instance` that implements the `OperationIdGenerator` interface (`com.apollographql.apollo3.compiler.OperationIdGenerator`) as the input. This option can be used to either specify a different hashing algorithm or to fetch the persisted query ID from a different place - e.g. a service or a CLI.
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -17,7 +17,7 @@ Both persisted queries and APQs require you to configure how your client makes r
 
 <ClientPQImplementation />
 
-## Requirements
+### 0. Requirements
 
 You can use APQs with the following versions of Apollo Kotlin, Apollo Server, and Apollo Router:
 - Apollo Kotlin (v1.0.0+)

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -11,6 +11,12 @@ Hashed queries are also sent by default using HTTP `GET` instead of the default 
 
 <ClientPQDifferences />
 
+## Implementation steps
+
+Both persisted queries and APQs require you to configure how your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate and publish an operation manifest.
+
+<ClientPQImplementation />
+
 ## Requirements
 
 You can use APQs with the following versions of Apollo Kotlin, Apollo Server, and Apollo Router:
@@ -24,20 +30,6 @@ Persisted queries is currently in [preview](/resources/product-launch-stages#pre
 - Apollo Kotlin (v3.8.2+)
 - [Apollo Router](/router) (v1.25.0+)
 - [GraphOS Enterprise plan](/graphos/enterprise/)
-
-## Implementation steps
-
-Both persisted queries and APQs require you to configure how your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate the operations manifest.
-
-We recommend you follow this order while implementing:
-
-1. **For persisted queries only**: Generate the operation manifest
-1. **For persisted queries only**: Publish the operation manifest
-1. **For both persisted queries and APQs**: Enable persisted queries on `ApolloClient`
-
-The rest of this article details these steps.
-
-> For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
 
 ### 1. Generate the operation manifest
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -26,12 +26,12 @@ You can use APQs with the following versions of Apollo Kotlin, Apollo Server, an
 - [Apollo Server](/apollo-server/) (v1.0.0+)
 - [Apollo Router](/router) (v0.1.0+)
 
+> **Note:** You can use _either_ Apollo Server _or_ Apollo Router for APQs. They don't need to be used together.
+
 Persisted queries is currently in [preview](/resources/product-launch-stages#preview) and has the following requirements:
 - Apollo Kotlin (v3.8.2+)
 - [Apollo Router](/router) (v1.25.0+)
 - [GraphOS Enterprise plan](/graphos/enterprise/)
-
-> **Note:** You can use _either_ Apollo Server _or_ Apollo Router for APQs. They don't need to be used together.
 
 ## Implementation steps
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -101,7 +101,7 @@ If you want to preregister your manifest as a safelist of trusted operations, yo
 
 ```bash title="Example command"
 rover persisted-queries publish my-graph@my-variant \
-  --manifest ./persistedQueryManifest.json
+  --manifest app/build/generated/manifest/apollo/api/persistedQueryManifest.json
 ```
 
 - Replace `my-graph@my-variant` with the **graph ref** of _any_ variant your PQL is [linked to](/graphos/operations/persisted-queries#12-link-the-pql-to-variants). Your platform team can provide this for you.

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -35,7 +35,7 @@ Persisted queries is currently in [preview](/resources/product-launch-stages#pre
 
 ## Implementation steps
 
-Both persisted queries and APQs require you to configure your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate an operations manifest.
+Both persisted queries and APQs require you to configure your client makes requests. If you intend to use persisted queries for safelisting, you also need to generate the operations manifest.
 
 We recommend you follow this order while implementing:
 
@@ -51,9 +51,9 @@ Persisted queries also requires you to create and link a PQL, and to configure y
 
 > This step is only required for implementing safelisting with persisted queries. It is _not_ required for APQs.
 
-An operation manifest acts as a safelist of trusted operations the [Apollo Router](/router/) can check incoming requests against. 
+The operation manifest acts as a safelist of trusted operations the [Apollo Router](/router/) can check incoming requests against. 
 
-To generate an operation manifest, set `operationManifestFormat` to `"persistedQueryManifest"` in your Gradle script:
+To generate the operation manifest, set `operationManifestFormat` to `"persistedQueryManifest"` in your Gradle script:
 
 ```kotlin
 // build.gradle.kts
@@ -69,7 +69,22 @@ apollo {
 
 The operation manifest is generated during code generation. This will happen automatically every time you build your project or you can trigger it manually by executing the `generateApolloSources` Gradle task. 
 
-The operation manifest will be generated in `build/generated/manifest/apollo/$serviceName/persistedQueryManifest.json`, where `$serviceName` is `"api"` here.
+The operation manifest is generated in `build/generated/manifest/apollo/$serviceName/persistedQueryManifest.json`, where `$serviceName` is `"api"` here. The resulting operation manifest looks something like this:
+
+```json title="persistedQueryManifest.json"
+{
+  "format": "apollo-persisted-query-manifest",
+  "version": 1,
+  "operations": [
+    {
+      "id": "e0321f6b438bb42c022f633d38c19549dea9a2d55c908f64c5c6cb8403442fef",
+      "body": "query GetItem { thing { __typename } }",
+      "name": "GetItem",
+      "type": "query"
+    }
+  ]
+}
+```
 
 ### 2. Publish operation manifests
 

--- a/docs/source/advanced/persisted-queries.mdx
+++ b/docs/source/advanced/persisted-queries.mdx
@@ -45,7 +45,7 @@ We recommend you follow this order while implementing:
 
 The rest of this article details these steps.
 
-Persisted queries also requires you to create and link a PQL, and to configure your router. For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
+> For more information on the other configuration aspects of persisted queries, see the [GraphOS persisted queries documentation](/graphos/operations/persisted-queries).
 
 ### 1. Generate the operation manifest
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -39,7 +39,8 @@
       "Error handling": "/essentials/errors",
       "Custom scalars": "/essentials/custom-scalars",
       "Fragments": "/essentials/fragments",
-      "@defer support (experimental)": "/fetching/defer"
+      "@defer support (experimental)": "/fetching/defer",
+      "Persisted queries": "/advanced/persisted-queries"
     },
     "Caching": {
       "Introduction": "/caching/introduction",
@@ -49,7 +50,6 @@
       "Watching cached data": "/caching/query-watchers",
       "ApolloStore": "/caching/store",
       "HTTP cache": "/caching/http-cache",
-      "Persisted queries": "/advanced/persisted-queries",
       "Troubleshooting": "/caching/troubleshooting"
     },
     "Networking": {


### PR DESCRIPTION
Currently the PQ updates are only appearing on the v4 kotlin docs: https://www.apollographql.com/docs/kotlin/v4/advanced/persisted-queries/

Since v3.8.2 also supports PQs they should appear in v3 (https://www.apollographql.com/docs/kotlin/advanced/persisted-queries) as well.