### PR TITLE
Add apollo-debug-server library

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -15,7 +15,7 @@ androidx-sqlite = "2.3.1"
 # This is used by the gradle integration tests to get the artifacts locally
 apollo = "4.0.0-beta.3-SNAPSHOT"
 # Used by the apollo-tooling project which uses a published version of Apollo
-apollo-published = "4.0.0-alpha.3"
+apollo-published = "4.0.0-beta.2"
 cache = "2.0.2"
 # See https://developer.android.com/jetpack/androidx/releases/compose-kotlin
 compose-compiler = "1.5.4-dev-k1.9.20-50f08dfa4b4"

--- a/libraries/apollo-debug-server/api/android/apollo-debug-server.api
+++ b/libraries/apollo-debug-server/api/android/apollo-debug-server.api
@@ -1,0 +1,7 @@
+public final class com/apollographql/apollo3/debugserver/ApolloDebugServer {
+	public static final field INSTANCE Lcom/apollographql/apollo3/debugserver/ApolloDebugServer;
+	public final fun registerApolloClient (Lcom/apollographql/apollo3/ApolloClient;Ljava/lang/String;)V
+	public static synthetic fun registerApolloClient$default (Lcom/apollographql/apollo3/debugserver/ApolloDebugServer;Lcom/apollographql/apollo3/ApolloClient;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun unregisterApolloClient (Lcom/apollographql/apollo3/ApolloClient;)V
+}
+

--- a/libraries/apollo-debug-server/api/jvm/apollo-debug-server.api
+++ b/libraries/apollo-debug-server/api/jvm/apollo-debug-server.api
@@ -1,0 +1,7 @@
+public final class com/apollographql/apollo3/debugserver/ApolloDebugServer {
+	public static final field INSTANCE Lcom/apollographql/apollo3/debugserver/ApolloDebugServer;
+	public final fun registerApolloClient (Lcom/apollographql/apollo3/ApolloClient;Ljava/lang/String;)V
+	public static synthetic fun registerApolloClient$default (Lcom/apollographql/apollo3/debugserver/ApolloDebugServer;Lcom/apollographql/apollo3/ApolloClient;Ljava/lang/String;ILjava/lang/Object;)V
+	public final fun unregisterApolloClient (Lcom/apollographql/apollo3/ApolloClient;)V
+}
+

--- a/libraries/apollo-debug-server/build.gradle.kts
+++ b/libraries/apollo-debug-server/build.gradle.kts
@@ -1,0 +1,94 @@
+import com.android.build.gradle.tasks.BundleAar
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
+
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+  id("com.android.library")
+  alias(libs.plugins.apollo.published)
+  id("com.google.devtools.ksp")
+}
+
+apolloLibrary(
+    javaModuleName = "com.apollographql.apollo3.debugserver",
+    withLinux = false,
+)
+
+kotlin {
+  sourceSets {
+    findByName("commonMain")?.apply {
+      kotlin.srcDir("build/generated/ksp/metadata/commonMain/kotlin")
+
+      dependencies {
+        implementation(project(":apollo-normalized-cache"))
+
+        // apollo-execution is not published: we bundle it into the aar artifact
+        compileOnly(project(":apollo-execution"))
+      }
+    }
+
+    findByName("androidMain")?.apply {
+      dependencies {
+        implementation(libs.androidx.startup.runtime)
+      }
+    }
+  }
+}
+
+val shadow = configurations.create("shadow") {
+  isCanBeConsumed = false
+  isCanBeResolved = true
+}
+
+dependencies {
+  add("kspCommonMainMetadata", project(":apollo-ksp"))
+  add("kspCommonMainMetadata", apollo.apolloKspProcessor(file("src/androidMain/resources/schema.graphqls"), "apolloDebugServer", "com.apollographql.apollo3.debugserver.internal.graphql"))
+  add(shadow.name, project(":apollo-execution")) {
+    isTransitive = false
+  }
+}
+
+configurations.getByName("compileOnly").extendsFrom(shadow)
+
+android {
+  compileSdk = libs.versions.android.sdkversion.compile.get().toInt()
+  namespace = "com.apollographql.apollo3.debugserver"
+
+  defaultConfig {
+    minSdk = libs.versions.android.sdkversion.min.get().toInt()
+  }
+}
+
+// KMP ksp configuration inspired by https://medium.com/@actiwerks/setting-up-kotlin-multiplatform-with-ksp-7f598b1681bf
+tasks.withType<KotlinCompile>().configureEach {
+  dependsOn("kspCommonMainKotlinMetadata")
+}
+
+tasks.withType<Kotlin2JsCompile>().configureEach {
+  dependsOn("kspCommonMainKotlinMetadata")
+}
+
+tasks.withType<KotlinNativeCompile>().configureEach {
+  dependsOn("kspCommonMainKotlinMetadata")
+}
+
+tasks.configureEach {
+  if (name.endsWith("sourcesJar", ignoreCase = true)) {
+    dependsOn("kspCommonMainKotlinMetadata")
+  }
+}
+
+// apollo-execution is not published: we bundle it into the aar artifact
+val jarApolloExecution = tasks.register<Jar>("jarApolloExecution") {
+  archiveBaseName.set("apollo-execution")
+  from(provider {
+    shadow.files.map { zipTree(it) }
+  })
+}
+
+tasks.withType<BundleAar>().configureEach {
+  from(jarApolloExecution) {
+    into("libs")
+  }
+}

