### PR TITLE
[IJ Plugin] Telemetry: settings and opt-out dialog

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
@@ -6,6 +6,7 @@ import com.apollographql.ijplugin.util.logd
 import com.apollographql.ijplugin.util.logw
 import com.apollographql.ijplugin.util.showNotification
 import com.intellij.ide.BrowserUtil
+import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
@@ -72,10 +73,8 @@ private class DownloadSchemaTask(project: Project) : Task.Backgroundable(
           title = ApolloBundle.message("action.DownloadSchemaAction.noTasksFound.title"),
           content = ApolloBundle.message("action.DownloadSchemaAction.noTasksFound.content"),
           type = NotificationType.WARNING,
-          object : AnAction(ApolloBundle.message("action.DownloadSchemaAction.openDocumentation")) {
-            override fun actionPerformed(e: AnActionEvent) {
-              BrowserUtil.browse(SCHEMA_CONFIGURATION_DOC_URL, project)
-            }
+          NotificationAction.create(ApolloBundle.message("action.DownloadSchemaAction.openDocumentation")) { _, _ ->
+            BrowserUtil.browse(SCHEMA_CONFIGURATION_DOC_URL, project)
           }
       )
       return

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -3,6 +3,7 @@ package com.apollographql.ijplugin.settings
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.studio.ApiKeyDialog
+import com.apollographql.ijplugin.telemetry.TELEMETRY_ENABLED
 import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.ui.AddEditRemovePanel
@@ -100,10 +101,12 @@ class SettingsComponent(private val project: Project) {
         }
       }
     }
