### PR TITLE
Invert memory vs SQL incubating benchmark

### DIFF
--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIncubatingTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIncubatingTests.kt
@@ -57,11 +57,11 @@ class CacheIncubatingTests {
 
   private fun <D : Query.Data> readFromCache(testName: String, query: Query<D>, sql: Boolean, check: (D) -> Unit) {
     val cache = if (sql) {
-      MemoryCacheFactory().create()
-    } else {
       Utils.dbFile.delete()
       // Pass context explicitly here because androidx.startup fails due to relocation
       SqlNormalizedCacheFactory(InstrumentationRegistry.getInstrumentation().context, Utils.dbName).create()
+    } else {
+      MemoryCacheFactory().create()
     }
     val data = query.parseJsonResponse(resource(R.raw.calendar_response).jsonReader()).data!!
 


### PR DESCRIPTION
This explains the surprising slowness of `CacheIncubatingTests.cache*Memory` and speed of `CacheIncubatingTests.cache*Sql` seen in #4231 