### PR TITLE
[IJ Plugin] Gather referenced fragments when opening in Apollo Sandbox

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/sandbox/SandboxService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/sandbox/SandboxService.kt
@@ -6,13 +6,13 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl
+import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.OnePixelSplitter
-import org.jetbrains.kotlin.idea.util.application.invokeLater
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 class SandboxService(


### PR DESCRIPTION
Fix for #5220


https://github.com/apollographql/apollo-kotlin/assets/372852/3f70985b-99c0-4943-9902-4b2162e5f721



Also fix an encoding issue where `#` was not escaped so files starting with comments would not open correctly.