-    row {
-      checkBox(ApolloBundle.message("settings.telemetry.telemetryEnabled.text"))
-          .comment(ApolloBundle.message("settings.telemetry.telemetryEnabled.comment"))
-          .bindSelected(telemetryEnabledProperty)
+    if (TELEMETRY_ENABLED) {
+      row {
+        checkBox(ApolloBundle.message("settings.telemetry.telemetryEnabled.text"))
+            .comment(ApolloBundle.message("settings.telemetry.telemetryEnabled.comment"))
+            .bindSelected(telemetryEnabledProperty)
+      }
     }
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -18,7 +18,7 @@ class SettingsComponent(private val project: Project) {
   private val propertyGraph = PropertyGraph()
   private val automaticCodegenTriggeringProperty = propertyGraph.property(false)
   private val contributeConfigurationToGraphqlPluginProperty = propertyGraph.property(false)
-  private val telemetryOptInProperty = propertyGraph.property(false)
+  private val telemetryEnabledProperty = propertyGraph.property(false)
 
   var automaticCodegenTriggering: Boolean by automaticCodegenTriggeringProperty
   var contributeConfigurationToGraphqlPlugin: Boolean by contributeConfigurationToGraphqlPluginProperty
@@ -27,7 +27,7 @@ class SettingsComponent(private val project: Project) {
     set(value) {
       addEditRemovePanel?.data = value.toMutableList()
     }
-  var telemetryOptIn: Boolean by telemetryOptInProperty
+  var telemetryEnabled: Boolean by telemetryEnabledProperty
 
   private lateinit var chkAutomaticCodegenTriggering: JCheckBox
   private var addEditRemovePanel: AddEditRemovePanel<ApolloKotlinServiceConfiguration>? = null
@@ -101,9 +101,9 @@ class SettingsComponent(private val project: Project) {
       }
     }
     row {
-      checkBox(ApolloBundle.message("settings.telemetry.telemetryOptIn.text"))
-          .comment(ApolloBundle.message("settings.telemetry.telemetryOptIn.comment"))
-          .bindSelected(telemetryOptInProperty)
+      checkBox(ApolloBundle.message("settings.telemetry.telemetryEnabled.text"))
+          .comment(ApolloBundle.message("settings.telemetry.telemetryEnabled.comment"))
+          .bindSelected(telemetryEnabledProperty)
     }
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -18,6 +18,7 @@ class SettingsComponent(private val project: Project) {
   private val propertyGraph = PropertyGraph()
   private val automaticCodegenTriggeringProperty = propertyGraph.property(false)
   private val contributeConfigurationToGraphqlPluginProperty = propertyGraph.property(false)
+  private val telemetryOptInProperty = propertyGraph.property(false)
 
   var automaticCodegenTriggering: Boolean by automaticCodegenTriggeringProperty
   var contributeConfigurationToGraphqlPlugin: Boolean by contributeConfigurationToGraphqlPluginProperty
@@ -26,6 +27,7 @@ class SettingsComponent(private val project: Project) {
     set(value) {
       addEditRemovePanel?.data = value.toMutableList()
     }
+  var telemetryOptIn: Boolean by telemetryOptInProperty
 
   private lateinit var chkAutomaticCodegenTriggering: JCheckBox
   private var addEditRemovePanel: AddEditRemovePanel<ApolloKotlinServiceConfiguration>? = null
@@ -97,6 +99,11 @@ class SettingsComponent(private val project: Project) {
               .comment(ApolloBundle.message("settings.studio.apiKeys.comment"))
         }
       }
+    }
+    row {
+      checkBox(ApolloBundle.message("settings.telemetry.telemetryOptIn.text"))
+          .comment(ApolloBundle.message("settings.telemetry.telemetryOptIn.comment"))
+          .bindSelected(telemetryOptInProperty)
     }
   }
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
@@ -18,19 +18,22 @@ class SettingsConfigurable(private val project: Project) : Configurable {
   override fun isModified(): Boolean {
     return settingsComponent!!.automaticCodegenTriggering != project.settingsState.automaticCodegenTriggering ||
         settingsComponent!!.contributeConfigurationToGraphqlPlugin != project.settingsState.contributeConfigurationToGraphqlPlugin ||
-        settingsComponent!!.apolloKotlinServiceConfigurations != project.settingsState.apolloKotlinServiceConfigurations
+        settingsComponent!!.apolloKotlinServiceConfigurations != project.settingsState.apolloKotlinServiceConfigurations ||
+        settingsComponent!!.telemetryOptIn != project.settingsState.telemetryOptIn
   }
 
   override fun apply() {
     project.settingsState.automaticCodegenTriggering = settingsComponent!!.automaticCodegenTriggering
     project.settingsState.contributeConfigurationToGraphqlPlugin = settingsComponent!!.contributeConfigurationToGraphqlPlugin
     project.settingsState.apolloKotlinServiceConfigurations = settingsComponent!!.apolloKotlinServiceConfigurations
+    project.settingsState.telemetryOptIn = settingsComponent!!.telemetryOptIn
   }
 
   override fun reset() {
     settingsComponent!!.automaticCodegenTriggering = project.settingsState.automaticCodegenTriggering
     settingsComponent!!.contributeConfigurationToGraphqlPlugin = project.settingsState.contributeConfigurationToGraphqlPlugin
     settingsComponent!!.apolloKotlinServiceConfigurations = project.settingsState.apolloKotlinServiceConfigurations
+    settingsComponent!!.telemetryOptIn = project.settingsState.telemetryOptIn
   }
 
   override fun getPreferredFocusedComponent() = settingsComponent!!.preferredFocusedComponent

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
@@ -19,21 +19,21 @@ class SettingsConfigurable(private val project: Project) : Configurable {
     return settingsComponent!!.automaticCodegenTriggering != project.settingsState.automaticCodegenTriggering ||
         settingsComponent!!.contributeConfigurationToGraphqlPlugin != project.settingsState.contributeConfigurationToGraphqlPlugin ||
         settingsComponent!!.apolloKotlinServiceConfigurations != project.settingsState.apolloKotlinServiceConfigurations ||
-        settingsComponent!!.telemetryOptIn != project.settingsState.telemetryOptIn
+        settingsComponent!!.telemetryEnabled != project.settingsState.telemetryEnabled
   }
 
   override fun apply() {
     project.settingsState.automaticCodegenTriggering = settingsComponent!!.automaticCodegenTriggering
     project.settingsState.contributeConfigurationToGraphqlPlugin = settingsComponent!!.contributeConfigurationToGraphqlPlugin
     project.settingsState.apolloKotlinServiceConfigurations = settingsComponent!!.apolloKotlinServiceConfigurations
-    project.settingsState.telemetryOptIn = settingsComponent!!.telemetryOptIn
+    project.settingsState.telemetryEnabled = settingsComponent!!.telemetryEnabled
   }
 
   override fun reset() {
     settingsComponent!!.automaticCodegenTriggering = project.settingsState.automaticCodegenTriggering
     settingsComponent!!.contributeConfigurationToGraphqlPlugin = project.settingsState.contributeConfigurationToGraphqlPlugin
     settingsComponent!!.apolloKotlinServiceConfigurations = project.settingsState.apolloKotlinServiceConfigurations
-    settingsComponent!!.telemetryOptIn = project.settingsState.telemetryOptIn
+    settingsComponent!!.telemetryEnabled = project.settingsState.telemetryEnabled
   }
 
   override fun getPreferredFocusedComponent() = settingsComponent!!.preferredFocusedComponent

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsService.kt
@@ -66,17 +66,17 @@ class SettingsService(private val project: Project) : PersistentStateComponent<S
       _state.telemetryInstanceId = value
     }
 
-  override var telemetryOptIn: Boolean
-    get() = _state.telemetryOptIn
+  override var telemetryEnabled: Boolean
+    get() = _state.telemetryEnabled
     set(value) {
-      _state.telemetryOptIn = value
+      _state.telemetryEnabled = value
       notifySettingsChanged()
     }
 
-  override var hasShownTelemetryOptInDialog: Boolean
-    get() = _state.hasShownTelemetryOptInDialog
+  override var hasShownTelemetryOptOutDialog: Boolean
+    get() = _state.hasShownTelemetryOptOutDialog
     set(value) {
-      _state.hasShownTelemetryOptInDialog = value
+      _state.hasShownTelemetryOptOutDialog = value
     }
 
   private var lastNotifiedSettingsState: SettingsState? = null
@@ -106,8 +106,8 @@ interface SettingsState {
   var contributeConfigurationToGraphqlPlugin: Boolean
   var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
   var telemetryInstanceId: String
-  var telemetryOptIn: Boolean
-  var hasShownTelemetryOptInDialog: Boolean
+  var telemetryEnabled: Boolean
+  var hasShownTelemetryOptOutDialog: Boolean
 }
 
 data class ApolloKotlinServiceConfiguration(
@@ -143,8 +143,8 @@ data class SettingsStateImpl(
     override var contributeConfigurationToGraphqlPlugin: Boolean = true,
     override var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration> = emptyList(),
     override var telemetryInstanceId: String = "",
-    override var telemetryOptIn: Boolean = false,
-    override var hasShownTelemetryOptInDialog: Boolean = false,
+    override var telemetryEnabled: Boolean = true,
+    override var hasShownTelemetryOptOutDialog: Boolean = false,
 ) : SettingsState
 
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsService.kt
@@ -73,6 +73,12 @@ class SettingsService(private val project: Project) : PersistentStateComponent<S
       notifySettingsChanged()
     }
 
+  override var hasShownTelemetryOptInDialog: Boolean
+    get() = _state.hasShownTelemetryOptInDialog
+    set(value) {
+      _state.hasShownTelemetryOptInDialog = value
+    }
+
   private var lastNotifiedSettingsState: SettingsState? = null
   private fun notifySettingsChanged() {
     if (lastNotifiedSettingsState != _state) {
@@ -101,6 +107,7 @@ interface SettingsState {
   var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
   var telemetryInstanceId: String
   var telemetryOptIn: Boolean
+  var hasShownTelemetryOptInDialog: Boolean
 }
 
 data class ApolloKotlinServiceConfiguration(
@@ -137,6 +144,7 @@ data class SettingsStateImpl(
     override var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration> = emptyList(),
     override var telemetryInstanceId: String = "",
     override var telemetryOptIn: Boolean = false,
+    override var hasShownTelemetryOptInDialog: Boolean = false,
 ) : SettingsState
 
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.telemetry
 
 import com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel
+import com.apollographql.ijplugin.settings.settingsState
 import com.apollographql.ijplugin.telemetry.TelemetryProperty.AndroidCompileSdk
 import com.apollographql.ijplugin.telemetry.TelemetryProperty.AndroidGradlePluginVersion
 import com.apollographql.ijplugin.telemetry.TelemetryProperty.AndroidMinSdk
@@ -92,7 +93,7 @@ class TelemetryService(
       apolloKotlinModuleCount?.let { add(ApolloKotlinModuleCount(it)) }
     }
     return TelemetrySession(
-        instanceId = "TODO", // TODO
+        instanceId = project.settingsState.telemetryInstanceId,
         properties = properties,
         events = telemetryEventList.events,
     )

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
@@ -56,6 +56,11 @@ import com.intellij.openapi.roots.ModuleRootListener
 
 private const val DATA_PRIVACY_URL = "https://www.apollographql.com/docs/graphos/data-privacy/"
 
+/**
+ * TODO remove this
+ */
+const val TELEMETRY_ENABLED = false
+
 @Service(Service.Level.PROJECT)
 class TelemetryService(
     private val project: Project,
@@ -122,6 +127,7 @@ class TelemetryService(
   }
 
   private fun maybeShowTelemetryOptOutDialog() {
+    if (!TELEMETRY_ENABLED) return
     if (project.settingsState.hasShownTelemetryOptOutDialog) return
     project.settingsState.hasShownTelemetryOptOutDialog = true
     createNotification(

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetryService.kt
@@ -74,7 +74,7 @@ class TelemetryService(
     onLibrariesChanged()
     startObserveLibraries()
 
-    maybeShowTelemetryOptInDialog()
+    maybeShowTelemetryOptOutDialog()
   }
 
   private fun startObserveLibraries() {
@@ -121,23 +121,19 @@ class TelemetryService(
     telemetrySession.properties.forEach { logd(it) }
   }
 
-  private fun maybeShowTelemetryOptInDialog() {
-    if (project.settingsState.hasShownTelemetryOptInDialog) return
-    project.settingsState.hasShownTelemetryOptInDialog = true
+  private fun maybeShowTelemetryOptOutDialog() {
+    if (project.settingsState.hasShownTelemetryOptOutDialog) return
+    project.settingsState.hasShownTelemetryOptOutDialog = true
     createNotification(
         notificationGroupId = NOTIFICATION_GROUP_ID_TELEMETRY,
-        title = ApolloBundle.message("telemetry.optInDialog.title"),
-        content = ApolloBundle.message("telemetry.optInDialog.content"),
+        title = ApolloBundle.message("telemetry.optOutDialog.title"),
+        content = ApolloBundle.message("telemetry.optOutDialog.content"),
         type = NotificationType.INFORMATION,
-        NotificationAction.create(ApolloBundle.message("telemetry.optInDialog.optOut")) { _, notification ->
-          project.settingsState.telemetryOptIn = false
+        NotificationAction.create(ApolloBundle.message("telemetry.optOutDialog.optOut")) { _, notification ->
+          project.settingsState.telemetryEnabled = false
           notification.expire()
         },
-        NotificationAction.create(ApolloBundle.message("telemetry.optInDialog.optIn")) { _, notification ->
-          project.settingsState.telemetryOptIn = true
-          notification.expire()
-        },
-        NotificationAction.create(ApolloBundle.message("telemetry.optInDialog.learnMore")) { _, _ ->
+        NotificationAction.create(ApolloBundle.message("telemetry.optOutDialog.learnMore")) { _, _ ->
           BrowserUtil.browse(DATA_PRIVACY_URL, project)
         },
     )

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Notifications.kt
@@ -8,14 +8,18 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.NlsContexts.NotificationContent
 import com.intellij.openapi.util.NlsContexts.NotificationTitle
 
+const val NOTIFICATION_GROUP_ID_MAIN = "apollo.main"
+const val NOTIFICATION_GROUP_ID_TELEMETRY = "apollo.telemetry"
+
 @Suppress("UnstableApiUsage")
 fun createNotification(
+    notificationGroupId: String = NOTIFICATION_GROUP_ID_MAIN,
     @NotificationTitle title: String = "",
     @NotificationContent content: String,
     type: NotificationType,
     vararg actions: AnAction,
 ): Notification = NotificationGroupManager.getInstance()
-    .getNotificationGroup("Apollo")
+    .getNotificationGroup(notificationGroupId)
     .createNotification(title, content, type)
     .apply {
       for (action in actions) {
@@ -31,6 +35,23 @@ fun showNotification(
     type: NotificationType,
     vararg actions: AnAction,
 ) = createNotification(
+    notificationGroupId = NOTIFICATION_GROUP_ID_MAIN,
+    title = title,
+    content = content,
+    type = type,
+    actions = actions,
+).notify(project)
+
+@Suppress("UnstableApiUsage")
+fun showNotification(
+    project: Project,
+    notificationGroupId: String,
+    @NotificationTitle title: String = "",
+    @NotificationContent content: String,
+    type: NotificationType,
+    vararg actions: AnAction,
+) = createNotification(
+    notificationGroupId = notificationGroupId,
     title = title,
     content = content,
     type = type,

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -149,9 +149,15 @@
 
     <!-- Notifications -->
     <notificationGroup
-        id="Apollo"
+        id="apollo.main"
         displayType="BALLOON"
-        key="notification.group.apollo"
+        key="notification.group.apollo.main"
+    />
+
+    <notificationGroup
+        id="apollo.telemetry"
+        displayType="STICKY_BALLOON"
+        key="notification.group.apollo.telemetry"
     />
 
   </extensions>

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -156,7 +156,7 @@
 
     <notificationGroup
         id="apollo.telemetry"
-        displayType="STICKY_BALLOON"
+        displayType="BALLOON"
         key="notification.group.apollo.telemetry"
     />
 

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -51,7 +51,7 @@ action.DownloadSchemaAction.description=Download the latest schema(s) from intro
 action.DownloadSchemaAction.progress=Downloading schema
 action.DownloadSchemaAction.noTasksFound.title=Could not download schema
 action.DownloadSchemaAction.noTasksFound.content=No download schema tasks were found. Please configure an <code>introspection</code> or <code>registry</code> in the Apollo Gradle configuration.
-action.DownloadSchemaAction.openDocumentation=Open Documentation
+action.DownloadSchemaAction.openDocumentation=Open documentation
 action.DownloadSchemaAction.buildFail.title=Could not download schema
 action.DownloadSchemaAction.buildFail.content=Gradle task execution failed: ''{0}''.<br>Try on the command line with <code>./gradlew {1}</code> for more information.
 action.DownloadSchemaAction.buildSuccess.content={0} downloaded successfully
@@ -135,4 +135,12 @@ inspection.endpointNotConfigured.quickFix=Add introspection block
 
 inspection.suppress.field=Suppress for field
 
-notification.group.apollo=Apollo
+notification.group.apollo.main=Apollo
+notification.group.apollo.telemetry=Apollo (telemetry)
+
+telemetry.optInDialog.title=Send usage statistics to Apollo
+telemetry.optInDialog.content=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
+  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. is included.
+telemetry.optInDialog.optOut=Don't send
+telemetry.optInDialog.optIn=Send anonymous data
+telemetry.optInDialog.learnMore=Learn more

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -139,8 +139,8 @@ notification.group.apollo.main=Apollo
 notification.group.apollo.telemetry=Apollo (telemetry)
 
 telemetry.optOutDialog.title=Send usage statistics to Apollo
-telemetry.optOutDialog.content=To help the team improve Apollo Kotlin, the plugin sends anonymous data to Apollo, such as which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc.<br>\
-  No personal data or any sensitive information, such as source code or file names, are included.<br>\
+telemetry.optOutDialog.content=To improve Apollo Kotlin, the plugin sends anonymous data to Apollo, such as Gradle plugin options, version of Android and Kotlin, number of modules in the project and other technical information.<br>\
+  No personal data or sensitive information, such as source code or file names are included.<br>\
   You can opt-out in the plugin's settings at any time.
 telemetry.optOutDialog.optOut=Don't send
 telemetry.optOutDialog.learnMore=Learn more

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -95,9 +95,9 @@ settings.studio.apiKeyDialog.graphOsApiKey.emptyText=service:graph:key
 settings.studio.apiKeyDialog.graphOsApiKey.invalid=API key should look like <code>service:graph:key</code> or <code>user:id:key</code>
 settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph ID:
 
-settings.telemetry.telemetryOptIn.text=Send usage statistics
-settings.telemetry.telemetryOptIn.comment=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
-  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. is included. <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">Learn more</a>.
+settings.telemetry.telemetryEnabled.text=Send usage statistics
+settings.telemetry.telemetryEnabled.comment=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
+  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. are included. <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">Learn more</a>.
 
 GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration
 
@@ -138,9 +138,9 @@ inspection.suppress.field=Suppress for field
 notification.group.apollo.main=Apollo
 notification.group.apollo.telemetry=Apollo (telemetry)
 
-telemetry.optInDialog.title=Send usage statistics to Apollo
-telemetry.optInDialog.content=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
-  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. is included.
-telemetry.optInDialog.optOut=Don't send
-telemetry.optInDialog.optIn=Send anonymous data
-telemetry.optInDialog.learnMore=Learn more
+telemetry.optOutDialog.title=Send usage statistics to Apollo
+telemetry.optOutDialog.content=To help the team improve Apollo Kotlin, the plugin sends anonymous data to Apollo, such as which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc.<br>\
+  No personal data or any sensitive information, such as source code or file names, are included.<br>\
+  You can opt-out in the plugin's settings at any time.
+telemetry.optOutDialog.optOut=Don't send
+telemetry.optOutDialog.learnMore=Learn more

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -95,6 +95,10 @@ settings.studio.apiKeyDialog.graphOsApiKey.emptyText=service:graph:key
 settings.studio.apiKeyDialog.graphOsApiKey.invalid=API key should look like <code>service:graph:key</code> or <code>user:id:key</code>
 settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph ID:
 
+settings.telemetry.telemetryOptIn.text=Send usage statistics
+settings.telemetry.telemetryOptIn.comment=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
+  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. is included. <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">Learn more</a>.
+
 GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration
 
 CompatToOperationBasedCodegenMigrationProcessor.title=Migrate to operationBased Codegen

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -96,7 +96,7 @@ settings.studio.apiKeyDialog.graphOsApiKey.invalid=API key should look like <cod
 settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph ID:
 
 settings.telemetry.telemetryEnabled.text=Send usage statistics
-settings.telemetry.telemetryEnabled.comment=Help Apollo improve Apollo Kotlin by sending anonymous data.<br>\
+settings.telemetry.telemetryEnabled.comment=Help improve Apollo Kotlin by sending anonymous data.<br>\
   Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. are included. <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">Learn more</a>.
 
 GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -97,7 +97,7 @@ settings.studio.apiKeyDialog.graphOsGraphName.label=GraphOS graph ID:
 
 settings.telemetry.telemetryEnabled.text=Send usage statistics
 settings.telemetry.telemetryEnabled.comment=Help improve Apollo Kotlin by sending anonymous data.<br>\
-  Data includes which Apollo Kotlin features, options and components are used, versions of Android and Kotlin, number of modules in the project, etc. No personal data or any sensitive information, such as source code, file names, etc. are included. <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">Learn more</a>.
+  Data includes Gradle plugin options, version of Android and Kotlin, number of modules in the project and other technical information. No personal data or sensitive information, such as source code or file names are included. For more details, consult our <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">privacy policy</a>.
 
 GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration
 


### PR DESCRIPTION
<img width="972" alt="Screenshot 2023-09-20 at 12 11 00" src="https://github.com/apollographql/apollo-kotlin/assets/372852/69066d4a-02ac-48b4-b3c6-06a93944a1fd">


<img width="390" alt="Screenshot 2023-09-20 at 12 01 54" src="https://github.com/apollographql/apollo-kotlin/assets/372852/69d650b5-a2a0-47c8-b847-bb59aa1fbb1e">


<img width="385" alt="Screenshot 2023-09-20 at 12 02 06" src="https://github.com/apollographql/apollo-kotlin/assets/372852/5d63ce63-7174-44c9-a854-178bc10b3c87">


Note: I've added a `TELEMETRY_ENABLED` feature flag to hide the UI for now, so we can merge this now even though it's incomplete.