--- a/libraries/apollo-debug-server/gradle.properties
+++ b/libraries/apollo-debug-server/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=apollo-debug-server
+POM_NAME=Apollo Kotlin Debug Server
+POM_DESCRIPTION=Apollo Kotlin debug server, used by tools to inspect running applications using Apollo.

--- a/libraries/apollo-debug-server/src/androidMain/AndroidManifest.xml
+++ b/libraries/apollo-debug-server/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools">
+  <application>
+    <provider
+        android:name="androidx.startup.InitializationProvider"
+        android:authorities="${applicationId}.androidx-startup"
+        android:exported="false"
+        tools:node="merge">
+      <!-- This entry makes ApolloDebugServerInitializer discoverable. -->
+      <meta-data
+          android:name="com.apollographql.apollo3.debugserver.internal.initializer.ApolloDebugServerInitializer"
+          android:value="androidx.startup" />
+    </provider>
+  </application>
+</manifest>

--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.android.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.android.kt
@@ -1,0 +1,14 @@
+package com.apollographql.apollo3.debugserver.internal.graphql
+
+import com.apollographql.apollo3.debugserver.internal.server.Server
+import okio.buffer
+import okio.source
+import kotlin.reflect.KClass
+
+internal actual fun getExecutableSchema(): String = Server::class.java.classLoader!!
+    .getResourceAsStream("schema.graphqls")!!
+    .source()
+    .buffer()
+    .readUtf8()
+
+internal actual fun KClass<*>.normalizedCacheName(): String = qualifiedName ?: toString()

--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/initializer/ApolloDebugServerInitializer.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/initializer/ApolloDebugServerInitializer.kt
@@ -1,0 +1,16 @@
+package com.apollographql.apollo3.debugserver.internal.initializer
+
+import android.content.Context
+import androidx.startup.Initializer
+
+internal class ApolloDebugServerInitializer : Initializer<Unit> {
+  override fun create(context: Context) {
+    packageName = context.packageName
+  }
+
+  override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
+
+  companion object {
+    lateinit var packageName: String
+  }
+}

