### PR TITLE
Introduce JsonReader.toApolloResponse

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -786,6 +786,11 @@ public final class com/apollographql/apollo3/api/Operations {
 	public static final fun parseJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
 	public static final fun parseJsonResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/util/Set;)Lcom/apollographql/apollo3/api/ApolloResponse;
 	public static synthetic fun parseJsonResponse$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/util/Set;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public static final fun parseResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public static final fun parseResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public static final fun parseResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public static final fun parseResponse (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/util/Set;)Lcom/apollographql/apollo3/api/ApolloResponse;
+	public static synthetic fun parseResponse$default (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/json/JsonReader;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/util/Set;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/ApolloResponse;
 }
 
 public abstract class com/apollographql/apollo3/api/Optional {

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Assertions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Assertions.kt
@@ -1,10 +1,7 @@
 @file:JvmName("Assertions")
 package com.apollographql.apollo3.api
 
-import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.DefaultApolloException
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.contract
 import kotlin.jvm.JvmName
 
 /**
@@ -12,6 +9,6 @@ import kotlin.jvm.JvmName
  */
 fun checkFieldNotMissing(value: Any?, name: String) {
   if (value == null) {
-    throw DefaultApolloException("Field $name is missing")
+    throw DefaultApolloException("Field '$name' is missing")
   }
 }

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/http/HttpNetworkTransport.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/http/HttpNetworkTransport.java
@@ -62,13 +62,9 @@ public class HttpNetworkTransport implements NetworkTransport {
           }
         } else {
           BufferedSourceJsonReader jsonReader = new BufferedSourceJsonReader(response.getBody());
-          try {
-            CustomScalarAdapters customScalarAdapters = request.getExecutionContext().get(CustomScalarAdapters.Key);
-            ApolloResponse<D> apolloResponse = Operations.parseJsonResponse(request.getOperation(), jsonReader, customScalarAdapters);
-            callback.onResponse(apolloResponse);
-          } catch (Exception e) {
-            callback.onResponse(getExceptionResponse(request, new ApolloParseException("Cannot parse response", e)));
-          }
+          CustomScalarAdapters customScalarAdapters = request.getExecutionContext().get(CustomScalarAdapters.Key);
+          ApolloResponse<D> apolloResponse = Operations.toApolloResponse(jsonReader, request.getOperation(), request.getRequestUuid(), customScalarAdapters, null);
+          callback.onResponse(apolloResponse);
         }
       }
 

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketNetworkTransport.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketNetworkTransport.java
@@ -141,7 +141,7 @@ public class WebSocketNetworkTransport implements NetworkTransport {
       CustomScalarAdapters customScalarAdapters = request.getExecutionContext().get(CustomScalarAdapters.Key);
       JsonReader jsonReader = new MapJsonReader(payload);
       //noinspection rawtypes
-      ApolloResponse apolloResponse = Operations.parseJsonResponse(request.getOperation(), jsonReader, customScalarAdapters).newBuilder().requestUuid(request.getRequestUuid()).build();
+      ApolloResponse apolloResponse = Operations.toApolloResponse(jsonReader, request.getOperation(), request.getRequestUuid(), customScalarAdapters, null);
       //noinspection unchecked
       subscriptionInfo.callback.onResponse(apolloResponse);
     }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.json.jsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.SubscriptionOperationException
@@ -311,11 +311,13 @@ private constructor(
           } else {
             responsePayload to null
           }
