### PR TITLE
Use windowSizeBytes argument of AndroidSqliteDriver

### DIFF
--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.cache.normalized.sql
 
 import android.content.Context
+import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -32,6 +32,7 @@ actual class SqlNormalizedCacheFactory actual constructor(
       factory: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory(),
       configure: ((SupportSQLiteDatabase) -> Unit)? = null,
       useNoBackupDirectory: Boolean = false,
+      windowSizeBytes: Long? = null,
       withDates: Boolean = false,
   ) : this(
       AndroidSqliteDriver(
@@ -39,7 +40,7 @@ actual class SqlNormalizedCacheFactory actual constructor(
           context.applicationContext,
           name,
           factory,
-          object : AndroidSqliteDriver.Callback(getSchema()) {
+          object : AndroidSqliteDriver.Callback(getSchema(withDates)) {
             override fun onConfigure(db: SupportSQLiteDatabase) {
               super.onConfigure(db)
               configure?.invoke(db)

--- a/libraries/apollo-normalized-cache-sqlite/api/android/apollo-normalized-cache-sqlite.api
+++ b/libraries/apollo-normalized-cache-sqlite/api/android/apollo-normalized-cache-sqlite.api
@@ -26,7 +26,8 @@ public final class com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedC
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;Z)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZLjava/lang/Long;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Landroidx/sqlite/db/SupportSQLiteOpenHelper$Factory;Lkotlin/jvm/functions/Function1;ZLjava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create ()Lcom/apollographql/apollo3/cache/normalized/api/NormalizedCache;

--- a/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
+++ b/libraries/apollo-normalized-cache-sqlite/src/androidMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCacheFactory.kt
@@ -22,6 +22,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
    * @param [configure] Optional callback, called when the database connection is being configured, to enable features such as
    *                    write-ahead logging or foreign key support. It should not modify the database except to configure it.
    * @param [useNoBackupDirectory] Sets whether to use a no backup directory or not.
+   * @param [windowSizeBytes] Size of cursor window in bytes, per [android.database.CursorWindow] (Android 28+ only), or null to use the default.
    */
   @JvmOverloads
   constructor(
@@ -30,6 +31,7 @@ actual class SqlNormalizedCacheFactory internal constructor(
       factory: SupportSQLiteOpenHelper.Factory = FrameworkSQLiteOpenHelperFactory(),
       configure: ((SupportSQLiteDatabase) -> Unit)? = null,
       useNoBackupDirectory: Boolean = false,
+      windowSizeBytes: Long? = null,
   ) : this(
       AndroidSqliteDriver(
           getSchema(),
@@ -42,7 +44,8 @@ actual class SqlNormalizedCacheFactory internal constructor(
               configure?.invoke(db)
             }
           },
-          useNoBackupDirectory = useNoBackupDirectory
+          useNoBackupDirectory = useNoBackupDirectory,
+          windowSizeBytes = windowSizeBytes,
       ),
   )
 


### PR DESCRIPTION
Now that https://github.com/cashapp/sqldelight/pull/4804 has been available in 4.0.1, we can actually use it.

Not really related but while here I also reported #5488 to the incubating version.

Related to #4072