### PR TITLE
Add FieldNameGenerator for cases where paginationArgs is not enough

### DIFF
--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -85,7 +85,9 @@ class ResolverContext(
     val variables: Executable.Variables,
     val parent: Map<String, @JvmSuppressWildcards Any?>,
     val parentId: String,
+    val parentType: String,
     val cacheHeaders: CacheHeaders,
+    val fieldNameGenerator: FieldNameGenerator,
 )
 
 /**
@@ -120,6 +122,19 @@ object DefaultCacheResolver : CacheResolver {
   }
 }
 
+/**
+ * An [ApolloResolver] that uses the parent to resolve fields.
+ */
+object DefaultApolloResolver : ApolloResolver {
+  override fun resolveField(context: ResolverContext): Any? {
+    val name = context.fieldNameGenerator.getFieldName(FieldNameContext(context.parentType, context.field, context.variables))
+    if (!context.parent.containsKey(name)) {
+      throw CacheMissException(context.parentId, name)
+    }
+
+    return context.parent[name]
+  }
+}
 
 /**
  * A cache resolver that uses the cache date as a receive date and expires after a fixed max age
@@ -160,7 +175,7 @@ class ReceiveDateApolloResolver(private val maxAge: Int) : ApolloResolver {
  * A cache resolver that uses the cache date as an expiration date and expires past it
  */
 @ApolloExperimental
