### PR TITLE
[IJ Plugin] Add inspection for @oneOf input type constructor invocation

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspection.kt
@@ -1,0 +1,44 @@
+package com.apollographql.ijplugin.inspection
+
+import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.navigation.findInputTypeGraphQLDefinitions
+import com.apollographql.ijplugin.navigation.isApolloInputClassReference
+import com.apollographql.ijplugin.project.apolloProjectService
+import com.apollographql.ijplugin.util.cast
+import com.apollographql.ijplugin.util.type
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.lang.jsgraphql.psi.GraphQLInputObjectTypeDefinition
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.parentOfType
+import org.jetbrains.kotlin.idea.base.utils.fqname.fqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
+import org.jetbrains.kotlin.psi.KtVisitorVoid
+
+class ApolloOneOfInputCreationInspection : LocalInspectionTool() {
+  override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+    return object : KtVisitorVoid() {
+      override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!expression.project.apolloProjectService.apolloVersion.isAtLeastV4) return
+        val reference = (expression.calleeExpression.cast<KtNameReferenceExpression>())
+        if (reference?.isApolloInputClassReference() != true) return
+        val inputTypeName = reference.text
+        val inputTypeDefinition = findInputTypeGraphQLDefinitions(reference.project, inputTypeName).firstOrNull()
+            ?.parentOfType<GraphQLInputObjectTypeDefinition>()
+            ?: return
+        val isOneOf = inputTypeDefinition.directives.any { it.name == "oneOf" }
+        if (!isOneOf) return
+        if (expression.valueArguments.size != 1) {
+          holder.registerProblem(expression.calleeExpression!!, ApolloBundle.message("inspection.oneOfInputCreation.reportText.wrongNumberOfArgs"))
+          return
+        }
+        val arg = expression.valueArguments.first()
+        if (arg.getArgumentExpression()?.type()?.fqName?.asString() == "com.apollographql.apollo3.api.Optional.Absent") {
+          holder.registerProblem(expression.calleeExpression!!, ApolloBundle.message("inspection.oneOfInputCreation.reportText.argIsAbsent"))
+        }
+      }
+    }
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Psi.kt
@@ -4,7 +4,9 @@ import com.intellij.openapi.diagnostic.ControlFlowException
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.idea.caches.resolve.getResolutionFacade
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
+import org.jetbrains.kotlin.idea.caches.resolve.safeAnalyze
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtBlockExpression
@@ -12,6 +14,7 @@ import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtLambdaArgument
@@ -19,6 +22,7 @@ import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.containingClass
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
+import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 fun PsiElement.containingKtFile(): KtFile? = getStrictParentOfType()
@@ -72,6 +76,8 @@ fun KtCallExpression.getMethodName(): String? = calleeExpression.cast<KtNameRefe
 
 fun KtCallExpression.lambdaBlockExpression(): KtBlockExpression? = valueArguments.firstIsInstanceOrNull<KtLambdaArgument>()?.getLambdaExpression()?.bodyExpression
 
-fun KtDeclaration.type() = (resolveToDescriptorIfAny() as? CallableDescriptor)?.returnType
+fun KtDeclaration.type(): KotlinType? = (resolveToDescriptorIfAny() as? CallableDescriptor)?.returnType
+
+fun KtExpression.type(): KotlinType? = safeAnalyze(getResolutionFacade()).getType(this)
 
 fun KtReferenceExpression.resolve() = mainReference.resolve()

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -136,6 +136,18 @@
         level="INFO"
     />
 
+    <!-- "OneOf Input creation" inspection  -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="kotlin"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloOneOfInputCreationInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.oneOfInputCreation.displayName"
+        enabledByDefault="true"
+        level="ERROR"
+    />
+
     <!-- Suppression of inspections on individual fields -->
     <lang.inspectionSuppressor
         language="GraphQL"

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloOneOfInputCreation.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloOneOfInputCreation.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+Reports invalid constructor invocations of <code>@oneOf</code> input types.
+<p>
+    Exactly one field must be set, and it must be <code>Present</code>.
+</p>
+</body>
+</html>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloOneOfInputCreation.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloOneOfInputCreation.html
@@ -2,7 +2,7 @@
 <body>
 Reports invalid constructor invocations of <code>@oneOf</code> input types.
 <p>
-    Exactly one field must be set, and it must be <code>Present</code>.
+    Constructor of `@oneOf` input class must have exactly one <code>Present</code> argument.
 </p>
 </body>
 </html>

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -143,7 +143,7 @@ inspection.endpointNotConfigured.reportText=GraphQL endpoint not configured
 inspection.endpointNotConfigured.quickFix=Add introspection block
 
 inspection.oneOfInputCreation.displayName=OneOf Input Object creation issue
