### PR TITLE
Fix partial data throwing with useV3ExceptionHandling and normalized cache

### DIFF
--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloGraphQLException
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.exception.DefaultApolloException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
@@ -143,7 +144,7 @@ internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
 
       request.fetchPolicyInterceptor.intercept(request, chain)
           .collect {
-            if (!hasEmitted && it.exception != null) {
+            if (!hasEmitted && it.exception != null && it.exception !is ApolloGraphQLException) {
               // Remember to send the exception later
               exceptions.add(it.exception!!)
               return@collect

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloGraphQLException
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.exception.DefaultApolloException
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
@@ -143,7 +144,7 @@ internal val FetchPolicyRouterInterceptor = object : ApolloInterceptor {
 
       request.fetchPolicyInterceptor.intercept(request, chain)
           .collect {
-            if (!hasEmitted && it.exception != null) {
+            if (!hasEmitted && it.exception != null && it.exception !is ApolloGraphQLException) {
               // Remember to send the exception later
               exceptions.add(it.exception!!)
               return@collect

--- a/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
@@ -3,7 +3,9 @@ package test
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
@@ -63,10 +65,11 @@ class ExceptionsTest {
     }
     assertNotNull(result.exceptionOrNull())
   }
+
   @Test
   @Suppress("DEPRECATION")
   fun toFlowDoesNotThrowOnV3() = runTest(before = { setUp() }, after = { tearDown() }) {
-      mockServer.enqueueString("""
+    mockServer.enqueueString("""
         {
           "errors": [
               {
@@ -81,8 +84,46 @@ class ExceptionsTest {
             ]
           }
       """.trimIndent())
-      val errorClient = apolloClient.newBuilder().useV3ExceptionHandling(true).build()
-      val response = errorClient.query(HeroNameQuery()).toFlow().toList()
-      assertTrue(response.first().errors?.isNotEmpty() ?: false)
+    val errorClient = apolloClient.newBuilder().useV3ExceptionHandling(true).build()
+    val response = errorClient.query(HeroNameQuery()).toFlow().toList()
+    assertTrue(response.first().errors?.isNotEmpty() ?: false)
+  }
+
+  @Test
+  @Suppress("DEPRECATION")
+  fun v3ExceptionHandlingKeepsPartialData() = runTest(before = { setUp() }, after = { tearDown() }) {
+    apolloClient = ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .useV3ExceptionHandling(true)
+        .build()
+    mockServer.enqueueString("""
+      {
+        "data": {
+          "hero": {
+            "name": "R2-D2",
+            "friends": null
+          }
+        },
+        "errors": [
+            {
+              "message": "Could not get friends",
+              "locations": [
+                {
+                  "line": 1,
+                  "column": 1
+                }
+              ],
+              "path": [
+                "hero",
+                "friends"
+              ]
+            }
+          ]
+        }
+    """.trimIndent())
+    val errorClient = apolloClient.newBuilder().build()
+    val response = errorClient.query(HeroAndFriendsNamesQuery(Episode.EMPIRE)).execute()
+    assertNotNull(response.data)
+    assertTrue(response.errors?.isNotEmpty() == true)
   }
 }


### PR DESCRIPTION
In `FetchPolicyRouterInterceptors`, `useV3ExceptionHandling` is handled by skipping responses that have an exception set. 

But this skipping shouldn't be done for `ApolloGraphQLException` since in v3 these don't throw - instead they should be emitted as usual.

Related to #5312