-class ExpireDateCacheResolver() : CacheResolver {
+class ExpireDateCacheResolver : CacheResolver {
   /**
    * @param parent a [Map] that represent the object containing this field. The map values can have the same types as the ones in  [Record]
    */
@@ -211,12 +226,18 @@ object FieldPolicyCacheResolver : CacheResolver {
 }
 
 /**
- * A [ApolloResolver] that uses @fieldPolicy annotations to resolve fields and delegates to [DefaultCacheResolver] else
+ * A [ApolloResolver] that uses @fieldPolicy annotations to resolve fields and delegates to [DefaultApolloResolver] else
  */
 object FieldPolicyApolloResolver : ApolloResolver {
   override fun resolveField(context: ResolverContext): Any? {
-    return FieldPolicyCacheResolver.resolveField(context.field, context.variables, context.parent, context.parentId)
+    val keyArgsValues = context.field.arguments.filter { it.isKey }.map {
+      resolveVariables(it.value, context.variables).toString()
+    }
+
+    if (keyArgsValues.isNotEmpty()) {
+      return CacheKey(context.field.type.rawType().name, keyArgsValues)
+    }
+
+    return DefaultApolloResolver.resolveField(context)
   }
 }
-
-

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/FieldNameGenerator.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/FieldNameGenerator.kt
@@ -1,0 +1,24 @@
+package com.apollographql.apollo3.cache.normalized.api
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.Executable
+
+@ApolloExperimental
+interface FieldNameGenerator {
+  fun getFieldName(context: FieldNameContext): String
+}
+
+@ApolloExperimental
+class FieldNameContext(
+    val parentType: String,
+    val field: CompiledField,
+    val variables: Executable.Variables,
+)
+
+@ApolloExperimental
+object DefaultFieldNameGenerator : FieldNameGenerator {
+  override fun getFieldName(context: FieldNameContext): String {
+    return context.field.nameWithArguments(context.variables)
+  }
+}

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/OperationCacheExtensions.kt
@@ -13,12 +13,13 @@ import com.apollographql.apollo3.api.toJson
 import com.apollographql.apollo3.api.variables
 import com.apollographql.apollo3.cache.normalized.api.internal.CacheBatchReader
 import com.apollographql.apollo3.cache.normalized.api.internal.Normalizer
+import kotlin.jvm.JvmOverloads
 
 fun <D : Operation.Data> Operation<D>.normalize(
     data: D,
     customScalarAdapters: CustomScalarAdapters,
     cacheKeyGenerator: CacheKeyGenerator,
-) = normalize(data, customScalarAdapters, cacheKeyGenerator, EmptyMetadataGenerator, CacheKey.rootKey().key)
+) = normalize(data, customScalarAdapters, cacheKeyGenerator, EmptyMetadataGenerator, DefaultFieldNameGenerator, CacheKey.rootKey().key)
 
 @ApolloExperimental
 fun <D : Operation.Data> Operation<D>.normalize(
@@ -26,7 +27,8 @@ fun <D : Operation.Data> Operation<D>.normalize(
     customScalarAdapters: CustomScalarAdapters,
     cacheKeyGenerator: CacheKeyGenerator,
     metadataGenerator: MetadataGenerator,
-) = normalize(data, customScalarAdapters, cacheKeyGenerator, metadataGenerator, CacheKey.rootKey().key)
+    fieldNameGenerator: FieldNameGenerator,
+) = normalize(data, customScalarAdapters, cacheKeyGenerator, metadataGenerator, fieldNameGenerator, CacheKey.rootKey().key)
 
 
 @Suppress("UNCHECKED_CAST")
@@ -39,7 +41,7 @@ fun <D : Executable.Data> Executable<D>.normalize(
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters, true)
-  return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator)
+  return Normalizer(variables, rootKey, cacheKeyGenerator, EmptyMetadataGenerator, DefaultFieldNameGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
 
@@ -50,12 +52,13 @@ fun <D : Executable.Data> Executable<D>.normalize(
     customScalarAdapters: CustomScalarAdapters,
     cacheKeyGenerator: CacheKeyGenerator,
     metadataGenerator: MetadataGenerator,
+    fieldNameGenerator: FieldNameGenerator,
     rootKey: String,
 ): Map<String, Record> {
   val writer = MapJsonWriter()
   adapter().toJson(writer, customScalarAdapters, data)
   val variables = variables(customScalarAdapters)
-  return Normalizer(variables, rootKey, cacheKeyGenerator, metadataGenerator)
+  return Normalizer(variables, rootKey, cacheKeyGenerator, metadataGenerator, fieldNameGenerator)
       .normalize(writer.root() as Map<String, Any?>, rootField().selections, rootField().type.rawType())
 }
 
@@ -72,12 +75,14 @@ fun <D : Executable.Data> Executable<D>.readDataFromCache(
     cacheHeaders = cacheHeaders,
 )
 
+@JvmOverloads
 fun <D : Executable.Data> Executable<D>.readDataFromCache(
     cacheKey: CacheKey,
     customScalarAdapters: CustomScalarAdapters,
     cache: ReadOnlyNormalizedCache,
     cacheResolver: CacheResolver,
     cacheHeaders: CacheHeaders,
+    fieldNameGenerator: FieldNameGenerator = DefaultFieldNameGenerator,
 ): D {
   val variables = variables(customScalarAdapters, true)
   return readInternal(
@@ -85,16 +90,19 @@ fun <D : Executable.Data> Executable<D>.readDataFromCache(
       cache = cache,
       cacheResolver = cacheResolver,
       cacheHeaders = cacheHeaders,
-      variables = variables
+      variables = variables,
+      fieldNameGenerator = fieldNameGenerator,
   ).toData(adapter(), customScalarAdapters, variables)
 }
 
+@JvmOverloads
 fun <D : Executable.Data> Executable<D>.readDataFromCache(
     cacheKey: CacheKey,
     customScalarAdapters: CustomScalarAdapters,
     cache: ReadOnlyNormalizedCache,
     cacheResolver: ApolloResolver,
     cacheHeaders: CacheHeaders,
+    fieldNameGenerator: FieldNameGenerator = DefaultFieldNameGenerator,
 ): D {
   val variables = variables(customScalarAdapters, true)
   return readInternal(
@@ -102,7 +110,8 @@ fun <D : Executable.Data> Executable<D>.readDataFromCache(
       cache = cache,
       cacheResolver = cacheResolver,
       cacheHeaders = cacheHeaders,
-      variables = variables
+      variables = variables,
+      fieldNameGenerator = fieldNameGenerator,
   ).toData(adapter(), customScalarAdapters, variables)
 }
 
@@ -113,12 +122,14 @@ fun <D : Executable.Data> Executable<D>.readDataFromCacheInternal(
     cacheResolver: CacheResolver,
     cacheHeaders: CacheHeaders,
     variables: Executable.Variables,
+    fieldNameGenerator: FieldNameGenerator,
 ): CacheData = readInternal(
     cacheKey = cacheKey,
     cache = cache,
     cacheResolver = cacheResolver,
     cacheHeaders = cacheHeaders,
     variables = variables,
+    fieldNameGenerator = fieldNameGenerator,
 )
 
 @ApolloInternal
@@ -128,12 +139,14 @@ fun <D : Executable.Data> Executable<D>.readDataFromCacheInternal(
     cacheResolver: ApolloResolver,
     cacheHeaders: CacheHeaders,
     variables: Executable.Variables,
+    fieldNameGenerator: FieldNameGenerator,
 ): CacheData = readInternal(
     cacheKey = cacheKey,
     cache = cache,
     cacheResolver = cacheResolver,
     cacheHeaders = cacheHeaders,
-    variables
+    variables = variables,
+    fieldNameGenerator = fieldNameGenerator,
 )
 
 
@@ -143,6 +156,7 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
     cacheResolver: Any,
     cacheHeaders: CacheHeaders,
     variables: Executable.Variables,
+    fieldNameGenerator: FieldNameGenerator,
 ): CacheData {
   return CacheBatchReader(
       cache = cache,
@@ -151,7 +165,8 @@ private fun <D : Executable.Data> Executable<D>.readInternal(
       variables = variables,
       rootKey = cacheKey.key,
       rootSelections = rootField().selections,
-      rootTypename = rootField().type.rawType().name
+      rootTypename = rootField().type.rawType().name,
+      fieldNameGenerator = fieldNameGenerator,
   ).collectData()
 }
 

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Normalizer.kt
@@ -14,6 +14,8 @@ import com.apollographql.apollo3.api.isComposite
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGeneratorContext
+import com.apollographql.apollo3.cache.normalized.api.FieldNameContext
+import com.apollographql.apollo3.cache.normalized.api.FieldNameGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
 import com.apollographql.apollo3.cache.normalized.api.Record
@@ -27,6 +29,7 @@ internal class Normalizer(
     private val rootKey: String,
     private val cacheKeyGenerator: CacheKeyGenerator,
     private val metadataGenerator: MetadataGenerator,
+    private val fieldNameGenerator: FieldNameGenerator,
 ) {
   private val records = mutableMapOf<String, Record>()
 
@@ -80,7 +83,7 @@ internal class Normalizer(
           .condition(emptyList())
           .build()
 
-      val fieldKey = mergedField.nameWithArguments(variables)
+      val fieldKey = fieldNameGenerator.getFieldName(FieldNameContext(parentType, mergedField, variables))
 
       val base = if (key == CacheKey.rootKey().key) {
         // If we're at the root level, skip `QUERY_ROOT` altogether to save a few bytes

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -9,8 +9,10 @@ import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
+import com.apollographql.apollo3.cache.normalized.api.DefaultFieldNameGenerator
 import com.apollographql.apollo3.cache.normalized.api.DefaultRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.EmptyMetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.FieldNameGenerator
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
@@ -196,7 +198,8 @@ fun ApolloStore(
     cacheKeyGenerator = cacheKeyGenerator,
     metadataGenerator = EmptyMetadataGenerator,
     cacheResolver = cacheResolver,
-    recordMerger = DefaultRecordMerger
+    recordMerger = DefaultRecordMerger,
+    fieldNameGenerator = DefaultFieldNameGenerator,
 )
 
 @ApolloExperimental
@@ -206,10 +209,12 @@ fun ApolloStore(
     metadataGenerator: MetadataGenerator,
     apolloResolver: ApolloResolver,
     recordMerger: RecordMerger = DefaultRecordMerger,
+    fieldNameGenerator: FieldNameGenerator = DefaultFieldNameGenerator,
 ): ApolloStore = DefaultApolloStore(
     normalizedCacheFactory = normalizedCacheFactory,
     cacheKeyGenerator = cacheKeyGenerator,
     metadataGenerator = metadataGenerator,
     cacheResolver = apolloResolver,
-    recordMerger = recordMerger
+    recordMerger = recordMerger,
+    fieldNameGenerator = fieldNameGenerator,
 )

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -20,6 +20,8 @@ import com.apollographql.apollo3.cache.normalized.api.ApolloResolver
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
+import com.apollographql.apollo3.cache.normalized.api.DefaultFieldNameGenerator
+import com.apollographql.apollo3.cache.normalized.api.FieldNameGenerator
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
@@ -119,6 +121,7 @@ fun ApolloClient.Builder.normalizedCache(
     metadataGenerator: MetadataGenerator,
     apolloResolver: ApolloResolver,
     recordMerger: RecordMerger,
+    fieldNameGenerator: FieldNameGenerator = DefaultFieldNameGenerator,
     writeToCacheAsynchronously: Boolean = false,
 ): ApolloClient.Builder {
   return store(
@@ -127,7 +130,8 @@ fun ApolloClient.Builder.normalizedCache(
           cacheKeyGenerator = cacheKeyGenerator,
           metadataGenerator = metadataGenerator,
           apolloResolver = apolloResolver,
-          recordMerger = recordMerger
+          recordMerger = recordMerger,
+          fieldNameGenerator = fieldNameGenerator,
       ), writeToCacheAsynchronously)
 }
 

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldNameGenerator
 import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
@@ -31,6 +32,7 @@ import kotlin.reflect.KClass
 internal class DefaultApolloStore(
     normalizedCacheFactory: NormalizedCacheFactory,
     private val cacheKeyGenerator: CacheKeyGenerator,
+    private val fieldNameGenerator: FieldNameGenerator,
     private val metadataGenerator: MetadataGenerator,
     private val cacheResolver: Any,
     private val recordMerger: RecordMerger,
@@ -102,6 +104,7 @@ internal class DefaultApolloStore(
         customScalarAdapters = customScalarAdapters,
         cacheKeyGenerator = cacheKeyGenerator,
         metadataGenerator = metadataGenerator,
+        fieldNameGenerator = fieldNameGenerator,
     )
   }
 
@@ -117,7 +120,8 @@ internal class DefaultApolloStore(
           cacheResolver = cacheResolver,
           cacheHeaders = cacheHeaders,
           cacheKey = CacheKey.rootKey(),
-          variables = variables
+          variables = variables,
+          fieldNameGenerator = fieldNameGenerator,
       )
     }.toData(operation.adapter(), customScalarAdapters, variables)
   }
@@ -137,6 +141,7 @@ internal class DefaultApolloStore(
           cacheHeaders = cacheHeaders,
           cacheKey = cacheKey,
           variables = variables,
+          fieldNameGenerator = fieldNameGenerator,
       )
     }.toData(fragment.adapter(), customScalarAdapters, variables)
   }
@@ -178,6 +183,7 @@ internal class DefaultApolloStore(
         customScalarAdapters = customScalarAdapters,
         cacheKeyGenerator = cacheKeyGenerator,
         metadataGenerator = metadataGenerator,
+        fieldNameGenerator = fieldNameGenerator,
         rootKey = cacheKey.key
     ).values
 
@@ -204,6 +210,7 @@ internal class DefaultApolloStore(
         customScalarAdapters = customScalarAdapters,
         cacheKeyGenerator = cacheKeyGenerator,
         metadataGenerator = metadataGenerator,
+        fieldNameGenerator = fieldNameGenerator,
     ).values.toSet()
 
     val changedKeys = lock.write {
@@ -230,6 +237,7 @@ internal class DefaultApolloStore(
         customScalarAdapters = customScalarAdapters,
         cacheKeyGenerator = cacheKeyGenerator,
         metadataGenerator = metadataGenerator,
+        fieldNameGenerator = fieldNameGenerator,
     ).values.map { record ->
       Record(
           key = record.key,
@@ -288,22 +296,25 @@ internal class DefaultApolloStore(
         cacheResolver: Any,
         cacheHeaders: CacheHeaders,
         variables: Executable.Variables,
+        fieldNameGenerator: FieldNameGenerator,
     ): CacheData {
       return when (cacheResolver) {
         is CacheResolver -> readDataFromCacheInternal(
-            cacheKey,
-            cache,
-            cacheResolver,
-            cacheHeaders,
-            variables
+            cacheKey = cacheKey,
+            cache = cache,
+            cacheResolver = cacheResolver,
+            cacheHeaders = cacheHeaders,
+            variables = variables,
+            fieldNameGenerator = fieldNameGenerator,
         )
 
         is ApolloResolver -> readDataFromCacheInternal(
-            cacheKey,
-            cache,
-            cacheResolver,
-            cacheHeaders,
-            variables
+            cacheKey = cacheKey,
+            cache = cache,
+            cacheResolver = cacheResolver,
+            cacheHeaders = cacheHeaders,
+            variables = variables,
+            fieldNameGenerator = fieldNameGenerator,
         )
 
         else -> throw IllegalStateException()

--- a/tests/pagination/src/commonMain/graphql/pagination/operations.graphql
+++ b/tests/pagination/src/commonMain/graphql/pagination/operations.graphql
@@ -42,3 +42,13 @@ query UsersOffsetBasedWithPage($offset: Int, $limit: Int) {
     }
   }
 }
+
+query UsersOffsetBasedWithPageAndInput($offset: Int, $limit: Int) {
+  usersOffsetBasedWithPageAndInput(usersInput: {sessionId: "42", offset: $offset, limit: $limit}) {
+    users {
+      id
+      name
+      email
+    }
+  }
+}

--- a/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
+++ b/tests/pagination/src/commonMain/graphql/pagination/schema.graphqls
@@ -1,7 +1,7 @@
 extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@typePolicy", "@fieldPolicy"])
 
 type Query
-@typePolicy(embeddedFields: "usersCursorBased, usersOffsetBasedWithPage" connectionFields: "usersCursorBased2, usersCursorBased3")
+@typePolicy(embeddedFields: "usersCursorBased, usersOffsetBasedWithPage, usersOffsetBasedWithPageAndInput" connectionFields: "usersCursorBased2, usersCursorBased3")
 @fieldPolicy(forField: "usersCursorBased", paginationArgs: "first, after, last, before")
 @fieldPolicy(forField: "usersOffsetBasedWithArray", paginationArgs: "offset, limit")
 @fieldPolicy(forField: "usersOffsetBasedWithPage", paginationArgs: "offset, limit")
@@ -13,6 +13,14 @@ type Query
   usersOffsetBasedWithArray(offset: Int = 0, limit: Int = 10): [User!]!
 
   usersOffsetBasedWithPage(offset: Int = 0, limit: Int = 10): UserPage!
+
+  usersOffsetBasedWithPageAndInput(usersInput: UsersInput!): UserPage!
+}
+
+input UsersInput {
+  sessionId: ID!
+  offset: Int = 0
+  limit: Int = 10
 }
 
 type UserConnection @typePolicy(embeddedFields: "pageInfo, edges") {

--- a/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPageAndInputPaginationTest.kt
+++ b/tests/pagination/src/commonTest/kotlin/OffsetBasedWithPageAndInputPaginationTest.kt
@@ -1,0 +1,260 @@
+package pagination
+
+import com.apollographql.apollo3.api.CompiledArgument
+import com.apollographql.apollo3.api.CompiledField
+import com.apollographql.apollo3.api.Executable
+import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.DefaultFieldNameGenerator
+import com.apollographql.apollo3.cache.normalized.api.FieldNameContext
+import com.apollographql.apollo3.cache.normalized.api.FieldNameGenerator
+import com.apollographql.apollo3.cache.normalized.api.FieldPolicyApolloResolver
+import com.apollographql.apollo3.cache.normalized.api.FieldRecordMerger
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.MetadataGenerator
+import com.apollographql.apollo3.cache.normalized.api.MetadataGeneratorContext
+import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo3.testing.internal.runTest
+import pagination.type.buildUser
+import pagination.type.buildUserPage
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class OffsetBasedWithPageAndInputPaginationTest {
+  @Test
+  fun offsetBasedWithPageAndInputMemoryCache() {
+    offsetBasedWithPageAndInput(MemoryCacheFactory())
+  }
+
+  @Test
+  fun offsetBasedWithPageAndInputBlobSqlCache() {
+    offsetBasedWithPageAndInput(SqlNormalizedCacheFactory(name = "blob", withDates = true))
+  }
+
+  @Test
+  fun offsetBasedWithPageAndInputJsonSqlCache() {
+    offsetBasedWithPageAndInput(SqlNormalizedCacheFactory(name = "json", withDates = false))
+  }
+
+  @Test
+  fun offsetBasedWithPageAndInputChainedCache() {
+    offsetBasedWithPageAndInput(MemoryCacheFactory().chain(SqlNormalizedCacheFactory(name = "json", withDates = false)))
+  }
+
+  private fun offsetBasedWithPageAndInput(cacheFactory: NormalizedCacheFactory) = runTest {
+    val apolloStore = ApolloStore(
+        normalizedCacheFactory = cacheFactory,
+        cacheKeyGenerator = TypePolicyCacheKeyGenerator,
+        metadataGenerator = OffsetPaginationMetadataGenerator("UserPage"),
+        apolloResolver = FieldPolicyApolloResolver,
+        recordMerger = FieldRecordMerger(OffsetPaginationFieldMerger()),
+        fieldNameGenerator = UsersNameGenerator,
+    )
+    apolloStore.clearAll()
+
+    // First page
+    val query1 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(42), limit = Optional.Present(2))
+    val data1 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "42" },
+            buildUser { id = "43" },
+        )
+      }
+    }
+    apolloStore.writeOperation(query1, data1)
+    var dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data1, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page after
+    val query2 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(44), limit = Optional.Present(2))
+    val data2 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "44" },
+            buildUser { id = "45" },
+        )
+      }
+    }
+    apolloStore.writeOperation(query2, data2)
+    dataFromStore = apolloStore.readOperation(query1)
+    var expectedData = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "42" },
+            buildUser { id = "43" },
+            buildUser { id = "44" },
+            buildUser { id = "45" },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page in the middle
+    val query3 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(44), limit = Optional.Present(3))
+    val data3 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "44" },
+            buildUser { id = "45" },
+            buildUser { id = "46" },
+        )
+      }
+    }
+    apolloStore.writeOperation(query3, data3)
+    dataFromStore = apolloStore.readOperation(query1)
+    expectedData = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "42" },
+            buildUser { id = "43" },
+            buildUser { id = "44" },
+            buildUser { id = "45" },
+            buildUser { id = "46" },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Page before
+    val query4 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(40), limit = Optional.Present(2))
+    val data4 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "40" },
+            buildUser { id = "41" },
+        )
+      }
+    }
+    apolloStore.writeOperation(query4, data4)
+    dataFromStore = apolloStore.readOperation(query1)
+    expectedData = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "40" },
+            buildUser { id = "41" },
+            buildUser { id = "42" },
+            buildUser { id = "43" },
+            buildUser { id = "44" },
+            buildUser { id = "45" },
+            buildUser { id = "46" },
+        )
+      }
+    }
+    assertEquals(expectedData, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Non-contiguous page (should reset)
+    val query5 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(50), limit = Optional.Present(2))
+    val data5 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = listOf(
+            buildUser { id = "50" },
+            buildUser { id = "51" },
+        )
+      }
+    }
+    apolloStore.writeOperation(query5, data5)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+
+    // Empty page (should keep previous result)
+    val query6 = UsersOffsetBasedWithPageAndInputQuery(offset = Optional.Present(52), limit = Optional.Present(2))
+    val data6 = UsersOffsetBasedWithPageAndInputQuery.Data {
+      usersOffsetBasedWithPage = buildUserPage {
+        users = emptyList()
+      }
+    }
+    apolloStore.writeOperation(query6, data6)
+    dataFromStore = apolloStore.readOperation(query1)
+    assertEquals(data5, dataFromStore)
+    assertChainedCachesAreEqual(apolloStore)
+  }
+
+  private class OffsetPaginationMetadataGenerator(private val typeName: String) : MetadataGenerator {
+    override fun metadataForObject(obj: Any?, context: MetadataGeneratorContext): Map<String, Any?> {
+      if (context.field.type.rawType().name == typeName) {
+        return mapOf("offset" to context.argumentValue("offset"))
+      }
+      return emptyMap()
+    }
+  }
+
+  private class OffsetPaginationFieldMerger : FieldRecordMerger.FieldMerger {
+    override fun mergeFields(existing: FieldRecordMerger.FieldInfo, incoming: FieldRecordMerger.FieldInfo): FieldRecordMerger.FieldInfo {
+      val existingOffset = existing.metadata["offset"] as? Int
+      val incomingOffset = incoming.metadata["offset"] as? Int
+      return if (existingOffset == null || incomingOffset == null) {
+        incoming
+      } else {
+        val existingValue = existing.value as Map<*, *>
+        val existingList = existingValue["users"] as List<*>
+        val incomingList = (incoming.value as Map<*, *>)["users"] as List<*>
+        val (mergedList, mergedOffset) = mergeLists(existingList, incomingList, existingOffset, incomingOffset)
+        val mergedFieldValue = existingValue.toMutableMap()
+        mergedFieldValue["users"] = mergedList
+        FieldRecordMerger.FieldInfo(
+            value = mergedFieldValue,
+            metadata = mapOf("offset" to mergedOffset)
+        )
+      }
+    }
+
+    private fun <T> mergeLists(existing: List<T>, incoming: List<T>, existingOffset: Int, incomingOffset: Int): Pair<List<T>, Int> {
+      if (incomingOffset > existingOffset + existing.size) {
+        // Incoming list's first item is further than immediately after the existing list's last item: can't merge. Handle it as a reset.
+        return incoming to incomingOffset
+      }
+
+      if (incomingOffset + incoming.size < existingOffset) {
+        // Incoming list's last item is further than immediately before the existing list's first item: can't merge. Handle it as a reset.
+        return incoming to incomingOffset
+      }
+
+      val merged = mutableListOf<T>()
+      val startOffset = min(existingOffset, incomingOffset)
+      val endOffset = max(existingOffset + existing.size, incomingOffset + incoming.size)
+      val incomingRange = incomingOffset until incomingOffset + incoming.size
+      for (i in startOffset until endOffset) {
+        if (i in incomingRange) {
+          merged.add(incoming[i - incomingOffset])
+        } else {
+          merged.add(existing[i - existingOffset])
+        }
+      }
+      return merged to startOffset
+    }
+  }
+
+  object UsersNameGenerator : FieldNameGenerator {
+    override fun getFieldName(context: FieldNameContext): String {
+      return if (context.parentType == "Query" && context.field.name == "usersOffsetBasedWithPageAndInput") {
+        context.field.nameWithoutPaginationArguments(context.variables)
+      } else {
+        DefaultFieldNameGenerator.getFieldName(context)
+      }
+    }
+
+    private fun CompiledField.nameWithoutPaginationArguments(variables: Executable.Variables): String {
+      val filteredArguments = arguments.map {
+        if (it.name == "usersInput") {
+          CompiledArgument.Builder(it.name, (it.value as Map<*, *>).filterKeys { it != "offset" && it != "limit" }).build()
+        } else {
+          it
+        }
+      }
+      return CompiledField.Builder(this)
+          .arguments(filteredArguments)
+          .build()
+          .nameWithArguments(variables)
+    }
+  }
+}


### PR DESCRIPTION
Adds a `FieldNameGenerator` to allow to programmatically customize the way field names are generated (by default, `CompiledField.nameWithArguments` is used).

This is useful when a field takes an Input describing the pagination arguments, rather than several arguments, which can be ignored thanks to `@fieldPolicy`'s `paginationArgs`.

Implementation: quite a bit of plumbing as the generator needs to be passed around to `Normalizer` and to `ApolloResolver` via its context.