-inspection.oneOfInputCreation.reportText.wrongNumberOfArgs=<html><tt>@oneOf</tt> input must have exactly one field set
+inspection.oneOfInputCreation.reportText.wrongNumberOfArgs=<html><tt>@oneOf</tt> input class constructor must have exactly one argument
 inspection.oneOfInputCreation.reportText.argIsAbsent=<html><tt>@oneOf</tt> input argument must be <tt>Present</tt>
 
 inspection.suppress.field=Suppress for field

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -144,7 +144,7 @@ inspection.endpointNotConfigured.quickFix=Add introspection block
 
 inspection.oneOfInputCreation.displayName=OneOf Input Object creation issue
 inspection.oneOfInputCreation.reportText.wrongNumberOfArgs=<html><tt>@oneOf</tt> input class constructor must have exactly one argument
-inspection.oneOfInputCreation.reportText.argIsAbsent=<html><tt>@oneOf</tt> input argument must be <tt>Present</tt>
+inspection.oneOfInputCreation.reportText.argIsAbsent=<html><tt>@oneOf</tt> input class argument must be <tt>Present</tt>
 
 inspection.suppress.field=Suppress for field
 

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -142,6 +142,10 @@ inspection.endpointNotConfigured.displayName=GraphQL endpoint not configured
 inspection.endpointNotConfigured.reportText=GraphQL endpoint not configured
 inspection.endpointNotConfigured.quickFix=Add introspection block
 
