### PR TITLE
Allow custom SupportSQLiteOpenHelper.Callback in the SqlNormalizedCacheFactory

### DIFF
--- a/libraries/apollo-normalized-cache-sqlite/api/android/apollo-normalized-cache-sqlite.api
+++ b/libraries/apollo-normalized-cache-sqlite/api/android/apollo-normalized-cache-sqlite.api
@@ -24,8 +24,9 @@ public final class com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedC
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;)V
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Z)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;Z)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create ()Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCache;

--- a/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -18,6 +18,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
   /**
    * @param [name] Name of the database file, or null for an in-memory database (as per Android framework implementation).
    * @param [factory] Factory class to create instances of [SupportSQLiteOpenHelper]
+   * @param [callback] Callback class to get database lifecycle events. Uses [AndroidSqliteDriver.Callback] by default.
    * @param [useNoBackupDirectory] Sets whether to use a no backup directory or not.
    */
   @JvmOverloads
@@ -25,6 +26,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
       context: Context,
       name: String? = "apollo.db",
       factory: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory(),
+      callback: SupportSQLiteOpenHelper.Callback = AndroidSqliteDriver.Callback(schema),
       useNoBackupDirectory: Boolean = false,
   ) : this(
       AndroidSqliteDriver(
@@ -32,6 +34,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
           context.applicationContext,
           name,
           factory,
+          callback,
           useNoBackupDirectory = useNoBackupDirectory
       ),
   )

--- a/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -26,7 +26,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
       context: Context,
       name: String? = "apollo.db",
       factory: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory(),
-      callback: SupportSQLiteOpenHelper.Callback = AndroidSqliteDriver.Callback(schema),
+      callback: SupportSQLiteOpenHelper.Callback = AndroidSqliteDriver.Callback(getSchema()),
       useNoBackupDirectory: Boolean = false,
   ) : this(
       AndroidSqliteDriver(

--- a/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.cache.normalized.sql
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
@@ -18,7 +19,8 @@ actual class SqlNormalizedCacheFactory internal constructor(
   /**
    * @param [name] Name of the database file, or null for an in-memory database (as per Android framework implementation).
    * @param [factory] Factory class to create instances of [SupportSQLiteOpenHelper]
-   * @param [callback] Callback class to get database lifecycle events. Uses [AndroidSqliteDriver.Callback] by default.
+   * @param [configure] Optional callback, called when the database connection is being configured, to enable features such as
+   *                    write-ahead logging or foreign key support. It should not modify the database except to configure it.
    * @param [useNoBackupDirectory] Sets whether to use a no backup directory or not.
    */
   @JvmOverloads
@@ -26,7 +28,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
       context: Context,
       name: String? = "apollo.db",
       factory: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory(),
-      callback: SupportSQLiteOpenHelper.Callback = AndroidSqliteDriver.Callback(getSchema()),
+      configure: ((SupportSQLiteDatabase) -> Unit)? = null,
       useNoBackupDirectory: Boolean = false,
   ) : this(
       AndroidSqliteDriver(
@@ -34,7 +36,12 @@ actual class SqlNormalizedCacheFactory internal constructor(
           context.applicationContext,
           name,
           factory,
-          callback,
+          object : AndroidSqliteDriver.Callback(getSchema()) {
+            override fun onConfigure(db: SupportSQLiteDatabase) {
+              super.onConfigure(db)
+              configure?.invoke(db)
+            }
+          },
           useNoBackupDirectory = useNoBackupDirectory
       ),
   )


### PR DESCRIPTION
A quick PR to allow custom callbacks in the `SqlNormalizedCacheFactory`. This should allow us to get lifecycle events and apply custom database settings if needed. The eventual plan is to allow us to try something like this: https://stackoverflow.com/questions/65425352/sqldelight-slow-performance-compared-to-room