--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
@@ -1,0 +1,105 @@
+package com.apollographql.apollo3.debugserver.internal.server
+
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.debugserver.internal.graphql.GraphQL
+import com.apollographql.apollo3.debugserver.internal.initializer.ApolloDebugServerInitializer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.io.BufferedReader
+import java.io.PrintStream
+import java.util.concurrent.Executors
+
+internal actual fun createServer(
+    apolloClients: Map<ApolloClient, String>,
+): Server = AndroidServer(apolloClients)
+
+private class AndroidServer(
+    apolloClients: Map<ApolloClient, String>,
+) : Server {
+  companion object {
+    private const val SOCKET_NAME_PREFIX = "apollo_debug_"
+  }
+
+  private var localServerSocket: LocalServerSocket? = null
+  private val dispatcher = Executors.newCachedThreadPool().asCoroutineDispatcher()
+  private val coroutineScope = CoroutineScope(SupervisorJob() + dispatcher)
+
+  private val graphQL = GraphQL(apolloClients)
+
+  override fun start() {
+    if (localServerSocket != null) error("Already started")
+    val localServerSocket = LocalServerSocket("$SOCKET_NAME_PREFIX${ApolloDebugServerInitializer.packageName}")
+    this.localServerSocket = localServerSocket
+    coroutineScope.launch {
+      while (true) {
+        val clientSocket = try {
+          localServerSocket.accept()
+        } catch (_: Exception) {
+          // Server socket has been closed (stop() was called)
+          break
+        }
+        launch { handleClient(clientSocket) }
+      }
+    }
+  }
+
+  private suspend fun handleClient(clientSocket: LocalSocket) {
+    try {
+      val bufferedReader = clientSocket.inputStream.bufferedReader()
+      val printWriter = PrintStream(clientSocket.outputStream.buffered(), true)
+      val httpRequest = readHttpRequest(bufferedReader)
+      if (httpRequest.method == "OPTIONS") {
+        printWriter.print("HTTP/1.1 204 No Content\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Allow-Methods: *\r\nAccess-Control-Allow-Headers: *\r\n\r\n")
+        return
+      }
+      printWriter.print("HTTP/1.1 200 OK\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\nContent-Type: application/json\r\n\r\n")
+      printWriter.print(graphQL.executeGraphQL(httpRequest.body ?: ""))
+    } catch (e: CancellationException) {
+      // Expected when the server is closed
+      throw e
+    } catch (_: Exception) {
+      // I/O error or otherwise: ignore
+    } finally {
+      runCatching { clientSocket.close() }
+    }
+  }
+
+  private class HttpRequest(
+      val method: String,
+      val path: String,
+      val headers: List<Pair<String, String>>,
+      val body: String?,
+  )
+
+  private fun readHttpRequest(bufferedReader: BufferedReader): HttpRequest {
+    val (method, path) = bufferedReader.readLine().split(" ")
+    val headers = mutableListOf<Pair<String, String>>()
+    while (true) {
+      val line = bufferedReader.readLine()
+      if (line.isEmpty()) break
+      val (key, value) = line.split(": ")
+      headers.add(key to value)
+    }
+    val contentLength = headers.firstOrNull { it.first.equals("Content-Length", ignoreCase = true) }?.second?.toLongOrNull() ?: 0
+    val body = if (contentLength <= 0) {
+      null
+    } else {
+      val buffer = CharArray(contentLength.toInt())
+      bufferedReader.read(buffer)
+      String(buffer)
+    }
+    return HttpRequest(method, path, headers, body)
+  }
+
+  override fun stop() {
+    runCatching { localServerSocket?.close() }
+    coroutineScope.cancel()
+    dispatcher.close()
+  }
+}

