### PR TITLE
Enable configuration cache

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -29,7 +29,7 @@ jobs:
           ./gradlew --stop
       - run: |
           # Build the libs
-          ./gradlew publishAllPublicationsToPluginTestRepository -x dokkaHtml
+          ./gradlew publishTestToPluginTest
       - run: |
           # Build the benchmark apks
           ./gradlew -p benchmark assembleRelease assembleReleaseAndroidTest

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -4,7 +4,7 @@ This is a standalone Android Studio project to benchmark performance. While the 
 opened with IntelliJ, this one requires Android Studio.
 
 It's not a composite build to workaround interop issues between AGP and multiplatform builds. 
-Use `publishAllPublicationsToPluginTestRepository` from `apollo-kotlin` to use the artifacts from the current version.
+Use `publishTestToPluginTest` from `apollo-kotlin` to use the artifacts from the current version.
 
 ## Running the tests
 

--- a/build-logic/gradle.properties
+++ b/build-logic/gradle.properties
@@ -6,4 +6,4 @@ kotlin.stdlib.default.dependency=false
 # Enable the build cache
 org.gradle.caching=true
 # Enable the configuration cache
-# org.gradle.unsafe.configuration-cache=true
+org.gradle.configuration-cache=true

--- a/build-logic/src/main/kotlin/KGPPublications.kt
+++ b/build-logic/src/main/kotlin/KGPPublications.kt
@@ -1,0 +1,52 @@
+
+import org.gradle.api.Project
+import org.gradle.api.publish.PublicationContainer
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinTargetComponent
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
+
+/**
+ * Copied from https://github.com/JetBrains/kotlin/blob/bcf27812cd28041e0b9ffa3bfe52fc58c397d0eb/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/Publishing.kt#L66
+ */
+fun duplicateTargetPublications(project: Project) {
+  val extension = project.kotlinExtension as KotlinMultiplatformExtension
+  val publishing = project.extensions.getByType(PublishingExtension::class.java)
+
+  publishing.publications.create("kotlinMultiplatformTest", MavenPublication::class.java).apply {
+    from(project.components.getByName("kotlin"))
+  }
+
+  extension.targets.matching { it.publishable }.all {
+    val kotlinTarget = this
+    if (kotlinTarget is KotlinAndroidTarget)
+      project.afterEvaluate {
+        kotlinTarget.createMavenPublications(publishing.publications)
+      }
+    else
+      kotlinTarget.createMavenPublications(publishing.publications)
+  }
+}
+
+@Suppress("UNCHECKED_CAST")
+private val KotlinTarget.kotlinComponents: Set<KotlinTargetComponent>
+  get() {
+    return this::class.java.getDeclaredMethod("getKotlinComponents").invoke(this) as Set<KotlinTargetComponent>
+  }
+
+private fun KotlinTarget.createMavenPublications(publications: PublicationContainer) {
+  components
+      .map { gradleComponent -> gradleComponent to kotlinComponents.single { it.name == gradleComponent.name } }
+      .forEach { (gradleComponent, kotlinComponent) ->
+        publications.create("${kotlinComponent.name}Test", MavenPublication::class.java).apply {
+          from(gradleComponent)
+          (this as MavenPublicationInternal).publishWithOriginalFileName()
+          artifactId = kotlinComponent.defaultArtifactId
+        }
+      }
+}
+

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -127,13 +127,6 @@ fun Project.configureMpp(
 
     configureSourceSetGraph()
     addTestDependencies()
-
-    tasks.withType(KotlinJsIrLink::class.java).configureEach {
-      notCompatibleWithConfigurationCache("https://youtrack.jetbrains.com/issue/KT-60311/")
-    }
-    tasks.withType(KotlinNativeLink::class.java).configureEach {
-      notCompatibleWithConfigurationCache("https://youtrack.jetbrains.com/issue/KT-60311/")
-    }
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
+
 import JapiCmp.configureJapiCmp
-import org.gradle.api.internal.tasks.testing.junit.result.TestClassResult
-import org.gradle.api.internal.tasks.testing.junit.result.TestResultSerializer
 
 plugins {
   id("apollo.library") apply false
@@ -34,7 +33,7 @@ tasks.register("ciPublishSnapshot") {
   description = "Publishes a SNAPSHOT"
 
   if (shouldPublishSnapshots()) {
-    dependsOn(subprojectTasks("publishAllPublicationsToOssSnapshotsRepository"))
+    dependsOn(subprojectTasks("publishMainToOssSnapshots"))
   } else {
     doFirst {
       error("We are not on a branch, fail snapshots publishing")
@@ -47,7 +46,7 @@ tasks.register("ciPublishRelease") {
   description = "Publishes all artifacts to OSSRH and the Gradle Plugin Portal"
 
   if (isTag()) {
-    dependsOn(subprojectTasks("publishAllPublicationsToOssStagingRepository"))
+    dependsOn(subprojectTasks("publishMainToOssStaging"))
     // Only publish plugins to the Gradle portal if everything else succeeded
     finalizedBy(":apollo-gradle-plugin:publishPlugins")
   } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,6 @@ kotlin.stdlib.default.dependency=false
 # Enable the build cache
 org.gradle.caching=true
 # Enable the configuration cache
-# org.gradle.configuration-cache=true
+org.gradle.configuration-cache=true
 
 org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-rc-3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -15,7 +15,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = false
 
 dependencies {
   /**
@@ -133,10 +133,12 @@ tasks.withType<Test> {
   dependsOn(":apollo-ast:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-normalized-cache-api:publishAllPublicationsToPluginTestRepository")
   dependsOn(":apollo-mpp-utils:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-compiler:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-gradle-plugin-external:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-tooling:publishAllPublicationsToPluginTestRepository")
-  dependsOn("publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-compiler:publishTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-gradle-plugin-external:publishTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-gradle-plugin:publishApolloGradlePluginPluginMarkerMavenPublicationToPluginTestRepository")
+  dependsOn(":apollo-tooling:publishTestPublicationToPluginTestRepository")
+  dependsOn("publishTestPublicationToPluginTestRepository")
+  dependsOn("publishApolloGradlePluginPluginMarkerMavenPublicationToPluginTestRepository")
 
   dependsOn("cleanStaleTestProjects")
 

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -15,7 +15,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = false
+val relocateJar = true
 
 dependencies {
   /**
@@ -128,15 +128,24 @@ tasks.register("cleanStaleTestProjects") {
 }
 
 tasks.withType<Test> {
-  dependsOn(":apollo-annotations:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-api:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-ast:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-normalized-cache-api:publishAllPublicationsToPluginTestRepository")
-  dependsOn(":apollo-mpp-utils:publishAllPublicationsToPluginTestRepository")
+  dependsOn(":apollo-annotations:publishKotlinMultiplatformTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-annotations:publishJvmTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-annotations:publishIosArm64TestPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishKotlinMultiplatformTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishJvmTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-api:publishIosArm64TestPublicationToPluginTestRepository")
+  dependsOn(":apollo-ast:publishKotlinMultiplatformTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-ast:publishJvmTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-normalized-cache-api:publishKotlinMultiplatformTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-normalized-cache-api:publishJvmTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-mpp-utils:publishKotlinMultiplatformTestPublicationToPluginTestRepository")
+  dependsOn(":apollo-mpp-utils:publishJvmTestPublicationToPluginTestRepository")
+
   dependsOn(":apollo-compiler:publishTestPublicationToPluginTestRepository")
   dependsOn(":apollo-gradle-plugin-external:publishTestPublicationToPluginTestRepository")
   dependsOn(":apollo-gradle-plugin:publishApolloGradlePluginPluginMarkerMavenPublicationToPluginTestRepository")
   dependsOn(":apollo-tooling:publishTestPublicationToPluginTestRepository")
+
   dependsOn("publishTestPublicationToPluginTestRepository")
   dependsOn("publishApolloGradlePluginPluginMarkerMavenPublicationToPluginTestRepository")
 

--- a/tests/gradle.properties
+++ b/tests/gradle.properties
@@ -10,6 +10,6 @@ kotlin.stdlib.default.dependency=false
 # Enable the build cache
 org.gradle.caching=true
 # Enable the configuration cache
-# org.gradle.configuration-cache=true
+org.gradle.configuration-cache=true
 
 org.gradle.parallel=true

--- a/tests/gzip/build.gradle.kts
+++ b/tests/gzip/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.targets.jvm.tasks.KotlinJvmTest
-
 plugins {
   id("org.jetbrains.kotlin.multiplatform")
   id("apollo.test")
@@ -30,8 +28,4 @@ apollo {
   service("service") {
     packageName.set("gzip")
   }
-}
-
-tasks.named("compileKotlinJvm").configure {
-  notCompatibleWithConfigurationCache("https://youtrack.jetbrains.com/issue/KT-60311/")
 }


### PR DESCRIPTION
Most of the issues we had were side effects of Dokka not supporting configuration cache (see https://youtrack.jetbrains.com/issue/KT-60311/).

Dokka is invoked from the publish task for `apollo-gradle-plugin:testJavaXY`. In order to remove that dependency, I duplicated the publications in all projects. There is now additional "${Target}Test" publications that do not include Kdoc.


Because all the publications are now duplicated, relying on `publishAllPublicationsTo${RepoName}Repository` is an error because it creates overlapping files. Instead, there are `publishMainTo${RepoName}` and `publishTestTo${RepoName}`:

* Instead of `publishToMavenLocal`, call `publishMainToMavenLocal`
* Instead of `publishAllPublicationsToOssStagingRepository`, call `publishMainToOssStaging`
* Instead of `publishAllPublicationsToPluginTestRepository`, call `publishTestToPluginTest`



