### PR TITLE
Enable all warnings as errors again

### DIFF
--- a/build-logic/src/main/kotlin/CompilerOptions.kt
+++ b/build-logic/src/main/kotlin/CompilerOptions.kt
@@ -89,9 +89,8 @@ fun Project.configureJavaAndKotlinCompilers() {
     // Ensure "org.gradle.jvm.version" is set to "8" in Gradle metadata of jvm-only modules.
     options.release.set(8)
   }
-
-  // https://youtrack.jetbrains.com/issue/KT-62653
-  // allWarningsAsErrors(true)
+  
+  allWarningsAsErrors(true)
 }
 
 @Suppress("UnstableApiUsage")

--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -185,7 +185,9 @@ private fun KotlinMultiplatformExtension.configureSourceSetGraph() {
   applyDefaultHierarchyTemplate {
     group("common") {
       group("concurrent") {
-        group("apple")
+        group("native") {
+          group("apple")
+        }
         withJvm()
       }
     }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -517,7 +517,6 @@ internal class IrOperationsBuilder(
     }.groupBy {
       it.responseName
     }.values.map { fieldsWithSameResponseName ->
-
       /**
        * Sanity checks, might be removed as this should be done during validation
        */

--- a/libraries/apollo-gradle-plugin/rules.pro
+++ b/libraries/apollo-gradle-plugin/rules.pro
@@ -19,7 +19,9 @@
     public static **[] values();
 }
 
-# Keep apollo-api for ApolloExperimental
+# Keep apollo-annotations for ApolloExperimental
+-keep class com.apollographql.apollo3.annotations.** { *; }
+# Do we need to keep apollo-api
 -keep class com.apollographql.apollo3.api.** { *; }
 # Keep the plugin API as it's used from build scripts
 -keep class com.apollographql.apollo3.gradle.api.** { *; }

--- a/tests/compiler-hooks/build.gradle.kts
+++ b/tests/compiler-hooks/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ApolloExperimental::class)
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.compiler.codegen.ResolverKey
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
@@ -327,7 +330,7 @@ class CapitalizeEnumValuesHooks : DefaultApolloCompilerKotlinHooks() {
                 member.toBuilder()
                     .apply {
                       val capitalizedEnumConstants = enumConstants.mapKeys { (key, _) ->
-                        key.toUpperCase()
+                        key.uppercase()
                       }
                       enumConstants.clear()
                       enumConstants.putAll(capitalizedEnumConstants)

--- a/tests/deprecated-requires-opt-in/build.gradle.kts
+++ b/tests/deprecated-requires-opt-in/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.apollographql.apollo3")
@@ -26,12 +28,14 @@ apollo {
   }
   service("none") {
     srcDir("graphql")
+    @OptIn(ApolloExperimental::class)
     requiresOptInAnnotation.set("none")
     packageName.set("none")
     languageVersion.set("1.5")
   }
   service("custom") {
     srcDir("graphql")
+    @OptIn(ApolloExperimental::class)
     requiresOptInAnnotation.set("com.example.MyRequiresOptIn")
     packageName.set("custom")
     languageVersion.set("1.5")

--- a/tests/deprecated-requires-opt-in/build.gradle.kts
+++ b/tests/deprecated-requires-opt-in/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.apollographql.apollo3.annotations.ApolloExperimental
-
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.apollographql.apollo3")
@@ -28,14 +26,14 @@ apollo {
   }
   service("none") {
     srcDir("graphql")
-    @OptIn(ApolloExperimental::class)
+    @OptIn(com.apollographql.apollo3.annotations.ApolloExperimental::class)
     requiresOptInAnnotation.set("none")
     packageName.set("none")
     languageVersion.set("1.5")
   }
   service("custom") {
     srcDir("graphql")
-    @OptIn(ApolloExperimental::class)
+    @OptIn(com.apollographql.apollo3.annotations.ApolloExperimental::class)
     requiresOptInAnnotation.set("com.example.MyRequiresOptIn")
     packageName.set("custom")
     languageVersion.set("1.5")


### PR DESCRIPTION
See https://youtrack.jetbrains.com/issue/KT-62653/SourceSet-with-2-parents-fails-with-w-duplicate-library-name-kotlinx-coroutines-coreconcurrentMain#focus=Comments-27-8388165.0-0. Many thanks @antohaby for the workaround