### PR TITLE
Rework the IrType hierarchy

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -411,14 +411,20 @@ public final class com/apollographql/apollo3/compiler/ir/IrClassName {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrEnumType : com/apollographql/apollo3/compiler/ir/IrNamedType, com/apollographql/apollo3/compiler/ir/IrType {
+public final class com/apollographql/apollo3/compiler/ir/IrEnumType : com/apollographql/apollo3/compiler/ir/IrNamedType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrEnumType$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrEnumType;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrEnumType;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
+	public fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
+	public fun getNullable ()Z
+	public fun getOptional ()Z
 	public fun hashCode ()I
 	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
 	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
@@ -451,14 +457,20 @@ public final class com/apollographql/apollo3/compiler/ir/IrGraphqlTargetArgument
 	public final fun getType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType, com/apollographql/apollo3/compiler/ir/IrType {
+public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
+	public fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
+	public fun getNullable ()Z
+	public fun getOptional ()Z
 	public fun hashCode ()I
 	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
 	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
@@ -482,12 +494,18 @@ public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType$Compa
 
 public final class com/apollographql/apollo3/compiler/ir/IrListType : com/apollographql/apollo3/compiler/ir/IrType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrListType$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;)V
+	public fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZ)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public final fun copy (Lcom/apollographql/apollo3/compiler/ir/IrType;)Lcom/apollographql/apollo3/compiler/ir/IrListType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrListType;Lcom/apollographql/apollo3/compiler/ir/IrType;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrListType;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZ)Lcom/apollographql/apollo3/compiler/ir/IrListType;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrListType;Lcom/apollographql/apollo3/compiler/ir/IrType;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrListType;
+	public fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getNullable ()Z
 	public final fun getOfType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
+	public fun getOptional ()Z
 	public fun hashCode ()I
 	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
 	public fun toString ()Ljava/lang/String;
