### PR TITLE
Bump uuid and okio

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Some platforms have specific runtime requirements:
 * Android API level 21+ (`apollo-http-cache` and `apollo-adapters` require enabling [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) on Android API levels < 26)
 * iOS 13+
 
-At build times, it requires:
+At build time, it requires:
 
 * Gradle 6.8+
 * Kotlin 1.8+ 

--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ Some platforms have specific runtime requirements:
 * Android API level 21+ (`apollo-http-cache` and `apollo-adapters` require enabling [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) on Android API levels < 26)
 * iOS 13+
 
-For building, it requires:
+At build times, it requires:
 
 * Gradle 6.8+
-* Kotlin 1.6+ (1.7+ for native)
+* Kotlin 1.8+ 
 
 ## Proguard / R8 configuration
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -141,7 +141,7 @@ Some platforms have specific runtime requirements:
 * Android API level 21+ (`apollo-http-cache` and `apollo-adapters` require enabling [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) on Android API levels < 26)
 * iOS 13+
 
-At build times, it requires:
+At build time, it requires:
 
 * Gradle 6.8+
 * Kotlin 1.8+

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -141,10 +141,10 @@ Some platforms have specific runtime requirements:
 * Android API level 21+ (`apollo-http-cache` and `apollo-adapters` require enabling [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) on Android API levels < 26)
 * iOS 13+
 
-For building, it requires:
+At build times, it requires:
 
 * Gradle 6.8+
-* Kotlin 1.6+ (1.7+ for native)
+* Kotlin 1.8+
 
 ## Proguard / R8 configuration
 

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -26,10 +26,10 @@ guava = "31.1-jre"
 javaPoet = "1.13.0"
 jetbrains-annotations = "24.0.1"
 junit = "4.13.2"
-kotlin-plugin-min = "1.6.0"
+kotlin-plugin-min = "1.8.0"
 kotlin-plugin = "1.9.0"
 kotlin-plugin-max = "1.9.0"
-kotlin-stdlib = "1.6.21"
+kotlin-stdlib = "1.8.0"
 kotlinx-coroutines = "1.7.3"
 kotlinx-datetime = "0.4.0"
 kotlinx-serialization-runtime = "1.5.0"
@@ -158,7 +158,7 @@ okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor",
 okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 okhttp-tls = { group = "com.squareup.okhttp3", name = "okhttp-tls", version.ref = "okhttp" }
 moshi = { group = "com.squareup.moshi", name = "moshi", version = "1.14.0" }
-okio = "com.squareup.okio:okio:3.2.0" # okio was pinned to 3.2.0 to stay compatible with Kotlin 1.5. Now that we have 1.6 as a minimum version, we could certainly update
+okio = "com.squareup.okio:okio:3.5.0"
 okio-nodefilesystem = "com.squareup.okio:okio-nodefilesystem:3.2.0"
 poet-java = { group = "com.squareup", name = "javapoet", version.ref = "javaPoet" }
 poet-kotlin = { group = "com.squareup", name = "kotlinpoet", version = "1.14.2" }
@@ -180,7 +180,7 @@ androidx-test-rules = "androidx.test:rules:1.5.0"
 androidx-test-runner = "androidx.test:runner:1.5.2"
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version = "0.7.0" }
-uuid = { group = "com.benasher44", name = "uuid", version = "0.6.0" } # Not updating to 0.7.0 because it pulls kotlin-stdlib 1.8 and consumers using 1.6 fail with: Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.8.0, expected version is 1.6.0
+uuid = { group = "com.benasher44", name = "uuid", version = "0.8.0" }
 vespene = { group = "net.mbonnin.vespene", name = "vespene-lib", version = "0.5" }
 
 [plugins]


### PR DESCRIPTION
We now require Kotlin 1.8+

See https://github.com/apollographql/apollo-kotlin/issues/5046#issuecomment-1689093251