### PR TITLE
Set remote build cache to push only if authenticated

### DIFF
--- a/gradle/ge.gradle
+++ b/gradle/ge.gradle
@@ -25,6 +25,8 @@ buildCache {
   }
   remote(gradleEnterprise.buildCache) {
     enabled = true
-    push = isCI
+    // Check access key presence to avoid build cache errors on PR builds when access key is not present
+    def accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
+    push = isCI && accessKey
   }
 }


### PR DESCRIPTION
Updated remote build cache config to only push when authenticated -> if an unauthenticated push is attempted remote build cache will get turned off for the rest of the build. This can happen (does) on forked PR builds which run in an unsecure environment.