### PR TITLE
docs: add file uploads caveats

### DIFF
--- a/docs/source/advanced/upload.mdx
+++ b/docs/source/advanced/upload.mdx
@@ -5,7 +5,7 @@ title: Uploading files
 Apollo Kotlin supports file uploads via the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec) with a few caveats:
 
 - Uploading files with GraphQL is most often suitable for proof-of-concept applications. In production, using purpose-built tools for file uploads may be preferable. Refer to this [blog post](https://www.apollographql.com/blog/backend/file-uploads/file-upload-best-practices/) for the advantages and disadvantages of multiple approaches.
-- Currently, the [Apollo Router](/router/) doesn't support `multipart-form` uploads.
+- The [Apollo Router](/router/) doesn't support `multipart-form` uploads.
 
 ## Uploading files with Apollo Kotlin
 

--- a/docs/source/advanced/upload.mdx
+++ b/docs/source/advanced/upload.mdx
@@ -2,21 +2,12 @@
 title: Uploading files
 ---
 
-## An important caveat about file uploads
+Apollo Kotlin supports file uploads via the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec) with a few caveats:
 
-Apollo recommends only using GraphQL file uploading for proof-of-concept applications. While there is a spec we presently support for making `multipart-form` requests with GraphQL, we've found that, in practice, it's much simpler to use more purpose-built tools for file upload.
-
-Apollo recommends using more traditional methods to upload your files, such as REST `multipart-form` uploads or SDK's that support file uploads, such as AmazonS3. 
-
-Also note that the [Apollo Router](https://www.apollographql.com/docs/router/) doest not support `multipart-form` uploads.
-
-[This article](https://www.apollographql.com/blog/backend/file-uploads/file-upload-best-practices/) contains recommendations about file uploads with GraphQL and Apollo.
-
-If you'd still prefer to upload directly with Apollo Kotlin, continue reading.
+- Uploading files with GraphQL is most often suitable for proof-of-concept applications. In production, using purpose-built tools for file uploads may be preferable. Refer to this [blog post](https://www.apollographql.com/blog/backend/file-uploads/file-upload-best-practices/) for the advantages and disadvantages of multiple approaches.
+- Currently, the [Apollo Router](/router/) doesn't support `multipart-form` uploads.
 
 ## Uploading files with Apollo Kotlin
-
-Apollo Kotlin supports file uploads via the [GraphQL multipart request specification](https://github.com/jaydenseric/graphql-multipart-request-spec).
 
 First, add the following custom scalar mapping to the Apollo Gradle plugin configuration:
 


### PR DESCRIPTION
A couple of principles I incorporated into this edit:
- Before diving into disclaimers, start with what _is_ supported / what the page describes
- Avoid "Apollo recommends" unless it's a nearly universal recommendation (based on the cited blog post, this may not be the case)
- Document all relevant caveats, even if they may change in the future