### PR TITLE
Remove kotlin-labs-0.1

### DIFF
--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -242,3 +242,5 @@ It is not possible to create a `Schema` from a File or String directly anymore. 
 ## Removed RxJava artifacts
 
 * Use `toFlow().asFlowable()` and [`kotlinx-coroutines-rx2`](https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx2) or [`kotlinx-coroutines-rx3`](https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx3)
+
+## KotlinLabs 0.1 is not supported anymore

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -768,9 +768,8 @@ public final class com/apollographql/apollo3/ast/GqldirectiveKt {
 }
 
 public final class com/apollographql/apollo3/ast/GqldocumentKt {
-	public static final fun apolloDefinitions ()Ljava/util/List;
-	public static final fun apolloDefinitions (Ljava/lang/String;)Ljava/util/List;
 	public static final fun builtinDefinitions ()Ljava/util/List;
+	public static final fun kotlinLabsDefinitions (Ljava/lang/String;)Ljava/util/List;
 	public static final fun linkDefinitions ()Ljava/util/List;
 	public static final fun toSchema (Lcom/apollographql/apollo3/ast/GQLDocument;)Lcom/apollographql/apollo3/ast/Schema;
 	public static final fun withBuiltinDefinitions (Lcom/apollographql/apollo3/ast/GQLDocument;)Lcom/apollographql/apollo3/ast/GQLDocument;

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -3,8 +3,7 @@ package com.apollographql.apollo3.ast
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.internal.ExtensionsMerger
-import com.apollographql.apollo3.ast.internal.apollo_v0_1_definitionsStr
-import com.apollographql.apollo3.ast.internal.apollo_v0_2_definitionsStr
+import com.apollographql.apollo3.ast.internal.apolloDefinitionsStr
 import com.apollographql.apollo3.ast.internal.builtinsDefinitionsStr
 import com.apollographql.apollo3.ast.internal.ensureSchemaDefinition
 import com.apollographql.apollo3.ast.internal.linkDefinitionsStr
@@ -79,18 +78,13 @@ fun builtinDefinitions() = definitionsFromString(builtinsDefinitionsStr)
  */
 fun linkDefinitions() = definitionsFromString(linkDefinitionsStr)
 
-@Deprecated("Use apolloDefinitions(version) instead", ReplaceWith("apolloDefinitions(\"v0.1\")"))
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_5_1)
-fun apolloDefinitions() = definitionsFromString(apollo_v0_1_definitionsStr)
-
 /**
  * Extra apollo specific definitions from https://specs.apollo.dev/kotlin_labs/<[version]>
  */
