### PR TITLE
Support setting port for Apollo MockServer

### DIFF
--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -53,7 +53,8 @@ public final class com/apollographql/apollo3/mockserver/MockServer$Builder {
 	public final fun handlePings (Z)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun handler (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun listener (Lcom/apollographql/apollo3/mockserver/MockServer$Listener;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
-	public final fun tcpServer (Lcom/apollographql/apollo3/mockserver/TcpServer;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+	public final fun tcpServer (Lcom/apollographql/apollo3/mockserver/TcpServer;I)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+	public static synthetic fun tcpServer$default (Lcom/apollographql/apollo3/mockserver/MockServer$Builder;Lcom/apollographql/apollo3/mockserver/TcpServer;IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 }
 
 public abstract interface class com/apollographql/apollo3/mockserver/MockServer$Listener {
@@ -67,7 +68,10 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static final fun MockServer (I)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;I)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static synthetic fun MockServer$default (IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static synthetic fun MockServer$default (Lcom/apollographql/apollo3/mockserver/MockServerHandler;IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V
@@ -77,6 +81,6 @@ public final class com/apollographql/apollo3/mockserver/MockServerKt {
 }
 
 public final class com/apollographql/apollo3/mockserver/TcpServer_concurrentKt {
-	public static final fun TcpServer ()Lcom/apollographql/apollo3/mockserver/TcpServer;
+	public static final fun TcpServer (I)Lcom/apollographql/apollo3/mockserver/TcpServer;
 }
 

--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -53,8 +53,8 @@ public final class com/apollographql/apollo3/mockserver/MockServer$Builder {
 	public final fun handlePings (Z)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun handler (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 	public final fun listener (Lcom/apollographql/apollo3/mockserver/MockServer$Listener;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
-	public final fun tcpServer (Lcom/apollographql/apollo3/mockserver/TcpServer;I)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
-	public static synthetic fun tcpServer$default (Lcom/apollographql/apollo3/mockserver/MockServer$Builder;Lcom/apollographql/apollo3/mockserver/TcpServer;IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+	public final fun port (I)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
+	public final fun tcpServer (Lcom/apollographql/apollo3/mockserver/TcpServer;)Lcom/apollographql/apollo3/mockserver/MockServer$Builder;
 }
 
 public abstract interface class com/apollographql/apollo3/mockserver/MockServer$Listener {
@@ -69,9 +69,8 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun MockServer (I)Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;I)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static synthetic fun MockServer$default (IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static synthetic fun MockServer$default (Lcom/apollographql/apollo3/mockserver/MockServerHandler;IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -82,7 +82,7 @@ interface MockServer : Closeable {
     private var handlePings: Boolean? = null
     private var tcpServer: TcpServer? = null
     private var listener: Listener? = null
-    private var customPort: Int = 0
+    private var port: Int? = null
 
     fun handler(handler: MockServerHandler) = apply {
       this.handler = handler
@@ -92,19 +92,23 @@ interface MockServer : Closeable {
       this.handlePings = handlePings
     }
 
-    fun tcpServer(tcpServer: TcpServer, port: Int = 0) = apply {
+    fun tcpServer(tcpServer: TcpServer) = apply {
       this.tcpServer = tcpServer
-      this.customPort = port
     }
 
+    fun port(port: Int) = apply {
+      this.port = port
+    }
 
     fun listener(listener: Listener) = apply {
       this.listener = listener
     }
-
-
+    
     fun build(): MockServer {
-      val server = tcpServer ?: TcpServer(customPort)
+      check (tcpServer == null || port == null) {
+        "It is an error to set both tcpServer and port"
+      }
+      val server = tcpServer ?: TcpServer(port ?: 0)
       return MockServerImpl(
           handler ?: QueueMockServerHandler(),
           handlePings ?: true,
@@ -254,11 +258,11 @@ fun MockServer(port: Int = 0): MockServer = MockServerImpl(
 
 @Deprecated("Use MockServer.Builder() instead", level = DeprecationLevel.ERROR)
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-fun MockServer(handler: MockServerHandler, port: Int = 0): MockServer =
+fun MockServer(handler: MockServerHandler): MockServer =
     MockServerImpl(
         handler,
         true,
-        TcpServer(port),
+        TcpServer(0),
         null)
 
 @Deprecated("Use enqueueString instead", ReplaceWith("enqueueString"), DeprecationLevel.ERROR)

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -16,6 +16,7 @@ import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.Closeable
 import kotlin.js.JsName
+import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -244,6 +245,7 @@ internal class MockServerImpl(
 }
 
 @JsName("createMockServer")
+@JvmOverloads
 fun MockServer(port: Int = 0): MockServer = MockServerImpl(
     QueueMockServerHandler(),
     true,

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.kt
@@ -56,4 +56,4 @@ class Address(
 )
 
 @ApolloExperimental
-expect fun TcpServer(): TcpServer
+expect fun TcpServer(port: Int): TcpServer

--- a/libraries/apollo-mockserver/src/concurrentMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.concurrent.kt
+++ b/libraries/apollo-mockserver/src/concurrentMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.concurrent.kt
@@ -20,13 +20,14 @@ import kotlinx.coroutines.withTimeout
 import okio.IOException
 import io.ktor.network.sockets.Socket as WrappedSocket
 
-actual fun TcpServer(): TcpServer = KtorTcpServer(0)
+actual fun TcpServer(port: Int): TcpServer = KtorTcpServer(port)
 
 @ApolloExperimental
-class KtorTcpServer(private val acceptDelayMillis: Int = 0, dispatcher: CoroutineDispatcher = Dispatchers.IO) : TcpServer {
+class KtorTcpServer(port: Int = 0, private val acceptDelayMillis: Int = 0, dispatcher: CoroutineDispatcher = Dispatchers.IO) : TcpServer {
   private val selectorManager = SelectorManager(dispatcher)
   private val scope = CoroutineScope(SupervisorJob() + dispatcher)
-  private val serverSocket = aSocket(selectorManager).tcp().bind("127.0.0.1")
+  private val serverSocket = aSocket(selectorManager).tcp().bind("127.0.0.1", port)
+
 
   override fun close() {
     scope.cancel()

--- a/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.js.kt
+++ b/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.js.kt
@@ -82,4 +82,4 @@ internal class NodeTcpServer : TcpServer {
   }
 }
 
-actual fun TcpServer(): TcpServer = NodeTcpServer()
+actual fun TcpServer(port: Int): TcpServer = NodeTcpServer()

--- a/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.js.kt
+++ b/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/TcpServer.js.kt
@@ -46,7 +46,7 @@ internal class NodeTcpSocket(private val netSocket: WrappedSocket) : TcpSocket {
   }
 }
 
-internal class NodeTcpServer : TcpServer {
+internal class NodeTcpServer(private val port: Int) : TcpServer {
   private var server: WrappedServer? = null
   private var address: Address? = null
 
@@ -56,7 +56,7 @@ internal class NodeTcpServer : TcpServer {
       block(NodeTcpSocket(netSocket))
     }
 
-    server!!.listen()
+    server!!.listen(port)
   }
 
   override suspend fun address(): Address {
@@ -82,4 +82,4 @@ internal class NodeTcpServer : TcpServer {
   }
 }
 
-actual fun TcpServer(port: Int): TcpServer = NodeTcpServer()
+actual fun TcpServer(port: Int): TcpServer = NodeTcpServer(port)


### PR DESCRIPTION
This PR adds support for optionally setting the port for the Apollo MockServer for kotlin. 

