### PR TITLE
Increase logging in CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,7 +24,7 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
-          ./gradlew -p tests ciBuild
+          ./gradlew -p tests ciBuild -i
           ./gradlew dokkaHtmlMultiModule
           ./gradlew ciPublishSnapshot
         env:


### PR DESCRIPTION
I've see a few cases where `ciBuild` hangs (like [here](https://github.com/apollographql/apollo-kotlin/actions/runs/6963985352/attempts/1) for an example)