### PR TITLE
Revive dataAssertNoErrors

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -102,10 +102,13 @@ private constructor(
    * to implement something like `ApolloResponse<D>.assertNoErrors(): ApolloResponse<D & Any>`
    */
   @get:JvmName("dataAssertNoErrors")
-  @Deprecated(message = "Use dataOrThrow instead", replaceWith = ReplaceWith("dataOrThrow()"))
   val dataAssertNoErrors: D
     get() {
-      return dataOrThrow()
+      return when {
+        hasErrors() -> throw ApolloGraphQLException(errors!!.first())
+        exception != null -> throw DefaultApolloException("An exception happened", exception)
+        else -> dataOrThrow()
+      }
     }
 
   /**


### PR DESCRIPTION
The semantics are subtly different from `dataOrThrow()`:

* `dataAssertNoErrors` fails on GraphQL errors
* `dataOrThrow()` fails if `data` is null

They are equivalent only for `@catch(to: THROW)` schemas.