### PR TITLE
Remove "ifFragments" deprecation

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/add_required_fields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/add_required_fields.kt
@@ -78,15 +78,6 @@ private fun List<GQLSelection>.addRequiredFields(
   val requiresTypename = when(addTypename) {
     "ifPolymorphic" -> isRoot && isPolymorphic(schema, fragments, parentType)
     "ifFragments" -> {
-      println("""Apollo: addTypename=\"ifFragments\" (default) is deprecated as it could lead to cache misses. Use \"always\" if you're using the cache or \"ifPolymorphic\" else:
-        |apollo {
-        |  service("service") {
-        |    addTypename.set("$ADD_TYPENAME_ALWAYS")
-        |    // or 
-        |    addTypename.set("$ADD_TYPENAME_IF_POLYMORPHIC")
-        |  }
-        |}
-      """.trimMargin())
       selectionSet.any { it is GQLFragmentSpread || it is GQLInlineFragment }
     }
     "ifAbstract" -> isRoot && schema.typeDefinition(parentType).isAbstract()


### PR DESCRIPTION
Keep "ifFragments" around. It's not too complicated to keep and migrating tests to "always" is a pain