### PR TITLE
Deprecate addTypename = "ifFragments" 

### DIFF
--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -190,6 +190,30 @@ apollo {
 
 - Enum class names now have their first letter capitalized, as other generated types.
 - To avoid a name clash with the introspection type of the same name, the `__Schema` type is now generated in a `schema` subpackage (instead of `type`) when using the `generateSchema` option.
+- `addTypename = "ifFragments"` is deprecated as it could lead to cache misses for cache users:
+
+```graphql
+{
+  node(id: 42) {
+    # no fragment here means but we if we don't query __typename, the query below will emit a cache miss 
+    title
+    price
+  }
+}
+
+{
+  product(id: 42) {
+    # __typename is added here automatically
+    __typename
+    ... on Product {
+      title
+      price
+    }
+  }
+}
+```
+
+Instead, use `"always"` if you're using the cache or `"ifPolymorphic"` else. See [#3965](https://github.com/apollographql/apollo-kotlin/issues/3965) for more details.
 
 ## Cache
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/add_required_fields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/add_required_fields.kt
@@ -77,7 +77,10 @@ private fun List<GQLSelection>.addRequiredFields(
 
   val requiresTypename = when(addTypename) {
     "ifPolymorphic" -> isRoot && isPolymorphic(schema, fragments, parentType)
-    "ifFragments" -> selectionSet.any { it is GQLFragmentSpread || it is GQLInlineFragment }
+    "ifFragments" -> {
+      println("Using addTypename=\"ifFragments\" is deprecated. Use \"always\" if you're using the cache or \"ifPolymorphic\" else.")
+      selectionSet.any { it is GQLFragmentSpread || it is GQLInlineFragment }
+    }
     "ifAbstract" -> isRoot && schema.typeDefinition(parentType).isAbstract()
     "always" -> isRoot
     else -> error("Unknown addTypename option: $addTypename")

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -454,27 +454,25 @@ interface Service {
   val codegenModels: Property<String>
 
   /**
-   * When to add __typename. One of "always", "ifFragments", "ifAbstract" or "ifPolymorphic"
+   * When to add __typename. One of "always", "ifAbstract", "ifPolymorphic" or "ifFragments"
    *
    * - "always": Add '__typename' for every composite field
    *
-   * - "ifFragments": Add '__typename' for every selection set that contains fragments (inline or named)
-   * This causes cache misses when introducing fragments where no fragment was present before and will be certainly removed in
-   * a future version.
-   *
    * - "ifAbstract": Add '__typename' for abstract fields, i.e. fields that are of union or interface type
-   * Note: It also adds '__typename' on fragment definitions that satisfy the same property because fragments
-   * could be read from the cache, and we don't have a containing field in that case.
    *
    * - "ifPolymorphic": Add '__typename' for polymorphic fields, i.e. fields that contains a subfragment
    * (inline or named) whose type condition isn't a super type of the field type.
    * If a field is monomorphic, no '__typename' will be added.
-   * This adds the bare minimum amount of __typename but the logic is substantially more complex and
-   * it could cause cache misses when using fragments on monomorphic fields because __typename can be
-   * required in some cases.
+   * This adds the bare minimum amount of __typename but the logic is substantially more complex than `ifAbstract`.
    *
-   * Note: It also adds '__typename' on fragment definitions that satisfy the same property because fragments
-   * could be read from the cache, and we don't have a containing field in that case.
+   * - "ifFragments" (deprecated): Add '__typename' for every selection set that contains fragments (inline or named)
+   * This causes cache misses when introducing fragments where no fragment was present before. This is deprecated and
+   * will be removed in a future version.
+   *
+   * Apollo Kotlin requires __typename to handle polymorphism and parsing fragments. By default, __typename is added on
+   * every composite field selection set. When using the cache, this also ensures that cache keys can read __typename.
+   * If you're not using the cache or do not use __typename in your cache keys, you can use "ifAbstract" or "ifPolymorphic"
+   * to reduce the number of __typename and the size of the network response.
    *
    * Default value: "ifFragments"
    */


### PR DESCRIPTION
Keep the default to `"ifFragments` for now as changing to `"always"` has a bunch of implications, especially in tests. Will change the default once we have a more compelling Data Builders story