### PR TITLE
Documentation updates.

### DIFF
--- a/docs/source/caching/programmatic-ids.mdx
+++ b/docs/source/caching/programmatic-ids.mdx
@@ -54,6 +54,14 @@ val cacheKeyGenerator = object : CacheKeyGenerator {
 You can also use the current object's typename to use _different_ cache ID generation logic for different object types.
 
 Note that for cache ID generation to work, your GraphQL operations must return whatever fields your custom code relies on (such as `id` above). If a query does not return a required field, the cache ID will be inconsistent, resulting in data duplication.
+Also, using `context.field.type.leafType().name` yields the typename of the Union as opposed to the expected runtime value of Union received in the response. Instead querying for the `__typename` is safer.
+To make sure `__typename` is included in all operations set the `adTypename` gradle config:
+```
+apollo {
+  addTypename.set("always")
+  //
+}
+```
 
 ## `CacheKeyResolver`
 

--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -322,7 +322,7 @@ The `fragments` synthetic property is not needed anymore:
 data.hero.fragments.heroDetails
 
 // With
-data.hero.fragments.heroDetails
+data.hero.heroDetails
 ```
 
 Finally some fields that were merged from inline fragments in their parents must now be accessed through the inline fragment:


### PR DESCRIPTION
Found a typo in the v3 to v4 migration guide.
And added some more info about the usage of `context.field.type.leafType().name` in `CacheKeyGenerator` with respect to `Union` types.