-fun apolloDefinitions(version: String): List<GQLDefinition> {
+fun kotlinLabsDefinitions(version: String): List<GQLDefinition> {
   return definitionsFromString(when (version) {
-    "v0.1" -> apollo_v0_1_definitionsStr
-    "v0.2" -> apollo_v0_2_definitionsStr
-    else -> error("Apollo definitions $version are not supported")
+    "v0.2" -> apolloDefinitionsStr
+    else -> error("kotlin_labs/$version definitions are not supported, please use v0.2")
   })
 }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/SchemaValidationScope.kt
@@ -35,7 +35,7 @@ import com.apollographql.apollo3.ast.OtherValidationIssue
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.Schema.Companion.TYPE_POLICY
 import com.apollographql.apollo3.ast.IncompatibleDirectiveDefinition
-import com.apollographql.apollo3.ast.apolloDefinitions
+import com.apollographql.apollo3.ast.kotlinLabsDefinitions
 import com.apollographql.apollo3.ast.builtinDefinitions
 import com.apollographql.apollo3.ast.canHaveKeyFields
 import com.apollographql.apollo3.ast.combineDefinitions
@@ -61,7 +61,7 @@ internal fun validateSchema(definitions: List<GQLDefinition>, requiresApolloDefi
 
   var directivesToStrip = foreignSchemas.flatMap { it.directivesToStrip }
 
-  val apolloDefinitions = apolloDefinitions("v0.2")
+  val apolloDefinitions = kotlinLabsDefinitions("v0.2")
 
   if (requiresApolloDefinitions && foreignSchemas.none { it.name == "kotlin_labs" }) {
     /**
@@ -246,7 +246,7 @@ private class ForeignSchema(
 /**
  * Parses the schema extensions
  *
- * Example: extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", import: ["@nonnull"])
+ * Example: extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@nonnull"])
  */
 private fun List<GQLSchemaExtension>.getForeignSchemas(
     issues: MutableList<Issue>,
@@ -330,7 +330,7 @@ private fun List<GQLSchemaExtension>.getForeignSchemas(
 
 
         if (foreignName == "kotlin_labs") {
-          val (definitions, renames) = apolloDefinitions(version).rename(mappings, prefix)
+          val (definitions, renames) = kotlinLabsDefinitions(version).rename(mappings, prefix)
           foreignSchemas.add(
               ForeignSchema(
                   name = foreignName,

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/definitions.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/definitions.kt
@@ -7,54 +7,7 @@ package com.apollographql.apollo3.ast.internal
  * - link.graphqls: the [core schemas](https://specs.apollo.dev/link/v1.0/) definitions.
  * - apollo-${version}.graphqls: the client directives supported by Apollo Kotlin. Changes are versioned at https://github.com/apollographql/specs. Changing them requires a new version and a PR.
  */
-
-internal val apollo_v0_1_definitionsStr = """
-  # Marks a field or variable definition as optional or required
-  # By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
-  # but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value
-  directive @optional(if: Boolean = true) on FIELD | VARIABLE_DEFINITION
-
-  # Marks a field as non-null. The corresponding Kotlin property will be made non-nullable even if the GraphQL type is nullable.
-  # When used on an object definition in a schema document, `fields` must be non-empty and contain a selection set of fields that should be non-null
-  # When used on a field from an executable document, `fields` must always be empty
-  #
-  # Setting the directive at the schema level is usually easier as there is little reason that a field would be non-null in one place
-  # and null in the other
-  directive @nonnull(fields: String! = "") on OBJECT | FIELD
-
-  # Attach extra information to a given type
-  # `keyFields`: a selection set containing fields used to compute the cache key of an object. Order is important.
-  # `embeddedFields`: a selection set containing fields that shouldn't create a new cache Record and should be
-  # embedded in their parent instead. Order is unimportant.
-  directive @typePolicy(keyFields: String! = "", embeddedFields: String! = "") on OBJECT | INTERFACE | UNION
-
-  # Attach extra information to a given field
-  # `keyArgs`: a list of arguments used to compute the cache key of the object this field is pointing to. 
-  # The list is parsed as a selection set: both spaces and comas are valid separators.
-  # `paginationArgs` (experimental): a list of arguments that vary when requesting different pages. 
-  # These arguments are omitted when computing the cache key of this field.
-  # The list is parsed as a selection set: both spaces and comas are valid separators.
-  directive @fieldPolicy(forField: String!, keyArgs: String! = "", paginationArgs: String! = "") repeatable on OBJECT
-
-  ""${'"'}
-  Indicates that the given field, argument, input field or enum value requires
-  giving explicit consent before being used.
-  ""${'"'}
-  directive @requiresOptIn(feature: String!) repeatable
-  on FIELD_DEFINITION
-      | ARGUMENT_DEFINITION
-      | INPUT_FIELD_DEFINITION
-      | ENUM_VALUE
-
-  # Use the specified name in the generated code instead of the GraphQL name.
-  # Use this for instance when the name would clash with a reserved keyword or field in the generated code.
-  # This directive is experimental.
-  directive @targetName(name: String!)
-  on OBJECT
-      | ENUM_VALUE
-""".trimIndent()
-
-internal val apollo_v0_2_definitionsStr = """
+internal val apolloDefinitionsStr = """
   ""${'"'}
   Marks a field or variable definition as optional or required
   By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -20,8 +20,8 @@ import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.UnknownDirective
 import com.apollographql.apollo3.ast.UnusedFragment
 import com.apollographql.apollo3.ast.UnusedVariable
-import com.apollographql.apollo3.ast.apolloDefinitions
 import com.apollographql.apollo3.ast.checkEmpty
+import com.apollographql.apollo3.ast.kotlinLabsDefinitions
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.pretty
 import com.apollographql.apollo3.ast.toGQLDocument
@@ -563,7 +563,7 @@ internal fun List<Issue>.group(
   val ignored = mutableListOf<Issue>()
   val warnings = mutableListOf<Issue>()
   val errors = mutableListOf<Issue>()
-  val apolloDirectives = apolloDefinitions("v0.1").mapNotNull { (it as? GQLDirectiveDefinition)?.name }.toSet()
+  val apolloDirectives = kotlinLabsDefinitions("v0.2").mapNotNull { (it as? GQLDirectiveDefinition)?.name }.toSet()
 
   forEach {
     val severity = when (it) {

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/extendsSchema.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/extendsSchema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
 
 type Query {
   node: Node

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/interfacesWithoutKeyFields.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/interfacesWithoutKeyFields.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
 
 type Query {
   book: Book!

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/nonexistentKeyField.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/nonexistentKeyField.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
 
 type Query {
   animal: Animal

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/objectAndInterfaceTypePolicySchema.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/objectAndInterfaceTypePolicySchema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy", "@keyFields"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy", "@keyFields"])
 
 type Query {
   node: Node

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/objectInheritingTwoInterfaces.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/objectInheritingTwoInterfaces.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
 
 type Query {
   book: Book!

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/schema.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/", import: ["@typePolicy"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
 
 type Query {
   book: Book!

--- a/libraries/apollo-compiler/src/test/validation/operation/default_namespace/schema.graphqls
+++ b/libraries/apollo-compiler/src/test/validation/operation/default_namespace/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1")
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2")
 
 type Query {
     field: String

--- a/libraries/apollo-compiler/src/test/validation/operation/definition_renames/schema.graphqls
+++ b/libraries/apollo-compiler/src/test/validation/operation/definition_renames/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", as: "apollo", import: ["@optional", { name: "@nonnull", as: "@my_nonnull" }])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", as: "apollo", import: ["@optional", { name: "@nonnull", as: "@my_nonnull" }])
 
 type Query {
     field: String

--- a/tests/deprecated-requires-opt-in/graphql/schema.graphqls
+++ b/tests/deprecated-requires-opt-in/graphql/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1", import: ["@requiresOptIn"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2", import: ["@requiresOptIn"])
 
 type Query {
   newField(input: SomeInput! @experimental): Direction! @requiresOptIn(feature: "experimental")


### PR DESCRIPTION
We don't need to support 2 versions of `kotlin-labs` in the codegen. `v0.2` is a superset of `v0.1`

If you were using 

```kotlin
extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.1/")
```

you now need to link v0.2:

```kotlin
extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/")
```
