### PR TITLE
Add APOLLO_RELOCATE_JAR and APOLLO_JVM_ONLY

### DIFF
--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -1,4 +1,3 @@
-
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -31,8 +30,9 @@ internal val hostTarget: String
     "macosX64"
   }
 
-private val enableLinux = true
-private val enableJs = true
+private val enableLinux = System.getenv("APOLLO_JVM_ONLY")?.toBoolean()?.not() ?: true
+private val enableJs = System.getenv("APOLLO_JVM_ONLY")?.toBoolean()?.not() ?: true
+private val enableApple = System.getenv("APOLLO_JVM_ONLY")?.toBoolean()?.not() ?: true
 
 fun Project.configureMppDefaults(withJs: Boolean, withLinux: Boolean, withAndroid: Boolean) {
   configureMpp(
@@ -116,19 +116,21 @@ fun Project.configureMpp(
       }
     }
 
-    appleTargets.toSet().intersect(allAppleTargets).forEach { presetName ->
-      when(presetName) {
-        "macosX64" -> macosX64()
-        "macosArm64" -> macosArm64()
-        "iosArm64" -> iosArm64()
-        "iosX64" -> iosX64()
-        "iosSimulatorArm64" -> iosSimulatorArm64()
-        "watchosArm32" -> watchosArm32()
-        "watchosArm64" -> watchosArm64()
-        "watchosSimulatorArm64" -> watchosSimulatorArm64()
-        "tvosArm64" -> tvosArm64()
-        "tvosX64" -> tvosX64()
-        "tvosSimulatorArm64" -> tvosSimulatorArm64()
+    if (enableApple) {
+      appleTargets.toSet().intersect(allAppleTargets).forEach { presetName ->
+        when (presetName) {
+          "macosX64" -> macosX64()
+          "macosArm64" -> macosArm64()
+          "iosArm64" -> iosArm64()
+          "iosX64" -> iosX64()
+          "iosSimulatorArm64" -> iosSimulatorArm64()
+          "watchosArm32" -> watchosArm32()
+          "watchosArm64" -> watchosArm64()
+          "watchosSimulatorArm64" -> watchosSimulatorArm64()
+          "tvosArm64" -> tvosArm64()
+          "tvosX64" -> tvosX64()
+          "tvosSimulatorArm64" -> tvosSimulatorArm64()
+        }
       }
     }
 

--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -1,4 +1,3 @@
-
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.gradle.BaseExtension
 import kotlinx.coroutines.runBlocking
@@ -11,7 +10,6 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
-import org.gradle.api.tasks.testing.Test
 import org.gradle.plugins.signing.Sign
 import org.gradle.plugins.signing.SigningExtension
 import org.jetbrains.dokka.gradle.AbstractDokkaTask
@@ -20,8 +18,8 @@ import org.jetbrains.dokka.gradle.DokkaTaskPartial
 
 fun Project.configurePublishing() {
   apply {
-      plugin("signing")
-    }
+    plugin("signing")
+  }
   apply {
     plugin("maven-publish")
   }
@@ -67,7 +65,12 @@ fun Project.configureDokka() {
      * Speed up development. When running the Gradle integration tests, we don't need KDoc to be generated
      */
     onlyIf {
-      gradle.taskGraph.allTasks.none { it.project.name == "apollo-gradle-plugin" && it is Test }
+      if (gradle.taskGraph.allTasks.any { it.name == "publishAllPublicationsToPluginTestRepository" ||
+              it.name == "publishToMavenLocal" } ) {
+        return@onlyIf false
+      }
+
+      true
     }
   }
 }
@@ -152,11 +155,13 @@ private fun Project.configurePublishingInternal() {
             }
           }
         }
+
         plugins.hasPlugin("com.gradle.plugin-publish") -> {
           /**
            * com.gradle.plugin-publish creates all publications
            */
         }
+
         plugins.hasPlugin("java-gradle-plugin") -> {
           /**
            * java-gradle-plugin creates 2 publications (one marker and one regular) but without source/javadoc.

--- a/libraries/apollo-api/build.gradle.kts
+++ b/libraries/apollo-api/build.gradle.kts
@@ -20,8 +20,6 @@ kotlin {
 
     findByName("commonTest")?.apply {
       dependencies {
-        //implementation(libs.kotlin.test.junit)
-        //implementation("org.jetbrains.kotlin:kotlin-test")
         implementation(libs.kotlin.test.asProvider().get().toString())
       }
     }

--- a/libraries/apollo-ast/build.gradle.kts
+++ b/libraries/apollo-ast/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
       }
     }
 
-    getByName("jsMain") {
+    findByName("jsMain")?.apply {
       dependencies {
         implementation(libs.okio.nodefilesystem)
       }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -15,7 +15,7 @@ configurations.create("gr8Classpath")
 val shadeConfiguration = configurations.create("shade")
 
 // Set to false to skip relocation and save some building time during development
-val relocateJar = true
+val relocateJar = System.getenv("APOLLO_RELOCATE_JAR")?.toBoolean() ?: true
 
 dependencies {
   /**


### PR DESCRIPTION
Add 2 development options:

* `APOLLO_RELOCATE_JAR` is for me to stop commiting the `build.gradle.kts` file all the time 😬 
* `APOLLO_JVM_ONLY` disables all non-JVM targets for faster iteration