### PR TITLE
[api] remove some of the ApolloResponse.Builders

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -106,9 +106,8 @@ public final class com/apollographql/apollo3/api/ApolloResponse {
 }
 
 public final class com/apollographql/apollo3/api/ApolloResponse$Builder {
+	public fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;)V
 	public fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation$Data;)V
-	public fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/List;Ljava/util/Map;)V
-	public fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/exception/ApolloException;)V
 	public final fun addExecutionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;
 	public final fun build ()Lcom/apollographql/apollo3/api/ApolloResponse;
 	public final fun data (Lcom/apollographql/apollo3/api/Operation$Data;)Lcom/apollographql/apollo3/api/ApolloResponse$Builder;

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloGraphQLException
 import com.apollographql.apollo3.exception.DefaultApolloException
@@ -137,36 +138,23 @@ private constructor(
     private var isLast = false
 
     /**
-     * Constructs a successful response with a valid data, no errors nor extensions
-     */
-    constructor(
-        operation: Operation<D>,
-        requestUuid: Uuid,
-        data: D,
-    ): this(operation, requestUuid, data, null, null, null)
-
-    /**
-     * Constructs a response from data, errors and extensions
+     * Construct a new [Builder] that doesn't contain data, errors nor exception
      *
-     * If there are GraphQL errors, they will also be forwarded to [exception] so that the caller can do all the
-     * checking in a single place
+     * While possible, this case is probably symptomatic of a buggy GraphQL implementation
+     * that returned no data while not setting any error
      */
     constructor(
         operation: Operation<D>,
         requestUuid: Uuid,
-        data: D?,
-        errors: List<Error>?,
-        extensions: Map<String, Any?>?,
-    ): this(operation, requestUuid, data, errors, extensions, null)
+    ): this(operation, requestUuid, null, null, null, null)
 