--- a/libraries/apollo-debug-server/src/androidMain/resources/schema.graphqls
+++ b/libraries/apollo-debug-server/src/androidMain/resources/schema.graphqls
@@ -1,0 +1,32 @@
+type Query {
+    version: Int!
+    clients: [Client!]!
+    normalizedCache(id: ID!): NormalizedCache!
+}
+
+type Client {
+    id: ID!
+    displayName: String!
+    normalizedCacheInfos: [NormalizedCacheInfo!]!
+}
+
+type NormalizedCacheInfo {
+    id: ID!
+    displayName: String!
+    recordCount: Int!
+}
+
+type NormalizedCache {
+    id: ID!
+    displayName: String!
+    clientDisplayName: String!
+    records: [KeyedRecord!]!
+}
+
+type KeyedRecord {
+    key: String!
+    record: Record!
+    size: Int!
+}
+
+scalar Record

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
@@ -1,0 +1,34 @@
+package com.apollographql.apollo3.debugserver
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.debugserver.internal.server.Server
+import com.apollographql.apollo3.debugserver.internal.server.createServer
+
+object ApolloDebugServer {
+  private val apolloClients = mutableMapOf<ApolloClient, String>()
+  private var server: Server? = null
+
+  fun registerApolloClient(apolloClient: ApolloClient, id: String = "client") {
+    if (apolloClients.containsKey(apolloClient)) error("Client '$apolloClient' already registered")
+    if (apolloClients.containsValue(id)) error("Name '$id' already registered")
+    apolloClients[apolloClient] = id
+    startOrStopServer()
+  }
+
+  fun unregisterApolloClient(apolloClient: ApolloClient) {
+    apolloClients.remove(apolloClient)
+    startOrStopServer()
+  }
+
+  private fun startOrStopServer() {
+    if (apolloClients.isEmpty()) {
+      server?.stop()
+    } else {
+      if (server == null) {
+        server = createServer(apolloClients).apply {
+          start()
+        }
+      }
+    }
+  }
+}

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
@@ -1,0 +1,219 @@
+package com.apollographql.apollo3.debugserver.internal.graphql
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloAdapter
+import com.apollographql.apollo3.annotations.ApolloObject
+import com.apollographql.apollo3.annotations.GraphQLName
+import com.apollographql.apollo3.api.Adapter
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.ExecutionContext
+import com.apollographql.apollo3.api.json.JsonReader
+import com.apollographql.apollo3.api.json.JsonWriter
+import com.apollographql.apollo3.api.json.writeObject
+import com.apollographql.apollo3.ast.toGQLDocument
+import com.apollographql.apollo3.ast.toSchema
+import com.apollographql.apollo3.cache.normalized.api.CacheKey
+import com.apollographql.apollo3.cache.normalized.api.Record
+import com.apollographql.apollo3.cache.normalized.apolloStore
+import com.apollographql.apollo3.debugserver.internal.graphql.execution.ApolloDebugServerAdapterRegistry
+import com.apollographql.apollo3.debugserver.internal.graphql.execution.ApolloDebugServerResolver
+import com.apollographql.apollo3.execution.ExecutableSchema
+import com.apollographql.apollo3.execution.GraphQLRequest
+import com.apollographql.apollo3.execution.GraphQLRequestError
+import com.apollographql.apollo3.execution.parsePostGraphQLRequest
+import okio.Buffer
+import kotlin.reflect.KClass
+
+internal expect fun KClass<*>.normalizedCacheName(): String
+
+internal expect fun getExecutableSchema(): String
+
+internal class GraphQL(
+    private val apolloClients: Map<ApolloClient, String>,
+) {
+  private val executableSchema: ExecutableSchema by lazy {
+    val schema = getExecutableSchema()
+        .toGQLDocument()
+        .toSchema()
+
+    ExecutableSchema.Builder()
+        .schema(schema)
+        .resolver(ApolloDebugServerResolver())
+        .adapterRegistry(ApolloDebugServerAdapterRegistry)
+        .build()
+  }
+
+  suspend fun executeGraphQL(jsonBody: String): String {
+    val graphQLRequestResult = Buffer().writeUtf8(jsonBody).parsePostGraphQLRequest()
+    if (graphQLRequestResult is GraphQLRequestError) {
+      return graphQLRequestResult.message
+    }
+    graphQLRequestResult as GraphQLRequest
+    val dumps = apolloClients.mapValues { (apolloClient, _) ->
+      apolloClient.apolloStore.dump()
+    }
+    val apolloDebugContext = ApolloDebugContext(apolloClients, dumps)
+    val graphQlResponse = executableSchema.execute(graphQLRequestResult, apolloDebugContext)
+    val buffer = Buffer()
+    graphQlResponse.serialize(buffer)
+    return buffer.readUtf8()
+  }
+
+  internal class ApolloDebugContext(
+      val apolloClients: Map<ApolloClient, String>,
+      val dumps: Map<ApolloClient, Map<KClass<*>, Map<String, Record>>>,
+  ) : ExecutionContext.Element {
+    override val key: ExecutionContext.Key<ApolloDebugContext> = Key
+
+    companion object Key : ExecutionContext.Key<ApolloDebugContext>
+  }
+}
+
+@ApolloObject
+internal class Query {
+  fun version() = 1
+
+  fun clients(executionContext: ExecutionContext): List<Client> {
+    val apolloDebugContext = executionContext[GraphQL.ApolloDebugContext]!!
+    return apolloDebugContext.apolloClients.map { (apolloClient, id) ->
+      Client(
+          id = id,
+          displayName = id,
+          normalizedCacheInfos = apolloDebugContext.dumps[apolloClient]!!.keys.map { clazz ->
+            NormalizedCacheInfo(
+                id = "$id:${clazz.normalizedCacheName()}",
+                displayName = clazz.normalizedCacheName(),
+                recordCount = apolloDebugContext.dumps[apolloClient]!![clazz]!!.size
+            )
+          }
+      )
+    }
+  }
+
+  fun normalizedCache(executionContext: ExecutionContext, id: String): NormalizedCache {
+    val apolloDebugContext = executionContext[GraphQL.ApolloDebugContext]!!
+    val clientId = id.substringBeforeLast(":")
+    val cacheId = id.substringAfterLast(":")
+    val entry = apolloDebugContext.apolloClients.entries.firstOrNull { it.value == clientId }
+    val apolloClient = entry?.key
+    if (apolloClient == null) {
+      error("Unknown client '$clientId'")
+    } else {
+      val cache = apolloDebugContext.dumps[apolloClient]!!.entries.firstOrNull { it.key.normalizedCacheName() == cacheId }?.value
+      if (cache == null) {
+        error("Unknown cache '$cacheId' for client '$clientId'")
+      } else {
+        return NormalizedCache(
+            id = id,
+            displayName = cacheId,
+            clientDisplayName = entry.value,
+            records = cache.map { (key, record) ->
+              KeyedRecord(
+                  key = key,
+                  record = record
+              )
+            }
+        )
+      }
+    }
+  }
+}
+
+@ApolloObject
+internal class Client(
+    private val id: String,
+    private val displayName: String,
+    private val normalizedCacheInfos: List<NormalizedCacheInfo>,
+) {
+  fun id() = id
+
+  fun displayName() = displayName
+
+  fun normalizedCacheInfos(): List<NormalizedCacheInfo> = normalizedCacheInfos
+}
+
+@ApolloObject
+internal class NormalizedCacheInfo(
+    private val id: String,
+    private val displayName: String,
+    private val recordCount: Int,
+) {
+  fun id() = id
+
+  fun displayName() = displayName
+
+  fun recordCount() = recordCount
+}
+
+@ApolloObject
+internal class NormalizedCache(
+    private val id: String,
+    private val displayName: String,
+    private val clientDisplayName: String,
+    private val records: List<KeyedRecord>,
+) {
+  fun id() = id
+
+  fun displayName() = displayName
+
+  fun clientDisplayName() = clientDisplayName
+
+  fun records(): List<KeyedRecord> = records
+}
+
+@ApolloObject
+internal class KeyedRecord(
+    private val key: String,
+    private val record: Record,
+) {
+  fun key() = key
+
+  fun record() = record
+
+  fun size() = record.sizeInBytes
+}
+
+@ApolloAdapter
+@GraphQLName(name = "Record")
+internal class RecordAdapter : Adapter<Record> {
+  override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): Record {
+    throw UnsupportedOperationException()
+  }
+
+  override fun toJson(writer: JsonWriter, customScalarAdapters: CustomScalarAdapters, value: Record) {
+    writer.writeObject {
+      for ((k, v) in value.fields) {
+        writer.name(k).writeJsonValue(v)
+      }
+    }
+  }
+
+  // Taken from JsonRecordSerializer
+  @Suppress("UNCHECKED_CAST")
+  private fun JsonWriter.writeJsonValue(value: Any?) {
+    when (value) {
+      null -> this.nullValue()
+      is String -> this.value(value)
+      is Boolean -> this.value(value)
+      is Int -> this.value(value)
+      is Long -> this.value(value)
+      is Double -> this.value(value)
+      is CacheKey -> this.value(value.serialize())
+      is List<*> -> {
+        this.beginArray()
+        value.forEach { writeJsonValue(it) }
+        this.endArray()
+      }
+
+      is Map<*, *> -> {
+        this.beginObject()
+        for (entry in value as Map<String, Any?>) {
+          this.name(entry.key).writeJsonValue(entry.value)
+        }
+        this.endObject()
+      }
+
+      else -> error("Unsupported record value type: '$value'")
+    }
+  }
+}

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.kt
@@ -1,0 +1,18 @@
+package com.apollographql.apollo3.debugserver.internal.server
+
+import com.apollographql.apollo3.ApolloClient
+
+internal interface Server {
+  fun start()
+  fun stop()
+}
+
+internal expect fun createServer(
+    apolloClients: Map<ApolloClient, String>,
+): Server
+
+internal class NoOpServer : Server {
+  override fun start() {}
+
+  override fun stop() {}
+}

