### PR TITLE
[gradle] Add apollo.deps

### DIFF
--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -21,10 +21,21 @@ public final class com/apollographql/apollo3/gradle/api/ApolloAttributes {
 public abstract interface class com/apollographql/apollo3/gradle/api/ApolloAttributes$Service : org/gradle/api/Named {
 }
 
+public final class com/apollographql/apollo3/gradle/api/ApolloDependencies {
+	public fun <init> (Lorg/gradle/api/artifacts/dsl/DependencyHandler;)V
+	public final fun getApi ()Lorg/gradle/api/artifacts/Dependency;
+	public final fun getAst ()Lorg/gradle/api/artifacts/Dependency;
+	public final fun getMockServer ()Lorg/gradle/api/artifacts/Dependency;
+	public final fun getNormalizedCache ()Lorg/gradle/api/artifacts/Dependency;
+	public final fun getNormalizedCacheSqlite ()Lorg/gradle/api/artifacts/Dependency;
+	public final fun getRuntime ()Lorg/gradle/api/artifacts/Dependency;
+}
+
 public abstract interface class com/apollographql/apollo3/gradle/api/ApolloExtension {
 	public abstract fun apolloKspProcessor (Ljava/io/File;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/Object;
 	public abstract fun createAllAndroidVariantServices (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
 	public abstract fun createAllKotlinSourceSetServices (Ljava/lang/String;Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public abstract fun getDeps ()Lcom/apollographql/apollo3/gradle/api/ApolloDependencies;
 	public abstract fun getGenerateSourcesDuringGradleSync ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLinkSqlite ()Lorg/gradle/api/provider/Property;
 	public abstract fun service (Ljava/lang/String;Lorg/gradle/api/Action;)V

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloDependencies.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloDependencies.kt
@@ -1,0 +1,13 @@
+package com.apollographql.apollo3.gradle.api
+
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+class ApolloDependencies(private val handler: DependencyHandler) {
+  val api: Dependency get() = handler.create("com.apollographql.apollo3:apollo-api")
+  val runtime: Dependency get() = handler.create("com.apollographql.apollo3:apollo-runtime")
+  val normalizedCache: Dependency get() = handler.create("com.apollographql.apollo3:apollo-normalized-cache")
+  val normalizedCacheSqlite: Dependency get() = handler.create("com.apollographql.apollo3:apollo-normalized-cache-sqlite")
+  val mockServer: Dependency get() = handler.create("com.apollographql.apollo3:apollo-mockserver")
+  val ast: Dependency get() = handler.create("com.apollographql.apollo3:apollo-ast")
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloExtension.kt
@@ -96,4 +96,9 @@ interface ApolloExtension {
    * - the apollo-ksp dependency
    */
   fun apolloKspProcessor(schema: File, service: String, packageName: String): Any
+
+  /**
+   * Common apollo dependencies using the same version as the Apollo Gradle Plugin currently in the classpath
+   */
+  val deps: ApolloDependencies
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.compiler.hooks.internal.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.hooks.internal.ApolloCompilerKotlinHooksChain
 import com.apollographql.apollo3.gradle.api.AndroidProject
 import com.apollographql.apollo3.gradle.api.ApolloAttributes
+import com.apollographql.apollo3.gradle.api.ApolloDependencies
 import com.apollographql.apollo3.gradle.api.ApolloExtension
 import com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel
 import com.apollographql.apollo3.gradle.api.SchemaConnection
@@ -996,4 +997,6 @@ abstract class DefaultApolloExtension(
 
     return project.dependencies.project(mapOf("path" to project.path, "configuration" to producer.name))
   }
+
+  override val deps: ApolloDependencies = ApolloDependencies(project.dependencies)
 }


### PR DESCRIPTION
Small helper object to save me and others from typing `"com.apollographql.apollo3..."`

```kotlin
dependencies {
  testImplementation(kotlin("test"))
  implementation(apollo.deps.runtime)
  implementation(apollo.deps.normalizedCache)
}
```