### PR TITLE
Expose ExecutionContext to HttpEngine and add OkHttp helpers

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -979,8 +979,9 @@ public final class com/apollographql/apollo3/api/http/HttpMethod : java/lang/Enu
 }
 
 public final class com/apollographql/apollo3/api/http/HttpRequest {
-	public synthetic fun <init> (Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/lang/String;Ljava/util/List;Lcom/apollographql/apollo3/api/http/HttpBody;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/lang/String;Ljava/util/List;Lcom/apollographql/apollo3/api/http/HttpBody;Lcom/apollographql/apollo3/api/ExecutionContext;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBody ()Lcom/apollographql/apollo3/api/http/HttpBody;
+	public final fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public final fun getHeaders ()Ljava/util/List;
 	public final fun getMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
 	public final fun getUrl ()Ljava/lang/String;
@@ -992,6 +993,7 @@ public final class com/apollographql/apollo3/api/http/HttpRequest {
 
 public final class com/apollographql/apollo3/api/http/HttpRequest$Builder {
 	public fun <init> (Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/lang/String;)V
+	public final fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/http/HttpRequest$Builder;
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/api/http/HttpRequest$Builder;
 	public final fun addHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/api/http/HttpRequest$Builder;
 	public final fun body (Lcom/apollographql/apollo3/api/http/HttpBody;)Lcom/apollographql/apollo3/api/http/HttpRequest$Builder;

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -53,13 +53,12 @@ class DefaultHttpRequestComposer(
     val sendApqExtensions = apolloRequest.sendApqExtensions ?: false
     val sendDocument = apolloRequest.sendDocument ?: true
 
-    return when (apolloRequest.httpMethod ?: HttpMethod.Post) {
+    val httpRequestBuilder = when (apolloRequest.httpMethod ?: HttpMethod.Post) {
       HttpMethod.Get -> {
         HttpRequest.Builder(
             method = HttpMethod.Get,
             url = buildGetUrl(serverUrl, operation, customScalarAdapters, sendApqExtensions, sendDocument),
-        ).addHeaders(requestHeaders)
-            .build()
+        )
       }
 
       HttpMethod.Post -> {
@@ -67,11 +66,14 @@ class DefaultHttpRequestComposer(
         HttpRequest.Builder(
             method = HttpMethod.Post,
             url = serverUrl,
-        ).addHeaders(requestHeaders)
-            .body(buildPostBody(operation, customScalarAdapters, sendApqExtensions, query))
-            .build()
+        ).body(buildPostBody(operation, customScalarAdapters, sendApqExtensions, query))
       }
     }
+
+    return httpRequestBuilder
+        .addHeaders(requestHeaders)
+        .addExecutionContext(apolloRequest.executionContext)
+        .build()
   }
 
   companion object {
@@ -149,7 +151,7 @@ class DefaultHttpRequestComposer(
 
     /**
      * This mostly duplicates [composePostParams] but encode variables and extensions as strings
-     * and not json elements. I tried factoring in that code but it ended up being more clunky that
+     * and not json elements. I tried factoring in that code, but it ended up being more clunky that
      * duplicating it
      */
     private fun <D : Operation.Data> composeGetParams(

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -203,6 +203,7 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpIntercepto
 }
 
 public final class com/apollographql/apollo3/network/http/DefaultHttpEngine : com/apollographql/apollo3/network/http/HttpEngine {
+	public static final field Companion Lcom/apollographql/apollo3/network/http/DefaultHttpEngine$Companion;
 	public fun <init> (J)V
 	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (JJ)V
@@ -212,6 +213,12 @@ public final class com/apollographql/apollo3/network/http/DefaultHttpEngine : co
 	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
+public final class com/apollographql/apollo3/network/http/DefaultHttpEngine$Companion {
+	public final fun execute (Lokhttp3/Call$Factory;Lokhttp3/Request;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun toApolloHttpResponse (Lokhttp3/Response;)Lcom/apollographql/apollo3/api/http/HttpResponse;
+	public final fun toOkHttpRequest (Lcom/apollographql/apollo3/api/http/HttpRequest;)Lokhttp3/Request;
+}
+
 public final class com/apollographql/apollo3/network/http/HeadersInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
 	public fun <init> (Ljava/util/List;)V
 	public fun intercept (Lcom/apollographql/apollo3/api/http/HttpRequest;Lcom/apollographql/apollo3/network/http/HttpInterceptorChain;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -219,6 +226,7 @@ public final class com/apollographql/apollo3/network/http/HeadersInterceptor : c
 
 public final class com/apollographql/apollo3/network/http/HttpCall {
 	public fun <init> (Lcom/apollographql/apollo3/network/http/HttpEngine;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/lang/String;)V
+	public final fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/network/http/HttpCall;
 	public final fun addHeader (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/network/http/HttpCall;
 	public final fun addHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/network/http/HttpCall;
 	public final fun body (Lcom/apollographql/apollo3/api/http/HttpBody;)Lcom/apollographql/apollo3/network/http/HttpCall;

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.network.http
 
+import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.http.HttpBody
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
@@ -30,7 +31,7 @@ interface HttpEngine {
 }
 
 /**
- * @param timeoutMillis: The timeout interval to use when connecting or waiting for additional data.
+ * @param timeoutMillis The timeout interval to use when connecting or waiting for additional data.
  *
  * - on iOS (NSURLRequest), it is used to set `NSMutableURLRequest.setTimeoutInterval`
  * - on Android (OkHttp), it is used to set both `OkHttpClient.connectTimeout` and `OkHttpClient.readTimeout`
@@ -60,6 +61,9 @@ class HttpCall(private val engine: HttpEngine, method: HttpMethod, url: String) 
     requestBuilder.addHeaders(headers)
   }
 
+  fun addExecutionContext(executionContext: ExecutionContext) = apply {
+    requestBuilder.addExecutionContext(executionContext)
+  }
   fun headers(headers: List<HttpHeader>) = apply {
     requestBuilder.headers(headers)
   }

--- a/tests/integration-tests/src/jvmTest/kotlin/test/ExecutionContextTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/ExecutionContextTest.kt
@@ -1,0 +1,77 @@
+package test
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ExecutionContext
+import com.apollographql.apollo3.api.http.HttpRequest
+import com.apollographql.apollo3.api.http.HttpResponse
+import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueString
+import com.apollographql.apollo3.network.http.DefaultHttpEngine.Companion.execute
+import com.apollographql.apollo3.network.http.DefaultHttpEngine.Companion.toApolloHttpResponse
+import com.apollographql.apollo3.network.http.DefaultHttpEngine.Companion.toOkHttpRequest
+import com.apollographql.apollo3.network.http.HttpEngine
+import com.apollographql.apollo3.testing.internal.runTest
+import okhttp3.OkHttpClient
+import org.junit.Test
+import kotlin.test.assertEquals
+
+internal class MyHttpEngine: HttpEngine {
+  val values = mutableListOf<String>()
+
+  private val okHttpClient = OkHttpClient()
+
+  override suspend fun execute(request: HttpRequest): HttpResponse {
+    val myExecutionContext  = request.executionContext[MyExecutionContext]?.also {
+      values.add(it.value)
+    }
+    val taggedRequest = request
+        .toOkHttpRequest()
+        .newBuilder()
+        .tag(MyExecutionContext::class.java, myExecutionContext)
+        .build()
+    return okHttpClient.execute(taggedRequest).toApolloHttpResponse()
+  }
+
+  override fun dispose() {
+
+  }
+}
+
+class ExecutionContextTest {
+  @Test
+  fun executionContextIsAvailableInHttpInterceptor() = runTest {
+
+    MockServer().use { mockServer ->
+      val myHttpEngine = MyHttpEngine()
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .httpEngine(myHttpEngine)
+          .build().use { apolloClient ->
+
+            // we don't need a response
+            mockServer.enqueueString(statusCode = 404)
+            apolloClient.query(HeroNameQuery())
+                .addExecutionContext(MyExecutionContext("value0"))
+                .execute()
+
+            mockServer.enqueueString(statusCode = 404)
+            apolloClient.query(HeroNameQuery())
+                .addExecutionContext(MyExecutionContext("value1"))
+                .execute()
+
+
+            assertEquals(2, myHttpEngine.values.size)
+            assertEquals("value0", myHttpEngine.values[0])
+            assertEquals("value1", myHttpEngine.values[1])
+          }
+    }
+  }
+}
+
+class MyExecutionContext(val value: String): ExecutionContext.Element {
+  companion object Key: ExecutionContext.Key<MyExecutionContext>
+
+  override val key: ExecutionContext.Key<MyExecutionContext>
+    get() = Key
+}


### PR DESCRIPTION
Makes it easier to create custom `HttpEngine` implementations and tag OkHttp requests. Makes it possible to do things like this: 

```kotlin
internal class MyHttpEngine: HttpEngine {
  private val okHttpClient = OkHttpClient()

  override suspend fun execute(request: HttpRequest): HttpResponse {
    val taggedRequest = request
        .toOkHttpRequest()
        .newBuilder()
        .tag(MyExecutionContext::class.java, request.executionContext[MyExecutionContext])
        .build()
    return okHttpClient.execute(taggedRequest).toApolloHttpResponse()
  }

  override fun dispose() {

  }
}
```