### PR TITLE
[apollo-mockserver] cosmetics and add listener

### DIFF
--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -52,7 +52,13 @@ public final class com/apollographql/apollo3/mockserver/MockServer$Builder {
 	public final fun build ()Lcom/apollographql/apollo3/mockserver/MockServer;
 	public final fun handlePings (Z)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun handler (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+	public final fun listener (Lcom/apollographql/apollo3/mockserver/MockServer$Listener;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun tcpServer (Lcom/apollographql/apollo3/mockserver/TcpServer;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+}
+
+public abstract interface class com/apollographql/apollo3/mockserver/MockServer$Listener {
+	public abstract fun onMessage (Lcom/apollographql/apollo3/mockserver/WebSocketMessage;)V
+	public abstract fun onRequest (Lcom/apollographql/apollo3/mockserver/MockRequestBase;)V
 }
 
 public abstract interface class com/apollographql/apollo3/mockserver/MockServerHandler {

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockRequestBase.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockRequestBase.kt
@@ -45,7 +45,7 @@ sealed interface WebSocketMessage
 @ApolloExperimental
 class TextMessage(val text: String) : WebSocketMessage
 @ApolloExperimental
-class BinaryMessage(val bytes: ByteArray) : WebSocketMessage
+class DataMessage(val data: ByteArray) : WebSocketMessage
 @ApolloExperimental
 class CloseFrame(val code: Int?, val reason: String?) : WebSocketMessage
 @ApolloExperimental

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/websocket.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/websocket.kt
@@ -107,7 +107,7 @@ internal suspend fun readFrames(reader: Reader, onMessage: (WebSocketMessage) ->
       OPCODE_BINARY -> {
         currentMessage.write(payload, payloadLength)
         if (fin) {
-          onMessage(BinaryMessage(currentMessage.readByteArray()))
+          onMessage(DataMessage(currentMessage.readByteArray()))
           currentOpcode = null
         } else {
           currentOpcode = opcode
@@ -226,7 +226,7 @@ private fun WebSocketMessage.toFrame(): ByteString {
     is PingFrame -> pingFrame().toByteString()
     is CloseFrame -> closeFrame(code, reason)
     is TextMessage -> textFrame(text)
-    is BinaryMessage -> binaryFrame(bytes)
+    is DataMessage -> binaryFrame(data)
   }
 }
 

--- a/tests/engine/src/commonTest/kotlin/WebSocketEngineTest.kt
+++ b/tests/engine/src/commonTest/kotlin/WebSocketEngineTest.kt
@@ -2,7 +2,7 @@ import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.ApolloWebSocketClosedException
-import com.apollographql.apollo3.mockserver.BinaryMessage
+import com.apollographql.apollo3.mockserver.DataMessage
 import com.apollographql.apollo3.mockserver.CloseFrame
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.TextMessage
@@ -72,11 +72,11 @@ class WebSocketEngineTest {
 
     connection.send("client->server".encodeUtf8())
     request.awaitMessage().apply {
-      assertIs<BinaryMessage>(this)
-      assertEquals("client->server", bytes.decodeToString())
+      assertIs<DataMessage>(this)
+      assertEquals("client->server", data.decodeToString())
     }
 
-    responseBody.enqueueMessage(BinaryMessage("server->client".encodeToByteArray()))
+    responseBody.enqueueMessage(DataMessage("server->client".encodeToByteArray()))
     assertEquals("server->client", connection.receive())
 
     connection.close()


### PR DESCRIPTION
A few small tweaks to [MockServer]: 

- improve KDoc
- add a listener for logging purposes
- rename `BinaryMessage` to `DataMessage` so that it's the same length as `TextMessage`