### PR TITLE
Make CodegenLayout internal again, use CodegenMetadata.resolveSchemaType instead

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -309,7 +309,19 @@ public final class com/apollographql/apollo3/compiler/VersionKt {
 	public static final field APOLLO_VERSION Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/compiler/codegen/CodegenLayout$Companion {
+public final class com/apollographql/apollo3/compiler/codegen/ResolverClassName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/codegen/ResolverClassName$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/apollographql/apollo3/compiler/codegen/ResolverClassName;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/apollographql/apollo3/compiler/codegen/ResolverClassName;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/apollographql/apollo3/compiler/codegen/ResolverClassName$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/apollographql/apollo3/compiler/codegen/ResolverKey {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.compiler
 
+import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.compiler.codegen.ResolverClassName
 import com.apollographql.apollo3.compiler.codegen.ResolverInfo
 import com.apollographql.apollo3.compiler.codegen.ResolverKeyKind
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -22,6 +24,11 @@ data class CodegenMetadata internal constructor(
 
 fun CodegenMetadata.schemaTypes(): Set<String> {
   return resolverInfo.entries.filter { it.key.kind == ResolverKeyKind.SchemaType }.map { it.key.id }.toSet()
+}
+
+@ApolloInternal
+fun CodegenMetadata.resolveSchemaType(name: String): ResolverClassName? {
+  return resolverInfo.entries.firstOrNull { it.key.kind == ResolverKeyKind.SchemaType && it.key.id == name }?.className
 }
 
 @OptIn(ExperimentalSerializationApi::class)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.findTargetName
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -28,14 +27,12 @@ class CodegenSchema(
     val generateDataBuilders: Boolean,
 )
 
-@ApolloInternal
-class CodegenType(
+internal class CodegenType(
     val name: String,
     val targetName: String?,
 )
 
-@ApolloInternal
-fun CodegenSchema.allTypes(): List<CodegenType> {
+internal fun CodegenSchema.allTypes(): List<CodegenType> {
   return schema.typeDefinitions.values.map {
     CodegenType(it.name, it.directives.findTargetName(schema))
   }.sortedBy { it.name }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler.codegen
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.compiler.CodegenType
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
@@ -18,8 +17,7 @@ import com.apollographql.apollo3.compiler.singularize
  *
  * Inputs should always be GraphQL identifiers and outputs are valid Kotlin/Java identifiers.
  */
-@ApolloInternal
-abstract class CodegenLayout(
+internal abstract class CodegenLayout(
     allTypes: List<CodegenType>,
     private val packageNameGenerator: PackageNameGenerator,
     private val schemaPackageName: String,
@@ -119,7 +117,7 @@ abstract class CodegenLayout(
   internal fun fragmentVariablesAdapterName(name: String) = fragmentName(name) + "_VariablesAdapter"
   internal fun fragmentSelectionsName(name: String) = regularIdentifier(name) + "Selections"
 
-  fun inputObjectName(name: String) = className(name)
+  internal fun inputObjectName(name: String) = className(name)
   internal fun inputObjectAdapterName(name: String) = inputObjectName(name) + "_InputAdapter"
 
   // Variables are escaped to avoid a clash with the model name if they are capitalized

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen
 
+import com.apollographql.apollo3.annotations.ApolloInternal
 import kotlinx.serialization.Serializable
 
 /**
@@ -14,8 +15,9 @@ internal class ResolverInfo(
     val entries: List<ResolverEntry>
 )
 
+@ApolloInternal
 @Serializable
-internal class ResolverClassName(val packageName: String, val simpleNames: List<String>) {
+class ResolverClassName(val packageName: String, val simpleNames: List<String>) {
   constructor(packageName: String, vararg simpleNames: String): this(packageName, simpleNames.toList())
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegenLayout.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.compiler.CodegenType
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout
@@ -8,8 +7,7 @@ import com.apollographql.apollo3.compiler.escapeKotlinReservedWord
 import com.apollographql.apollo3.compiler.escapeKotlinReservedWordInEnum
 import com.apollographql.apollo3.compiler.escapeKotlinReservedWordInSealedClass
 
-@ApolloInternal
-class KotlinCodegenLayout(
+internal class KotlinCodegenLayout(
     allTypes: List<CodegenType>,
     packageNameGenerator: PackageNameGenerator,
     schemaPackageName: String,

--- a/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
+++ b/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
@@ -1,0 +1,165 @@
+package com.apollographql.apollo3.ksp
+
+import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.ast.GQLEnumTypeDefinition
+import com.apollographql.apollo3.ast.GQLInputObjectTypeDefinition
+import com.apollographql.apollo3.ast.GQLInterfaceTypeDefinition
+import com.apollographql.apollo3.ast.GQLListType
+import com.apollographql.apollo3.ast.GQLNamedType
+import com.apollographql.apollo3.ast.GQLNonNullType
+import com.apollographql.apollo3.ast.GQLObjectTypeDefinition
+import com.apollographql.apollo3.ast.GQLScalarTypeDefinition
+import com.apollographql.apollo3.ast.GQLType
+import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
+import com.apollographql.apollo3.ast.Schema
+import com.apollographql.apollo3.compiler.CodegenMetadata
+import com.apollographql.apollo3.compiler.ScalarInfo
+import com.apollographql.apollo3.compiler.codegen.ResolverClassName
+import com.apollographql.apollo3.compiler.ir.IrClassName
+import com.apollographql.apollo3.compiler.ir.IrInputObjectType
+import com.apollographql.apollo3.compiler.ir.IrListType
+import com.apollographql.apollo3.compiler.ir.IrNonNullType
+import com.apollographql.apollo3.compiler.ir.IrObjectType
+import com.apollographql.apollo3.compiler.ir.IrOptionalType
+import com.apollographql.apollo3.compiler.ir.IrScalarType
+import com.apollographql.apollo3.compiler.ir.IrType
+import com.apollographql.apollo3.compiler.resolveSchemaType
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.Nullability
+
+class IncompatibleType(message: String) : Exception(message)
+
+@OptIn(ApolloInternal::class)
+internal class ValidationScope(
+    private val objectMapping: Map<String, ObjectInfo>,
+    private val scalarMapping: Map<String, ScalarInfo>,
+    private val schema: Schema,
+    private val codegenMetadata: CodegenMetadata
+) {
+  fun validateAndCoerce(ksTypeReference: KSTypeReference, expectedType: GQLType, allowCovariant: Boolean): IrType {
+    val ksType = ksTypeReference.resolve()
+    val className = ksType.declaration.acClassName()
+
+    var expectedNullableType = expectedType
+    if (expectedType is GQLNonNullType) {
+      expectedNullableType = expectedType.type
+    }
+
+    val irType = when (expectedNullableType) {
+      is GQLListType -> {
+        if (className != listClassName) {
+          throw IncompatibleType("Expected list type at ${ksTypeReference.location}")
+        }
+        IrListType(
+            validateAndCoerce(
+                ksTypeReference.element!!.typeArguments.single().type!!,
+                expectedNullableType.type,
+                allowCovariant,
+            )
+        )
+      }
+
+      is GQLNamedType -> {
+        when (val typeDefinition = schema.typeDefinition(expectedNullableType.name)) {
+          is GQLScalarTypeDefinition -> {
+            val scalarInfo = scalarMapping.get(typeDefinition.name)
+            if (scalarInfo == null) {
+              throw IncompatibleType("Expected scalar type '${typeDefinition.name}' but no adapter found. Did you forget a @ApolloAdapter? at ${ksTypeReference.location}")
+            }
+            if (scalarInfo.targetName != className.asString()) {
+              throw IncompatibleType("Scalar type '${typeDefinition.name}' is mapped to '${scalarInfo.targetName} but '${className.asString()} was found at ${ksTypeReference.location}")
+            }
+            IrScalarType(typeDefinition.name)
+          }
+
+          is GQLInputObjectTypeDefinition -> {
+            val expectedFQDN = codegenMetadata.resolveSchemaType(typeDefinition.name)?.toIrClassName() ?: error("Cannot resolve input ${typeDefinition.name}")
+            if (className != expectedFQDN) {
+              throw IncompatibleType("Input object type '${typeDefinition.name}' is mapped to '${expectedFQDN} but '${className.asString()} was found at ${ksTypeReference.location}")
+            }
+
+            IrInputObjectType(typeDefinition.name)
+          }
+
+          is GQLEnumTypeDefinition -> {
+            val expectedFQDN = codegenMetadata.resolveSchemaType(typeDefinition.name)?.toIrClassName() ?: error("Cannot resolve enum ${typeDefinition.name}")
+            if (className != expectedFQDN) {
+              throw IncompatibleType("Enum type '${typeDefinition.name}' is mapped to '${expectedFQDN} but '${className.asString()} was found at ${ksTypeReference.location}")
+            }
+
+            IrInputObjectType(typeDefinition.name)
+          }
+
+          is GQLObjectTypeDefinition, is GQLUnionTypeDefinition, is GQLInterfaceTypeDefinition -> {
+            /**
+             * Because of interfaces we do the lookup the other way around. Contrary to scalars, there cannot be multiple objects mapped to the same target
+             */
+            /**
+             * Because of interfaces we do the lookup the other way around. Contrary to scalars, there cannot be multiple objects mapped to the same target
+             */
+            val objectInfoEntry =
+                objectMapping.entries.firstOrNull { it.value.className.asString() == className.asString() }
+
+            if (objectInfoEntry == null) {
+              throw IncompatibleType("Expected a composite type '${typeDefinition.name}' but no object found. Did you forget a @ApolloObject? at ${ksTypeReference.location}")
+            }
+            if (!schema.possibleTypes(typeDefinition.name).contains(objectInfoEntry.key)) {
+              throw IncompatibleType("Expected type '${typeDefinition.name}' but '${objectInfoEntry.key}' is not a subtype at ${ksTypeReference.location}")
+            }
+
+            IrObjectType(typeDefinition.name)
+          }
+        }
+      }
+
+      is GQLNonNullType -> error("")
+    }
+
+    if (expectedType is GQLNonNullType) {
+      if (ksType.nullability != Nullability.NOT_NULL) {
+        throw IncompatibleType("Expected non-nullable type at ${ksTypeReference.location}, got nullable")
+      }
+    } else {
+      if (!allowCovariant) {
+        if (ksType.nullability == Nullability.NOT_NULL) {
+          throw IncompatibleType("Expected nullable type at ${ksTypeReference.location}, got non nullable")
+        }
+      }
+    }
+
+    return if (ksType.nullability == Nullability.NOT_NULL) {
+      IrNonNullType(irType)
+    } else {
+      irType
+    }
+  }
+}
+
+private fun ResolverClassName.toIrClassName(): IrClassName {
+  return IrClassName(packageName, simpleNames)
+}
+
+
+internal fun ValidationScope.validateAndCoerceArgumentType(
+    targetName: String,
+    typeReference: KSTypeReference,
+    gqlType: GQLType,
+    hasDefault: Boolean
+): IrType {
+  val type = typeReference.resolve()
+  val className = type.declaration.acClassName()
+  val gqlOptional = gqlType !is GQLNonNullType && !hasDefault
+  if (className == optionalClassName != gqlOptional) {
+    if (gqlOptional) {
+      throw IncompatibleType("The '$targetName' argument can be absent in GraphQL and must be of Optional<> type in Kotlin at ${typeReference.location}")
+    } else {
+      throw IncompatibleType("The '$targetName' argument is always present in GraphQL and must not be of Optional<> type in Kotlin at ${typeReference.location}")
+    }
+  }
+
+  return if (className == optionalClassName) {
+    IrOptionalType(validateAndCoerce(typeReference.element!!.typeArguments.first().type!!, gqlType, false))
+  } else {
+    validateAndCoerce(typeReference, gqlType, false)
+  }
+}

--- a/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
+++ b/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
@@ -94,9 +94,6 @@ internal class ValidationScope(
             /**
              * Because of interfaces we do the lookup the other way around. Contrary to scalars, there cannot be multiple objects mapped to the same target
              */
-            /**
-             * Because of interfaces we do the lookup the other way around. Contrary to scalars, there cannot be multiple objects mapped to the same target
-             */
             val objectInfoEntry =
                 objectMapping.entries.firstOrNull { it.value.className.asString() == className.asString() }
 


### PR DESCRIPTION
Fix for https://github.com/apollographql/apollo-kotlin/pull/5281/files#r1345525292

Also move the validation part out of ApolloProcessor