### PR TITLE
[apollo-execution] Allow to pass arguments to the root types

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -23,6 +23,9 @@
     <Properties>
       <option name="KEEP_BLANK_LINES" value="true" />
     </Properties>
+    <ScalaCodeStyleSettings>
+      <option name="MULTILINE_STRING_CLOSING_QUOTES_ON_NEW_LINE" value="true" />
+    </ScalaCodeStyleSettings>
     <XML>
       <option name="XML_SPACE_INSIDE_EMPTY_TAG" value="true" />
     </XML>

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -666,8 +666,9 @@ public final class com/apollographql/apollo3/compiler/ir/IrTargetKt {
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrTargetObject {
-	public fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/compiler/ir/IrClassName;ZLjava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/compiler/ir/IrClassName;ZZLjava/lang/String;Ljava/util/List;)V
 	public final fun getFields ()Ljava/util/List;
+	public final fun getHasNoArgsConstructor ()Z
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOperationType ()Ljava/lang/String;
 	public final fun getTargetClassName ()Lcom/apollographql/apollo3/compiler/ir/IrClassName;

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/ExecutableSchemaBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/ExecutableSchemaBuilderBuilder.kt
@@ -1,0 +1,81 @@
+package com.apollographql.apollo3.compiler.codegen.kotlin
+
+import com.apollographql.apollo3.compiler.capitalizeFirstLetter
+import com.apollographql.apollo3.compiler.ir.IrTargetObject
+import com.apollographql.apollo3.compiler.ir.asKotlinPoet
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.joinToCode
+
+internal class ExecutableSchemaBuilderBuilder(
+    private val context: KotlinContext,
+    private val serviceName: String,
+    private val mainResolver: ClassName,
+    private val adapterRegistry: MemberName,
+    private val irTargetObjects: List<IrTargetObject>,
+) : CgFileBuilder {
+  val simpleName = context.layout.capitalizedIdentifier("${serviceName}ExecutableSchemaBuilder")
+  override fun prepare() {
+
+  }
+
+  override fun build(): CgFile {
+    return CgFile(packageName = context.layout.executionPackageName(), fileName = simpleName, funSpecs = listOf(funSpec())
+    )
+  }
+
+  private fun funSpec(): FunSpec {
+    val rootIrTargetObjects = listOf("query", "mutation", "subscription").map { operationType ->
+      irTargetObjects.find { it.operationType == operationType }
+    }
+
+    return FunSpec.builder(simpleName)
+        .returns(KotlinSymbols.ExecutableSchemaBuilder)
+        .apply {
+          addParameter(ParameterSpec.builder("schema", KotlinSymbols.Schema).build())
+          rootIrTargetObjects.forEach { irTargetObject ->
+            if (irTargetObject != null) {
+              addParameter(
+                  ParameterSpec.builder(
+                      name = "root${irTargetObject.operationType?.capitalizeFirstLetter()}Object",
+                      type = LambdaTypeName.get(parameters = emptyList(), returnType = irTargetObject.targetClassName.asKotlinPoet())
+                  ).apply {
+                    if (irTargetObject.isSingleton) {
+                      defaultValue(CodeBlock.of("{ %L }", irTargetObject.targetClassName.asKotlinPoet()))
+                    } else if (irTargetObject.hasNoArgsConstructor) {
+                      defaultValue(CodeBlock.of("{ %L() }", irTargetObject.targetClassName.asKotlinPoet()))
+                    }
+                  }.build())
+            }
+          }
+        }
+        .addCode(
+            CodeBlock.builder()
+                .add("return %L()\n", KotlinSymbols.ExecutableSchemaBuilder)
+                .add(".schema(schema)\n")
+                .add(".resolver(%L)\n", mainResolver)
+                .add(".adapterRegistry(%L)\n", adapterRegistry)
+                .add(".roots(%L.create(", KotlinSymbols.Roots)
+                .apply {
+                  rootIrTargetObjects.map { irTargetObject ->
+                    if (irTargetObject == null) {
+                      CodeBlock.of("null")
+                    } else {
+                      CodeBlock.of("root${irTargetObject.operationType?.capitalizeFirstLetter()}Object")
+                    }
+                  }.joinToCode(", ")
+                      .let {
+                        add(it)
+                      }
+                }
+                .add("))\n")
+                .build()
+        )
+        .build()
+  }
+
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -389,18 +389,27 @@ internal object KotlinCodeGen {
 
     val builders = mutableListOf<CgFileBuilder>()
 
-    builders.add(
-        MainResolverBuilder(
-            context = context,
-            serviceName = serviceName,
-            irTargetObjects = irTargetObjects
-        )
+    val mainResolverBuilder = MainResolverBuilder(
+        context = context,
+        serviceName = serviceName,
+        irTargetObjects = irTargetObjects
     )
+    builders.add(mainResolverBuilder)
+
+    val adapterRegistryBuilder = AdapterRegistryBuilder(
+        context = context,
+        serviceName = serviceName,
+        codegenSchema = codegenSchema
+    )
+    builders.add(adapterRegistryBuilder)
+
     builders.add(
-        AdapterRegistryBuilder(
+        ExecutableSchemaBuilderBuilder(
             context = context,
             serviceName = serviceName,
-            codegenSchema = codegenSchema
+            mainResolver = mainResolverBuilder.className,
+            adapterRegistry = adapterRegistryBuilder.memberName,
+            irTargetObjects = irTargetObjects
         )
     )
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -15,8 +15,11 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
  * Symbols can be [ClassName] or [MemberName]
  */
 internal object KotlinSymbols {
+  val ExecutableSchemaBuilder = ClassName("com.apollographql.apollo3.execution", "ExecutableSchema", "Builder")
   val Resolver = ClassName("com.apollographql.apollo3.execution", "Resolver")
   val ResolveInfo = ClassName("com.apollographql.apollo3.execution", "ResolveInfo")
+  val Roots = ClassName("com.apollographql.apollo3.execution", "Roots")
+  val Schema = ClassName("com.apollographql.apollo3.ast", "Schema")
   val ObjectType = ClassNames.ObjectType.toKotlinPoetClassName()
   val ObjectTypeBuilder = ClassNames.ObjectTypeBuilder.toKotlinPoetClassName()
   val InterfaceType = ClassNames.InterfaceType.toKotlinPoetClassName()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/AdapterRegistryBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/AdapterRegistryBuilder.kt
@@ -16,6 +16,7 @@ import com.apollographql.apollo3.compiler.ir.IrInputObjectType
 import com.apollographql.apollo3.compiler.ir.IrNonNullType
 import com.apollographql.apollo3.compiler.ir.IrScalarType
 import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.PropertySpec
 
 internal class AdapterRegistryBuilder(
@@ -23,8 +24,10 @@ internal class AdapterRegistryBuilder(
     val serviceName: String,
     val codegenSchema: CodegenSchema
 ) : CgFileBuilder {
-  val packageName = context.layout.executionPackageName()
-  val simpleName = context.layout.capitalizedIdentifier("${serviceName}AdapterRegistry")
+  private val packageName = context.layout.executionPackageName()
+  private val simpleName = context.layout.capitalizedIdentifier("${serviceName}AdapterRegistry")
+
+  val memberName = MemberName(packageName, simpleName)
 
   override fun prepare() {
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrTarget.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrTarget.kt
@@ -33,6 +33,7 @@ class IrTargetObject(
     val name: String,
     val targetClassName: IrClassName,
     val isSingleton: Boolean,
+    val hasNoArgsConstructor: Boolean,
     val operationType: String?,
     val fields: List<IrTargetField>,
 )

--- a/libraries/apollo-debug-server/build.gradle.kts
+++ b/libraries/apollo-debug-server/build.gradle.kts
@@ -23,9 +23,8 @@ kotlin {
       dependencies {
         implementation(project(":apollo-normalized-cache"))
 
-        // apollo-execution is not published: we bundle it into the aar artifact
-        compileOnly(project(":apollo-execution"))
         api(project(":apollo-ast"))
+        api(project(":apollo-api"))
       }
     }
 
@@ -52,12 +51,13 @@ dependencies {
           packageName = "com.apollographql.apollo3.debugserver.internal.graphql"
       )
   )
+  // apollo-execution is not published: we bundle it into the aar artifact
   add(shadow.name, project(":apollo-execution")) {
     isTransitive = false
   }
 }
 
-configurations.getByName("compileOnly").extendsFrom(shadow)
+configurations.getByName(kotlin.sourceSets.getByName("commonMain").compileOnlyConfigurationName).extendsFrom(shadow)
 
 android {
   compileSdk = libs.versions.android.sdkversion.compile.get().toInt()

--- a/libraries/apollo-debug-server/build.gradle.kts
+++ b/libraries/apollo-debug-server/build.gradle.kts
@@ -44,7 +44,14 @@ val shadow = configurations.create("shadow") {
 
 dependencies {
   add("kspCommonMainMetadata", project(":apollo-ksp"))
-  add("kspCommonMainMetadata", apollo.apolloKspProcessor(file("src/androidMain/resources/schema.graphqls"), "apolloDebugServer", "com.apollographql.apollo3.debugserver.internal.graphql"))
+  add(
+      "kspCommonMainMetadata",
+      apollo.apolloKspProcessor(
+          schema = file(path = "src/androidMain/resources/schema.graphqls"),
+          service = "apolloDebugServer",
+          packageName = "com.apollographql.apollo3.debugserver.internal.graphql"
+      )
+  )
   add(shadow.name, project(":apollo-execution")) {
     isTransitive = false
   }

--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
@@ -14,13 +14,14 @@ import kotlinx.coroutines.launch
 import java.io.BufferedReader
 import java.io.PrintStream
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicReference
 
 internal actual fun createServer(
-    apolloClients: Map<ApolloClient, String>,
+    apolloClients: AtomicReference<Map<ApolloClient, String>>,
 ): Server = AndroidServer(apolloClients)
 
 private class AndroidServer(
-    apolloClients: Map<ApolloClient, String>,
+    apolloClients: AtomicReference<Map<ApolloClient, String>>,
 ) : Server {
   companion object {
     private const val SOCKET_NAME_PREFIX = "apollo_debug_"

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
@@ -3,26 +3,34 @@ package com.apollographql.apollo3.debugserver
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.debugserver.internal.server.Server
 import com.apollographql.apollo3.debugserver.internal.server.createServer
+import okio.withLock
+import java.util.concurrent.locks.ReentrantLock
 
 object ApolloDebugServer {
   private val apolloClients = mutableMapOf<ApolloClient, String>()
   private var server: Server? = null
+  private val lock = ReentrantLock()
 
   fun registerApolloClient(apolloClient: ApolloClient, id: String = "client") {
-    if (apolloClients.containsKey(apolloClient)) error("Client '$apolloClient' already registered")
-    if (apolloClients.containsValue(id)) error("Name '$id' already registered")
-    apolloClients[apolloClient] = id
-    startOrStopServer()
+    lock.withLock {
+      if (apolloClients.containsKey(apolloClient)) error("Client '$apolloClient' already registered")
+      if (apolloClients.containsValue(id)) error("Name '$id' already registered")
+      apolloClients[apolloClient] = id
+      startOrStopServer()
+    }
   }
 
   fun unregisterApolloClient(apolloClient: ApolloClient) {
-    apolloClients.remove(apolloClient)
-    startOrStopServer()
+    lock.withLock {
+      apolloClients.remove(apolloClient)
+      startOrStopServer()
+    }
   }
 
   private fun startOrStopServer() {
     if (apolloClients.isEmpty()) {
       server?.stop()
+      server = null
     } else {
       if (server == null) {
         server = createServer(apolloClients).apply {

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/ApolloDebugServer.kt
@@ -3,32 +3,26 @@ package com.apollographql.apollo3.debugserver
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.debugserver.internal.server.Server
 import com.apollographql.apollo3.debugserver.internal.server.createServer
-import okio.withLock
-import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.atomic.AtomicReference
 
 object ApolloDebugServer {
-  private val apolloClients = mutableMapOf<ApolloClient, String>()
+  private val apolloClients = AtomicReference<Map<ApolloClient, String>>(emptyMap())
   private var server: Server? = null
-  private val lock = ReentrantLock()
 
   fun registerApolloClient(apolloClient: ApolloClient, id: String = "client") {
-    lock.withLock {
-      if (apolloClients.containsKey(apolloClient)) error("Client '$apolloClient' already registered")
-      if (apolloClients.containsValue(id)) error("Name '$id' already registered")
-      apolloClients[apolloClient] = id
-      startOrStopServer()
-    }
+    if (apolloClients.get().containsKey(apolloClient)) error("Client '$apolloClient' already registered")
+    if (apolloClients.get().containsValue(id)) error("Name '$id' already registered")
+    apolloClients.set(apolloClients.get() + (apolloClient to id))
+    startOrStopServer()
   }
 
   fun unregisterApolloClient(apolloClient: ApolloClient) {
-    lock.withLock {
-      apolloClients.remove(apolloClient)
-      startOrStopServer()
-    }
+    apolloClients.set(apolloClients.get() - apolloClient)
+    startOrStopServer()
   }
 
   private fun startOrStopServer() {
-    if (apolloClients.isEmpty()) {
+    if (apolloClients.get().isEmpty()) {
       server?.stop()
       server = null
     } else {

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
@@ -22,12 +22,13 @@ import com.apollographql.apollo3.execution.GraphQLRequestError
 import com.apollographql.apollo3.execution.parsePostGraphQLRequest
 import kotlinx.coroutines.runBlocking
 import okio.Buffer
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KClass
 
 internal expect fun getExecutableSchema(): String
 
 internal class GraphQL(
-    private val apolloClients: Map<ApolloClient, String>,
+    private val apolloClients: AtomicReference<Map<ApolloClient, String>>,
 ) {
   private val executableSchema: ExecutableSchema by lazy {
     val schema = getExecutableSchema()
@@ -55,9 +56,9 @@ internal class GraphQL(
 }
 
 @ApolloObject
-internal class Query(private val apolloClients: Map<ApolloClient, String>) {
+internal class Query(private val apolloClients: AtomicReference<Map<ApolloClient, String>>) {
   private fun graphQLApolloClients() =
-      apolloClients.map { (apolloClient, apolloClientId) ->
+      apolloClients.get().map { (apolloClient, apolloClientId) ->
         GraphQLApolloClient(
             id = apolloClientId,
             apolloClient = apolloClient

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
@@ -53,11 +53,6 @@ internal class GraphQL(
   }
 }
 
-internal class ApolloDebugContext(
-    val apolloClients: Map<ApolloClient, String>,
-    val dumps: Map<ApolloClient, Map<KClass<*>, Map<String, Record>>>,
-)
-
 @ApolloObject
 internal class Query(private val apolloClients: Map<ApolloClient, String>) {
   private fun graphQLApolloClients() =
@@ -98,7 +93,7 @@ internal class GraphQLApolloClient(
 
 @ApolloObject
 internal class NormalizedCache(
-    private val apolloClientId: String,
+    apolloClientId: String,
     private val clazz: KClass<*>,
     private val records: Map<String, Record>
 ) {

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.debugserver.internal.server
 
 import com.apollographql.apollo3.ApolloClient
+import java.util.concurrent.atomic.AtomicReference
 
 internal interface Server {
   fun start()
@@ -8,7 +9,7 @@ internal interface Server {
 }
 
 internal expect fun createServer(
-    apolloClients: Map<ApolloClient, String>,
+    apolloClients: AtomicReference<Map<ApolloClient, String>>,
 ): Server
 
 internal class NoOpServer : Server {

--- a/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.jvm.kt
+++ b/libraries/apollo-debug-server/src/jvmMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.jvm.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.debugserver.internal.server
 
 import com.apollographql.apollo3.ApolloClient
+import java.util.concurrent.atomic.AtomicReference
 
-internal actual fun createServer(apolloClients: Map<ApolloClient, String>): Server = NoOpServer()
+internal actual fun createServer(apolloClients: AtomicReference<Map<ApolloClient, String>>): Server = NoOpServer()

--- a/libraries/apollo-execution/api/apollo-execution.api
+++ b/libraries/apollo-execution/api/apollo-execution.api
@@ -8,20 +8,11 @@ public final class com/apollographql/apollo3/execution/ExecutableSchema$Builder 
 	public final fun adapterRegistry (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
 	public final fun addInstrumentation (Lcom/apollographql/apollo3/execution/Instrumentation;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/execution/ExecutableSchema;
-	public final fun getAdapterRegistry ()Lcom/apollographql/apollo3/api/CustomScalarAdapters;
-	public final fun getInstrumentations ()Ljava/util/List;
-	public final fun getPersistedDocumentCache ()Lcom/apollographql/apollo3/execution/PersistedDocumentCache;
-	public final fun getResolver ()Lcom/apollographql/apollo3/execution/MainResolver;
-	public final fun getSchema ()Lcom/apollographql/apollo3/ast/Schema;
 	public final fun persistedDocumentCache (Lcom/apollographql/apollo3/execution/PersistedDocumentCache;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
 	public final fun resolver (Lcom/apollographql/apollo3/execution/MainResolver;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
+	public final fun roots (Lcom/apollographql/apollo3/execution/Roots;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
 	public final fun schema (Lcom/apollographql/apollo3/ast/Schema;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
 	public final fun schema (Ljava/lang/String;)Lcom/apollographql/apollo3/execution/ExecutableSchema$Builder;
-	public final fun setAdapterRegistry (Lcom/apollographql/apollo3/api/CustomScalarAdapters;)V
-	public final fun setInstrumentations (Ljava/util/List;)V
-	public final fun setPersistedDocumentCache (Lcom/apollographql/apollo3/execution/PersistedDocumentCache;)V
-	public final fun setResolver (Lcom/apollographql/apollo3/execution/MainResolver;)V
-	public final fun setSchema (Lcom/apollographql/apollo3/ast/Schema;)V
 }
 
 public final class com/apollographql/apollo3/execution/GraphQLRequest : com/apollographql/apollo3/execution/GraphQLRequestResult {
@@ -94,9 +85,6 @@ public abstract interface class com/apollographql/apollo3/execution/Instrumentat
 }
 
 public abstract interface class com/apollographql/apollo3/execution/MainResolver : com/apollographql/apollo3/execution/Resolver {
-	public abstract fun rootMutationObject ()Ljava/lang/Object;
-	public abstract fun rootQueryObject ()Ljava/lang/Object;
-	public abstract fun rootSubscriptionObject ()Ljava/lang/Object;
 	public abstract fun typename (Ljava/lang/Object;)Ljava/lang/String;
 }
 
@@ -104,6 +92,13 @@ public final class com/apollographql/apollo3/execution/MergedField {
 	public fun <init> (Lcom/apollographql/apollo3/ast/GQLField;Ljava/util/List;)V
 	public final fun getFirst ()Lcom/apollographql/apollo3/ast/GQLField;
 	public final fun getSelections ()Ljava/util/List;
+}
+
+public final class com/apollographql/apollo3/execution/NullRoots : com/apollographql/apollo3/execution/Roots {
+	public static final field INSTANCE Lcom/apollographql/apollo3/execution/NullRoots;
+	public fun mutation ()Ljava/lang/Object;
+	public fun query ()Ljava/lang/Object;
+	public fun subscription ()Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/execution/PersistedDocument {
@@ -136,11 +131,15 @@ public abstract interface class com/apollographql/apollo3/execution/Resolver {
 	public abstract fun resolve (Lcom/apollographql/apollo3/execution/ResolveInfo;)Ljava/lang/Object;
 }
 
-public abstract class com/apollographql/apollo3/execution/RootlessResolver : com/apollographql/apollo3/execution/MainResolver {
-	public fun <init> ()V
-	public final fun rootMutationObject ()Ljava/lang/Object;
-	public final fun rootQueryObject ()Ljava/lang/Object;
-	public final fun rootSubscriptionObject ()Ljava/lang/Object;
+public abstract interface class com/apollographql/apollo3/execution/Roots {
+	public static final field Companion Lcom/apollographql/apollo3/execution/Roots$Companion;
+	public abstract fun mutation ()Ljava/lang/Object;
+	public abstract fun query ()Ljava/lang/Object;
+	public abstract fun subscription ()Ljava/lang/Object;
+}
+
+public final class com/apollographql/apollo3/execution/Roots$Companion {
+	public final fun create (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/apollographql/apollo3/execution/Roots;
 }
 
 public abstract interface class com/apollographql/apollo3/execution/SubscriptionItem {
@@ -156,7 +155,7 @@ public final class com/apollographql/apollo3/execution/SubscriptionItemResponse 
 	public final fun getResponse ()Lcom/apollographql/apollo3/execution/GraphQLResponse;
 }
 
-public final class com/apollographql/apollo3/execution/ThrowingResolver : com/apollographql/apollo3/execution/RootlessResolver {
+public final class com/apollographql/apollo3/execution/ThrowingResolver : com/apollographql/apollo3/execution/MainResolver {
 	public static final field INSTANCE Lcom/apollographql/apollo3/execution/ThrowingResolver;
 	public fun resolve (Lcom/apollographql/apollo3/execution/ResolveInfo;)Ljava/lang/Object;
 	public fun typename (Ljava/lang/Object;)Ljava/lang/String;

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo3/execution/ExecutableSchema.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo3/execution/ExecutableSchema.kt
@@ -26,14 +26,16 @@ class ExecutableSchema internal constructor(
     private val instrumentations: List<Instrumentation>,
     private val mainResolver: MainResolver,
     private val adapterRegistry: CustomScalarAdapters,
+    private val roots: Roots,
 ) {
 
   class Builder {
-    var persistedDocumentCache: PersistedDocumentCache? = null
-    var instrumentations = mutableListOf<Instrumentation>()
-    var resolver: MainResolver? = null
-    var adapterRegistry: CustomScalarAdapters? = null
-    var schema: Schema? = null
+    private var persistedDocumentCache: PersistedDocumentCache? = null
+    private var instrumentations = mutableListOf<Instrumentation>()
+    private var resolver: MainResolver? = null
+    private var adapterRegistry: CustomScalarAdapters? = null
+    private var schema: Schema? = null
+    private var roots: Roots? = null
 
     fun persistedDocumentCache(persistedDocumentCache: PersistedDocumentCache?): Builder = apply {
       this.persistedDocumentCache = persistedDocumentCache
@@ -59,6 +61,10 @@ class ExecutableSchema internal constructor(
       this.resolver = mainResolver
     }
 
+    fun roots(roots: Roots): Builder = apply {
+      this.roots = roots
+    }
+
     fun build(): ExecutableSchema {
       return ExecutableSchema(
           schema ?: error("A schema is required to build an ExecutableSchema"),
@@ -66,6 +72,7 @@ class ExecutableSchema internal constructor(
           instrumentations,
           resolver ?: ThrowingResolver,
           adapterRegistry ?: CustomScalarAdapters.Empty,
+          roots ?: NullRoots
       )
     }
   }
@@ -201,6 +208,7 @@ class ExecutableSchema internal constructor(
             mainResolver = mainResolver,
             adapters = adapterRegistry,
             instrumentations = instrumentations,
+            roots = roots
         )
     )
   }

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo3/execution/OperationExecutor.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo3/execution/OperationExecutor.kt
@@ -36,6 +36,7 @@ internal class OperationExecutor(
     val mainResolver: MainResolver,
     val adapters: CustomScalarAdapters,
     val instrumentations: List<Instrumentation>,
+    val roots: Roots,
 ) {
 
   private var errors = mutableListOf<Error>()
@@ -48,8 +49,8 @@ internal class OperationExecutor(
       return errorResponse("'${operationDefinition.operationType}' is not supported")
     }
     val rootObject = when (operationDefinition.operationType) {
-      "query" -> mainResolver.rootQueryObject()
-      "mutation" -> mainResolver.rootMutationObject()
+      "query" -> roots.query()
+      "mutation" -> roots.mutation()
       "subscription" -> error("Use executeSubscription() to execute subscriptions")
       else -> error("Unknown operation type '${operationDefinition.operationType}")
     }
@@ -82,7 +83,7 @@ internal class OperationExecutor(
       return errorFlow("'${operationDefinition.operationType}' is not supported")
     }
     val rootObject = when (operationDefinition.operationType) {
-      "subscription" -> mainResolver.rootSubscriptionObject()
+      "subscription" -> roots.subscription()
       else -> return errorFlow("Unknown operation type '${operationDefinition.operationType}.")
     }
 

--- a/libraries/apollo-execution/src/commonTest/kotlin/test/ExecutionTest.kt
+++ b/libraries/apollo-execution/src/commonTest/kotlin/test/ExecutionTest.kt
@@ -10,12 +10,12 @@ import com.apollographql.apollo3.ast.GQLType
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.execution.ExecutableSchema
 import com.apollographql.apollo3.execution.GraphQLRequest
+import com.apollographql.apollo3.execution.MainResolver
 import com.apollographql.apollo3.execution.ResolveInfo
 import com.apollographql.apollo3.execution.Resolver
-import com.apollographql.apollo3.execution.RootlessResolver
 import kotlin.test.Test
 
-private val randomResolver = object : RootlessResolver() {
+private val randomResolver = object : MainResolver {
     fun GQLType.randomValue(schema: Schema): Any? {
         return when (this) {
             is GQLNonNullType -> type.randomValue(schema)
@@ -70,7 +70,7 @@ class ExecutionTest {
             }
         """.trimIndent()
 
-        val simpleMainResolver = object : RootlessResolver() {
+        val simpleMainResolver = object : MainResolver {
             override fun resolve(resolveInfo: ResolveInfo): Any? {
                 if (resolveInfo.parentType != "Query" || resolveInfo.fieldName != "foo") return null
                 return Resolver { 42 }

--- a/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
+++ b/libraries/apollo-ksp/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
@@ -19,6 +19,7 @@ import com.apollographql.apollo3.compiler.ir.IrGraphqlTargetArgument
 import com.apollographql.apollo3.compiler.ir.IrTargetArgument
 import com.apollographql.apollo3.compiler.ir.IrTargetField
 import com.apollographql.apollo3.compiler.ir.IrTargetObject
+import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.isPrivate
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -244,6 +245,7 @@ class ApolloProcessor(
           targetClassName = entry.value.className,
           fields = fields.toList(),
           isSingleton = entry.value.classDeclaration.classKind == ClassKind.OBJECT,
+          hasNoArgsConstructor = entry.value.classDeclaration.hasNoArgsConstructor(),
           operationType = operationType
       )
     }
@@ -270,6 +272,12 @@ class ApolloProcessor(
     }
 
     return emptyList()
+  }
+}
+
+private fun KSClassDeclaration.hasNoArgsConstructor(): Boolean {
+  return getConstructors().any {
+    it.parameters.isEmpty()
   }
 }
 

--- a/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/SampleServer.kt
+++ b/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/SampleServer.kt
@@ -46,6 +46,7 @@ import org.http4k.websocket.WsMessage
 import org.http4k.websocket.WsResponse
 import org.http4k.websocket.WsStatus
 import sample.server.execution.SampleserverAdapterRegistry
+import sample.server.execution.SampleserverExecutableSchemaBuilder
 import sample.server.execution.SampleserverResolver
 import java.io.Closeable
 import java.time.Duration
@@ -60,10 +61,7 @@ fun ExecutableSchema(): ExecutableSchema {
       .toGQLDocument()
       .toSchema()
 
-  return ExecutableSchema.Builder()
-      .schema(schema)
-      .resolver(SampleserverResolver())
-      .adapterRegistry(SampleserverAdapterRegistry)
+  return SampleserverExecutableSchemaBuilder(schema)
       .build()
 }
 


### PR DESCRIPTION

Add a `${ServiceName}ExecutableSchemaBuilder()` constructor function that sets up a pre-configured `ExecutableSchema.Builder`. 

This function takes a `() -> QueryType`, etc.. for root types so it's easier to pass arguments to the root instances. 