+inspection.oneOfInputCreation.displayName=OneOf Input Object creation issue
+inspection.oneOfInputCreation.reportText.wrongNumberOfArgs=<html><tt>@oneOf</tt> input must have exactly one field set
+inspection.oneOfInputCreation.reportText.argIsAbsent=<html><tt>@oneOf</tt> input argument must be <tt>Present</tt>
+
 inspection.suppress.field=Suppress for field
 
 notification.group.apollo.main=Apollo

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspectionTest.kt
@@ -17,8 +17,8 @@ class ApolloOneOfInputCreationInspectionTest : ApolloTestCase() {
   fun testOneOfConstructorInvocations() {
     myFixture.configureFromTempProjectFile("src/main/kotlin/com/example/OneOf.kt")
     val highlightInfos = doHighlighting()
-    assertTrue(highlightInfos.any { it.description == "@oneOf input must have exactly one field set" && it.text == "FindUserInput" && it.line == 8})
-    assertTrue(highlightInfos.any { it.description == "@oneOf input must have exactly one field set" && it.text == "FindUserInput" && it.line == 10})
-    assertTrue(highlightInfos.any { it.description == "@oneOf input argument must be Present" && it.text == "FindUserInput" && it.line == 20})
+    assertTrue(highlightInfos.any { it.description == "@oneOf input class constructor must have exactly one argument" && it.text == "FindUserInput" && it.line == 8 })
+    assertTrue(highlightInfos.any { it.description == "@oneOf input class constructor must have exactly one argument" && it.text == "FindUserInput" && it.line == 10 })
+    assertTrue(highlightInfos.any { it.description == "@oneOf input class argument must be Present" && it.text == "FindUserInput" && it.line == 20 })
   }
 }

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloOneOfInputCreationInspectionTest.kt
@@ -1,0 +1,24 @@
+package com.apollographql.ijplugin.inspection
+
+import com.apollographql.ijplugin.ApolloTestCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class ApolloOneOfInputCreationInspectionTest : ApolloTestCase() {
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ApolloOneOfInputCreationInspection())
+  }
+
+  @Test
+  fun testOneOfConstructorInvocations() {
+    myFixture.configureFromTempProjectFile("src/main/kotlin/com/example/OneOf.kt")
+    val highlightInfos = doHighlighting()
+    assertTrue(highlightInfos.any { it.description == "@oneOf input must have exactly one field set" && it.text == "FindUserInput" && it.line == 8})
+    assertTrue(highlightInfos.any { it.description == "@oneOf input must have exactly one field set" && it.text == "FindUserInput" && it.line == 10})
+    assertTrue(highlightInfos.any { it.description == "@oneOf input argument must be Present" && it.text == "FindUserInput" && it.line == 20})
+  }
+}

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -820,10 +820,10 @@ public final class com/apollographql/apollo3/api/Operations {
 
 public abstract class com/apollographql/apollo3/api/Optional {
 	public static final field Companion Lcom/apollographql/apollo3/api/Optional$Companion;
-	public static final fun absent ()Lcom/apollographql/apollo3/api/Optional;
+	public static final fun absent ()Lcom/apollographql/apollo3/api/Optional$Absent;
 	public final fun getOrNull ()Ljava/lang/Object;
 	public final fun getOrThrow ()Ljava/lang/Object;
-	public static final fun present (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
+	public static final fun present (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional$Present;
 	public static final fun presentIfNotNull (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
 }
 
@@ -832,8 +832,8 @@ public final class com/apollographql/apollo3/api/Optional$Absent : com/apollogra
 }
 
 public final class com/apollographql/apollo3/api/Optional$Companion {
-	public final fun absent ()Lcom/apollographql/apollo3/api/Optional;
-	public final fun present (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
+	public final fun absent ()Lcom/apollographql/apollo3/api/Optional$Absent;
+	public final fun present (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional$Present;
 	public final fun presentIfNotNull (Ljava/lang/Object;)Lcom/apollographql/apollo3/api/Optional;
 }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Optional.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Optional.kt
@@ -33,10 +33,10 @@ sealed class Optional<out V> {
 
   companion object {
     @JvmStatic
-    fun <V> absent(): Optional<V> = Absent
+    fun absent(): Absent = Absent
 
     @JvmStatic
-    fun <V> present(value: V): Optional<V> = Present(value)
+    fun <V> present(value: V): Present<V> = Present(value)
 
     @JvmStatic
     fun <V : Any> presentIfNotNull(value: V?): Optional<V> = if (value == null) Absent else Present(value)
@@ -51,7 +51,7 @@ fun <V> Optional<V>.getOrElse(fallback: V): V = (this as? Present)?.value ?: fal
 @ApolloExperimental
 fun <V, R> Optional<V>.map(mapper: (V) -> R): Optional<R> {
   return when(this) {
-    is Optional.Absent -> Optional.Absent
-    is Optional.Present -> Optional.present(mapper(value))
+    is Absent -> Absent
+    is Present -> Optional.present(mapper(value))
   }
 }

--- a/libraries/apollo-api/src/commonTest/kotlin/test/OptionalTest.kt
+++ b/libraries/apollo-api/src/commonTest/kotlin/test/OptionalTest.kt
@@ -37,7 +37,7 @@ class OptionalTest {
 
   @Test
   fun getOrThrowAbsent() {
-    val optional = Optional.absent<String?>()
+    val optional: Optional<String?> = Optional.absent()
     try {
       val value = optional.getOrThrow()
       fail("An exception was expected but got '$value' instead")

--- a/tests/intellij-plugin-test-project/src/main/graphql/FindUserQuery.graphql
+++ b/tests/intellij-plugin-test-project/src/main/graphql/FindUserQuery.graphql
@@ -1,0 +1,5 @@
+query FindUsersQuery($findUserInput: FindUserInput!) {
+  findUser(findUserInput: $findUserInput) {
+    id
+  }
+}

--- a/tests/intellij-plugin-test-project/src/main/graphql/schema.graphqls
+++ b/tests/intellij-plugin-test-project/src/main/graphql/schema.graphqls
@@ -2,6 +2,7 @@ type Query {
   animals: [Animal!]!
   computers: [Computer!]!
   myEnum(inputEnum: myEnum): myEnum
+  findUser(findUserInput: FindUserInput!): User
 }
 
 type Mutation {
@@ -63,4 +64,29 @@ input personInput {
 input AddressInput {
   num: Int
   street: String
+}
+
+
+
+directive @oneOf on INPUT_OBJECT
+
+type User {
+  id: ID!
+}
+
+input FindUserInput @oneOf {
+  email: String
+  name: String
+  identity: FindUserBySocialNetworkInput
+  friends: FindUserByFriendInput
+}
+
+input FindUserBySocialNetworkInput @oneOf {
+  facebookId: String
+  googleId: String
+}
+
+input FindUserByFriendInput {
+  socialNetworkId: ID!
+  friendId: ID!
 }

--- a/tests/intellij-plugin-test-project/src/main/kotlin/com/example/OneOf.kt
+++ b/tests/intellij-plugin-test-project/src/main/kotlin/com/example/OneOf.kt
@@ -1,0 +1,23 @@
+package com.example
+
+import com.apollographql.apollo3.api.Optional
+import com.apollographql.apollo3.api.Optional.Absent
+import com.example.generated.type.FindUserInput
+
+fun oneOf() {
+  FindUserInput()
+
+  FindUserInput(
+    email = Optional.present("a@a.com"),
+    name = Optional.present("John"),
+  )
+
+  FindUserInput(
+    email = Optional.present("a@a.com")
+  )
+
+  val absentEmail: Absent = Optional.absent()
+  FindUserInput(
+    email = absentEmail
+  )
+}


### PR DESCRIPTION
<img width="605" alt="Screenshot 2023-11-23 at 20 11 47" src="https://github.com/apollographql/apollo-kotlin/assets/372852/d598571c-ab4d-4639-9a9c-776f71648d42">

----
Note: this also changes the return types of `Optional.absent()` and `Optional.present()`.