### PR TITLE
Target Java17 for Android .aars and Java11 for apollo-gradle-plugin.jar

### DIFF
--- a/build-logic/src/main/kotlin/api.kt
+++ b/build-logic/src/main/kotlin/api.kt
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 fun Project.apolloLibrary(
     javaModuleName: String?,
+    jvmTarget: Int? = null,
     withJs: Boolean = true,
     withLinux: Boolean = true,
     withApple: Boolean = true,
@@ -15,8 +16,8 @@ fun Project.apolloLibrary(
   version = property("VERSION_NAME")!!
 
   commonSetup()
+  configureJavaAndKotlinCompilers(jvmTarget)
 
-  configureJavaAndKotlinCompilers()
   addOptIn(
       "com.apollographql.apollo3.annotations.ApolloExperimental",
       "com.apollographql.apollo3.annotations.ApolloInternal"
@@ -63,7 +64,7 @@ fun Project.apolloTest(
     browserTest: Boolean = false,
 ) {
   commonSetup()
-  configureJavaAndKotlinCompilers()
+  configureJavaAndKotlinCompilers(null)
   addOptIn(
       "com.apollographql.apollo3.annotations.ApolloExperimental",
       "com.apollographql.apollo3.annotations.ApolloInternal",

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -3,9 +3,9 @@
 # Can be as high as IJ supports
 android-plugin = "8.2.1"
 # The version we compile against
-android-plugin-min = "3.4.2"
-# The latest version that has been tested to work
-android-plugin-max = "8.2.0-alpha03"
+android-plugin-min = "8.0.0"
+# The version used by the 'android-plugin-max' test
+android-plugin-max = "8.2.1"
 android-sdkversion-compile = "33"
 android-sdkversion-compilebenchmark = "34"
 android-sdkversion-min = "16"

--- a/libraries/apollo-gradle-plugin-external/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin-external/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 }
 
 apolloLibrary(
-  javaModuleName = "com.apollographql.apollo3.gradle"
+    javaModuleName = "com.apollographql.apollo3.gradle",
+    jvmTarget = 11 // AGP requires 11
 )
 
 dependencies {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/AndroidPluginFacade.kt
@@ -2,7 +2,6 @@ package com.apollographql.apollo3.gradle.internal
 
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.FeatureExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.BaseVariant
@@ -34,12 +33,6 @@ private fun Project.getVariants(): NamedDomainObjectContainer<BaseVariant> {
 
     is AppExtension -> {
       extension.applicationVariants.all { variant ->
-        container.add(variant)
-      }
-    }
-
-    is FeatureExtension -> {
-      extension.featureVariants.all { variant ->
         container.add(variant)
       }
     }

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -6,7 +6,8 @@ plugins {
 }
 
 apolloLibrary(
-    javaModuleName = null
+    javaModuleName = null,
+    jvmTarget = 11 // AGP requires 11
 )
 
 // Configuration for extra jar to pass to R8 to give it more context about what can be relocated


### PR DESCRIPTION
Looks like D8 can now support 17. 
And AGP requires 11.