### PR TITLE
Fix converting GrpaphQL Float values to Kotlin

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Value.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Value.kt
@@ -51,7 +51,7 @@ internal fun IrValue.codeBlock(): CodeBlock {
     }
 
     is IrFloatValue -> {
-      val asDouble = value.toIntOrNull()
+      val asDouble = value.toDoubleOrNull()
       if (asDouble != null) {
         // The value fits in a kotlin Double
         CodeBlock.of(L, value)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/Value.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/Value.kt
@@ -51,7 +51,7 @@ internal fun IrValue.codeBlock(): CodeBlock {
     }
 
     is IrFloatValue -> {
-      val asDouble = value.toIntOrNull()
+      val asDouble = value.toDoubleOrNull()
       if (asDouble != null) {
         // The value fits in a kotlin Double
         CodeBlock.of("%L", value)

--- a/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/java/operationBased/arguments_hardcoded/selections/TestQuerySelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/java/operationBased/arguments_hardcoded/selections/TestQuerySelections.java.expected
@@ -10,7 +10,6 @@ import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledListType;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.apollographql.apollo3.api.json.JsonNumber;
 import com.example.arguments_hardcoded.type.GraphQLInt;
 import com.example.arguments_hardcoded.type.GraphQLString;
 import com.example.arguments_hardcoded.type.Review;
@@ -24,7 +23,7 @@ public class TestQuerySelections {
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(
-    new CompiledField.Builder("reviews", new CompiledListType(Review.type)).arguments(Arrays.asList(new CompiledArgument.Builder("episode").value("JEDI").build(), new CompiledArgument.Builder("starsFloat").value(new JsonNumber("9.9")).build(), new CompiledArgument.Builder("starsInt").value(10).build())).selections(__reviews).build(),
+    new CompiledField.Builder("reviews", new CompiledListType(Review.type)).arguments(Arrays.asList(new CompiledArgument.Builder("episode").value("JEDI").build(), new CompiledArgument.Builder("starsFloat").value(9.9).build(), new CompiledArgument.Builder("starsInt").value(10).build())).selections(__reviews).build(),
     new CompiledField.Builder("testNullableArguments", new CompiledNotNullType(GraphQLInt.type)).arguments(Arrays.asList(new CompiledArgument.Builder("boolean").value(null).build(), new CompiledArgument.Builder("episode").value(null).build(), new CompiledArgument.Builder("float").value(null).build(), new CompiledArgument.Builder("int").value(null).build(), new CompiledArgument.Builder("list").value(null).build(), new CompiledArgument.Builder("review").value(null).build(), new CompiledArgument.Builder("string").value(null).build())).build()
   );
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/kotlin/responseBased/arguments_hardcoded/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/kotlin/responseBased/arguments_hardcoded/selections/TestQuerySelections.kt.expected
@@ -8,7 +8,6 @@ package com.example.arguments_hardcoded.selections
 import com.apollographql.apollo3.api.CompiledArgument
 import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledSelection
-import com.apollographql.apollo3.api.json.JsonNumber
 import com.apollographql.apollo3.api.list
 import com.apollographql.apollo3.api.notNull
 import com.example.arguments_hardcoded.type.GraphQLInt
@@ -34,7 +33,7 @@ public object TestQuerySelections {
           type = Review.type.list()
         ).arguments(listOf(
           CompiledArgument.Builder("episode").value("JEDI").build(),
-          CompiledArgument.Builder("starsFloat").value(JsonNumber("9.9")).build(),
+          CompiledArgument.Builder("starsFloat").value(9.9).build(),
           CompiledArgument.Builder("starsInt").value(10).build()
         ))
         .selections(__reviews)

--- a/libraries/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,11 +2,11 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  197830
-aggregate-kotlin-responseBased                                                                  63172
+aggregate-all                                                                                  197828
+aggregate-kotlin-responseBased                                                                  63171
 aggregate-kotlin-operationBased                                                                 40971
 aggregate-kotlin-compat                                                                             0
-aggregate-java-operationBased                                                                   93687
+aggregate-java-operationBased                                                                   93686
 
 java-operationBased-fragments_with_defer_and_include_directives                                  5590
 kotlin-operationBased-fragments_with_defer_and_include_directives                                3510
@@ -198,7 +198,7 @@ kotlin-responseBased-hero_name                                                  
 kotlin-operationBased-interface_on_interface                                                      497
 kotlin-responseBased-hero_name_query_long_name                                                    495
 kotlin-responseBased-interface_always_nested                                                      492
-java-operationBased-arguments_hardcoded                                                           489
+java-operationBased-arguments_hardcoded                                                           488
 kotlin-operationBased-root_query_fragment                                                         486
 kotlin-responseBased-custom_scalar_type                                                           484
 kotlin-responseBased-variable_default_value                                                       469
@@ -231,7 +231,7 @@ kotlin-operationBased-inline_fragment_simple                                    
 kotlin-responseBased-starships                                                                    384
 kotlin-responseBased-java8annotation                                                              383
 kotlin-responseBased-antlr_tokens                                                                 381
-kotlin-responseBased-arguments_hardcoded                                                          372
+kotlin-responseBased-arguments_hardcoded                                                          371
 kotlin-responseBased-subscriptions                                                                371
 kotlin-responseBased-enums_as_sealed                                                              353
 kotlin-responseBased-operation_id_generator                                                       339


### PR DESCRIPTION
When storing GraphQL values in Kotlin (used for defaultValues) we we using the wrong conversion. I don't think this has a strong impact as `Int` would be coerced to `Double` later on and if it couldn't be an `Int`, it would fallback to `JsonNumber` anyways. But it's more idiomatic this way.