### PR TITLE
[IJ Plugin] Fix v3->v4 migration with ApolloCompositeException

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -21,6 +21,7 @@ import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchM
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateEnumClassUpperCase
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateFieldNameInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateMultiModuleConfiguration
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateThrowApolloCompositeException
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateWebSocketReconnectWhen
 import com.intellij.openapi.project.Project
 
@@ -39,6 +40,7 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
       UpdateFieldName("$apollo3.api.ApolloResponse", "dataAssertNoErrors", "dataOrThrow()"),
       UpdateFieldName("$apollo3.exception.ApolloCompositeException", "first", "suppressedExceptions.first()"),
       UpdateFieldName("$apollo3.exception.ApolloCompositeException", "second", "suppressedExceptions.getOrNull(1)"),
+      UpdateThrowApolloCompositeException,
       UpdateClassName("$apollo3.exception.ApolloCompositeException", "$apollo3.exception.ApolloException"),
       UpdateClassName("$apollo3.exception.ApolloCanceledException", "$apollo3.exception.ApolloException"),
       UpdateClassName("$apollo3.exception.ApolloGenericException", "$apollo3.exception.ApolloException"),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateThrowApolloCompositeException.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/UpdateThrowApolloCompositeException.kt
@@ -1,0 +1,36 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.ijplugin.refactoring.findClassReferences
+import com.apollographql.ijplugin.refactoring.findOrCreateClass
+import com.apollographql.ijplugin.refactoring.migration.apollo3
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.apollographql.ijplugin.util.cast
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtPsiFactory
+
+object UpdateThrowApolloCompositeException : MigrationItem() {
+  override fun prepare(project: Project, migration: PsiMigration) {
+    findOrCreateClass(project, migration, "$apollo3.exception.ApolloCompositeException")
+  }
+
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    return findClassReferences(project, "$apollo3.exception.ApolloCompositeException")
+        .toMigrationItemUsageInfo()
+        .filter { it.element.parent.cast<KtCallExpression>()?.valueArguments?.size == 2 }
+        .map { it.element.parent.toMigrationItemUsageInfo() }
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    val element = usage.element
+    val psiFactory = KtPsiFactory(project)
+    val (arg1, arg2) = element.cast<KtCallExpression>()!!.valueArguments.map { it.getArgumentExpression()!!.text }
+    element.replace(psiFactory.createExpression("DefaultApolloException(cause = $arg1).apply { addSuppressed($arg2) }"))
+  }
+
+  override fun importsToAdd()=setOf("$apollo3.exception.DefaultApolloException")
+}

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations.kt
@@ -40,6 +40,9 @@ suspend fun test() {
   println(compositeException!!.first)
   println(compositeException!!.second)
 
+  val first = Exception("first")
+  throw ApolloCompositeException(first = first, Exception("second"))
+
   apolloClient!!.query(query!!).executeCacheAndNetwork()
 
   apolloClient!!.apolloStore.clearAll()

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/deprecations_after.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.cache.normalized.apolloStore
 import com.apollographql.apollo3.cache.normalized.watch
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.network.ws.WebSocketNetworkTransport
+import com.apollographql.apollo3.exception.DefaultApolloException
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 
@@ -37,6 +38,9 @@ suspend fun test() {
   val compositeException: ApolloException? = null
   println(compositeException!!.suppressedExceptions.first())
   println(compositeException!!.suppressedExceptions.getOrNull(1))
+
+  val first = Exception("first")
+  throw DefaultApolloException(cause = first).apply { addSuppressed(Exception("second")) }
 
   apolloClient!!.query(query!!).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()
 


### PR DESCRIPTION
`throw ApolloCompositeException(a, b)` -> `throw DefaultApolloException(cause = a).apply { addSuppressed(b) }`

Thanks @rohandhruva for finding the issue!