### PR TITLE
Logging a single line response body

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/LoggingInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/LoggingInterceptor.kt
@@ -99,11 +99,7 @@ class LoggingInterceptor(
         val read = this@intercept.read(tmp, byteCount)
         buffer.writeAll(tmp.peek())
         while (true) {
-          val next = buffer.indexOf('\n'.code.toByte())
-          if (next == -1L) {
-            break
-          }
-          log(buffer.readUtf8Line()!!)
+          buffer.readUtf8Line()?.let { log(it) } ?: break
         }
         sink.writeAll(tmp)
         return read


### PR DESCRIPTION
**Problem**: A single line response body is not logged since it contains no `\n` and that char is used for terminating logging.
**Solution**: Use okio's null return on `buffer.readUtf8Line()` when the buffer is empty to terminate logging instead.
**Usecase**: AWS AppSync seems to always return single line response.