### PR TITLE
Don't crash if ApolloDebugServerInitializer is not run (e.g. in unit tests)

### DIFF
--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/initializer/ApolloDebugServerInitializer.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/initializer/ApolloDebugServerInitializer.kt
@@ -11,6 +11,6 @@ internal class ApolloDebugServerInitializer : Initializer<Unit> {
   override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()
 
   companion object {
-    lateinit var packageName: String
+    var packageName: String? = null
   }
 }

--- a/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
+++ b/libraries/apollo-debug-server/src/androidMain/kotlin/com/apollographql/apollo3/debugserver/internal/server/Server.android.kt
@@ -35,7 +35,8 @@ private class AndroidServer(
 
   override fun start() {
     if (localServerSocket != null) error("Already started")
-    val localServerSocket = LocalServerSocket("$SOCKET_NAME_PREFIX${ApolloDebugServerInitializer.packageName}")
+    val packageName = ApolloDebugServerInitializer.packageName ?: "unknown.${System.currentTimeMillis()}"
+    val localServerSocket = LocalServerSocket("$SOCKET_NAME_PREFIX$packageName")
     this.localServerSocket = localServerSocket
     coroutineScope.launch {
       while (true) {


### PR DESCRIPTION
Thanks @rohandhruva for the report!