### PR TITLE
Lock down apollo-compiler API

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -1,6 +1,3 @@
-public final class com/apollographql/apollo3/compiler/-checkCapitalizedFields {
-}
-
 public abstract interface class com/apollographql/apollo3/compiler/AdapterInitializer {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/AdapterInitializer$Companion;
 }
@@ -9,17 +6,25 @@ public final class com/apollographql/apollo3/compiler/AdapterInitializer$Compani
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class com/apollographql/apollo3/compiler/ApolloCompiler$Logger {
-	public abstract fun warning (Ljava/lang/String;)V
+public final class com/apollographql/apollo3/compiler/ApolloCompiler {
+	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ApolloCompiler;
+	public final fun build (Ljava/util/Set;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;Ljava/io/File;)V
+	public final fun build (Ljava/util/Set;Ljava/util/Set;Ljava/io/File;Ljava/io/File;Ljava/io/File;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;Ljava/io/File;)V
+	public static synthetic fun build$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/util/Set;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+	public static synthetic fun build$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/util/Set;Ljava/util/Set;Ljava/io/File;Ljava/io/File;Ljava/io/File;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+	public final fun buildCodegenSchema (Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Ljava/io/File;Ljava/io/File;)V
+	public static synthetic fun buildCodegenSchema$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+	public final fun buildIrOperations (Ljava/io/File;Ljava/util/Set;Ljava/util/Set;Ljava/io/File;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)V
+	public static synthetic fun buildIrOperations$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/io/File;Ljava/util/Set;Ljava/util/Set;Ljava/io/File;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;ILjava/lang/Object;)V
+	public final fun buildIrSchema (Ljava/io/File;Ljava/util/Set;Ljava/io/File;)V
+	public final fun buildSchemaAndOperationSources (Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/util/Set;Ljava/io/File;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Ljava/io/File;Ljava/io/File;Ljava/io/File;)V
+	public static synthetic fun buildSchemaAndOperationSources$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/io/File;Ljava/io/File;Ljava/io/File;Ljava/util/Set;Ljava/io/File;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerKotlinHooks;Lcom/apollographql/apollo3/compiler/hooks/ApolloCompilerJavaHooks;Ljava/io/File;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+	public final fun resolverFileSpecs (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/CodegenMetadata;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Ljava/util/List;
+	public final fun schemaFileSpecs (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/lang/String;)Lkotlin/Pair;
 }
 
-public final class com/apollographql/apollo3/compiler/CodegenMetadata {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenMetadata$Companion;
-	public final fun copy (Lcom/apollographql/apollo3/compiler/codegen/ResolverInfo;)Lcom/apollographql/apollo3/compiler/CodegenMetadata;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/CodegenMetadata;Lcom/apollographql/apollo3/compiler/codegen/ResolverInfo;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/CodegenMetadata;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
+public abstract interface class com/apollographql/apollo3/compiler/ApolloCompiler$Logger {
+	public abstract fun warning (Ljava/lang/String;)V
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenMetadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -38,7 +43,6 @@ public final class com/apollographql/apollo3/compiler/CodegenMetadata$Companion 
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenMetadataKt {
-	public static final fun schemaTypes (Lcom/apollographql/apollo3/compiler/CodegenMetadata;)Ljava/util/Set;
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenOptions {
@@ -90,6 +94,18 @@ public final class com/apollographql/apollo3/compiler/CodegenSchema$$serializer 
 
 public final class com/apollographql/apollo3/compiler/CodegenSchema$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/apollographql/apollo3/compiler/CodegenSchemaOptions {
+	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions$Companion;
+	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCodegenModels ()Ljava/lang/String;
+	public final fun getGenerateDataBuilders ()Ljava/lang/Boolean;
+	public final fun getPackageName ()Ljava/lang/String;
+	public final fun getPackageNamesFromFilePaths ()Ljava/lang/Boolean;
+	public final fun getScalarMapping ()Ljava/util/Map;
+	public final fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenSchemaOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -176,6 +192,25 @@ public final class com/apollographql/apollo3/compiler/GeneratedMethod : java/lan
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/GeneratedMethod;
 	public static fun values ()[Lcom/apollographql/apollo3/compiler/GeneratedMethod;
+}
+
+public final class com/apollographql/apollo3/compiler/GeneratedMethod$Companion {
+	public final fun fromName (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/GeneratedMethod;
+}
+
+public final class com/apollographql/apollo3/compiler/IrOptions {
+	public static final field Companion Lcom/apollographql/apollo3/compiler/IrOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAddTypename ()Ljava/lang/String;
+	public final fun getAlwaysGenerateTypesMatching ()Ljava/util/Set;
+	public final fun getDecapitalizeFields ()Ljava/lang/Boolean;
+	public final fun getFailOnWarnings ()Ljava/lang/Boolean;
+	public final fun getFieldsOnDisjointTypesMustMerge ()Ljava/lang/Boolean;
+	public final fun getFlattenModels ()Ljava/lang/Boolean;
+	public final fun getGenerateOptionalOperationVariables ()Ljava/lang/Boolean;
+	public final fun getWarnOnDeprecatedUsages ()Ljava/lang/Boolean;
 }
 
 public final class com/apollographql/apollo3/compiler/IrOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -310,16 +345,8 @@ public abstract interface class com/apollographql/apollo3/compiler/PackageNameGe
 
 public final class com/apollographql/apollo3/compiler/PackageNameGenerator$Flat : com/apollographql/apollo3/compiler/PackageNameGenerator {
 	public fun <init> (Ljava/lang/String;)V
-	public final fun getPackageName ()Ljava/lang/String;
 	public fun getVersion ()Ljava/lang/String;
 	public fun packageName (Ljava/lang/String;)Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/compiler/ReservedKeywordsKt {
-	public static final fun escapeJavaReservedWord (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun escapeKotlinReservedWord (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun escapeKotlinReservedWordInEnum (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun escapeKotlinReservedWordInSealedClass (Ljava/lang/String;)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/compiler/RuntimeAdapterInitializer : com/apollographql/apollo3/compiler/AdapterInitializer {
@@ -363,10 +390,6 @@ public final class com/apollographql/apollo3/compiler/TargetLanguage : java/lang
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/TargetLanguage;
 	public static fun values ()[Lcom/apollographql/apollo3/compiler/TargetLanguage;
-}
-
-public final class com/apollographql/apollo3/compiler/UsedCoordinatesKt {
-	public static final fun mergeWith (Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 }
 
 public final class com/apollographql/apollo3/compiler/VersionKt {
@@ -461,56 +484,8 @@ public final class com/apollographql/apollo3/compiler/codegen/java/adapter/Adapt
 	public static synthetic fun singletonAdapterInitializer$default (Lcom/squareup/javapoet/TypeName;Lcom/squareup/javapoet/TypeName;ZILjava/lang/Object;)Lcom/squareup/javapoet/CodeBlock;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrCatchTo : java/lang/Enum {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrCatchTo$Companion;
-	public static final field NoCatch Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public static final field Null Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public static final field Result Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public static fun values ()[Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-}
-
 public final class com/apollographql/apollo3/compiler/ir/IrCatchTo$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrClassName {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
-	public final fun asString ()Ljava/lang/String;
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lcom/apollographql/apollo3/compiler/ir/IrClassName;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrClassName;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrClassName;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getNames ()Ljava/util/List;
-	public final fun getPackageName ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrEnumType : com/apollographql/apollo3/compiler/ir/IrNamedType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrEnumType$Companion;
-	public fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun component4 ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public final fun component5 ()Z
-	public final fun copy (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrEnumType;Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
-	public fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public fun getMaybeError ()Z
-	public fun getName ()Ljava/lang/String;
-	public fun getNullable ()Z
-	public fun getOptional ()Z
-	public fun hashCode ()I
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrEnumType;
-	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrEnumType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -528,41 +503,6 @@ public final class com/apollographql/apollo3/compiler/ir/IrEnumType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrExecutionContextTargetArgument : com/apollographql/apollo3/compiler/ir/IrTargetArgument {
-	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrExecutionContextTargetArgument;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrGraphqlTargetArgument : com/apollographql/apollo3/compiler/ir/IrTargetArgument {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lcom/apollographql/apollo3/compiler/ir/IrType;)V
-	public final fun getName ()Ljava/lang/String;
-	public final fun getTargetName ()Ljava/lang/String;
-	public final fun getType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType$Companion;
-	public fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun component4 ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public final fun component5 ()Z
-	public final fun copy (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
-	public fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public fun getMaybeError ()Z
-	public fun getName ()Ljava/lang/String;
-	public fun getNullable ()Z
-	public fun getOptional ()Z
-	public fun hashCode ()I
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType;
-	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrInputObjectType$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
@@ -576,29 +516,6 @@ public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType$$seri
 
 public final class com/apollographql/apollo3/compiler/ir/IrInputObjectType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrListType : com/apollographql/apollo3/compiler/ir/IrType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrListType$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)V
-	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun component4 ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public final fun component5 ()Z
-	public final fun copy (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)Lcom/apollographql/apollo3/compiler/ir/IrListType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrListType;Lcom/apollographql/apollo3/compiler/ir/IrType;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrListType;
-	public fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public fun getMaybeError ()Z
-	public fun getNullable ()Z
-	public final fun getOfType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun getOptional ()Z
-	public fun hashCode ()I
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrListType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -616,38 +533,23 @@ public final class com/apollographql/apollo3/compiler/ir/IrListType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public abstract interface class com/apollographql/apollo3/compiler/ir/IrNamedType : com/apollographql/apollo3/compiler/ir/IrType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrNamedType$Companion;
-	public abstract fun getName ()Ljava/lang/String;
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
+public final class com/apollographql/apollo3/compiler/ir/IrModelType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrModelType$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/apollographql/apollo3/compiler/ir/IrModelType;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/apollographql/apollo3/compiler/ir/IrModelType;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/apollographql/apollo3/compiler/ir/IrModelType$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrNamedType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrObjectType : com/apollographql/apollo3/compiler/ir/IrNamedType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrObjectType$Companion;
-	public fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun component4 ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public final fun component5 ()Z
-	public final fun copy (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrObjectType;Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
-	public fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public fun getMaybeError ()Z
-	public fun getName ()Ljava/lang/String;
-	public fun getNullable ()Z
-	public fun getOptional ()Z
-	public fun hashCode ()I
-	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrObjectType;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrObjectType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -670,30 +572,6 @@ public abstract interface class com/apollographql/apollo3/compiler/ir/IrOperatio
 	public abstract fun getUsedFields ()Ljava/util/Map;
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrScalarType : com/apollographql/apollo3/compiler/ir/IrNamedType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrScalarType$Companion;
-	public fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)V
-	public synthetic fun <init> (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Z
-	public final fun component3 ()Z
-	public final fun component4 ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public final fun component5 ()Z
-	public final fun copy (Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;Z)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
-	public static synthetic fun copy$default (Lcom/apollographql/apollo3/compiler/ir/IrScalarType;Ljava/lang/String;ZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ZILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
-	public fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public fun equals (Ljava/lang/Object;)Z
-	public fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public fun getMaybeError ()Z
-	public fun getName ()Ljava/lang/String;
-	public fun getNullable ()Z
-	public fun getOptional ()Z
-	public fun hashCode ()I
-	public synthetic fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-	public fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrScalarType;
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class com/apollographql/apollo3/compiler/ir/IrScalarType$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrScalarType$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
@@ -712,57 +590,11 @@ public final class com/apollographql/apollo3/compiler/ir/IrScalarType$Companion 
 public abstract interface class com/apollographql/apollo3/compiler/ir/IrSchema {
 }
 
-public final class com/apollographql/apollo3/compiler/ir/IrSchemaBuilder {
-	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ir/IrSchemaBuilder;
-	public final fun build (Lcom/apollographql/apollo3/ast/Schema;Ljava/util/Map;Ljava/util/Set;)Lcom/apollographql/apollo3/compiler/ir/IrSchema;
-}
-
-public abstract interface class com/apollographql/apollo3/compiler/ir/IrTargetArgument {
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrTargetField {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLcom/apollographql/apollo3/compiler/ir/IrType;Ljava/util/List;)V
-	public final fun getArguments ()Ljava/util/List;
-	public final fun getName ()Ljava/lang/String;
-	public final fun getTargetName ()Ljava/lang/String;
-	public final fun getType ()Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public final fun isFunction ()Z
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrTargetKt {
-	public static final fun asKotlinPoet (Lcom/apollographql/apollo3/compiler/ir/IrClassName;)Lcom/squareup/kotlinpoet/ClassName;
-}
-
-public final class com/apollographql/apollo3/compiler/ir/IrTargetObject {
-	public fun <init> (Ljava/lang/String;Lcom/apollographql/apollo3/compiler/ir/IrClassName;ZZLjava/lang/String;Ljava/util/List;)V
-	public final fun getFields ()Ljava/util/List;
-	public final fun getHasNoArgsConstructor ()Z
-	public final fun getName ()Ljava/lang/String;
-	public final fun getOperationType ()Ljava/lang/String;
-	public final fun getTargetClassName ()Lcom/apollographql/apollo3/compiler/ir/IrClassName;
-	public final fun isSingleton ()Z
-}
-
-public abstract interface class com/apollographql/apollo3/compiler/ir/IrType {
-	public static final field Companion Lcom/apollographql/apollo3/compiler/ir/IrType$Companion;
-	public abstract fun copyWith (ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public static synthetic fun copyWith$default (Lcom/apollographql/apollo3/compiler/ir/IrType;ZZZLcom/apollographql/apollo3/compiler/ir/IrCatchTo;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public abstract fun getCatchTo ()Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;
-	public abstract fun getMaybeError ()Z
-	public abstract fun getNullable ()Z
-	public abstract fun getOptional ()Z
-	public abstract fun rawType ()Lcom/apollographql/apollo3/compiler/ir/IrNamedType;
-}
-
 public final class com/apollographql/apollo3/compiler/ir/IrType$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class com/apollographql/apollo3/compiler/ir/IrTypeKt {
-	public static final fun catchTo (Lcom/apollographql/apollo3/compiler/ir/IrType;Lcom/apollographql/apollo3/compiler/ir/IrCatchTo;)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public static final fun maybeError (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public static final fun nullable (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
-	public static final fun optional (Lcom/apollographql/apollo3/compiler/ir/IrType;Z)Lcom/apollographql/apollo3/compiler/ir/IrType;
 }
 
 public final class com/apollographql/apollo3/compiler/operationoutput/OperationDescriptor {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompiler.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler
 
-import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.ast.DeprecatedUsage
 import com.apollographql.apollo3.ast.DifferentShape
 import com.apollographql.apollo3.ast.DirectiveRedefinition
@@ -32,6 +31,13 @@ import com.apollographql.apollo3.compiler.codegen.java.JavaCodeGen
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinCodeGen
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
+import com.apollographql.apollo3.compiler.internal.addRequiredFields
+import com.apollographql.apollo3.compiler.internal.checkApolloInlineFragmentsHaveTypeCondition
+import com.apollographql.apollo3.compiler.internal.checkApolloReservedEnumValueNames
+import com.apollographql.apollo3.compiler.internal.checkApolloTargetNameClashes
+import com.apollographql.apollo3.compiler.internal.checkCapitalizedFields
+import com.apollographql.apollo3.compiler.internal.checkConditionalFragments
+import com.apollographql.apollo3.compiler.internal.checkKeyFields
 import com.apollographql.apollo3.compiler.ir.DefaultIrOperations
 import com.apollographql.apollo3.compiler.ir.IrOperations
 import com.apollographql.apollo3.compiler.ir.IrOperationsBuilder
@@ -43,9 +49,7 @@ import com.apollographql.apollo3.compiler.pqm.toPersistedQueryManifest
 import com.squareup.kotlinpoet.FileSpec
 import java.io.File
 
-@ApolloExperimental
 object ApolloCompiler {
-
   interface Logger {
     fun warning(message: String)
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
@@ -7,16 +7,13 @@ import com.apollographql.apollo3.compiler.codegen.ResolverKeyKind
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class CodegenMetadata internal constructor(
+@ApolloInternal
+class CodegenMetadata internal constructor(
     /**
      * resolver info used by the codegen to lookup already existing ClassNames
      */
     internal val resolverInfo: ResolverInfo,
 )
-
-fun CodegenMetadata.schemaTypes(): Set<String> {
-  return resolverInfo.entries.filter { it.key.kind == ResolverKeyKind.SchemaType }.map { it.key.id }.toSet()
-}
 
 @ApolloInternal
 fun CodegenMetadata.resolveSchemaType(name: String): ResolverClassName? {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3.compiler
 
 import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.ast.findTargetName
+import com.apollographql.apollo3.compiler.internal.SchemaSerializer
 import kotlinx.serialization.Serializable
 
 /**

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/OperationOutputGenerator.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/OperationOutputGenerator.kt
@@ -24,7 +24,7 @@ interface OperationOutputGenerator {
    *
    * Two different implementations **must** have different versions.
    *
-   * When using the compiler outside of a Gradle context, [version] is not used, making it the empty string is fine.
+   * When using the compiler outside a Gradle context, [version] is not used, making it the empty string is fine.
    */
   val version: String
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.compiler
 
 import com.apollographql.apollo3.annotations.ApolloExperimental
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
 import kotlinx.serialization.SerialName
@@ -114,7 +113,6 @@ enum class GeneratedMethod {
   DATA_CLASS,
   ;
 
-  @ApolloInternal
   companion object {
     fun fromName(name: String): GeneratedMethod? {
       return when (name) {
@@ -128,7 +126,6 @@ enum class GeneratedMethod {
   }
 }
 
-@ApolloExperimental
 @Serializable
 class CodegenSchemaOptions(
     /**
@@ -143,7 +140,6 @@ class CodegenSchemaOptions(
     val packageName: String? = null
 )
 
-@ApolloExperimental
 @Serializable
 class IrOptions(
     /**

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/PackageNameGenerator.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/PackageNameGenerator.kt
@@ -25,12 +25,16 @@ interface PackageNameGenerator {
    */
   val version: String
 
-  class Flat(val packageName: String) : PackageNameGenerator {
-    override fun packageName(filePath: String) = packageName
+  class Flat(private val packageName: String): PackageNameGenerator {
+    override fun packageName(filePath: String): String {
+      return packageName
+    }
+
     override val version: String
-      get() = "Flat-$packageName"
+      get() = error("this should only be called from the Gradle Plugin")
   }
 }
+
 
 /**
  * A helper class to get a package name from a list of root folders

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
@@ -1,7 +1,5 @@
 package com.apollographql.apollo3.compiler
 
-import okio.Buffer
-
 /**
  * A variation of [String.capitalize] that:
  * - skips initial underscore, especially found in introspection queries

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/UsedCoordinates.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/UsedCoordinates.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler
 
 typealias UsedCoordinates = Map<String, Set<String>>
 
-fun UsedCoordinates.mergeWith(other: UsedCoordinates): UsedCoordinates {
+internal fun UsedCoordinates.mergeWith(other: UsedCoordinates): UsedCoordinates {
   return (entries + other.entries).groupBy { it.key }.mapValues {
     it.value.map { it.value }.fold(emptySet()) { acc, set ->
       (acc + set).toSet()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.compiler.ir.IrListType
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.TypeSet
-import com.apollographql.apollo3.compiler.singularize
+import com.apollographql.apollo3.compiler.internal.singularize
 
 /**
  * The central place where the names/packages of the different classes are decided and escape rules done.

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Resolver.kt
@@ -15,8 +15,8 @@ internal class ResolverInfo(
     val entries: List<ResolverEntry>
 )
 
-@ApolloInternal
 @Serializable
+@ApolloInternal
 class ResolverClassName(val packageName: String, val simpleNames: List<String>) {
   constructor(packageName: String, vararg simpleNames: String): this(packageName, simpleNames.toList())
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegenLayout.kt
@@ -3,8 +3,8 @@ package com.apollographql.apollo3.compiler.codegen.java
 import com.apollographql.apollo3.compiler.CodegenType
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout
-import com.apollographql.apollo3.compiler.escapeJavaReservedWord
-import com.apollographql.apollo3.compiler.escapeTypeReservedWord
+import com.apollographql.apollo3.compiler.internal.escapeTypeReservedWord
+import com.apollographql.apollo3.compiler.internal.escapeJavaReservedWord
 
 internal class JavaCodegenLayout(
     allTypes: List<CodegenType>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommon.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.java.adapter
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.RESPONSE_NAMES
 import com.apollographql.apollo3.compiler.codegen.Identifier.__path

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3.compiler.codegen.java.file
 
 import com.apollographql.apollo3.ast.QueryDocumentMinifier
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_DOCUMENT
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_ID

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/BuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/BuilderBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.java.helpers
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.L

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/DataClass.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/DataClass.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.helpers
 
 import com.apollographql.apollo3.compiler.GeneratedMethod
 import com.apollographql.apollo3.compiler.GeneratedMethod.*
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.__h
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.L

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Doc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/Doc.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3.compiler.codegen.java.helpers
 
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/model/ModelBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/model/ModelBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.java.model
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.upperCamelCaseIgnoringNonLetters
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegenLayout.kt
@@ -3,9 +3,9 @@ package com.apollographql.apollo3.compiler.codegen.kotlin
 import com.apollographql.apollo3.compiler.CodegenType
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout
-import com.apollographql.apollo3.compiler.escapeKotlinReservedWord
-import com.apollographql.apollo3.compiler.escapeKotlinReservedWordInEnum
-import com.apollographql.apollo3.compiler.escapeKotlinReservedWordInSealedClass
+import com.apollographql.apollo3.compiler.internal.escapeKotlinReservedWord
+import com.apollographql.apollo3.compiler.internal.escapeKotlinReservedWordInEnum
+import com.apollographql.apollo3.compiler.internal.escapeKotlinReservedWordInSealedClass
 
 internal class KotlinCodegenLayout(
     allTypes: List<CodegenType>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/AdapterCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/AdapterCommon.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.RESPONSE_NAMES
 import com.apollographql.apollo3.compiler.codegen.Identifier.__path
 import com.apollographql.apollo3.compiler.codegen.Identifier.__typename

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/ImplementationAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/ImplementationAdapterBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/PolymorphicFieldResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/adapter/PolymorphicFieldResponseAdapterBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.__typename
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
 import com.apollographql.apollo3.compiler.codegen.Identifier.fromJson

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/MainResolverBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/MainResolverBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
 import com.apollographql.apollo3.ast.QueryDocumentMinifier
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_DOCUMENT
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_ID

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/JsExport.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/JsExport.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.helpers
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/KDoc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/KDoc.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.helpers
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinResolver
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrEnum

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/NamedType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/NamedType.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.helpers
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrInputField

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/model/ModelBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/model/ModelBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.model
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.upperCamelCaseIgnoringNonLetters
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/selections/CompiledSelectionsBuilder.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.selections
 
-import com.apollographql.apollo3.compiler.applyIf
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.root
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/hooks/internal/AddInternalCompilerHooks.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/hooks/internal/AddInternalCompilerHooks.kt
@@ -1,6 +1,6 @@
 package com.apollographql.apollo3.compiler.hooks.internal
 
-import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
 import com.apollographql.apollo3.compiler.hooks.DefaultApolloCompilerKotlinHooks
 import com.squareup.kotlinpoet.FunSpec
@@ -17,7 +17,7 @@ import com.squareup.kotlinpoet.TypeSpec
  * - to match classes under a specific package, use `"com\\.example\\.subpackage\\..*"`
  * - to match a specific operation, use `"com\\.example\\.MyQuery"`
  */
-@ApolloInternal
+@ApolloExperimental
 class AddInternalCompilerHooks(namePatterns: Set<String>) : DefaultApolloCompilerKotlinHooks() {
   constructor(vararg namePatterns: String) : this(namePatterns.toSet())
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/Inflector.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/Inflector.kt
@@ -1,5 +1,6 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
+import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import java.util.regex.Pattern
 
 /**

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/ReservedKeywords.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/ReservedKeywords.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 // Reference:
 // https://docs.oracle.com/javase/tutorial/java/nutsandbolts/_keywords.html
@@ -14,10 +14,10 @@ private val TYPE_REGEX = "(?:type)_*".toRegex()
 private val COMPANION_REGEX = "(?:Companion)_*".toRegex()
 private val KOTLIN_ENUM_RESERVED_WORDS_REGEX = "(?:name|ordinal)_*".toRegex()
 
-fun String.escapeJavaReservedWord() = if (this in JAVA_RESERVED_WORDS) "${this}_" else this
+internal fun String.escapeJavaReservedWord() = if (this in JAVA_RESERVED_WORDS) "${this}_" else this
 
 // Does nothing. KotlinPoet will add the backticks
-fun String.escapeKotlinReservedWord() = this
+internal fun String.escapeKotlinReservedWord() = this
 
 internal fun String.escapeTypeReservedWord(): String? {
   return when {
@@ -37,7 +37,7 @@ private fun String.escapeCompanionReservedWord(): String? {
   }
 }
 
-fun String.escapeKotlinReservedWordInEnum(): String {
+internal fun String.escapeKotlinReservedWordInEnum(): String {
   return when {
     // name and ordinal are forbidden because already used in Kotlin
     // See https://kotlinlang.org/docs/enum-classes.html#working-with-enum-constants:~:text=properties%20for%20obtaining%20its%20name%20and%20position
@@ -46,6 +46,6 @@ fun String.escapeKotlinReservedWordInEnum(): String {
   }
 }
 
-fun String.escapeKotlinReservedWordInSealedClass(): String {
+internal fun String.escapeKotlinReservedWordInSealedClass(): String {
   return escapeTypeReservedWord() ?: escapeCompanionReservedWord() ?: escapeKotlinReservedWord()
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/addRequiredFields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/addRequiredFields.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLField
 import com.apollographql.apollo3.ast.GQLFragmentDefinition

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloInlineFragmentsHaveTypeCondition.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloInlineFragmentsHaveTypeCondition.kt
@@ -1,6 +1,6 @@
 @file:JvmName("-checkApolloInlineFragmentsHaveTypeCondition")
 
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLDefinition
 import com.apollographql.apollo3.ast.GQLField

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloReservedEnumValueNames.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloReservedEnumValueNames.kt
@@ -1,6 +1,6 @@
 @file:JvmName("-checkApolloReservedEnumValueNames")
 
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLEnumTypeDefinition
 import com.apollographql.apollo3.ast.Issue

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloTargetNameClashes.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkApolloTargetNameClashes.kt
@@ -1,6 +1,6 @@
 @file:JvmName("-checkApolloDuplicateTargetNames")
 
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLTypeDefinition
 import com.apollographql.apollo3.ast.Issue

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkCapitalizedFields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkCapitalizedFields.kt
@@ -1,8 +1,7 @@
 @file:JvmName("-checkCapitalizedFields")
 
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.ast.GQLDefinition
 import com.apollographql.apollo3.ast.GQLField
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
@@ -13,8 +12,7 @@ import com.apollographql.apollo3.ast.GQLSelection
 import com.apollographql.apollo3.ast.Issue
 import com.apollographql.apollo3.ast.UpperCaseField
 
-@ApolloInternal
-fun checkCapitalizedFields(definitions: List<GQLDefinition>, checkFragmentsOnly: Boolean): List<Issue> {
+internal fun checkCapitalizedFields(definitions: List<GQLDefinition>, checkFragmentsOnly: Boolean): List<Issue> {
   val scope = object : ValidationScope {
     override val issues = mutableListOf<Issue>()
     override val fragmentsByName = definitions.filterIsInstance<GQLFragmentDefinition>().associateBy { it.name }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkConditionalFragment.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkConditionalFragment.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.ConditionalFragment
 import com.apollographql.apollo3.ast.GQLDefinition

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkKeyFields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkKeyFields.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLDirective
 import com.apollographql.apollo3.ast.GQLField

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/scoping.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/scoping.kt
@@ -1,3 +1,3 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 internal inline fun <T> T.applyIf(condition: Boolean, block: T.() -> Unit): T = if (condition) apply(block) else this

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/serialization.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/serialization.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler
+package com.apollographql.apollo3.compiler.internal
 
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLType

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
@@ -2,9 +2,9 @@ package com.apollographql.apollo3.compiler.ir
 
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLType
-import com.apollographql.apollo3.compiler.BooleanExpressionSerializer
-import com.apollographql.apollo3.compiler.GQLFragmentDefinitionSerializer
-import com.apollographql.apollo3.compiler.GQLTypeSerializer
+import com.apollographql.apollo3.compiler.internal.BooleanExpressionSerializer
+import com.apollographql.apollo3.compiler.internal.GQLTypeSerializer
+import com.apollographql.apollo3.compiler.internal.GQLFragmentDefinitionSerializer
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchemaBuilder.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.ast.GQLScalarTypeDefinition
 import com.apollographql.apollo3.ast.GQLUnionTypeDefinition
 import com.apollographql.apollo3.ast.Schema
 
-object IrSchemaBuilder {
+internal object IrSchemaBuilder {
   fun build(
       schema: Schema,
       usedFields: Map<String, Set<String>>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrTarget.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrTarget.kt
@@ -1,7 +1,9 @@
 package com.apollographql.apollo3.compiler.ir
 
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.squareup.kotlinpoet.ClassName
 
+@ApolloInternal
 data class IrClassName(
     val packageName: String,
     val names: List<String>
@@ -11,8 +13,9 @@ data class IrClassName(
   }
 }
 
-fun IrClassName.asKotlinPoet(): ClassName = ClassName(packageName, names)
+internal fun IrClassName.asKotlinPoet(): ClassName = ClassName(packageName, names)
 
+@ApolloInternal
 class IrTargetField(
     val name: String,
     val targetName: String,
@@ -21,14 +24,20 @@ class IrTargetField(
     val arguments: List<IrTargetArgument>
 )
 
+@ApolloInternal
 sealed interface IrTargetArgument
+
+@ApolloInternal
 object IrExecutionContextTargetArgument: IrTargetArgument
+
+@ApolloInternal
 class IrGraphqlTargetArgument(
     val name: String,
     val targetName: String,
     val type: IrType,
 ): IrTargetArgument
 
+@ApolloInternal
 class IrTargetObject(
     val name: String,
     val targetClassName: IrClassName,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrType.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.compiler.ir
 
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.ast.GQLEnumTypeDefinition
 import com.apollographql.apollo3.ast.GQLInputObjectTypeDefinition
 import com.apollographql.apollo3.ast.GQLInterfaceTypeDefinition
@@ -42,6 +43,7 @@ import kotlinx.serialization.Serializable
  * In java `Option` and `Nullable` might be represented using the same `Optional` depending on the settings.
  */
 @Serializable
+@ApolloInternal
 sealed interface IrType {
   /**
    * This type is nullable in Kotlin
@@ -75,19 +77,21 @@ sealed interface IrType {
 }
 
 @Serializable
+@ApolloInternal
 enum class IrCatchTo {
   Null,
   Result,
   NoCatch
 }
 
-fun IrType.nullable(nullable: Boolean): IrType = copyWith(nullable = nullable)
-fun IrType.optional(optional: Boolean): IrType = copyWith(optional = optional)
-fun IrType.catchTo(catchTo: IrCatchTo): IrType = copyWith(catchTo = catchTo)
-fun IrType.maybeError(maybeError: Boolean): IrType = copyWith(maybeError = maybeError)
+@ApolloInternal fun IrType.nullable(nullable: Boolean): IrType = copyWith(nullable = nullable)
+@ApolloInternal fun IrType.optional(optional: Boolean): IrType = copyWith(optional = optional)
+internal fun IrType.catchTo(catchTo: IrCatchTo): IrType = copyWith(catchTo = catchTo)
+internal fun IrType.maybeError(maybeError: Boolean): IrType = copyWith(maybeError = maybeError)
 
 @Serializable
 @SerialName("list")
+@ApolloInternal
 data class IrListType(
     val ofType: IrType,
     override val nullable: Boolean = false,
@@ -101,6 +105,7 @@ data class IrListType(
 }
 
 @Serializable
+@ApolloInternal
 sealed interface IrNamedType : IrType {
   override fun rawType() = this
   val name: String
@@ -108,6 +113,7 @@ sealed interface IrNamedType : IrType {
 
 @Serializable
 @SerialName("scalar")
+@ApolloInternal
 data class IrScalarType(
     override val name: String,
     override val nullable: Boolean = false,
@@ -121,6 +127,7 @@ data class IrScalarType(
 
 @Serializable
 @SerialName("input")
+@ApolloInternal
 data class IrInputObjectType(
     override val name: String,
     override val nullable: Boolean = false,
@@ -134,6 +141,7 @@ data class IrInputObjectType(
 
 @Serializable
 @SerialName("enum")
+@ApolloInternal
 data class IrEnumType(
     override val name: String,
     override val nullable: Boolean = false,
@@ -147,6 +155,7 @@ data class IrEnumType(
 
 @Serializable
 @SerialName("object")
+@ApolloInternal
 data class IrObjectType(
     override val name: String,
     override val nullable: Boolean = false,
@@ -179,7 +188,8 @@ data class IrObjectType(
  */
 @Serializable
 @SerialName("model")
-internal data class IrModelType(
+@ApolloInternal
+data class IrModelType(
     val path: String,
     override val nullable: Boolean = false,
     override val optional: Boolean = false,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedModelGroupBuilder.kt
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.lowerCamelCaseIgnoringNonLetters
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.modelName
 import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
-import com.apollographql.apollo3.compiler.escapeKotlinReservedWord
+import com.apollographql.apollo3.compiler.internal.escapeKotlinReservedWord
 
 internal class OperationBasedModelGroupBuilder(
     private val schema: Schema,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedWithInterfacesModelGroupBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/OperationBasedWithInterfacesModelGroupBuilder.kt
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.lowerCamelCaseIgnoringNonLetters
 import com.apollographql.apollo3.compiler.codegen.CodegenLayout.Companion.modelName
 import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
-import com.apollographql.apollo3.compiler.escapeKotlinReservedWord
+import com.apollographql.apollo3.compiler.internal.escapeKotlinReservedWord
 
 /**
  * Very similar to [OperationBasedModelGroupBuilder] except:

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/json.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/json.kt
@@ -56,8 +56,7 @@ fun CodegenOptions.writeTo(file: File) = encodeToJson(file)
 internal fun File.toCodegenSchema(): CodegenSchema = parseFromJson()
 internal fun File.toIrOperations(): IrOperations = parseFromJson<DefaultIrOperations>()
 internal fun File.toIrSchema(): IrSchema = parseFromJson<DefaultIrSchema>()
-@ApolloInternal // XXX: make internal
-fun File.toCodegenMetadata(): CodegenMetadata = parseFromJson()
+internal fun File.toCodegenMetadata(): CodegenMetadata = parseFromJson()
 // Public on purpose
 @JvmName("readOperationOutput")
 fun File.toOperationOutput(): OperationOutput = parseFromJson<Map<String, OperationDescriptor>>()

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TypenameTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/TypenameTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ast.GQLOperationDefinition
 import com.apollographql.apollo3.ast.toExecutableDocument
 import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.toUtf8
+import com.apollographql.apollo3.compiler.internal.addRequiredFields
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/ValidationTest.kt
@@ -6,6 +6,9 @@ import com.apollographql.apollo3.ast.validateAsSchemaAndAddApolloDefinition
 import com.apollographql.apollo3.compiler.TestUtils.checkExpected
 import com.apollographql.apollo3.compiler.TestUtils.serialize
 import com.apollographql.apollo3.compiler.TestUtils.testParametersForGraphQLFilesIn
+import com.apollographql.apollo3.compiler.internal.checkApolloReservedEnumValueNames
+import com.apollographql.apollo3.compiler.internal.checkApolloTargetNameClashes
+import com.apollographql.apollo3.compiler.internal.checkCapitalizedFields
 import okio.buffer
 import okio.source
 import org.junit.Test

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
@@ -9,8 +9,8 @@ import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toGQLDocument
 import com.apollographql.apollo3.ast.toSchema
 import com.apollographql.apollo3.ast.validateAsSchema
-import com.apollographql.apollo3.compiler.addRequiredFields
-import com.apollographql.apollo3.compiler.checkKeyFields
+import com.apollographql.apollo3.compiler.internal.addRequiredFields
+import com.apollographql.apollo3.compiler.internal.checkKeyFields
 import okio.Path.Companion.toPath
 import kotlin.test.Test
 import kotlin.test.assertContains

--- a/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
@@ -1,7 +1,5 @@
 package com.apollographql.apollo3.gradle.test
 
-import com.apollographql.apollo3.compiler.schemaTypes
-import com.apollographql.apollo3.compiler.toCodegenMetadata
 import com.google.common.truth.Truth
 import org.gradle.testkit.runner.TaskOutcome
 import org.gradle.testkit.runner.UnexpectedBuildFailure
@@ -96,9 +94,8 @@ class MultiModulesTests {
       // Date and GeoPoint is generated in the root module
       Assert.assertTrue(File(dir, "root/build/generated/source/apollo/service/com/library/type/Date.kt").exists())
       Assert.assertTrue(File(dir, "root/build/generated/source/apollo/service/com/library/type/GeoPoint.kt").exists())
-      // Leaf metadata doesn't contain anything regarding Date
-      val codegenMetadata = File(dir, "leaf/build/generated/metadata/apollo/service/metadata.json").toCodegenMetadata()
-      Truth.assertThat(codegenMetadata.schemaTypes()).doesNotContain("Date")
+      // Leaf metadata doesn't contain Date
+      Assert.assertTrue(dir.walk().filter { it.isFile && it.name == "Data.kt" }.toList().isEmpty())
     }
   }
 


### PR DESCRIPTION
Except for one tiny functional change, this is mostly moving things around & tweaking public visibility.

`ApolloCompiler` and all `FooOptions` are now public. 

Made some of `IrFoo` internal. Unfortunately, a lot has to be public for `ksp-processor` usage. Will dig more into this.

