### PR TITLE
[apollo-cli] Publish apollo-cli-incubating again

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,14 @@ And then use the `4.0.0-beta.5-SNAPSHOT` version for the plugin and libraries.
 
 Snapshots for the Android Studio / IntelliJ plugin [are also available](https://github.com/apollographql/apollo-kotlin/tree/main/intellij-plugin#snapshots). 
 
-## Deprecation policy
+## Stability of different artifacts
 
-The project observes [Semantic Versioning](https://semver.org/). No breaking change should be introduced in minor or patch releases.
+Apollo Kotlin is very modular and publishes several artifacts.
+
+* Artifacts ending with `-incubating` are not finalized yet and subject to change any time.
+* Other artifacts observe [Semantic Versioning](https://semver.org/).
+    * No breaking change should be introduced in minor or patch releases except for symbols annotated with `@ApolloExperimental` that are subject to change at any time.
+    * Deprecated symbols may be removed in the next major release. We strongly recommend removing deprecated usages before migrating to the next major version.
 
 ## Contributing
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -218,9 +218,14 @@ And then use the `4.0.0-beta.5-SNAPSHOT` version for the plugin and libraries.
 
 Snapshots for the Android Studio / IntelliJ plugin [are also available](tree/main/intellij-plugin#snapshots). 
 
-## Deprecation policy
+## Stability of different artifacts
 
-The project observes [Semantic Versioning](https://semver.org/). No breaking change should be introduced in minor or patch releases.
+Apollo Kotlin is very modular and publishes several artifacts. 
+
+* Artifacts ending with `-incubating` are not finalized yet and subject to change any time.
+* Other artifacts observe [Semantic Versioning](https://semver.org/). 
+  * No breaking change should be introduced in minor or patch releases except for symbols annotated with `@ApolloExperimental` that are subject to change at any time.
+  * Deprecated symbols may be removed in the next major release. We strongly recommend removing deprecated usages before migrating to the next major version.
 
 ## Contributing
 

--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -9,7 +9,7 @@ Apollo Kotlin 3.0 was a major rewrite of Apollo in Kotlin multiplatform.
 
 Apollo Kotlin 4.0 focuses on tooling, stability and fixing some API regrets that came with 3.x.
 
-Because most of the common APIs stayed the same, we [kept the package name unchanged](https://github.com/apollographql/apollo-kotlin/issues/4710). 
+Because most of the common APIs stayed the same, we [kept the package name unchanged](https://github.com/apollographql/apollo-kotlin/issues/4710). Apollo Kotlin 4.0 removes some deprecated symbols. We strongly recommend removing deprecated usages before migrating to 4.0.  
 
 If you are using a lib that depends on Apollo Kotlin transitively, you need it to update to 4.x before you can update your own app to 4.0.
 

--- a/libraries/apollo-cli-incubating/build.gradle.kts
+++ b/libraries/apollo-cli-incubating/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 
 apolloLibrary(
     javaModuleName = "com.apollographql.apollo3.cli",
-    publish = false
 )
+
 dependencies {
   implementation(project(":apollo-tooling"))
   implementation(project(":apollo-annotations"))


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-kotlin/issues/5468

Since `apollo-cli-incubating` was published before, let's keep it around. Also explicit a bit more the stability of different artifacts until we figure out if we want more fine-grained versioning.
