### PR TITLE
Schema Nullability Extensions

### DIFF
--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -838,6 +838,10 @@ public final class com/apollographql/apollo3/ast/IssueKt {
 	public static final fun containsError (Ljava/util/List;)Z
 }
 
+public final class com/apollographql/apollo3/ast/MergeOptions$Companion {
+	public final fun getDefault ()Lcom/apollographql/apollo3/ast/MergeOptions;
+}
+
 public final class com/apollographql/apollo3/ast/NodeContainer {
 	public fun <init> (Ljava/util/List;)V
 	public final fun assert ()V

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -26,6 +26,7 @@ import com.apollographql.apollo3.ast.GQLTypeDefinition.Companion.builtInTypes
 import com.apollographql.apollo3.ast.GQLTypeSystemExtension
 import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.Issue
+import com.apollographql.apollo3.ast.MergeOptions
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.Schema.Companion.TYPE_POLICY
 import com.apollographql.apollo3.ast.apolloDefinitions
@@ -141,7 +142,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
    * I'm not 100% clear on the order of validations, here I'm merging the extensions first thing
    */
   val dedupedDefinitions = listOfNotNull(schemaDefinition) + directiveDefinitions.values + typeDefinitions.values
-  val mergedDefinitions = ExtensionsMerger(dedupedDefinitions + typeSystemExtensions).merge().getOrThrow()
+  val mergedDefinitions = ExtensionsMerger(dedupedDefinitions + typeSystemExtensions, MergeOptions(true)).merge().getOrThrow()
 
   val foreignNames = foreignSchemas.flatMap {
     it.newNames.entries

--- a/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/TypeExtensionsMergeTest.kt
+++ b/libraries/apollo-ast/src/jvmTest/kotlin/com/apollographql/apollo3/graphql/ast/test/TypeExtensionsMergeTest.kt
@@ -1,0 +1,70 @@
+package com.apollographql.apollo3.graphql.ast.test
+
+import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
+import com.apollographql.apollo3.ast.MergeOptions
+import com.apollographql.apollo3.ast.mergeExtensions
+import com.apollographql.apollo3.ast.toMergedGQLDocument
+import com.apollographql.apollo3.ast.toGQLDocument
+import com.apollographql.apollo3.ast.toUtf8
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TypeExtensionsMergeTest {
+  @Test
+  fun simpleTest() {
+    @Language("graphqls")
+    val sdl = """
+      type Query {
+        random: Int
+        list: [String]
+        required: Int!
+      }
+      
+      extend type Query {
+        random: Int!
+        list: [String!]!
+        required: Int
+        new: Float
+      }
+    """.trimIndent()
+
+    val result = sdl.toGQLDocument().toMergedGQLDocument(MergeOptions(true))
+        .definitions
+        .single() as GQLObjectTypeDefinition
+
+
+    assertEquals("Int!", result.fields.first { it.name == "random" }.type.toUtf8())
+    assertEquals("[String!]!", result.fields.first { it.name == "list" }.type.toUtf8())
+    assertEquals("Int", result.fields.first { it.name == "required" }.type.toUtf8())
+    assertEquals("Float", result.fields.first { it.name == "new" }.type.toUtf8())
+  }
+
+  @Test
+  fun errors() {
+    @Language("graphqls")
+    val sdl = """
+      type Query {
+        random: Int
+        list: [String]
+        required: Int! 
+      }
+      
+      directive @custom on FIELD_DEFINITION
+      
+      extend type Query {
+        random: String
+        list(arg: String): [String!]!
+        required: Int @custom
+      }
+    """.trimIndent()
+
+    val issues = sdl.toGQLDocument().mergeExtensions(MergeOptions(true)).issues
+
+    assertEquals(3, issues.size)
+    assertTrue(issues[0].message.contains("its type is not compatible with the original type"))
+    assertTrue(issues[1].message.contains("its arguments do not match the arguments of the original field definition"))
+    assertTrue(issues[2].message.contains("Cannot add directives to existing field definition"))
+  }
+}


### PR DESCRIPTION
Add Schema Nullability Extensions. This is similar to a `@nonnull` schema directive but works with lists. 

Given the following SDL:

```graphql
# schema.graphqls
type Query {
  random: Int
  list: [String]
  required: Int!
}
```

You can extend it like so:

```graphql
# extra.graphqls
extend type Query {
  # make random non-nullable
  random: Int!
  # make list and list items non-nullable
  list: [String!]!
  # make required nullable
  required: Int
  # add a new field
  new: Float
}
```