### PR TITLE
Remove unnecessary suspend from ApolloStore functions

### DIFF
--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -373,7 +373,7 @@ import com.example.type.__Schema
 import data.builders.schema.__Schema
 ```
 
-### KotlinLabs directive are now version 0.2
+### KotlinLabs directives are now version 0.2
 
 The embedded [kotlinlabs/0.2](https://specs.apollo.dev/kotlin_labs/v0.2/) directives are now version 0.2.
 
@@ -391,6 +391,15 @@ This is a backward compatible change.
 
 
 ## Cache
+
+### ApolloStore
+
+In Apollo Kotlin 3.x, most `ApolloStore` functions were marked as `suspend` even though they were not actually suspending and perform the work in the thread they are called from.
+In particular, they can be blocking when the underlying cache is doing IO, so calling them from the main thread can lead to ANRs.
+
+In Apollo Kotlin 4.0 this is still the case but the functions are no longer marked as `suspend` to avoid any confusion.
+
+### Configuration order
 
 The normalized cache must be configured before the auto persisted queries, configuring it after will now fail (see https://github.com/apollographql/apollo-kotlin/pull/4709).
 

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo3/debugserver/internal/graphql/GraphQL.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.debugserver.internal.graphql
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.GraphQLAdapter
-import com.apollographql.apollo3.annotations.GraphQLObject
 import com.apollographql.apollo3.annotations.GraphQLName
+import com.apollographql.apollo3.annotations.GraphQLObject
 import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.ExecutionContext
@@ -20,7 +20,6 @@ import com.apollographql.apollo3.execution.ExecutableSchema
 import com.apollographql.apollo3.execution.GraphQLRequest
 import com.apollographql.apollo3.execution.GraphQLRequestError
 import com.apollographql.apollo3.execution.parsePostGraphQLRequest
-import kotlinx.coroutines.runBlocking
 import okio.Buffer
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KClass
@@ -86,7 +85,7 @@ internal class GraphQLApolloClient(
 
   fun normalizedCaches(): List<NormalizedCache> {
     val apolloStore = runCatching {  apolloClient.apolloStore }.getOrNull() ?: return emptyList()
-    return runBlocking { apolloStore.dump() }.map {
+    return apolloStore.dump().map {
       NormalizedCache(id, it.key, it.value)
     }
   }

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -31,7 +31,7 @@ import kotlin.reflect.KClass
  */
 interface ApolloStore {
   /**
-   * Expose the keys of records that have changed.
+   * Exposes the keys of records that have changed.
    */
   val changedKeys: SharedFlow<Set<String>>
 

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -25,10 +25,13 @@ import kotlin.reflect.KClass
 
 /**
  * ApolloStore exposes a thread-safe api to access a [com.apollographql.apollo3.cache.normalized.api.NormalizedCache].
+ *
+ * Note that most operations are synchronous and might block if the underlying cache is doing IO - calling them from the main thread
+ * should be avoided.
  */
 interface ApolloStore {
   /**
-   * [changedKeys] will emit changes as they are written
+   * Expose the keys of records that have changed.
    */
   val changedKeys: SharedFlow<Set<String>>
 
@@ -108,6 +111,7 @@ interface ApolloStore {
 
   /**
    * Write operation data to the optimistic store.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
    * @param operation     [Operation] response data of which should be written to the store
    * @param operationData [Operation.Data] operation response data to be written to the store
@@ -124,6 +128,7 @@ interface ApolloStore {
 
   /**
    * Rollback operation data optimistic updates.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
    * @param mutationId mutation unique identifier
    * @return the changed keys
@@ -161,6 +166,9 @@ interface ApolloStore {
    */
   fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
 
+  /**
+   * Normalize [data] to a map of [Record] keyed by [Record.key].
+   */
   fun <D : Operation.Data> normalize(
       operation: Operation<D>,
       data: D,
@@ -174,15 +182,20 @@ interface ApolloStore {
 
   /**
    * Direct access to the cache.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
-   * @param block a function that can access the cache. The function will be called from a background thread
+   * @param block a function that can access the cache.
    */
   fun <R> accessCache(block: (NormalizedCache) -> R): R
 
+  /**
+   * Dump the content of the store for debugging purposes.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
+   */
   fun dump(): Map<KClass<*>, Map<String, Record>>
 
   /**
-   * releases resources associated with this store.
+   * Release resources associated with this store.
    */
   fun dispose()
 }

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -43,7 +43,7 @@ interface ApolloStore {
    *
    * @return the operation data
    */
-  suspend fun <D : Operation.Data> readOperation(
+  fun <D : Operation.Data> readOperation(
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
       cacheHeaders: CacheHeaders = CacheHeaders.NONE,
@@ -61,7 +61,7 @@ interface ApolloStore {
    *
    * @return the fragment data
    */
-  suspend fun <D : Fragment.Data> readFragment(
+  fun <D : Fragment.Data> readFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -78,7 +78,7 @@ interface ApolloStore {
    * @param publish       whether to publish the changed keys to listeners
    * @return the changed keys
    */
-  suspend fun <D : Operation.Data> writeOperation(
+  fun <D : Operation.Data> writeOperation(
       operation: Operation<D>,
       operationData: D,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -97,7 +97,7 @@ interface ApolloStore {
    * @param publish whether to publish the changed keys to listeners
    * @return the changed keys
    */
-  suspend fun <D : Fragment.Data> writeFragment(
+  fun <D : Fragment.Data> writeFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       fragmentData: D,
@@ -114,7 +114,7 @@ interface ApolloStore {
    * @param mutationId    mutation unique identifier
    * @return the changed keys
    */
-  suspend fun <D : Operation.Data> writeOptimisticUpdates(
+  fun <D : Operation.Data> writeOptimisticUpdates(
       operation: Operation<D>,
       operationData: D,
       mutationId: Uuid,
@@ -128,7 +128,7 @@ interface ApolloStore {
    * @param mutationId mutation unique identifier
    * @return the changed keys
    */
-  suspend fun rollbackOptimisticUpdates(
+  fun rollbackOptimisticUpdates(
       mutationId: Uuid,
       publish: Boolean = true,
   ): Set<String>
@@ -149,7 +149,7 @@ interface ApolloStore {
    * @param cascade defines if remove operation is propagated to the referenced entities
    * @return `true` if the record was successfully removed, `false` otherwise
    */
-  suspend fun remove(cacheKey: CacheKey, cascade: Boolean = true): Boolean
+  fun remove(cacheKey: CacheKey, cascade: Boolean = true): Boolean
 
   /**
    * Remove a list of cache records
@@ -159,7 +159,7 @@ interface ApolloStore {
    * @param cacheKeys keys of records to be removed
    * @return the number of records that have been removed
    */
-  suspend fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
+  fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
 
   fun <D : Operation.Data> normalize(
       operation: Operation<D>,
@@ -170,16 +170,16 @@ interface ApolloStore {
   /**
    * @param keys A set of keys of [Record] which have changed.
    */
-  suspend fun publish(keys: Set<String>)
+  fun publish(keys: Set<String>)
 
   /**
    * Direct access to the cache.
    *
    * @param block a function that can access the cache. The function will be called from a background thread
    */
-  suspend fun <R> accessCache(block: (NormalizedCache) -> R): R
+  fun <R> accessCache(block: (NormalizedCache) -> R): R
 
-  suspend fun dump(): Map<KClass<*>, Map<String, Record>>
+  fun dump(): Map<KClass<*>, Map<String, Record>>
 
   /**
    * releases resources associated with this store.

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 internal class ApolloCacheInterceptor(
     val store: ApolloStore,
 ) : ApolloInterceptor {
-  private suspend fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: suspend () -> Unit) {
+  private fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: () -> Unit) {
     if (request.writeToCacheAsynchronously) {
       val scope = request.executionContext[ConcurrencyInfo]!!.coroutineScope
       scope.launch {
@@ -56,7 +56,7 @@ internal class ApolloCacheInterceptor(
   /**
    * @param extraKeys extra keys to publish in case there is optimistic data
    */
-  private suspend fun <D : Operation.Data> maybeWriteToCache(
+  private fun <D : Operation.Data> maybeWriteToCache(
       request: ApolloRequest<D>,
       response: ApolloResponse<D>,
       customScalarAdapters: CustomScalarAdapters,
@@ -198,7 +198,7 @@ internal class ApolloCacheInterceptor(
     }
   }
 
-  private suspend fun <D : Query.Data> readFromCache(
+  private fun <D : Query.Data> readFromCache(
       request: ApolloRequest<D>,
       customScalarAdapters: CustomScalarAdapters,
   ): ApolloResponse<D> {
@@ -248,7 +248,7 @@ internal class ApolloCacheInterceptor(
   }
 
 
-  private suspend fun <D : Operation.Data> readFromNetwork(
+  private fun <D : Operation.Data> readFromNetwork(
       request: ApolloRequest<D>,
       chain: ApolloInterceptorChain,
       customScalarAdapters: CustomScalarAdapters,

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -53,12 +53,12 @@ internal class DefaultApolloStore(
 
   private val lock = Lock()
 
-  override suspend fun publish(keys: Set<String>) {
+  override fun publish(keys: Set<String>) {
     if (keys.isEmpty()) {
       return
     }
 
-    changedKeysEvents.emit(keys)
+    changedKeysEvents.tryEmit(keys)
   }
 
   override fun clearAll(): Boolean {
@@ -68,7 +68,7 @@ internal class DefaultApolloStore(
     return true
   }
 
-  override suspend fun remove(
+  override fun remove(
       cacheKey: CacheKey,
       cascade: Boolean,
   ): Boolean {
@@ -77,7 +77,7 @@ internal class DefaultApolloStore(
     }
   }
 
-  override suspend fun remove(
+  override fun remove(
       cacheKeys: List<CacheKey>,
       cascade: Boolean,
   ): Int {
@@ -105,7 +105,7 @@ internal class DefaultApolloStore(
     )
   }
 
-  override suspend fun <D : Operation.Data> readOperation(
+  override fun <D : Operation.Data> readOperation(
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters,
       cacheHeaders: CacheHeaders,
@@ -122,7 +122,7 @@ internal class DefaultApolloStore(
     }.toData(operation.adapter(), customScalarAdapters, variables)
   }
 
-  override suspend fun <D : Fragment.Data> readFragment(
+  override fun <D : Fragment.Data> readFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       customScalarAdapters: CustomScalarAdapters,
@@ -141,15 +141,14 @@ internal class DefaultApolloStore(
     }.toData(fragment.adapter(), customScalarAdapters, variables)
   }
 
-
-  override suspend fun <R> accessCache(block: (NormalizedCache) -> R): R {
+  override fun <R> accessCache(block: (NormalizedCache) -> R): R {
     /**
      * We don't know how the cache is going to be used, assume write access
      */
     return lock.write { block(cache) }
   }
 
-  override suspend fun <D : Operation.Data> writeOperation(
+  override fun <D : Operation.Data> writeOperation(
       operation: Operation<D>,
       operationData: D,
       customScalarAdapters: CustomScalarAdapters,
@@ -165,7 +164,7 @@ internal class DefaultApolloStore(
     ).second
   }
 
-  override suspend fun <D : Fragment.Data> writeFragment(
+  override fun <D : Fragment.Data> writeFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       fragmentData: D,
@@ -192,7 +191,7 @@ internal class DefaultApolloStore(
     return changedKeys
   }
 
-  suspend fun <D : Operation.Data> writeOperationWithRecords(
+  private fun <D : Operation.Data> writeOperationWithRecords(
       operation: Operation<D>,
       operationData: D,
       cacheHeaders: CacheHeaders,
@@ -218,7 +217,7 @@ internal class DefaultApolloStore(
   }
 
 
-  override suspend fun <D : Operation.Data> writeOptimisticUpdates(
+  override fun <D : Operation.Data> writeOptimisticUpdates(
       operation: Operation<D>,
       operationData: D,
       mutationId: Uuid,
@@ -252,7 +251,7 @@ internal class DefaultApolloStore(
     return changedKeys
   }
 
-  override suspend fun rollbackOptimisticUpdates(
+  override fun rollbackOptimisticUpdates(
       mutationId: Uuid,
       publish: Boolean,
   ): Set<String> {
@@ -273,7 +272,7 @@ internal class DefaultApolloStore(
     }
   }
 
-  override suspend fun dump(): Map<KClass<*>, Map<String, Record>> {
+  override fun dump(): Map<KClass<*>, Map<String, Record>> {
     return lock.read {
       cache.dump()
     }

--- a/libraries/apollo-normalized-cache/api/apollo-normalized-cache.api
+++ b/libraries/apollo-normalized-cache/api/apollo-normalized-cache.api
@@ -1,27 +1,27 @@
 public abstract interface class com/apollographql/apollo3/cache/normalized/ApolloStore {
-	public abstract fun accessCache (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun accessCache (Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 	public abstract fun clearAll ()Z
 	public abstract fun dispose ()V
-	public abstract fun dump (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun dump ()Ljava/util/Map;
 	public abstract fun getChangedKeys ()Lkotlinx/coroutines/flow/SharedFlow;
 	public abstract fun normalize (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;)Ljava/util/Map;
-	public abstract fun publish (Ljava/util/Set;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun readFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun readFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun readOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun readOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun remove (Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun remove (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/List;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun rollbackOptimisticUpdates (Ljava/util/UUID;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun rollbackOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/UUID;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun writeFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun writeFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun writeOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun writeOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun writeOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun publish (Ljava/util/Set;)V
+	public abstract fun readFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Lcom/apollographql/apollo3/api/Fragment$Data;
+	public static synthetic fun readFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Fragment$Data;
+	public abstract fun readOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public static synthetic fun readOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ILjava/lang/Object;)Lcom/apollographql/apollo3/api/Operation$Data;
+	public abstract fun remove (Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Z)Z
+	public abstract fun remove (Ljava/util/List;Z)I
+	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;ZILjava/lang/Object;)Z
+	public static synthetic fun remove$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/List;ZILjava/lang/Object;)I
+	public abstract fun rollbackOptimisticUpdates (Ljava/util/UUID;Z)Ljava/util/Set;
+	public static synthetic fun rollbackOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Ljava/util/UUID;ZILjava/lang/Object;)Ljava/util/Set;
+	public abstract fun writeFragment (Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Z)Ljava/util/Set;
+	public static synthetic fun writeFragment$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Fragment;Lcom/apollographql/apollo3/cache/normalized/api/CacheKey;Lcom/apollographql/apollo3/api/Fragment$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZILjava/lang/Object;)Ljava/util/Set;
+	public abstract fun writeOperation (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;Z)Ljava/util/Set;
+	public static synthetic fun writeOperation$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/cache/normalized/api/CacheHeaders;ZILjava/lang/Object;)Ljava/util/Set;
+	public abstract fun writeOptimisticUpdates (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Z)Ljava/util/Set;
+	public static synthetic fun writeOptimisticUpdates$default (Lcom/apollographql/apollo3/cache/normalized/ApolloStore;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Ljava/util/UUID;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZILjava/lang/Object;)Ljava/util/Set;
 }
 
 public final class com/apollographql/apollo3/cache/normalized/ApolloStoreKt {

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -37,7 +37,7 @@ interface ApolloStore {
    *
    * @return the operation data
    */
-  suspend fun <D : Operation.Data> readOperation(
+  fun <D : Operation.Data> readOperation(
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
       cacheHeaders: CacheHeaders = CacheHeaders.NONE,
@@ -55,7 +55,7 @@ interface ApolloStore {
    *
    * @return the fragment data
    */
-  suspend fun <D : Fragment.Data> readFragment(
+  fun <D : Fragment.Data> readFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -72,7 +72,7 @@ interface ApolloStore {
    * @param publish       whether to publish the changed keys to listeners
    * @return the changed keys
    */
-  suspend fun <D : Operation.Data> writeOperation(
+  fun <D : Operation.Data> writeOperation(
       operation: Operation<D>,
       operationData: D,
       customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -91,7 +91,7 @@ interface ApolloStore {
    * @param publish whether to publish the changed keys to listeners
    * @return the changed keys
    */
-  suspend fun <D : Fragment.Data> writeFragment(
+  fun <D : Fragment.Data> writeFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       fragmentData: D,
@@ -108,7 +108,7 @@ interface ApolloStore {
    * @param mutationId    mutation unique identifier
    * @return the changed keys
    */
-  suspend fun <D : Operation.Data> writeOptimisticUpdates(
+  fun <D : Operation.Data> writeOptimisticUpdates(
       operation: Operation<D>,
       operationData: D,
       mutationId: Uuid,
@@ -122,7 +122,7 @@ interface ApolloStore {
    * @param mutationId mutation unique identifier
    * @return the changed keys
    */
-  suspend fun rollbackOptimisticUpdates(
+  fun rollbackOptimisticUpdates(
       mutationId: Uuid,
       publish: Boolean = true,
   ): Set<String>
@@ -143,7 +143,7 @@ interface ApolloStore {
    * @param cascade defines if remove operation is propagated to the referenced entities
    * @return `true` if the record was successfully removed, `false` otherwise
    */
-  suspend fun remove(cacheKey: CacheKey, cascade: Boolean = true): Boolean
+  fun remove(cacheKey: CacheKey, cascade: Boolean = true): Boolean
 
   /**
    * Remove a list of cache records
@@ -153,7 +153,7 @@ interface ApolloStore {
    * @param cacheKeys keys of records to be removed
    * @return the number of records that have been removed
    */
-  suspend fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
+  fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
 
   fun <D : Operation.Data> normalize(
       operation: Operation<D>,
@@ -164,16 +164,16 @@ interface ApolloStore {
   /**
    * @param keys A set of keys of [Record] which have changed.
    */
-  suspend fun publish(keys: Set<String>)
+  fun publish(keys: Set<String>)
 
   /**
    * Direct access to the cache.
    *
    * @param block a function that can access the cache. The function will be called from a background thread
    */
-  suspend fun <R> accessCache(block: (NormalizedCache) -> R): R
+  fun <R> accessCache(block: (NormalizedCache) -> R): R
 
-  suspend fun dump(): Map<KClass<*>, Map<String, Record>>
+  fun dump(): Map<KClass<*>, Map<String, Record>>
 
   /**
    * releases resources associated with this store.

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -25,7 +25,7 @@ import kotlin.reflect.KClass
  */
 interface ApolloStore {
   /**
-   * Expose the keys of records that have changed.
+   * Exposes the keys of records that have changed.
    */
   val changedKeys: SharedFlow<Set<String>>
 

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -19,10 +19,13 @@ import kotlin.reflect.KClass
 
 /**
  * ApolloStore exposes a thread-safe api to access a [com.apollographql.apollo3.cache.normalized.api.NormalizedCache].
+ *
+ * Note that most operations are synchronous and might block if the underlying cache is doing IO - calling them from the main thread
+ * should be avoided.
  */
 interface ApolloStore {
   /**
-   * [changedKeys] will emit changes as they are written
+   * Expose the keys of records that have changed.
    */
   val changedKeys: SharedFlow<Set<String>>
 
@@ -102,6 +105,7 @@ interface ApolloStore {
 
   /**
    * Write operation data to the optimistic store.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
    * @param operation     [Operation] response data of which should be written to the store
    * @param operationData [Operation.Data] operation response data to be written to the store
@@ -118,6 +122,7 @@ interface ApolloStore {
 
   /**
    * Rollback operation data optimistic updates.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
    * @param mutationId mutation unique identifier
    * @return the changed keys
@@ -155,6 +160,9 @@ interface ApolloStore {
    */
   fun remove(cacheKeys: List<CacheKey>, cascade: Boolean = true): Int
 
+  /**
+   * Normalize [data] to a map of [Record] keyed by [Record.key].
+   */
   fun <D : Operation.Data> normalize(
       operation: Operation<D>,
       data: D,
@@ -168,15 +176,20 @@ interface ApolloStore {
 
   /**
    * Direct access to the cache.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
    *
-   * @param block a function that can access the cache. The function will be called from a background thread
+   * @param block a function that can access the cache.
    */
   fun <R> accessCache(block: (NormalizedCache) -> R): R
 
+  /**
+   * Dump the content of the store for debugging purposes.
+   * This is a synchronous operation that might block if the underlying cache is doing IO.
+   */
   fun dump(): Map<KClass<*>, Map<String, Record>>
 
   /**
-   * releases resources associated with this store.
+   * Release resources associated with this store.
    */
   fun dispose()
 }

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 internal class ApolloCacheInterceptor(
     val store: ApolloStore,
 ) : ApolloInterceptor {
-  private suspend fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: suspend () -> Unit) {
+  private fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: () -> Unit) {
     if (request.writeToCacheAsynchronously) {
       val scope = request.executionContext[ConcurrencyInfo]!!.coroutineScope
       scope.launch {
@@ -56,7 +56,7 @@ internal class ApolloCacheInterceptor(
   /**
    * @param extraKeys extra keys to publish in case there is optimistic data
    */
-  private suspend fun <D : Operation.Data> maybeWriteToCache(
+  private fun <D : Operation.Data> maybeWriteToCache(
       request: ApolloRequest<D>,
       response: ApolloResponse<D>,
       customScalarAdapters: CustomScalarAdapters,
@@ -198,7 +198,7 @@ internal class ApolloCacheInterceptor(
     }
   }
 
-  private suspend fun <D : Query.Data> readFromCache(
+  private fun <D : Query.Data> readFromCache(
       request: ApolloRequest<D>,
       customScalarAdapters: CustomScalarAdapters,
   ): ApolloResponse<D> {
@@ -247,7 +247,7 @@ internal class ApolloCacheInterceptor(
   }
 
 
-  private suspend fun <D : Operation.Data> readFromNetwork(
+  private fun <D : Operation.Data> readFromNetwork(
       request: ApolloRequest<D>,
       chain: ApolloInterceptorChain,
       customScalarAdapters: CustomScalarAdapters,

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -45,12 +45,12 @@ internal class DefaultApolloStore(
 
   private val lock = Lock()
 
-  override suspend fun publish(keys: Set<String>) {
+  override fun publish(keys: Set<String>) {
     if (keys.isEmpty()) {
       return
     }
 
-    changedKeysEvents.emit(keys)
+    changedKeysEvents.tryEmit(keys)
   }
 
   override fun clearAll(): Boolean {
@@ -60,7 +60,7 @@ internal class DefaultApolloStore(
     return true
   }
 
-  override suspend fun remove(
+  override fun remove(
       cacheKey: CacheKey,
       cascade: Boolean,
   ): Boolean {
@@ -69,7 +69,7 @@ internal class DefaultApolloStore(
     }
   }
 
-  override suspend fun remove(
+  override fun remove(
       cacheKeys: List<CacheKey>,
       cascade: Boolean,
   ): Int {
@@ -96,7 +96,7 @@ internal class DefaultApolloStore(
     )
   }
 
-  override suspend fun <D : Operation.Data> readOperation(
+  override fun <D : Operation.Data> readOperation(
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters,
       cacheHeaders: CacheHeaders,
@@ -112,7 +112,7 @@ internal class DefaultApolloStore(
     }.toData(operation.adapter(), customScalarAdapters, variables)
   }
 
-  override suspend fun <D : Fragment.Data> readFragment(
+  override fun <D : Fragment.Data> readFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       customScalarAdapters: CustomScalarAdapters,
@@ -130,14 +130,14 @@ internal class DefaultApolloStore(
     }.toData(fragment.adapter(), customScalarAdapters, variables)
   }
 
-  override suspend fun <R> accessCache(block: (NormalizedCache) -> R): R {
+  override fun <R> accessCache(block: (NormalizedCache) -> R): R {
     /**
      * We don't know how the cache is going to be used, assume write access
      */
     return lock.write { block(cache) }
   }
 
-  override suspend fun <D : Operation.Data> writeOperation(
+  override fun <D : Operation.Data> writeOperation(
       operation: Operation<D>,
       operationData: D,
       customScalarAdapters: CustomScalarAdapters,
@@ -153,7 +153,7 @@ internal class DefaultApolloStore(
     ).second
   }
 
-  override suspend fun <D : Fragment.Data> writeFragment(
+  override fun <D : Fragment.Data> writeFragment(
       fragment: Fragment<D>,
       cacheKey: CacheKey,
       fragmentData: D,
@@ -179,7 +179,7 @@ internal class DefaultApolloStore(
     return changedKeys
   }
 
-  suspend fun <D : Operation.Data> writeOperationWithRecords(
+  private fun <D : Operation.Data> writeOperationWithRecords(
       operation: Operation<D>,
       operationData: D,
       cacheHeaders: CacheHeaders,
@@ -204,7 +204,7 @@ internal class DefaultApolloStore(
   }
 
 
-  override suspend fun <D : Operation.Data> writeOptimisticUpdates(
+  override fun <D : Operation.Data> writeOptimisticUpdates(
       operation: Operation<D>,
       operationData: D,
       mutationId: Uuid,
@@ -236,7 +236,7 @@ internal class DefaultApolloStore(
     return changedKeys
   }
 
-  override suspend fun rollbackOptimisticUpdates(
+  override fun rollbackOptimisticUpdates(
       mutationId: Uuid,
       publish: Boolean,
   ): Set<String> {
@@ -251,7 +251,7 @@ internal class DefaultApolloStore(
     return changedKeys
   }
 
-  override suspend fun dump(): Map<KClass<*>, Map<String, Record>> {
+  override fun dump(): Map<KClass<*>, Map<String, Record>> {
     return lock.read {
       cache.dump()
     }


### PR DESCRIPTION
These were marked `suspend` but were actually blocking the calling thread