### PR TITLE
Unbreak benchmarks

### DIFF
--- a/benchmark/app/build.gradle.kts
+++ b/benchmark/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-  namespace = "app_under_test"
+  namespace = "app.under.test"
 
   compileSdk = libs.versions.android.sdkversion.compilebenchmark.get().toInt()
 

--- a/benchmark/app/src/main/kotlin/app.under.test/MainActivity.kt
+++ b/benchmark/app/src/main/kotlin/app.under.test/MainActivity.kt
@@ -1,4 +1,4 @@
-package app_under_test
+package app.under.test
 
 import android.content.Context
 import android.os.Bundle

--- a/benchmark/macrobenchmark/src/main/kotlin/macrobenchmark/StartupTest.kt
+++ b/benchmark/macrobenchmark/src/main/kotlin/macrobenchmark/StartupTest.kt
@@ -47,7 +47,7 @@ abstract class AbstractStartupBenchmark(private val startupMode: StartupMode) {
   )
 
   private fun startup(compilationMode: CompilationMode) = benchmarkRule.measureRepeated(
-      packageName = "app_under_test.benchmark",
+      packageName = "app.under.test.benchmark",
       metrics = listOf(StartupTimingMetric()),
       compilationMode = compilationMode,
       iterations = 10,


### PR DESCRIPTION
AGP requires a dot in `namespace`