-    /**
-     * Constructs an exception response
-     */
+    @Deprecated("Use 2 params constructor instead", ReplaceWith("Builder(operation = operation, requestUuid = requestUuid).data(data = data)"))
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
     constructor(
         operation: Operation<D>,
         requestUuid: Uuid,
-        exception: ApolloException
-    ): this(operation, requestUuid, null, null, null, exception)
+        data: D?
+    ): this(operation, requestUuid, data, null, null, null)
 
     fun addExecutionContext(executionContext: ExecutionContext) = apply {
       this.executionContext = this.executionContext + executionContext

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Error.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
  * See https://spec.graphql.org/draft/#sec-Errors.Error-result-format
  */
 class Error
-@Deprecated("Use Error.Builder instead")
+@Deprecated("Use Error.Builder instead", ReplaceWith("Builder(message = message).locations(locations).path(path).extensions(extensions)"))
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 constructor(
     /**

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -120,7 +120,8 @@ fun <D : Operation.Data> Operation<D>.parseResponse(
           cause = throwable
       )
     }
-    return ApolloResponse.Builder(requestUuid = requestUuid ?: uuid4(), operation = this, exception = apolloException)
+    return ApolloResponse.Builder(requestUuid = requestUuid ?: uuid4(), operation = this)
+        .exception(exception = apolloException)
         .isLast(true)
         .build()
   }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
@@ -44,7 +44,11 @@ internal object ResponseParser {
 
     jsonReader.endObject()
 
-    return ApolloResponse.Builder(requestUuid = requestUuid ?: uuid4(), operation = operation, data = data, errors = errors, extensions = extensions).build()
+    return ApolloResponse.Builder(operation = operation, requestUuid = requestUuid ?: uuid4())
+        .errors(errors)
+        .data(data)
+        .extensions(extensions)
+        .build()
   }
 
   fun parseError(

--- a/libraries/apollo-compose-support-incubating/src/main/java/com/apollographql/apollo3/compose/State.kt
+++ b/libraries/apollo-compose-support-incubating/src/main/java/com/apollographql/apollo3/compose/State.kt
@@ -37,7 +37,7 @@ import kotlin.coroutines.EmptyCoroutineContext
 fun <D : Operation.Data> ApolloCall<D>.toState(context: CoroutineContext = EmptyCoroutineContext): State<ApolloResponse<D>?> {
   val responseFlow = remember {
     toFlow()
-        .catch { emit(ApolloResponse.Builder(operation, uuid4(), it as? ApolloException ?: throw it).build()) }
+        .catch { emit(ApolloResponse.Builder(operation, uuid4()).exception(it as? ApolloException ?: throw it).build()) }
   }
   return responseFlow.collectAsState(initial = null, context = context)
 }
@@ -62,7 +62,7 @@ fun <D : Operation.Data> ApolloCall<D>.toState(context: CoroutineContext = Empty
 fun <D : Query.Data> ApolloCall<D>.watchAsState(context: CoroutineContext = EmptyCoroutineContext): State<ApolloResponse<D>?> {
   val responseFlow = remember {
     watch()
-        .catch { emit(ApolloResponse.Builder(operation, uuid4(), it as? ApolloException ?: throw it).build()) }
+        .catch { emit(ApolloResponse.Builder(operation, uuid4()).exception(it as? ApolloException ?: throw it).build()) }
   }
   return responseFlow.collectAsState(initial = null, context = context)
 }

--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -70,9 +70,7 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static final fun MockServer (I)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
-	public static synthetic fun MockServer$default (IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V

--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -70,7 +70,9 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static final fun MockServer (I)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static synthetic fun MockServer$default (IILjava/lang/Object;)Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -179,7 +179,8 @@ internal object FetchPolicyRouterInterceptor : ApolloInterceptor {
         }
 
         emit(
-            ApolloResponse.Builder(request.operation, request.requestUuid, exception)
+            ApolloResponse.Builder(request.operation, request.requestUuid)
+                .exception(exception)
                 .build()
 
         )

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -215,8 +215,8 @@ internal class ApolloCacheInterceptor(
       return ApolloResponse.Builder(
           requestUuid = request.requestUuid,
           operation = operation,
-          exception = e,
       )
+          .exception(e)
           .addExecutionContext(request.executionContext)
           .cacheInfo(
               CacheInfo.Builder()
@@ -233,10 +233,9 @@ internal class ApolloCacheInterceptor(
     return ApolloResponse.Builder(
         requestUuid = request.requestUuid,
         operation = operation,
-        data = data,
-        errors = null,
-        extensions = null
-    ).addExecutionContext(request.executionContext)
+    )
+        .data(data)
+        .addExecutionContext(request.executionContext)
         .cacheInfo(
             CacheInfo.Builder()
                 .cacheStartMillis(startMillis)

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -179,7 +179,8 @@ internal object FetchPolicyRouterInterceptor : ApolloInterceptor {
         }
 
         emit(
-            ApolloResponse.Builder(request.operation, request.requestUuid, exception)
+            ApolloResponse.Builder(request.operation, request.requestUuid)
+                .exception(exception)
                 .build()
 
         )

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -215,8 +215,8 @@ internal class ApolloCacheInterceptor(
       return ApolloResponse.Builder(
           requestUuid = request.requestUuid,
           operation = operation,
-          exception = e,
       )
+          .exception(e)
           .addExecutionContext(request.executionContext)
           .cacheInfo(
               CacheInfo.Builder()
@@ -233,10 +233,8 @@ internal class ApolloCacheInterceptor(
     return ApolloResponse.Builder(
         requestUuid = request.requestUuid,
         operation = operation,
-        data = data,
-        errors = null,
-        extensions = null,
-    ).addExecutionContext(request.executionContext)
+    ).data(data)
+        .addExecutionContext(request.executionContext)
         .cacheInfo(
             CacheInfo.Builder()
                 .cacheStartMillis(startMillis)

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/interceptor/internal/AutoPersistedQueryInterceptor.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/interceptor/internal/AutoPersistedQueryInterceptor.java
@@ -50,7 +50,8 @@ public class AutoPersistedQueryInterceptor implements ApolloInterceptor {
         if (isPersistedQueryNotFound(response.errors)) {
           continueWithDocumentRequest(chain, request, callback);
         } else if (isPersistedQueryNotSupported(response.errors)) {
-          callback.onResponse(new ApolloResponse.Builder<>(request.getOperation(), request.getRequestUuid(), new AutoPersistedQueriesNotSupported())
+          callback.onResponse(new ApolloResponse.Builder<>(request.getOperation(), request.getRequestUuid())
+              .exception(new AutoPersistedQueriesNotSupported())
               .build());
         } else {
           // Cache hit

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/http/HttpNetworkTransport.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/http/HttpNetworkTransport.java
@@ -75,7 +75,8 @@ public class HttpNetworkTransport implements NetworkTransport {
   }
 
   @NotNull private static <D extends Operation.Data> ApolloResponse<D> getExceptionResponse(@NotNull ApolloRequest<D> request, @NotNull ApolloException exception) {
-    return new ApolloResponse.Builder<>(request.getOperation(), request.getRequestUuid(), exception)
+    return new ApolloResponse.Builder<>(request.getOperation(), request.getRequestUuid())
+        .exception(exception)
         .build();
   }
 

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketNetworkTransport.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketNetworkTransport.java
@@ -151,7 +151,8 @@ public class WebSocketNetworkTransport implements NetworkTransport {
       if (subscriptionInfo == null) return;
       ApolloRequest<?> request = subscriptionInfo.request;
       //noinspection unchecked,rawtypes
-      subscriptionInfo.callback.onResponse(new ApolloResponse.Builder(request.getOperation(), request.getRequestUuid(), new SubscriptionOperationException(request.getOperation().name(), payload))
+      subscriptionInfo.callback.onResponse(new ApolloResponse.Builder(request.getOperation(), request.getRequestUuid())
+          .exception(new SubscriptionOperationException(request.getOperation().name(), payload))
           .build());
       disposeSubscription(id);
     }
@@ -190,7 +191,8 @@ public class WebSocketNetworkTransport implements NetworkTransport {
         activeSubscriptions.clear();
         for (SubscriptionInfo subscriptionInfo : activeSubscriptionList) {
           //noinspection unchecked,rawtypes
-          subscriptionInfo.callback.onResponse(new ApolloResponse.Builder(subscriptionInfo.request.getOperation(), subscriptionInfo.request.getRequestUuid(), networkException)
+          subscriptionInfo.callback.onResponse(new ApolloResponse.Builder(subscriptionInfo.request.getOperation(), subscriptionInfo.request.getRequestUuid())
+              .exception(networkException)
               .build());
           subscriptionInfo.disposable.dispose();
         }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/interceptor/AutoPersistedQueryInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/interceptor/AutoPersistedQueryInterceptor.kt
@@ -51,7 +51,8 @@ class AutoPersistedQueryInterceptor(
         }
         isPersistedQueryNotSupported(response.errors) -> {
           emit(
-              ApolloResponse.Builder(request.operation, request.requestUuid, AutoPersistedQueriesNotSupported())
+              ApolloResponse.Builder(request.operation, request.requestUuid)
+                  .exception(AutoPersistedQueriesNotSupported())
                   .build()
           )
           return@flow

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -108,7 +108,8 @@ private constructor(
           cause = throwable
       )
     }
-    return ApolloResponse.Builder(requestUuid = uuid4(), operation = operation, exception = apolloException)
+    return ApolloResponse.Builder(requestUuid = uuid4(), operation = operation,)
+        .exception(apolloException)
         .isLast(true)
         .build()
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/WebSocketNetworkTransport.kt
@@ -340,7 +340,8 @@ private constructor(
   private fun <D : Operation.Data> errorResponse(
       request: ApolloRequest<D>,
       apolloException: ApolloException,
-  ) = ApolloResponse.Builder(requestUuid = request.requestUuid, operation = request.operation, exception = apolloException)
+  ) = ApolloResponse.Builder(requestUuid = request.requestUuid, operation = request.operation)
+      .exception(apolloException)
       .isLast(true)
       .build()
 

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/TestNetworkTransport.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/TestNetworkTransport.kt
@@ -34,7 +34,9 @@ class QueueTestNetworkTransport : NetworkTransport {
 
       val apolloResponse = when (response) {
         is TestResponse.NetworkError -> {
-          ApolloResponse.Builder(operation = request.operation, requestUuid = request.requestUuid, exception = ApolloNetworkException("Network error queued in QueueTestNetworkTransport")).build()
+          ApolloResponse.Builder(operation = request.operation, requestUuid = request.requestUuid)
+              .exception(exception = ApolloNetworkException("Network error queued in QueueTestNetworkTransport"))
+              .build()
         }
 
         is TestResponse.Response -> {
@@ -77,7 +79,9 @@ class MapTestNetworkTransport : NetworkTransport {
 
       val apolloResponse = when (response) {
         is TestResponse.NetworkError -> {
-          ApolloResponse.Builder(operation = request.operation, requestUuid = request.requestUuid, exception = ApolloNetworkException("Network error registered in MapTestNetworkTransport")).build()
+          ApolloResponse.Builder(operation = request.operation, requestUuid = request.requestUuid)
+              .exception(exception = ApolloNetworkException("Network error registered in MapTestNetworkTransport"))
+              .build()
         }
 
         is TestResponse.Response -> {
@@ -119,10 +123,9 @@ fun <D : Operation.Data> ApolloClient.enqueueTestResponse(
     ApolloResponse.Builder(
         operation = operation,
         requestUuid = uuid4(),
-        data = data,
-        errors = errors,
-        extensions = null
     )
+        .data(data)
+        .errors(errors)
         .build()
 )
 
@@ -149,10 +152,9 @@ fun <D : Operation.Data> ApolloClient.registerTestResponse(
     ApolloResponse.Builder(
         operation = operation,
         requestUuid = uuid4(),
-        data = data,
-        errors = errors,
-        extensions = null
     )
+        .data(data)
+        .errors(errors)
         .build()
 )
 

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -299,28 +299,28 @@ class DeferNormalizedCacheTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null))
-            )
-        ).build(),
+        ).data(WithFragmentSpreadsQuery.Data(
+            listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null))
+        )).build(),
 
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
-                    ComputerFields.Screen("Screen", "640x480", null))))
-            )
-        ).build(),
+        ).data(WithFragmentSpreadsQuery.Data(
+            listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                ComputerFields.Screen("Screen", "640x480", null))))
+        )).build(),
 
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
-                    ComputerFields.Screen("Screen", "640x480", null))))
-            )
         )
+            .data(
+                WithFragmentSpreadsQuery.Data(
+                    listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                        ComputerFields.Screen("Screen", "640x480", null))))
+                )
+            )
             .errors(
                 listOf(
                     Error.Builder(message = "Cannot resolve isColor")
@@ -350,19 +350,17 @@ class DeferNormalizedCacheTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null))
-            )
-        ).build(),
+        ).data(WithFragmentSpreadsQuery.Data(
+            listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null))
+        )).build(),
 
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
-                    ComputerFields.Screen("Screen", "640x480", null))))
-            )
-        ).build(),
+        ).data(WithFragmentSpreadsQuery.Data(
+            listOf(WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                ComputerFields.Screen("Screen", "640x480", null))))
+        )).build(),
     )
 
     apolloClient = ApolloClient.Builder()
@@ -378,7 +376,8 @@ class DeferNormalizedCacheTest {
                     emit(networkResponse as ApolloResponse<D>)
                   }
                   delay(10)
-                  emit(ApolloResponse.Builder(requestUuid = uuid, operation = query, exception = ApolloNetworkException("Network error"))
+                  emit(ApolloResponse.Builder(requestUuid = uuid, operation = query)
+                      .exception(ApolloNetworkException("Network error"))
                       .isLast(true)
                       .build() as ApolloResponse<D>)
                 }

--- a/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
@@ -173,18 +173,18 @@ class DeferTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(
-                    WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null),
-                    WithFragmentSpreadsQuery.Computer("Computer", "Computer2", null),
-                )
+        ).data(WithFragmentSpreadsQuery.Data(
+            listOf(
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer1", null),
+                WithFragmentSpreadsQuery.Computer("Computer", "Computer2", null),
             )
-        ).build(),
+        )).build(),
 
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
+        ).data(
+            WithFragmentSpreadsQuery.Data(
                 listOf(
                     WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
                         ComputerFields.Screen("Screen", "640x480", null))),
@@ -196,14 +196,16 @@ class DeferTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
-                listOf(
-                    WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
-                        ComputerFields.Screen("Screen", "640x480", null))),
-                    WithFragmentSpreadsQuery.Computer("Computer", "Computer2", null),
-                )
-            )
         )
+            .data(
+                WithFragmentSpreadsQuery.Data(
+                    listOf(
+                        WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
+                            ComputerFields.Screen("Screen", "640x480", null))),
+                        WithFragmentSpreadsQuery.Computer("Computer", "Computer2", null),
+                    )
+                )
+            )
             .errors(
                 listOf(
                     Error.Builder(message = "Cannot resolve isColor")
@@ -217,7 +219,8 @@ class DeferTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
+        ).data(
+            WithFragmentSpreadsQuery.Data(
                 listOf(
                     WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
                         ComputerFields.Screen("Screen", "640x480", null))),
@@ -230,7 +233,8 @@ class DeferTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = WithFragmentSpreadsQuery.Data(
+        ).data(
+            WithFragmentSpreadsQuery.Data(
                 listOf(
                     WithFragmentSpreadsQuery.Computer("Computer", "Computer1", ComputerFields("386", 1993,
                         ComputerFields.Screen("Screen", "640x480", null))),

--- a/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferWithRouterTest.kt
@@ -275,23 +275,27 @@ class DeferWithRouterTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = HandlesErrorsThrownInDeferredFragmentsQuery.Data(
-                HandlesErrorsThrownInDeferredFragmentsQuery.Computer(
-                    "Computer", "Computer1", null
+        )
+            .data(
+                HandlesErrorsThrownInDeferredFragmentsQuery.Data(
+                    HandlesErrorsThrownInDeferredFragmentsQuery.Computer(
+                        "Computer", "Computer1", null
+                    )
                 )
             )
-        )
             .build(),
 
         ApolloResponse.Builder(
             query,
             uuid,
-            data = HandlesErrorsThrownInDeferredFragmentsQuery.Data(
-                HandlesErrorsThrownInDeferredFragmentsQuery.Computer(
-                    "Computer", "Computer1", ComputerErrorField(null)
+        )
+            .data(
+                HandlesErrorsThrownInDeferredFragmentsQuery.Data(
+                    HandlesErrorsThrownInDeferredFragmentsQuery.Computer(
+                        "Computer", "Computer1", ComputerErrorField(null)
+                    )
                 )
             )
-        )
             .errors(
                 listOf(
                     Error.Builder(message = "Subgraph errors redacted")
@@ -319,7 +323,8 @@ class DeferWithRouterTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Data(
+        ).data(
+            HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Data(
                 HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Computer(
                     "Computer", "Computer1", null
                 )
@@ -330,12 +335,14 @@ class DeferWithRouterTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Data(
-                HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Computer(
-                    "Computer", "Computer1", null
+        )
+            .data(
+                HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Data(
+                    HandlesNonNullableErrorsThrownInDeferredFragmentsQuery.Computer(
+                        "Computer", "Computer1", null
+                    )
                 )
             )
-        )
             .errors(listOf(Error.Builder(message = "Subgraph errors redacted").build()))
             .build(),
     )
@@ -355,7 +362,8 @@ class DeferWithRouterTest {
         ApolloResponse.Builder(
             query,
             uuid,
-            data = HandlesNonNullableErrorsThrownOutsideDeferredFragmentsQuery.Data(
+        ).data(
+            HandlesNonNullableErrorsThrownOutsideDeferredFragmentsQuery.Data(
                 null
             )
         )

--- a/tests/test-network-transport/src/test/kotlin/testnetworktransport/CustomTestNetworkTransportHandlerTest.kt
+++ b/tests/test-network-transport/src/test/kotlin/testnetworktransport/CustomTestNetworkTransportHandlerTest.kt
@@ -41,7 +41,8 @@ class CustomTestNetworkTransportHandlerTest {
           ApolloResponse.Builder(
               operation = GetHeroQuery("mock"),
               requestUuid = request.requestUuid,
-              data = GetHeroQuery.Data {
+          ).data(
+              GetHeroQuery.Data {
                 hero = buildDroid {
                   name = "Droid ${counter++}"
                 }
@@ -67,7 +68,7 @@ class CustomTestNetworkTransportHandlerTest {
   @Test
   fun registerAndQueueMethodsFail() = runTest(before = { setUp() }, after = { tearDown() }) {
     assertFailsWith(IllegalStateException::class) {
-      apolloClient.enqueueTestResponse(ApolloResponse.Builder(GetHeroQuery("id"), uuid4(), DefaultApolloException()).build())
+      apolloClient.enqueueTestResponse(ApolloResponse.Builder(GetHeroQuery("id"), uuid4()).exception( DefaultApolloException()).build())
     }
     assertFailsWith(IllegalStateException::class) {
       apolloClient.registerTestResponse(GetHeroQuery("id"), null)

--- a/tests/test-network-transport/src/test/kotlin/testnetworktransport/MapTestNetworkTransportHandlerTest.kt
+++ b/tests/test-network-transport/src/test/kotlin/testnetworktransport/MapTestNetworkTransportHandlerTest.kt
@@ -33,16 +33,13 @@ class MapTestNetworkTransportHandlerTest {
     val query1 = GetHeroQuery("001")
     val testResponse1 = ApolloResponse.Builder(
         operation = query1,
-        requestUuid = uuid4(),
-        data = null,
-        errors = listOf(
-            Error.Builder(message = "There was an error")
-                .locations(listOf(Error.Location(line = 1, column = 2)))
-                .path(listOf("hero", "name"))
-                .build()
-        ),
-        extensions = null
-    ).build()
+        requestUuid = uuid4()
+    ).errors(listOf(
+        Error.Builder(message = "There was an error")
+            .locations(listOf(Error.Location(line = 1, column = 2)))
+            .path(listOf("hero", "name"))
+            .build()
+    )).build()
 
     val query2 = GetHeroQuery("002")
     val query2TestData = GetHeroQuery.Data(
@@ -54,10 +51,11 @@ class MapTestNetworkTransportHandlerTest {
             onHuman = null
         )
     )
-    val testResponse2 = ApolloResponse.Builder(query2, uuid4(), query2TestData).build()
+    val testResponse2 = ApolloResponse.Builder(query2, uuid4()).data(query2TestData).build()
 
     val query3 = GetHeroNameOnlyQuery()
-    val testResponse3 = ApolloResponse.Builder(query3, uuid4(), GetHeroNameOnlyQuery.Data(GetHeroNameOnlyQuery.Hero(name = "Darth Vader")))
+    val testResponse3 = ApolloResponse.Builder(query3, uuid4())
+        .data(GetHeroNameOnlyQuery.Data(GetHeroNameOnlyQuery.Hero(name = "Darth Vader")))
         .build()
 
     apolloClient.apply {

--- a/tests/test-network-transport/src/test/kotlin/testnetworktransport/QueueTestNetworkTransportHandlerTest.kt
+++ b/tests/test-network-transport/src/test/kotlin/testnetworktransport/QueueTestNetworkTransportHandlerTest.kt
@@ -36,14 +36,13 @@ class QueueTestNetworkTransportHandlerTest {
     val testResponse1 = ApolloResponse.Builder(
         operation = query1,
         requestUuid = uuid4(),
-        data = null,
-        errors = listOf(
+    ).errors(
+        listOf(
             Error.Builder(message = "There was an error")
                 .locations(listOf(Error.Location(line = 1, column = 2)))
                 .path(listOf("hero", "name"))
                 .build()
-        ),
-        extensions = null
+        )
     ).build()
 
     val query2 = GetHeroQuery("002")
@@ -56,10 +55,11 @@ class QueueTestNetworkTransportHandlerTest {
             onHuman = null
         )
     )
-    val testResponse2 = ApolloResponse.Builder(query2, uuid4(), query2TestData).build()
+    val testResponse2 = ApolloResponse.Builder(query2, uuid4()).data(query2TestData).build()
 
     val query3 = GetHeroNameOnlyQuery()
-    val testResponse3 = ApolloResponse.Builder(query3, uuid4(), GetHeroNameOnlyQuery.Data(GetHeroNameOnlyQuery.Hero(name = "Darth Vader")))
+    val testResponse3 = ApolloResponse.Builder(query3, uuid4())
+        .data(GetHeroNameOnlyQuery.Data(GetHeroNameOnlyQuery.Hero(name = "Darth Vader")))
         .build()
 
     apolloClient.apply {


### PR DESCRIPTION
Right now we have:

1 `Builder(operation, uuid, data)`
2 `Builder(operation, uuid, exception)`
3 `Builder(operation, uuid, data, errors, extensions, exception)`

1 & 2 are somewhat misleading because they could imply that `data` & `exception` are exclusive which is not the case. 

3. is redundant with calling the different methods of the Builder.

Replace all 3 builders with:

* `Builder(operation, uuid)`