### PR TITLE
Make test pass if plugin relocation is disabled

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -166,6 +166,7 @@ fun createTests(javaVersion: Int) {
     testClassesDirs = sourceSet.output.classesDirs
     classpath = configurations[sourceSet.runtimeClasspathConfigurationName] + sourceSet.output
 
+    environment("APOLLO_RELOCATE_JAR", System.getenv("APOLLO_RELOCATE_JAR"))
     setTestToolchain(project, this, javaVersion)
   }
 

--- a/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/GradleVersionTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/GradleVersionTests.kt
@@ -2,14 +2,14 @@ package com.apollographql.apollo3.gradle.test
 
 import com.apollographql.apollo3.compiler.APOLLO_VERSION
 import com.apollographql.apollo3.gradle.internal.DefaultApolloExtension.Companion.MIN_GRADLE_VERSION
-import util.TestUtils
-import util.TestUtils.withTestProject
 import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Test
+import util.TestUtils
+import util.TestUtils.withTestProject
 import java.io.File
 
 class GradleVersionTests {
@@ -23,6 +23,12 @@ class GradleVersionTests {
 
   @Test
   fun `minGradleVersion is working and does not show warnings`() {
+
+    if (System.getenv("APOLLO_RELOCATE_JAR") == "false") {
+      // Fails with java.lang.NoClassDefFoundError: kotlin/enums/EnumEntriesKt without relocation
+      return
+    }
+
     withTestProject("gradle-min-version") { dir ->
       dir.setApolloPluginVersion()
       val result = TestUtils.executeGradleWithVersion(dir, MIN_GRADLE_VERSION, "generateApolloSources")


### PR DESCRIPTION
Locally I have `APOLLO_RELOCATE_JAR=false` in my env to iterate faster but some tests rely on that (for good reasons). It's not the stuff that changes a lot though so for the purpose of local iterations, allow to skip those tests, volkswagen CI style.