--- a/libraries/apollo-debug-server/src/jsMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.js.kt
+++ b/libraries/apollo-debug-server/src/jsMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.js.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.debugserver.internal.graphql
+
+import kotlin.reflect.KClass
+
+internal actual fun getExecutableSchema(): String = throw UnsupportedOperationException("Not supported on this platform")
+internal actual fun KClass<*>.normalizedCacheName(): String = toString()

--- a/libraries/apollo-debug-server/src/jsMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.js.kt
+++ b/libraries/apollo-debug-server/src/jsMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.js.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.debugserver.internal.server
+
+import com.apollographql.apollo3.ApolloClient
+
+internal actual fun createServer(apolloClients: Map<ApolloClient, String>): Server = NoOpServer()

--- a/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.jvm.kt
+++ b/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.jvm.kt
@@ -1,0 +1,7 @@
+package com.apollographql.apollo3.debugserver.internal.graphql
+
+import kotlin.reflect.KClass
+
+internal actual fun getExecutableSchema(): String = throw UnsupportedOperationException("Not supported on this platform")
+
+internal actual fun KClass<*>.normalizedCacheName(): String = qualifiedName ?: toString()

--- a/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.jvm.kt
+++ b/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.jvm.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.debugserver.internal.server
+
+import com.apollographql.apollo3.ApolloClient
+
+internal actual fun createServer(apolloClients: Map<ApolloClient, String>): Server = NoOpServer()

