### PR TITLE
[IJ Plugin] Bump pluginUntilBuild to 233

### DIFF
--- a/intellij-plugin/gradle.properties
+++ b/intellij-plugin/gradle.properties
@@ -11,7 +11,7 @@ pluginRepositoryUrl=https://github.com/apollographql/apollo-kotlin
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=223
 # This can be kept empty to mean no upper bound, but it's recommended to set it to whatever was tested
-pluginUntilBuild=232.*
+pluginUntilBuild=233.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
 # Corresponds to AS Giraffe 2022.3.1 -> https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -172,6 +172,14 @@
         anchor="bottom"
         canCloseContents="true"
     />
+
+    <!-- Suggest plugin when Apollo Kotlin is a project dependency -->
+    <!-- See https://plugins.jetbrains.com/docs/marketplace/intellij-plugin-recommendations.html#c2909003_6 -->
+    <dependencySupport
+        kind="java"
+        coordinate="com.apollographql.apollo3:apollo-api-jvm"
+        displayName="Apollo Kotlin"
+    />
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">


### PR DESCRIPTION
Also, add `dependencySupport` which should suggest the plugin when a project depends on Apollo Kotlin.