-          val apolloResponse: ApolloResponse<D> = request.operation
-              .parseJsonResponse(jsonReader = payload.jsonReader(), customScalarAdapters = requestCustomScalarAdapters, deferredFragmentIdentifiers = mergedFragmentIds)
-              .newBuilder()
-              .requestUuid(request.requestUuid)
-              .build()
+          val apolloResponse: ApolloResponse<D> = payload.jsonReader().toApolloResponse(
+              operation = request.operation,
+              requestUuid = request.requestUuid,
+              customScalarAdapters = requestCustomScalarAdapters,
+              deferredFragmentIdentifiers = mergedFragmentIds
+          )
+
           if (!deferredJsonMerger.hasNext) {
             // Last deferred payload: reset the deferredJsonMerger for potential subsequent responses
             deferredJsonMerger.reset()

--- a/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
+++ b/tests/include-skip-operation-based/src/test/kotlin/IncludeTest.kt
@@ -1,10 +1,11 @@
+
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.GlobalBuilder
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.json.MapJsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.normalize
 import com.example.GetCatIncludeFalseQuery
@@ -27,7 +28,7 @@ import kotlin.test.assertNull
 class IncludeTest {
 
   private fun <D : Operation.Data> Operation<D>.parseData(data: Map<String, Any?>): ApolloResponse<D> {
-    return parseJsonResponse(MapJsonReader(mapOf("data" to data)))
+    return MapJsonReader(mapOf("data" to data)).toApolloResponse(this)
   }
 
   @Test

--- a/tests/integration-tests/src/kotlinCodegenTest/kotlin/test/NormalizerTest.kt
+++ b/tests/integration-tests/src/kotlinCodegenTest/kotlin/test/NormalizerTest.kt
@@ -4,6 +4,7 @@ import IdCacheKeyGenerator
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
@@ -248,7 +249,7 @@ class NormalizerTest {
 
   companion object {
     internal fun <D : Operation.Data> records(operation: Operation<D>, name: String): Map<String, Record> {
-      val response = operation.parseJsonResponse(testFixtureToJsonReader(name))
+      val response = testFixtureToJsonReader(name).toApolloResponse(operation)
       return operation.normalize(data = response.data!!, CustomScalarAdapters.Empty, cacheKeyGenerator = IdCacheKeyGenerator)
     }
 

--- a/tests/js/src/jsTest/kotlin/JsTest.kt
+++ b/tests/js/src/jsTest/kotlin/JsTest.kt
@@ -1,5 +1,5 @@
 import com.apollographql.apollo3.api.json.DynamicJsJsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import js.test.CreateCustomerMutation
 import js.test.GetSalesPeopleQuery
 import kotlin.test.Test
@@ -28,7 +28,7 @@ class JsTest {
         """.trimIndent()) as dynamic
     val query = GetSalesPeopleQuery()
     val jsonReader = DynamicJsJsonReader(dynamicResponse)
-    val response = query.parseJsonResponse(jsonReader)
+    val response = jsonReader.toApolloResponse(operation = query)
     assertEquals(
         GetSalesPeopleQuery.Data(
             getSalesPeople = listOf(

--- a/tests/models-operation-based-with-interfaces/src/test/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-operation-based-with-interfaces/src/test/kotlin/test/ParseResponseBodyTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import okio.Buffer
 import testFixtureToJsonReader
 import testFixtureToUtf8
@@ -18,7 +19,7 @@ class ParseResponseBodyTest {
    */
   @Test
   fun allPlanetQuery() {
-    val data = AllPlanetsQuery().parseJsonResponse(testFixtureToJsonReader("AllPlanets.json")).data
+    val data = testFixtureToJsonReader("AllPlanets.json").toApolloResponse(operation = AllPlanetsQuery()).data
 
     assertEquals(data!!.allPlanets?.planets?.size, 60)
     val planets = data.allPlanets?.planets?.mapNotNull {
@@ -48,7 +49,7 @@ class ParseResponseBodyTest {
     val expected = testFixtureToUtf8("OperationJsonWriter.json")
 
     val query = AllPlanetsQuery()
-    val data = query.parseJsonResponse(Buffer().writeUtf8(expected).jsonReader()).data
+    val data = Buffer().writeUtf8(expected).jsonReader().toApolloResponse(operation = query).data
     val actual = buildJsonString(indent = "  ") {
       query.composeJsonResponse(this, data!!)
     }

--- a/tests/models-operation-based/src/kotlinCodegenTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-operation-based/src/kotlinCodegenTest/kotlin/test/ParseResponseBodyTest.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
-import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import okio.Buffer
 import testFixtureToJsonReader
 import testFixtureToUtf8
@@ -18,7 +18,7 @@ class ParseResponseBodyTest {
    */
   @Test
   fun allPlanetQuery() {
-    val data = AllPlanetsQuery().parseJsonResponse(testFixtureToJsonReader("AllPlanets.json")).data
+    val data = testFixtureToJsonReader("AllPlanets.json").toApolloResponse(operation = AllPlanetsQuery()).data
 
     assertEquals(data!!.allPlanets?.planets?.size, 60)
     val planets = data.allPlanets?.planets?.mapNotNull {
@@ -48,7 +48,7 @@ class ParseResponseBodyTest {
     val expected = testFixtureToUtf8("OperationJsonWriter.json")
 
     val query = AllPlanetsQuery()
-    val data = query.parseJsonResponse(Buffer().writeUtf8(expected).jsonReader()).data
+    val data = Buffer().writeUtf8(expected).jsonReader().toApolloResponse(operation = query).data
     val actual = buildJsonString(indent = "  ") {
       query.composeJsonResponse(this, data!!)
     }

--- a/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.mpp.platform
 import okio.Buffer
@@ -23,7 +24,7 @@ class ParseResponseBodyTest {
    */
   @Test
   fun allPlanetQuery() {
-    val data = AllPlanetsQuery().parseJsonResponse(testFixtureToJsonReader("AllPlanets.json")).data
+    val data = testFixtureToJsonReader("AllPlanets.json").toApolloResponse(operation = AllPlanetsQuery()).data
 
     assertEquals(data!!.allPlanets?.planets?.size, 60)
     val planets = data.allPlanets?.planets?.mapNotNull {
@@ -52,7 +53,7 @@ class ParseResponseBodyTest {
   fun operationJsonWriter() {
     val expected = testFixtureToUtf8("OperationJsonWriter.json")
     val query = AllPlanetsQuery()
-    val data = query.parseJsonResponse(Buffer().writeUtf8(expected).jsonReader()).data
+    val data = Buffer().writeUtf8(expected).jsonReader().toApolloResponse(operation = query).data
     val actual = buildJsonString(indent = "  ") {
       query.composeJsonResponse(this, data!!)
     }

--- a/tests/no-runtime/src/test/kotlin/test/NoRuntimeTest.kt
+++ b/tests/no-runtime/src/test/kotlin/test/NoRuntimeTest.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.composeJsonRequest
 import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
-import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.example.GetRandomQuery
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -59,7 +59,7 @@ class NoRuntimeTest {
     assertTrue(response.body != null)
 
     val apolloResponse = response.body?.use {
-      query.parseJsonResponse(BufferedSourceJsonReader(it.source()))
+      BufferedSourceJsonReader(it.source()).toApolloResponse(operation = query)
     }
 
     assertEquals(42, apolloResponse?.data?.random)

--- a/tests/normalization-tests/src/test/kotlin/com/example/NormalizationTest.kt
+++ b/tests/normalization-tests/src/test/kotlin/com/example/NormalizationTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
@@ -48,7 +49,7 @@ class NormalizationTest {
 
     val query = Issue3672Query()
 
-    val data1 = query.parseJsonResponse(Buffer().writeUtf8(nestedResponse).jsonReader(), CustomScalarAdapters.Empty).dataOrThrow()
+    val data1 = Buffer().writeUtf8(nestedResponse).jsonReader().toApolloResponse(operation = query, customScalarAdapters = CustomScalarAdapters.Empty).dataOrThrow()
     store.writeOperation(query, data1)
 
     val data2 = store.readOperation(query)
@@ -65,7 +66,7 @@ class NormalizationTest {
 
     val query = NestedFragmentQuery()
 
-    val data1 = query.parseJsonResponse(Buffer().writeUtf8(nestedResponse_list).jsonReader(), CustomScalarAdapters.Empty).dataOrThrow()
+    val data1 = Buffer().writeUtf8(nestedResponse_list).jsonReader().toApolloResponse(operation = query, customScalarAdapters = CustomScalarAdapters.Empty).dataOrThrow()
     store.writeOperation(query, data1)
 
     val data2 = store.readOperation(query)

--- a/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
+++ b/tests/outofbounds/src/test/kotlin/test/OutOfBoundsTest.kt
@@ -2,6 +2,7 @@ package test
 
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.toApolloResponse
 import okio.buffer
 import okio.source
 import org.junit.Test
@@ -11,6 +12,6 @@ import java.io.File
 class OutOfBoundsTest {
   @Test
   fun checkOutOfBounds() {
-    GetAnimalQuery().parseJsonResponse(File("src/main/json/response.json").source().buffer().jsonReader()).dataOrThrow()
+    File("src/main/json/response.json").source().buffer().jsonReader().toApolloResponse(operation = GetAnimalQuery()).dataOrThrow()
   }
 }


### PR DESCRIPTION
Deprecate parseJsonResponse because:
* it closes the input JsonReader
* it may throw

Instead, introduce `JsonReader.toApolloResponse()` that makes it explicit that the jsonReader is going to be completely consumed and never throws. Instead it returns an `ApolloResponse` with `exception != null`

See https://github.com/apollographql/apollo-kotlin/issues/5217