@@ -511,48 +529,27 @@ public final class com/apollographql/apollo3/compiler/ir/IrListType$Companion {
 public abstract interface class com/apollographql/apollo3/compiler/ir/IrNamedType : com/apollographql/apollo3/compiler/ir/IrType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrNamedType$Companion;
 	public abstract fun getName ()Ljava/lang/String;
+	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrNamedType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrNonNullType : com/apollographql/apollo3/compiler/ir/IrType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrNonNullType$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;)V
-	public final fun component1 ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public final fun copy (Lcom/apollographql/apollo3/compiler/ir/IrType;)Lcom/apollographql/apollo3/compiler/ir/IrNonNullType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrNonNullType;Lcom/apollographql/apollo3/compiler/ir/IrType;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrNonNullType;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getOfType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun hashCode ()I
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrNonNullType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrNonNullType$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/apollographql/apollo3/compiler/ir/IrNonNullType;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/apollographql/apollo3/compiler/ir/IrNonNullType;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrNonNullType$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType, com/apollographql/apollo3/compiler/ir/IrType {
+public final class com/apollographql/apollo3/compiler/ir/IrObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrObjectType$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrObjectType;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrObjectType;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
+	public fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
+	public fun getNullable ()Z
+	public fun getOptional ()Z
 	public fun hashCode ()I
 	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
 	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
@@ -584,42 +581,20 @@ public final class com/apollographql/apollo3/compiler/ir/IrOperationsKt {
 	public static final fun writeTo (Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/io/File;)V
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrOptionalType : com/apollographql/apollo3/compiler/ir/IrType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrOptionalType$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;)V
-	public final fun component1 ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public final fun copy (Lcom/apollographql/apollo3/compiler/ir/IrType;)Lcom/apollographql/apollo3/compiler/ir/IrOptionalType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrOptionalType;Lcom/apollographql/apollo3/compiler/ir/IrType;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrOptionalType;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getOfType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun hashCode ()I
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrOptionalType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrOptionalType$$serializer;
-	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/apollographql/apollo3/compiler/ir/IrOptionalType;
-	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/apollographql/apollo3/compiler/ir/IrOptionalType;)V
-	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrOptionalType$Companion {
-	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrScalarType : com/apollographql/apollo3/compiler/ir/IrNamedType, com/apollographql/apollo3/compiler/ir/IrType {
+public final class com/apollographql/apollo3/compiler/ir/IrScalarType : com/apollographql/apollo3/compiler/ir/IrNamedType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrScalarType$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrScalarType;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;ZZ)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrScalarType;Ljava/lang/String;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
+	public fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getName ()Ljava/lang/String;
+	public fun getNullable ()Z
+	public fun getOptional ()Z
 	public fun hashCode ()I
 	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
 	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
@@ -677,11 +652,29 @@ public final class com/apollographql/apollo3/compiler/ir/IrTargetObject {
 
 public abstract interface class com/apollographql/apollo3/compiler/ir/IrType {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrType$Companion;
+	public abstract fun copyWith (ZZ)Lcom/apollographql/apollo3/compiler/ir/IrType;
+	public static synthetic fun copyWith$default (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrType;
+	public abstract fun getNullable ()Z
+	public abstract fun getOptional ()Z
 	public abstract fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/apollographql/apollo3/compiler/ir/IrTypeKt {
+	public static final fun getWrapper (Lcom/apollographql/apollo3/compiler/ir/IrType;)Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
+	public static final fun nullable (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
+	public static final fun optional (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
+}
+
+public final class com/apollographql/apollo3/compiler/ir/IrTypeWrapper : java/lang/Enum {
+	public static final field None Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
+	public static final field Optional Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
+	public static fun values ()[Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
 }
 
 public final class com/apollographql/apollo3/compiler/operationoutput/OperationDescriptor {

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -664,17 +664,8 @@ public final class com/apollographql/apollo3/compiler/ir/IrType$Companion {
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrTypeKt {
-	public static final fun getWrapper (Lcom/apollographql/apollo3/compiler/ir/IrType;)Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
 	public static final fun nullable (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
 	public static final fun optional (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrTypeWrapper : java/lang/Enum {
-	public static final field None Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
-	public static final field Optional Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
-	public static fun values ()[Lcom/apollographql/apollo3/compiler/ir/IrTypeWrapper;
 }
 
 public final class com/apollographql/apollo3/compiler/operationoutput/OperationDescriptor {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
 import com.apollographql.apollo3.compiler.ir.IrFieldInfo
 import com.apollographql.apollo3.compiler.ir.IrListType
-import com.apollographql.apollo3.compiler.ir.IrNonNullType
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.TypeSet
@@ -176,7 +175,6 @@ internal abstract class CodegenLayout(
     private fun IrType.isList(): Boolean {
       return when (this) {
         is IrListType -> true
-        is IrNonNullType -> ofType.isList()
         else -> false
       }
     }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaResolver.kt
@@ -117,8 +117,6 @@ internal class JavaResolver(
     return result
   }
 
-  fun canResolveSchemaType(name: String) = resolve(ResolverKey(ResolverKeyKind.SchemaType, name)) != null
-
   private fun register(kind: ResolverKeyKind, id: String, className: ClassName) = classNames.put(ResolverKey(kind, id), className)
 
   fun resolveIrType(type: IrType): TypeName {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/InputAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/InputAdapter.kt
@@ -3,7 +3,6 @@
  */
 package com.apollographql.apollo3.compiler.codegen.java.adapter
 
-import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.Empty
 import com.apollographql.apollo3.compiler.codegen.Identifier.adapterContext
 import com.apollographql.apollo3.compiler.codegen.Identifier.fromJson
@@ -20,7 +19,6 @@ import com.apollographql.apollo3.compiler.codegen.java.helpers.NamedType
 import com.apollographql.apollo3.compiler.codegen.java.helpers.beginOptionalControlFlow
 import com.apollographql.apollo3.compiler.codegen.java.helpers.suppressDeprecatedAnnotation
 import com.apollographql.apollo3.compiler.ir.isComposite
-import com.apollographql.apollo3.compiler.ir.isOptional
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterizedTypeName
@@ -87,7 +85,7 @@ private fun NamedType.writeToResponseCodeBlock(context: JavaContext): CodeBlock 
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(graphQlName)
 
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.beginOptionalControlFlow(propertyName, context.nullableFieldStyle)
   }
   builder.add("$writer.name($S);\n", graphQlName)
@@ -96,7 +94,7 @@ private fun NamedType.writeToResponseCodeBlock(context: JavaContext): CodeBlock 
   } else {
     builder.addStatement("$L.$toJson($writer, $value.$propertyName, $adapterContext)", adapterInitializer)
   }
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.endControlFlow()
   }
   return builder.build()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/VariablesAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/VariablesAdapter.kt
@@ -20,7 +20,6 @@ import com.apollographql.apollo3.compiler.codegen.java.helpers.beginOptionalCont
 import com.apollographql.apollo3.compiler.codegen.java.helpers.codeBlock
 import com.apollographql.apollo3.compiler.ir.IrVariable
 import com.apollographql.apollo3.compiler.ir.isComposite
-import com.apollographql.apollo3.compiler.ir.isOptional
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.TypeName
@@ -68,7 +67,7 @@ private fun IrVariable.writeToResponseCodeBlock(context: JavaContext): CodeBlock
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(name)
 
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.beginOptionalControlFlow(propertyName, context.nullableFieldStyle)
   }
 
@@ -78,7 +77,7 @@ private fun IrVariable.writeToResponseCodeBlock(context: JavaContext): CodeBlock
   } else {
     builder.addStatement("$L.$toJson($writer, $value.$propertyName, $adapterContext)", adapterInitializer)
   }
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.endControlFlow()
     if (defaultValue != null) {
       builder.beginControlFlow("else if ($withDefaultValues)")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinResolver.kt
@@ -76,19 +76,15 @@ internal class KotlinResolver(
     classNames.put(ResolverKey(kind, id), ClassName(memberName.packageName, memberName.simpleName))
   }
 
-  internal fun resolveIrType(type: IrType, jsExport: Boolean, isInterface: Boolean = false, override: (IrType) -> TypeName? = { null }): TypeName {
+  internal fun resolveIrType(type: IrType, jsExport: Boolean, isInterface: Boolean = false): TypeName {
     if (type.optional) {
-      return KotlinSymbols.Optional.parameterizedBy(resolveIrType(type.optional(false), jsExport, isInterface, override = override))
+      return KotlinSymbols.Optional.parameterizedBy(resolveIrType(type.optional(false), jsExport, isInterface))
     } else if (!type.nullable) {
-      return resolveIrType(type.nullable(true), jsExport, isInterface, override = override).copy(nullable = false)
+      return resolveIrType(type.nullable(true), jsExport, isInterface).copy(nullable = false)
     }
-
-    override(type)?.let {
-      return it
-    }
-
+    
     return when (type) {
-      is IrListType -> toListType(resolveIrType(type.ofType, jsExport, isInterface, override), jsExport, isInterface)
+      is IrListType -> toListType(resolveIrType(type.ofType, jsExport, isInterface), jsExport, isInterface)
       is IrScalarType -> resolveIrScalarType(type)
       is IrModelType -> resolveAndAssert(ResolverKeyKind.Model, type.path)
       is IrEnumType -> if (jsExport) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/InputAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/InputAdapter.kt
@@ -14,7 +14,6 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.NamedType
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.requiresOptInAnnotation
-import com.apollographql.apollo3.compiler.ir.isOptional
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -81,12 +80,12 @@ private fun NamedType.writeToResponseCodeBlock(context: KotlinContext): CodeBloc
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(graphQlName)
 
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.beginControlFlow("if ($value.%N is %T)", propertyName, KotlinSymbols.Present)
   }
   builder.addStatement("$writer.name(%S)", graphQlName)
   builder.addSerializeStatement(adapterInitializer, propertyName)
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.endControlFlow()
   }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/VariablesAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/VariablesAdapter.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.codeBlock
 import com.apollographql.apollo3.compiler.ir.IrVariable
-import com.apollographql.apollo3.compiler.ir.isOptional
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -54,12 +53,12 @@ private fun IrVariable.writeToResponseCodeBlock(context: KotlinContext): CodeBlo
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(name)
 
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.beginControlFlow("if ($value.%N is %T)", propertyName, KotlinSymbols.Present)
   }
   builder.addStatement("$writer.name(%S)", name)
   builder.addSerializeStatement(adapterInitializer, propertyName)
-  if (type.isOptional()) {
+  if (type.optional) {
     builder.endControlFlow()
     if (defaultValue != null) {
       builder.beginControlFlow("else if ($withDefaultValues)")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/AdapterRegistryBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/AdapterRegistryBuilder.kt
@@ -13,8 +13,8 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrEnumType
 import com.apollographql.apollo3.compiler.ir.IrInputObjectType
-import com.apollographql.apollo3.compiler.ir.IrNonNullType
 import com.apollographql.apollo3.compiler.ir.IrScalarType
+import com.apollographql.apollo3.compiler.ir.nullable
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.PropertySpec
@@ -64,12 +64,12 @@ internal class AdapterRegistryBuilder(
               }
               else -> {
                 val type = when (it) {
-                  is GQLEnumTypeDefinition -> IrEnumType(it.name)
-                  is GQLInputObjectTypeDefinition -> IrInputObjectType(it.name)
-                  is GQLScalarTypeDefinition -> IrScalarType(it.name)
+                  is GQLEnumTypeDefinition -> IrEnumType(it.name, nullable = true)
+                  is GQLInputObjectTypeDefinition -> IrInputObjectType(it.name, nullable = true)
+                  is GQLScalarTypeDefinition -> IrScalarType(it.name, nullable = true)
                   else -> error("")
                 }
-                add(".add(%S,·%L)\n", it.name, context.resolver.adapterInitializer(IrNonNullType(type), false, false, ""))
+                add(".add(%S,·%L)\n", it.name, context.resolver.adapterInitializer(type.nullable(false), false, false, ""))
               } }
           }
         }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InputObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/InputObjectBuilder.kt
@@ -13,8 +13,6 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toParameterSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toPropertySpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toSetterFunSpec
 import com.apollographql.apollo3.compiler.ir.IrInputObject
-import com.apollographql.apollo3.compiler.ir.IrNonNullType
-import com.apollographql.apollo3.compiler.ir.IrOptionalType
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -90,7 +88,7 @@ private fun List<NamedType>.toBuildFunSpec(context: KotlinContext, returnedClass
                 forEach {
                   val propertyName = context.layout.propertyName(it.graphQlName)
                   add("%L·=·%L", propertyName, propertyName)
-                  if (it.type is IrNonNullType && it.type.ofType !is IrOptionalType) {
+                  if (!it.type.nullable && !it.type.optional) {
                     add("·?:·error(\"missing·value·for·$propertyName\")")
                   }
                   add(",\n")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/MainResolverBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/MainResolverBuilder.kt
@@ -8,11 +8,11 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
 import com.apollographql.apollo3.compiler.ir.IrExecutionContextTargetArgument
 import com.apollographql.apollo3.compiler.ir.IrGraphqlTargetArgument
-import com.apollographql.apollo3.compiler.ir.IrOptionalType
 import com.apollographql.apollo3.compiler.ir.IrTargetArgument
 import com.apollographql.apollo3.compiler.ir.IrTargetField
 import com.apollographql.apollo3.compiler.ir.IrTargetObject
 import com.apollographql.apollo3.compiler.ir.asKotlinPoet
+import com.apollographql.apollo3.compiler.ir.optional
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -191,8 +191,8 @@ internal class MainResolverBuilder(
         /**
          * Unwrap the optional because getArgument always return an optional value
          */
-        val type = if (irTargetArgument.type is IrOptionalType) {
-          irTargetArgument.type.ofType
+        val type = if (irTargetArgument.type.optional) {
+          irTargetArgument.type.optional(false)
         } else {
           irTargetArgument.type
         }
@@ -202,7 +202,7 @@ internal class MainResolverBuilder(
             context.resolver.resolveIrType(type = type, jsExport = false, isInterface = false),
             irTargetArgument.name,
         )
-        if (irTargetArgument.type !is IrOptionalType) {
+        if (!irTargetArgument.type.optional) {
           builder.add(".getOrThrow()")
         }
       }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -401,7 +401,7 @@ internal class IrOperationsBuilder(
     var irType = type.toIr()
     if (type !is GQLNonNullType) {
       // If the type is nullable, the variable might be omitted, make it optional
-      irType = irType.makeOptional()
+      irType = irType.optional(true)
     }
     return IrVariable(
         name = name,
@@ -413,14 +413,14 @@ internal class IrOperationsBuilder(
   private fun GQLVariableDefinition.toIr(): IrVariable {
     var irType = type.toIr()
     when {
-      irType is IrNonNullType && defaultValue == null -> {
+      !irType.nullable && defaultValue == null -> {
         // The variable is non-nullable and has no defaultValue => it must always be sent
         // Leave irType as-is
       }
 
       defaultValue != null -> {
         // the variable has a defaultValue meaning that there is a use case for not providing it
-        irType = irType.makeOptional()
+        irType = irType.optional(true)
       }
 
       else -> {
@@ -436,7 +436,7 @@ internal class IrOperationsBuilder(
 
         val makeOptional = directives.optionalValue(schema) ?: generateOptionalOperationVariables
         if (makeOptional) {
-          irType = irType.makeOptional()
+          irType = irType.optional(true)
         }
       }
     }
@@ -576,9 +576,9 @@ internal class IrOperationsBuilder(
 
       var irType = first.type.toIr()
       if (forceNonNull) {
-        irType = irType.makeNonNull()
+        irType = irType.nullable(false)
       } else if (forceOptional) {
-        irType = irType.makeNullable()
+        irType = irType.nullable(true)
       }
 
       /**
@@ -806,6 +806,6 @@ internal fun IrFieldInfo.maybeNullable(makeNullable: Boolean): IrFieldInfo {
   }
 
   return copy(
-      type = type.makeNullable()
+      type = type.nullable(true)
   )
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
@@ -94,7 +94,7 @@ internal data class IrScalar(
     val description: String?,
     val deprecationReason: String?,
 ) : IrSchemaType {
-  val type = IrScalarType(name)
+  val type = IrScalarType(name, nullable = true)
 }
 
 /**
@@ -119,7 +119,7 @@ internal data class IrEnum(
     val description: String?,
     val values: List<Value>,
 ) : IrSchemaType {
-  val type = IrEnumType(name)
+  val type = IrEnumType(name, nullable = true)
 
   data class Value(
       val name: String,
@@ -296,7 +296,7 @@ private fun GQLInputValueDefinition.toIrInputField(schema: Schema): IrInputField
      * Contrary to [IrVariable], we default to making input fields optional as they are out of control of the user, and
      * we don't want to force users to fill all values to define an input object
      */
-    irType = irType.makeOptional()
+    irType = irType.optional(true)
   }
   return IrInputField(
       name = name,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
@@ -14,11 +14,33 @@ import com.apollographql.apollo3.ast.Schema
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-enum class IrTypeWrapper {
-  None,
-  Optional,
-}
-
+/**
+ * The IR representation of an input or output field
+ *
+ * **Allowed**
+ *
+ * * `T`
+ * * `Nullable<T>`
+ * * `Option<T>`
+ * * `Option<Nullable<T>>`
+ * * `Result<T>`
+ * * `Result<Nullable<T>>`
+ * * All `List` variations of the above
+ *
+ * **Disallowed**
+ *
+ * * `Nullable<Option<T>>`
+ * * `Nullable<Result<T>>`
+ * * `Nullable<Nullable<T>>`
+ * * `Option<Option<T>>`
+ * * `Option<Result<T>>`
+ * * `Result<Option<T>>`
+ * * `Result<Result<T>>`
+ * * etc...
+ *
+ * We need both `Option` and `Nullable` to distinguish `?` vs `Option` in Kotlin (see this [Arrow article](https://arrow-kt.io/learn/typed-errors/nullable-and-option/)).
+ * In java `Option` and `Nullable` might be represented using the same `Optional` depending on the settings.
+ */
 @Serializable
 sealed interface IrType {
   val nullable: Boolean
@@ -26,11 +48,6 @@ sealed interface IrType {
 
   fun copyWith(nullable: Boolean = this.nullable, optional: Boolean = this.optional): IrType
   fun rawType(): IrNamedType
-}
-
-val IrType.wrapper: IrTypeWrapper get() = when {
-  this.optional -> IrTypeWrapper.Optional
-  else -> IrTypeWrapper.None
 }
 
 fun IrType.nullable(nullable: Boolean): IrType = copyWith(nullable = nullable)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
@@ -11,64 +11,90 @@ import com.apollographql.apollo3.ast.GQLScalarTypeDefinition
 import com.apollographql.apollo3.ast.GQLType
 import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.Schema
-import com.apollographql.apollo3.compiler.codegen.Identifier
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+enum class IrTypeWrapper {
+  None,
+  Optional,
+}
+
 @Serializable
 sealed interface IrType {
+  val nullable: Boolean
+  val optional: Boolean
+
+  fun copyWith(nullable: Boolean = this.nullable, optional: Boolean = this.optional): IrType
   fun rawType(): IrNamedType
 }
 
-@Serializable
-@SerialName("nonnull")
-data class IrNonNullType(val ofType: IrType) : IrType {
-  init {
-    check(ofType !is IrNonNullType)
-  }
-
-  override fun rawType() = ofType.rawType()
+val IrType.wrapper: IrTypeWrapper get() = when {
+  this.optional -> IrTypeWrapper.Optional
+  else -> IrTypeWrapper.None
 }
 
-@Serializable
-@SerialName("optional")
-data class IrOptionalType(val ofType: IrType) : IrType {
-  override fun rawType() = ofType.rawType()
-}
+fun IrType.nullable(nullable: Boolean): IrType = copyWith(nullable = nullable)
+fun IrType.optional(optional: Boolean): IrType = copyWith(optional = optional)
 
 @Serializable
 @SerialName("list")
-data class IrListType(val ofType: IrType) : IrType {
-  init {
-    check(ofType !is IrOptionalType)
-  }
+data class IrListType(
+    val ofType: IrType,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrType {
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
 
   override fun rawType() = ofType.rawType()
 }
 
 @Serializable
-sealed interface IrNamedType: IrType {
+sealed interface IrNamedType : IrType {
+  override fun rawType() = this
   val name: String
 }
 
 @Serializable
 @SerialName("scalar")
-data class IrScalarType(override val name: String) : IrType, IrNamedType {
+data class IrScalarType(
+    override val name: String,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrNamedType {
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
   override fun rawType() = this
 }
+
 @Serializable
 @SerialName("input")
-data class IrInputObjectType(override val name: String) : IrType, IrNamedType {
+data class IrInputObjectType(
+    override val name: String,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrNamedType {
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
   override fun rawType() = this
 }
+
 @Serializable
 @SerialName("enum")
-data class IrEnumType(override val name: String) : IrType, IrNamedType {
+data class IrEnumType(
+    override val name: String,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrNamedType {
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
   override fun rawType() = this
 }
+
 @Serializable
 @SerialName("object")
-data class IrObjectType(override val name: String) : IrType, IrNamedType {
+data class IrObjectType(
+    override val name: String,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrNamedType {
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
   override fun rawType() = this
 }
 
@@ -93,9 +119,15 @@ data class IrObjectType(override val name: String) : IrType, IrNamedType {
  */
 @Serializable
 @SerialName("model")
-internal data class IrModelType(val path: String) : IrType, IrNamedType {
+internal data class IrModelType(
+    val path: String,
+    override val nullable: Boolean = false,
+    override val optional: Boolean = false,
+) : IrNamedType {
   override val name: String
-    get() =  path
+    get() = path
+
+  override fun copyWith(nullable: Boolean, optional: Boolean): IrType = copy(nullable = nullable, optional = optional)
   override fun rawType() = this
 }
 
@@ -104,30 +136,9 @@ internal const val MODEL_FRAGMENT_DATA = "fragmentData"
 internal const val MODEL_FRAGMENT_INTERFACE = "fragmentInterface"
 internal const val MODEL_UNKNOWN = "?"
 
-internal fun IrType.makeOptional(): IrType = IrNonNullType(IrOptionalType(this))
-internal fun IrType.makeNullable(): IrType = if (this is IrNonNullType) {
-  this.ofType.makeNullable()
-} else {
-  this
-}
-
-internal fun IrType.makeNonNull(): IrType = if (this is IrNonNullType) {
-  this
-} else {
-  IrNonNullType(this)
-}
-
-internal fun IrType.isOptional() = (this is IrNonNullType) && (this.ofType is IrOptionalType)
-
-internal fun IrType.makeNonOptional(): IrType {
-  return ((this as? IrNonNullType)?.ofType as? IrOptionalType)?.ofType ?: error("${Identifier.type} is not an optional type")
-}
-
-
 internal fun IrType.replacePlaceholder(newPath: String): IrType {
   return when (this) {
-    is IrNonNullType -> IrNonNullType(ofType = ofType.replacePlaceholder(newPath))
-    is IrListType -> IrListType(ofType = ofType.replacePlaceholder(newPath))
+    is IrListType -> copy(ofType = ofType.replacePlaceholder(newPath))
     is IrModelType -> copy(path = newPath)
     else -> error("Not a compound type?")
   }
@@ -135,42 +146,44 @@ internal fun IrType.replacePlaceholder(newPath: String): IrType {
 
 internal fun GQLType.toIr(schema: Schema): IrType {
   return when (this) {
-    is GQLNonNullType -> IrNonNullType(ofType = type.toIr(schema))
-    is GQLListType -> IrListType(ofType = type.toIr(schema))
+    is GQLNonNullType -> type.toIr(schema).copyWith(nullable = false)
+    is GQLListType -> IrListType(ofType = type.toIr(schema), nullable = true)
     is GQLNamedType -> {
       when (schema.typeDefinition(name)) {
         is GQLScalarTypeDefinition -> {
-          IrScalarType(name)
+          IrScalarType(name, nullable = true)
         }
 
         is GQLEnumTypeDefinition -> {
-          IrEnumType(name = name)
+          IrEnumType(name, nullable = true)
         }
 
         is GQLInputObjectTypeDefinition -> {
-          IrInputObjectType(name)
+          IrInputObjectType(name, nullable = true)
         }
 
         is GQLObjectTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN)
+          IrModelType(MODEL_UNKNOWN, nullable = true)
         }
 
         is GQLInterfaceTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN)
+          IrModelType(MODEL_UNKNOWN, nullable = true)
         }
 
         is GQLUnionTypeDefinition -> {
-          IrModelType(MODEL_UNKNOWN)
+          IrModelType(MODEL_UNKNOWN, nullable = true)
         }
       }
     }
   }
 }
 
-internal fun IrType.isComposite(): Boolean {
-  return when(this) {
+internal fun IrNamedType.isComposite(): Boolean {
+  return when (this) {
     is IrScalarType -> false
     is IrEnumType -> false
-    else -> true
+    is IrInputObjectType -> true
+    is IrModelType -> true
+    is IrObjectType -> true
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
@@ -24,7 +24,7 @@ internal class OperationBasedModelGroupBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = GQLNamedType(name = rawTypeName)),
@@ -57,7 +57,7 @@ internal class OperationBasedModelGroupBuilder(
     val info = IrFieldInfo(
         responseName = fragmentName,
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = fragmentDefinition.typeCondition),
@@ -218,9 +218,9 @@ internal class OperationBasedModelGroupBuilder(
                 }
                 childCondition = entry.key.and(childCondition).simplify()
 
-                var type: IrType = IrModelType(MODEL_UNKNOWN)
+                var type: IrType = IrModelType(MODEL_UNKNOWN, nullable = true)
                 if (childCondition == BooleanExpression.True) {
-                  type = IrNonNullType(type)
+                  type = type.nullable(false)
                 }
 
                 val childInfo = IrFieldInfo(
@@ -281,9 +281,9 @@ internal class OperationBasedModelGroupBuilder(
 
           val fragmentModelPath = "${MODEL_FRAGMENT_DATA}.${first.name}.${first.name}"
 
-          var type: IrType = IrModelType(fragmentModelPath)
+          var type: IrType = IrModelType(fragmentModelPath, nullable = true)
           if (childCondition == BooleanExpression.True) {
-            type = IrNonNullType(type)
+            type = type.nullable(false)
           }
 
           val childInfo = IrFieldInfo(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedWithInterfacesModelGroupBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedWithInterfacesModelGroupBuilder.kt
@@ -37,7 +37,7 @@ internal class OperationBasedWithInterfacesModelGroupBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = GQLNamedType(name = rawTypeName))
@@ -69,7 +69,7 @@ internal class OperationBasedWithInterfacesModelGroupBuilder(
     val info = IrFieldInfo(
         responseName = fragmentName,
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = fragmentDefinition.typeCondition),
@@ -153,9 +153,9 @@ internal class OperationBasedWithInterfacesModelGroupBuilder(
             BooleanExpression.Element(BPossibleTypes(possibleTypes))
           }
 
-          var type: IrType = IrModelType(MODEL_UNKNOWN)
+          var type: IrType = IrModelType(MODEL_UNKNOWN, nullable = true)
           if (childCondition == BooleanExpression.True) {
-            type = IrNonNullType(type)
+            type = type.nullable(false)
           }
 
           val childInfo = IrFieldInfo(
@@ -211,9 +211,9 @@ internal class OperationBasedWithInterfacesModelGroupBuilder(
            */
           val fragmentModelPath = "${MODEL_FRAGMENT_DATA}.${first.name}.${first.name}"
 
-          var type: IrType = IrModelType(fragmentModelPath)
+          var type: IrType = IrModelType(fragmentModelPath, nullable = true)
           if (childCondition == BooleanExpression.True) {
-            type = IrNonNullType(type)
+            type = type.nullable(false)
           }
 
           val childInfo = IrFieldInfo(
@@ -396,8 +396,8 @@ internal class OperationBasedWithInterfacesModelGroupBuilder(
 
     if (isSynthetic) {
       condition = this.condition.simplify(possibleTypes)
-      info = if (condition is BooleanExpression.True && this.info.type !is IrNonNullType) {
-        this.info.copy(type = IrNonNullType(this.info.type))
+      info = if (condition is BooleanExpression.True && this.info.type.nullable) {
+        this.info.copy(type = this.info.type.nullable(false))
       } else {
         this.info
       }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/ResponseBasedModelGroupBuilder.kt
@@ -122,7 +122,7 @@ private class FieldNodeBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = GQLNamedType(name = rawTypeName)),
@@ -146,7 +146,7 @@ private class FieldNodeBuilder(
       val info = IrFieldInfo(
           responseName = name,
           description = null,
-          type = IrModelType(MODEL_UNKNOWN),
+          type = IrModelType(MODEL_UNKNOWN, nullable = true),
           deprecationReason = null,
           optInFeature = null,
           gqlType = GQLNonNullType(type = fragment.typeCondition),
@@ -171,7 +171,7 @@ private class FieldNodeBuilder(
     val info = IrFieldInfo(
         responseName = "data",
         description = null,
-        type = IrNonNullType(IrModelType(MODEL_UNKNOWN)),
+        type = IrModelType(MODEL_UNKNOWN),
         deprecationReason = null,
         optInFeature = null,
         gqlType = GQLNonNullType(type = fragment.typeCondition),
@@ -514,12 +514,7 @@ private fun ResponseFieldSet.toIrModel(parentResponseField: ResponseField): IrMo
 private fun ResponseField.toIrProperty(): IrProperty {
   var type = info.type
   if (condition != BooleanExpression.True) {
-    // Convert to a nullable type if needed
-    // Consecutive IrNonNullType are most likely an error at this point but do not fail if
-    // that happens
-    while (type is IrNonNullType) {
-      type = type.ofType
-    }
+    type = type.nullable(true)
   }
   return IrProperty(
       info = info.copy(type = type),


### PR DESCRIPTION
Prep work for `@catch` and result types. Change the internal representation of `IrType` to remove `IrOptionalType` and `IrNonNullType`. Not only does it make it easier to reason about types but it considerably reduces the cardinality of cases we have to handle:

**Allowed**

* `T`
* `Nullable<T>`
* `Option<T>`
* `Option<Nullable<T>>`
* `Result<T>`
* `Result<Nullable<T>>`
* All `List` variations of the above

**Disallowed**

* `Nullable<Option<T>>`
* `Nullable<Result<T>>`
* `Nullable<Nullable<T>>`
* `Option<Option<T>>`
* `Option<Result<T>>`
* `Result<Option<T>>`
* `Result<Result<T>>`
* etc...

We need both `Option` and `Nullable` to distinguish `?` vs `Option` in Kotlin (see this [Arrow article](https://arrow-kt.io/learn/typed-errors/nullable-and-option/)). In java `Option` and `Nullable` might be represented using the same `Optional` depending the settings.

Most of this change was made with structural search and replace but some had to be done manually because there is no 1:1 mapping between the old IrTypes and the new ones. This is the case for `adapterInitializer` for an example.