--- a/libraries/apollo-debug-server/src/nativeMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.native.kt
+++ b/libraries/apollo-debug-server/src/nativeMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.native.kt
@@ -1,0 +1,8 @@
+package com.apollographql.apollo3.debugserver.internal.graphql
+
+
+import kotlin.reflect.KClass
+
+internal actual fun getExecutableSchema(): String = throw UnsupportedOperationException("Not supported on this platform")
+
+internal actual fun KClass<*>.normalizedCacheName(): String = qualifiedName ?: toString()

--- a/libraries/apollo-debug-server/src/nativeMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.native.kt
+++ b/libraries/apollo-debug-server/src/nativeMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.native.kt
@@ -1,0 +1,6 @@
+package com.apollographql.apollo3.debugserver.internal.server
+
+import com.apollographql.apollo3.ApolloClient
+
+internal actual fun createServer(apolloClients: Map<ApolloClient, String>): Server = NoOpServer()
+


### PR DESCRIPTION
This adds a library `apollo-debug-server`, meant to be added to apps' debug builds only. Two APIs are then available: 
- `ApolloDebugServer.registerApolloClient(apolloClient: ApolloClient, id: String = "client")` 
- `ApolloDebugServer.unregisterApolloClient(apolloClient: ApolloClient)`.

When an ApolloClient is registered, a minimalist GraphQL server runs at a unix socket named with the scheme `apollo_debug_<app's package name>` (package name is retrieved through an [`InitializationProvider`](https://developer.android.com/topic/libraries/app-startup)).

Interested tools can then:
- list these named sockets with `adb cat /proc/net/unix` and look for the ones starting with `apollo_debug_`
- forward them to a local port with `adb forward tcp:<some port> localabstract:<the socket name>`, e.g. `adb forward tcp:12200 localabstract:apollo_debug_com.example.myapp`
- execute GraphQL queries on `http://localhost:<the chosen port>`, to get the list of normalized caches, and retrieve them

This mechanism is modeled on what the [Chrome Dev Tools do](https://github.com/GoogleChrome/lighthouse/blob/main/docs/readme.md) to inspect running WebViews, which is also used by [Stetho](https://github.com/facebookarchive/stetho/blob/main/stetho/src/main/java/com/facebook/stetho/Stetho.java#L448).

The module is multiplatform but only the Android target actually does anything (the other targets have no-op implementations) - allowing clients to call `registerApolloClient` in common code.

For GraphQL, this uses the `apollo-execution` incubating library which is currently not published, that's why it is shaded into the `aar`.