### PR TITLE
Add a few symbols as ERROR deprecation for the migration

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -289,6 +289,7 @@ public final class com/apollographql/apollo3/api/CompiledCondition {
 }
 
 public final class com/apollographql/apollo3/api/CompiledField : com/apollographql/apollo3/api/CompiledSelection {
+	public final fun argumentValue (Ljava/lang/String;Lcom/apollographql/apollo3/api/Executable$Variables;)Lcom/apollographql/apollo3/api/Optional;
 	public final fun getAlias ()Ljava/lang/String;
 	public final fun getArguments ()Ljava/util/List;
 	public final fun getCondition ()Ljava/util/List;
@@ -298,7 +299,7 @@ public final class com/apollographql/apollo3/api/CompiledField : com/apollograph
 	public final fun getType ()Lcom/apollographql/apollo3/api/CompiledType;
 	public final fun nameWithArguments (Lcom/apollographql/apollo3/api/Executable$Variables;)Ljava/lang/String;
 	public final fun newBuilder ()Lcom/apollographql/apollo3/api/CompiledField$Builder;
-	public final fun resolveArgument (Ljava/lang/String;Lcom/apollographql/apollo3/api/Executable$Variables;)Lcom/apollographql/apollo3/api/Optional;
+	public final fun resolveArgument (Ljava/lang/String;Lcom/apollographql/apollo3/api/Executable$Variables;)Ljava/lang/Object;
 }
 
 public final class com/apollographql/apollo3/api/CompiledField$Builder {
@@ -412,6 +413,9 @@ public final class com/apollographql/apollo3/api/CustomScalarAdapters$Key : com/
 public final class com/apollographql/apollo3/api/CustomScalarType : com/apollographql/apollo3/api/CompiledNamedType {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun getClassName ()Ljava/lang/String;
+}
+
+public abstract interface class com/apollographql/apollo3/api/CustomTypeAdapter {
 }
 
 public class com/apollographql/apollo3/api/DefaultFakeResolver : com/apollographql/apollo3/api/FakeResolver {

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Adapters.kt
@@ -2,6 +2,7 @@
 
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
@@ -453,3 +454,16 @@ fun <T> Adapter<T>.errorAware(): Adapter<T> = ErrorAwareAdapter(this)
 
 @JvmName("-catchToNull")
 fun <T> Adapter<T>.catchToNull(): Adapter<T?> = CatchToNullAdapter(this)
+
+/**
+ * A replica of Apollo Android v2's CustomTypeAdapter, to ease migration from v2 to v3.
+ *
+ * Make your CustomTypeAdapters implement this interface by updating the imports
+ * from `com.apollographql.apollo.api` to `com.apollographql.apollo3.api`.
+ *
+ * **Note**: [Adapter]s are called from multiple threads and implementations must be thread safe.
+ */
+@Deprecated("Used for backward compatibility with 2.x, use Adapter instead", level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+interface CustomTypeAdapter<T> {
+}

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/CompiledGraphQL.kt
@@ -34,7 +34,21 @@ class CompiledField internal constructor(
    * @return [Optional.Absent] if no runtime value is present for this argument else returns the argument
    * value with variables substituted for their values.
    */
+  @Deprecated("This function does not distinguish between null and absent arguments. Use argumentValue instead", ReplaceWith("argumentValue(name = name, variables = variables)"))
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   fun resolveArgument(
+      name: String,
+      variables: Executable.Variables,
+  ): Any? {
+    return argumentValue(name, variables).getOrNull()
+  }
+  /**
+   * Resolves field argument value by [name].
+   *
+   * @return [Optional.Absent] if no runtime value is present for this argument else returns the argument
+   * value with variables substituted for their values.
+   */
+  fun argumentValue(
       name: String,
       variables: Executable.Variables,
   ): Optional<ApolloJsonElement> {
@@ -62,7 +76,7 @@ class CompiledField internal constructor(
    * Absent arguments are not returned
    */
   @ApolloExperimental
-  fun resolveArguments(variables: Executable.Variables, filter: (CompiledArgument) -> Boolean= {true}): Map<String, ApolloJsonElement> {
+  fun argumentValues(variables: Executable.Variables, filter: (CompiledArgument) -> Boolean= {true}): Map<String, ApolloJsonElement> {
     val arguments = arguments.filter(filter).filter { it.value is Optional.Present<*> }
     if (arguments.isEmpty()) {
       return emptyMap()
@@ -79,7 +93,7 @@ class CompiledField internal constructor(
    * This is mostly used internally to compute records
    */
   fun nameWithArguments(variables: Executable.Variables): String {
-    val arguments = resolveArguments(variables) { !it.isPagination }
+    val arguments = argumentValues(variables) { !it.isPagination }
     if (arguments.isEmpty()) {
       return name
     }

--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -17,6 +17,8 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockRequest
 
 public final class com/apollographql/apollo3/mockserver/MockResponse {
 	public fun <init> ()V
+	public fun <init> (ILkotlinx/coroutines/flow/Flow;Ljava/util/Map;J)V
+	public synthetic fun <init> (ILkotlinx/coroutines/flow/Flow;Ljava/util/Map;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBody ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getDelayMillis ()J
 	public final fun getHeaders ()Ljava/util/Map;

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockResponse.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockResponse.kt
@@ -1,12 +1,16 @@
 package com.apollographql.apollo3.mockserver
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 
-class MockResponse internal constructor(
+class MockResponse
+@Deprecated("Use MockResponse.Builder instead", ReplaceWith("MockResponse.Builder().statusCode(statusCode).headers(headers).body(body).delayMillis(delayMillis).build()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_3_1)
+constructor(
     val statusCode: Int = 200,
     val body: Flow<ByteString> = emptyFlow(),
     val headers: Map<String, String> = mapOf("Content-Length" to "0"),
@@ -48,6 +52,8 @@ class MockResponse internal constructor(
 
     fun build(): MockResponse {
       val headersWithContentLength = if (contentLength == null) headers else headers + mapOf("Content-Length" to contentLength.toString())
+      // https://youtrack.jetbrains.com/issue/KT-34480
+      @Suppress("DEPRECATION_ERROR")
       return MockResponse(statusCode = statusCode, body = body, headers = headersWithContentLength, delayMillis = delayMillis)
     }
   }

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKey.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKey.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.cache.normalized.api
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import kotlin.jvm.JvmStatic
 
 /**
@@ -69,5 +70,19 @@ class CacheKey constructor(val key: String) {
     fun rootKey(): CacheKey {
       return ROOT_CACHE_KEY
     }
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    @Deprecated("Use the constructor instead", ReplaceWith("CacheKey(typename, values)"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+    fun from(typename: String, values: List<String>) = CacheKey(typename, values)
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    @Deprecated("Use the constructor instead", ReplaceWith("CacheKey(typename, values)"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+    fun from(typename: String, vararg values: String) = CacheKey(typename, values.toList())
   }
 }

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -197,7 +197,7 @@ object FieldPolicyCacheResolver : CacheResolver {
       parent: Map<String, @JvmSuppressWildcards Any?>,
       parentId: String,
   ): Any? {
-    val keyArgsValues = field.resolveArguments(variables) { it.isKey }.values.map { it.toString() }
+    val keyArgsValues = field.argumentValues(variables) { it.isKey }.values.map { it.toString() }
 
     if (keyArgsValues.isNotEmpty()) {
       return CacheKey(field.type.rawType().name, keyArgsValues)

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/MetadataGenerator.kt
@@ -15,11 +15,11 @@ class MetadataGeneratorContext(
     val variables: Executable.Variables,
 ) {
   fun argumentValue(argumentName: String): Any? {
-    return field.resolveArgument(argumentName, variables).getOrNull()
+    return field.argumentValue(argumentName, variables).getOrNull()
   }
 
   fun allArgumentValues(): Map<String, Any?> {
-    return field.resolveArguments(variables) { !it.isPagination }
+    return field.argumentValues(variables) { !it.isPagination }
   }
 }
 

--- a/libraries/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
+++ b/libraries/apollo-normalized-cache-api/api/apollo-normalized-cache-api.api
@@ -43,6 +43,8 @@ public final class com/apollographql/apollo3/cache/normalized/api/CacheKey {
 public final class com/apollographql/apollo3/cache/normalized/api/CacheKey$Companion {
 	public final fun canDeserialize (Ljava/lang/String;)Z
 	public final fun deserialize (Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;
+	public final fun from (Ljava/lang/String;Ljava/util/List;)Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;
+	public final fun from (Ljava/lang/String;[Ljava/lang/String;)Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;
 	public final fun rootKey ()Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;
 }
 

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKey.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheKey.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.cache.normalized.api
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import kotlin.jvm.JvmStatic
 
 /**
@@ -68,5 +69,19 @@ class CacheKey constructor(val key: String) {
     fun rootKey(): CacheKey {
       return ROOT_CACHE_KEY
     }
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    @Deprecated("Use the constructor instead", ReplaceWith("CacheKey(typename, values)"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+    fun from(typename: String, values: List<String>) = CacheKey(typename, values)
+
+    /**
+     * Helper function to build a cache key from a list of strings
+     */
+    @Deprecated("Use the constructor instead", ReplaceWith("CacheKey(typename, values)"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+    fun from(typename: String, vararg values: String) = CacheKey(typename, values.toList())
   }
 }

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/CacheResolver.kt
@@ -176,7 +176,7 @@ object FieldPolicyCacheResolver : CacheResolver {
       parent: Map<String, @JvmSuppressWildcards Any?>,
       parentId: String,
   ): Any? {
-    val keyArgsValues = field.resolveArguments(variables) {it.isKey }.values.map { it.toString() }
+    val keyArgsValues = field.argumentValues(variables) {it.isKey }.values.map { it.toString() }
 
     if (keyArgsValues.isNotEmpty()) {
       return CacheKey(field.type.rawType().name, keyArgsValues)

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -644,3 +644,13 @@ fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: Ca
 
 val <D : Operation.Data> ApolloResponse<D>.cacheHeaders
   get() = executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE
+
+/**
+ * Gets the result from the cache first and always fetch from the network. Use this to get an early
+ * cached result while also updating the network values.
+ *
+ * Any [FetchPolicy] previously set will be ignored
+ */
+@Deprecated("Use fetchPolicy(FetchPolicy.CacheAndNetwork) instead", ReplaceWith("fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_7_5)
+fun <D : Query.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> = TODO()

--- a/libraries/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/libraries/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -100,6 +100,7 @@ public final class com/apollographql/apollo3/cache/normalized/NormalizedCache {
 	public static synthetic fun configureApolloClientBuilder$default (Lcom/apollographql/apollo3/ApolloClient$Builder;Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCacheFactory;Lcom/apollographql/apollo3/cache/normalized/api/CacheKeyGenerator;Lcom/apollographql/apollo3/cache/normalized/api/CacheResolver;ZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun doNotStore (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
 	public static final fun emitCacheMisses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Lcom/apollographql/apollo3/api/MutableExecutionOptions;
+	public static final fun executeCacheAndNetwork (Lcom/apollographql/apollo3/ApolloCall;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun fetchPolicy (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/cache/normalized/FetchPolicy;)Ljava/lang/Object;
 	public static final fun fetchPolicyInterceptor (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Ljava/lang/Object;
 	public static final fun getApolloStore (Lcom/apollographql/apollo3/ApolloClient;)Lcom/apollographql/apollo3/cache/normalized/ApolloStore;

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -617,3 +617,13 @@ fun <D : Operation.Data> ApolloResponse.Builder<D>.cacheHeaders(cacheHeaders: Ca
 
 val <D : Operation.Data> ApolloResponse<D>.cacheHeaders
   get() = executionContext[CacheHeadersContext]?.value ?: CacheHeaders.NONE
+
+/**
+ * Gets the result from the cache first and always fetch from the network. Use this to get an early
+ * cached result while also updating the network values.
+ *
+ * Any [FetchPolicy] previously set will be ignored
+ */
+@Deprecated("Use fetchPolicy(FetchPolicy.CacheAndNetwork) instead", ReplaceWith("fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_7_5)
+fun <D : Query.Data> ApolloCall<D>.executeCacheAndNetwork(): Flow<ApolloResponse<D>> = TODO()

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -35,6 +35,7 @@ public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apol
 public final class com/apollographql/apollo3/ApolloClient : com/apollographql/apollo3/api/ExecutionOptions, java/io/Closeable {
 	public static final field Companion Lcom/apollographql/apollo3/ApolloClient$Companion;
 	public synthetic fun <init> (Lcom/apollographql/apollo3/network/NetworkTransport;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/network/NetworkTransport;Ljava/util/List;Lcom/apollographql/apollo3/api/ExecutionContext;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun builder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun close ()V
 	public final fun dispose ()V
 	public final fun executeAsFlow (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;
@@ -116,6 +117,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 }
 
 public final class com/apollographql/apollo3/ApolloClient$Companion {
+	public final fun builder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 }
 
 public final class com/apollographql/apollo3/AutoPersistedQueryInfo : com/apollographql/apollo3/api/ExecutionContext$Element {
@@ -144,8 +146,6 @@ public final class com/apollographql/apollo3/ConcurrencyInfo$Key : com/apollogra
 }
 
 public final class com/apollographql/apollo3/ConflatedResponsesKt {
-	public static final fun conflateFetchPolicyInterceptorResponses (Lcom/apollographql/apollo3/api/MutableExecutionOptions;Z)Ljava/lang/Object;
-	public static final fun getConflateFetchPolicyInterceptorResponses (Lcom/apollographql/apollo3/api/ApolloRequest;)Z
 }
 
 public abstract interface class com/apollographql/apollo3/interceptor/ApolloInterceptor {

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
 import okio.Closeable
 import kotlin.jvm.JvmOverloads
+import kotlin.jvm.JvmStatic
 
 /**
  * The main entry point for the Apollo runtime. An [ApolloClient] is responsible for executing queries, mutations and subscriptions
@@ -616,5 +617,10 @@ private constructor(
     return builder.copy()
   }
 
-  companion object
+  companion object {
+    @Deprecated("Used for backward compatibility with 2.x", ReplaceWith("ApolloClient.Builder()"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v3_0_0)
+    @JvmStatic
+    fun builder() = Builder()
+  }
 }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ConflatedResponses.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ConflatedResponses.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.MutableExecutionOptions
@@ -21,6 +22,7 @@ import com.apollographql.apollo3.api.Operation
  */
 @Deprecated("Handle each ApolloResponse.exception instead")
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@ApolloInternal
 fun <T> MutableExecutionOptions<T>.conflateFetchPolicyInterceptorResponses(conflateResponses: Boolean) = addExecutionContext(
     ConflateResponsesContext(conflateResponses)
 )
@@ -32,6 +34,6 @@ internal class ConflateResponsesContext(val conflateResponses: Boolean) : Execut
   companion object Key : ExecutionContext.Key<ConflateResponsesContext>
 }
 
-
+@ApolloInternal
 val <D : Operation.Data> ApolloRequest<D>.conflateFetchPolicyInterceptorResponses
   get() = executionContext[ConflateResponsesContext]?.conflateResponses ?: false

--- a/tests/integration-tests/src/commonTest/kotlin/Utils.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/Utils.kt
@@ -26,7 +26,7 @@ fun assertEquals2(actual: Any?, expected: Any?) = assertEquals(expected, actual)
  */
 object IdCacheResolver: CacheResolver {
   override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
-    val id = field.resolveArgument("id", variables).getOrNull()?.toString()
+    val id = field.argumentValue("id", variables).getOrNull()?.toString()
     if (id != null) {
       return CacheKey(id)
     }

--- a/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/declarativecache/DeclarativeCacheTest.kt
@@ -99,7 +99,7 @@ class DeclarativeCacheTest {
       override fun resolveField(field: CompiledField, variables: Executable.Variables, parent: Map<String, Any?>, parentId: String): Any? {
         if (field.name == "books") {
           @Suppress("UNCHECKED_CAST")
-          val isbns = field.resolveArgument("isbns", variables).getOrThrow() as? List<String>
+          val isbns = field.argumentValue("isbns", variables).getOrThrow() as? List<String>
           if (isbns != null) {
             return isbns.map { CacheKey(field.type.rawType().name, listOf(it)) }
           }


### PR DESCRIPTION
A few symbols were removed without going through `ERROR` deprecation. Keep them around for a bit more time