### PR TITLE
KDocs: fix publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew -p tests ciBuild -i
-          ./gradlew :apollo-kdoc:dokkatooGeneratePublicationHtml
+          ./gradlew :apollo-kdoc:dokkatooGeneratePublicationHtml --no-build-cache
           ./gradlew ciPublishSnapshot
         env:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
See [this CI run](https://github.com/apollographql/apollo-kotlin/actions/runs/7540490310). Dokka isn't ready yet for Gradle build-cache