### PR TITLE
Fix `Optional<V>.getOrThrow()` when V is nullable

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Optional.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Optional.kt
@@ -12,8 +12,20 @@ import kotlin.jvm.JvmStatic
  * serialized (even if it's null) and the case where it's absent and shouldn't be serialized.
  */
 sealed class Optional<out V> {
-  fun getOrNull() = (this as? Present)?.value
-  fun getOrThrow() = getOrNull() ?: throw MissingValueException()
+  /**
+   * Returns the value if this [Optional] is [Present] or null else.
+   */
+  fun getOrNull(): V? = (this as? Present)?.value
+
+  /**
+   * Returns the value if this [Optional] is [Present] or throws [MissingValueException] else.
+   */
+  fun getOrThrow(): V {
+    if (this is Present) {
+      return value
+    }
+    throw MissingValueException()
+  }
 
   data class Present<V>(val value: V) : Optional<V>()
   object Absent : Optional<Nothing>()

--- a/libraries/apollo-api/src/commonTest/kotlin/test/OptionalTest.kt
+++ b/libraries/apollo-api/src/commonTest/kotlin/test/OptionalTest.kt
@@ -1,20 +1,47 @@
 package test
 
 import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.exception.MissingValueException
 import kotlin.test.Test
-import kotlin.test.assertFails
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.fail
 
 class OptionalTest {
   @Test
-  fun presentTest() {
+  fun present() {
     assertIs<Optional.Present<*>>(Optional.present("some value"))
     assertIs<Optional.Present<*>>(Optional.present(null))
   }
 
   @Test
-  fun presentIfNotNullTest() {
+  fun presentIfNotNull() {
     assertIs<Optional.Present<*>>(Optional.presentIfNotNull("some value"))
     assertIs<Optional.Absent>(Optional.presentIfNotNull(null))
+  }
+
+  @Test
+  fun getOrThrowNull() {
+    val optional = Optional.present<String?>(null)
+    val value = optional.getOrThrow()
+    assertNull(value)
+  }
+
+  @Test
+  fun getOrThrowPresent() {
+    val optional = Optional.present<String?>("hello")
+    val value = optional.getOrThrow()
+    assertEquals("hello", value)
+  }
+
+  @Test
+  fun getOrThrowAbsent() {
+    val optional = Optional.absent<String?>()
+    try {
+      val value = optional.getOrThrow()
+      fail("An exception was expected but got '$value' instead")
+    } catch (_: MissingValueException) {
+    }
   }
 }


### PR DESCRIPTION
The following would throw :(

```kotlin
val optional = Optional.present<String?>(null)
val value = optional.getOrThrow()

```