### PR TITLE
Remove MockServer(port) as it clashes with 3.x MockServer(timeout)

### DIFF
--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -70,9 +70,7 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static final fun MockServer (I)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static synthetic fun MockServer$default (IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -16,7 +16,6 @@ import okio.ByteString
 import okio.ByteString.Companion.encodeUtf8
 import okio.Closeable
 import kotlin.js.JsName
-import kotlin.jvm.JvmOverloads
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -249,11 +248,10 @@ internal class MockServerImpl(
 }
 
 @JsName("createMockServer")
-@JvmOverloads
-fun MockServer(port: Int = 0): MockServer = MockServerImpl(
+fun MockServer(): MockServer = MockServerImpl(
     QueueMockServerHandler(),
     true,
-    TcpServer(port),
+    TcpServer(0),
     null)
 
 @Deprecated("Use MockServer.Builder() instead", level = DeprecationLevel.ERROR)


### PR DESCRIPTION
See [here](https://github.com/apollographql/apollo-kotlin/pull/5418/files#diff-79bdedd59fc1530b6d765978a0aa9a15053e0f614d681a2c338e8e15500119c0L57) for an example