### PR TITLE
Select all types in pre-introspection query

### DIFF
--- a/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/ConfigurationCacheTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/ConfigurationCacheTests.kt
@@ -15,25 +15,9 @@ class ConfigurationCacheTests {
     val preIntrospectionResponse = """
       {
         "data": {
-          "schema": {
-            "__typename": "__Type",
-            "fields": []
-          },
-          "type": {
-            "__typename": "__Type",
-            "fields": []
-          },
-          "directive": {
-            "__typename": "__Type",
-            "fields": []
-          },
-          "field": {
-            "__typename": "__Type",
-            "fields": []
-          },
-          "inputValue": {
-            "__typename": "__Type",
-            "fields": []
+          "__schema": {
+            "__typename": "__Schema",
+            "types": []
           }
         }
       }

--- a/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/DownloadSchemaTests.kt
@@ -13,7 +13,6 @@ import okhttp3.tls.HeldCertificate
 import okio.Buffer
 import okio.buffer
 import okio.source
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -37,25 +36,9 @@ class DownloadSchemaTests {
   private val preIntrospectionResponse = """
   {
     "data": {
-      "schema": {
-        "__typename": "__Type",
-        "fields": []
-      },
-      "type": {
-        "__typename": "__Type",
-        "fields": []
-      },
-      "directive": {
-        "__typename": "__Type",
-        "fields": []
-      },
-      "field": {
-        "__typename": "__Type",
-        "fields": []
-      },
-      "inputValue": {
-        "__typename": "__Type",
-        "fields": []
+      "__schema": {
+        "__typename": "__Schema",
+        "types": []
       }
     }
   }

--- a/libraries/apollo-tooling/src/main/graphql/graphql/pre-introspection.graphql
+++ b/libraries/apollo-tooling/src/main/graphql/graphql/pre-introspection.graphql
@@ -1,14 +1,15 @@
 # Pre-introspection query allowing to retrieve the server's supported features.
 
 query PreIntrospectionQuery {
-  schema: __type(name: "__Schema") { ...TypeFields }
-  type: __type(name: "__Type") { ...TypeFields }
-  directive: __type(name: "__Directive") { ...TypeFields }
-  field: __type(name: "__Field") { ...TypeFields }
-  inputValue: __type(name: "__InputValue") { ...TypeFields }
+  __schema {
+    types {
+      ...TypeFields
+    }
+  }
 }
 
 fragment TypeFields on __Type {
+  name
   fields {
     name
     args {

--- a/libraries/apollo-tooling/src/main/graphql/graphql/pre-introspection.graphql
+++ b/libraries/apollo-tooling/src/main/graphql/graphql/pre-introspection.graphql
@@ -1,4 +1,6 @@
 # Pre-introspection query allowing to retrieve the server's supported features.
+# Note: selecting only the relevant types would be more optimized, but we've found it is rejected by api.github.com
+# see https://github.com/apollographql/apollo-kotlin/pull/5547 and https://github.com/orgs/community/discussions/101382
 
 query PreIntrospectionQuery {
   __schema {

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/GraphQLFeature.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/GraphQLFeature.kt
@@ -52,6 +52,11 @@ enum class GraphQLFeature {
 }
 
 internal fun PreIntrospectionQuery.Data.getFeatures(): Set<GraphQLFeature> {
+  val schema = __schema.types.firstOrNull { it.typeFields.name == "__Schema" }
+  val type = __schema.types.firstOrNull { it.typeFields.name == "__Type" }
+  val directive = __schema.types.firstOrNull { it.typeFields.name == "__Directive" }
+  val field = __schema.types.firstOrNull { it.typeFields.name == "__Field" }
+  val inputValue = __schema.types.firstOrNull { it.typeFields.name == "__InputValue" }
   return buildSet {
     if (schema?.typeFields?.fields.orEmpty().any { it.name == "description" }) {
       add(SchemaDescription)

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt
@@ -17,6 +17,7 @@ import com.apollographql.apollo3.network.okHttpClient
 import com.apollographql.apollo3.tooling.SchemaHelper.reworkFullTypeFragment
 import com.apollographql.apollo3.tooling.SchemaHelper.reworkInputValueFragment
 import com.apollographql.apollo3.tooling.SchemaHelper.reworkIntrospectionQuery
+import com.apollographql.apollo3.tooling.graphql.PreIntrospectionQuery
 import com.apollographql.apollo3.tooling.platformapi.public.DownloadSchemaQuery
 import kotlinx.coroutines.runBlocking
 import okio.buffer
@@ -139,16 +140,12 @@ object SchemaDownloader {
       headers: Map<String, String>,
       insecure: Boolean,
   ): String {
-    val features = try {
-      SchemaHelper.executePreIntrospectionQuery(
-          endpoint = endpoint,
-          headers = headers,
-          insecure = insecure,
-      ).getFeatures()
-    } catch (e: Exception) {
-      // Some servers (e.g. api.github.com) don't support the pre-introspection query, fallback to the minimal set of features
-      emptySet()
-    }
+    val preIntrospectionData: PreIntrospectionQuery.Data = SchemaHelper.executePreIntrospectionQuery(
+        endpoint = endpoint,
+        headers = headers,
+        insecure = insecure,
+    )
+    val features = preIntrospectionData.getFeatures()
     val introspectionQuery = getIntrospectionQuery(features)
     return SchemaHelper.executeIntrospectionQuery(
         introspectionQuery = introspectionQuery,

--- a/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-draft.json
+++ b/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-draft.json
@@ -1,179 +1,189 @@
 {
   "data": {
-    "schema": {
-      "__typename": "__Type",
-      "fields": [
+    "__schema": {
+      "__typename": "__Schema",
+      "types": [
         {
-          "name": "types",
-          "args": []
-        },
-        {
-          "name": "queryType",
-          "args": []
-        },
-        {
-          "name": "mutationType",
-          "args": []
-        },
-        {
-          "name": "subscriptionType",
-          "args": []
-        },
-        {
-          "name": "directives",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        }
-      ]
-    },
-    "type": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "kind",
-          "args": []
-        },
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "fields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Schema",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "types",
+              "args": []
+            },
+            {
+              "name": "queryType",
+              "args": []
+            },
+            {
+              "name": "mutationType",
+              "args": []
+            },
+            {
+              "name": "subscriptionType",
+              "args": []
+            },
+            {
+              "name": "directives",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
             }
           ]
         },
         {
-          "name": "interfaces",
-          "args": []
-        },
-        {
-          "name": "possibleTypes",
-          "args": []
-        },
-        {
-          "name": "enumValues",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Type",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "kind",
+              "args": []
+            },
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "fields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "interfaces",
+              "args": []
+            },
+            {
+              "name": "possibleTypes",
+              "args": []
+            },
+            {
+              "name": "enumValues",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "inputFields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "ofType",
+              "args": []
+            },
+            {
+              "name": "specifiedByURL",
+              "args": []
             }
           ]
         },
         {
-          "name": "inputFields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Directive",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "locations",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "isRepeatable",
+              "args": []
             }
           ]
         },
         {
-          "name": "ofType",
-          "args": []
-        },
-        {
-          "name": "specifiedByURL",
-          "args": []
-        }
-      ]
-    },
-    "directive": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "locations",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Field",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
             }
           ]
         },
         {
-          "name": "isRepeatable",
-          "args": []
-        }
-      ]
-    },
-    "field": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": [
+          "__typename": "__Type",
+          "name": "__InputValue",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
+            },
+            {
+              "name": "defaultValue",
+              "args": []
             }
           ]
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        }
-      ]
-    },
-    "inputValue": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        },
-        {
-          "name": "defaultValue",
-          "args": []
         }
       ]
     }

--- a/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-june2018.json
+++ b/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-june2018.json
@@ -1,147 +1,157 @@
 {
   "data": {
-    "schema": {
-      "__typename": "__Type",
-      "fields": [
+    "__schema": {
+      "__typename": "__Schema",
+      "types": [
         {
-          "name": "types",
-          "args": []
-        },
-        {
-          "name": "queryType",
-          "args": []
-        },
-        {
-          "name": "mutationType",
-          "args": []
-        },
-        {
-          "name": "subscriptionType",
-          "args": []
-        },
-        {
-          "name": "directives",
-          "args": []
-        }
-      ]
-    },
-    "type": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "kind",
-          "args": []
-        },
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "fields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Schema",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "types",
+              "args": []
+            },
+            {
+              "name": "queryType",
+              "args": []
+            },
+            {
+              "name": "mutationType",
+              "args": []
+            },
+            {
+              "name": "subscriptionType",
+              "args": []
+            },
+            {
+              "name": "directives",
+              "args": []
             }
           ]
         },
         {
-          "name": "interfaces",
-          "args": []
-        },
-        {
-          "name": "possibleTypes",
-          "args": []
-        },
-        {
-          "name": "enumValues",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Type",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "kind",
+              "args": []
+            },
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "fields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "interfaces",
+              "args": []
+            },
+            {
+              "name": "possibleTypes",
+              "args": []
+            },
+            {
+              "name": "enumValues",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "inputFields",
+              "args": []
+            },
+            {
+              "name": "ofType",
+              "args": []
             }
           ]
         },
         {
-          "name": "inputFields",
-          "args": []
+          "__typename": "__Type",
+          "name": "__Directive",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "locations",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": []
+            }
+          ]
         },
         {
-          "name": "ofType",
-          "args": []
-        }
-      ]
-    },
-    "directive": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
+          "__typename": "__Type",
+          "name": "__Field",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
+            }
+          ]
         },
         {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "locations",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": []
-        }
-      ]
-    },
-    "field": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        }
-      ]
-    },
-    "inputValue": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "defaultValue",
-          "args": []
+          "__typename": "__Type",
+          "name": "__InputValue",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "defaultValue",
+              "args": []
+            }
+          ]
         }
       ]
     }

--- a/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-october2021.json
+++ b/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-october2021.json
@@ -1,159 +1,169 @@
 {
   "data": {
-    "schema": {
-      "__typename": "__Type",
-      "fields": [
+    "__schema": {
+      "__typename": "__Schema",
+      "types": [
         {
-          "name": "types",
-          "args": []
-        },
-        {
-          "name": "queryType",
-          "args": []
-        },
-        {
-          "name": "mutationType",
-          "args": []
-        },
-        {
-          "name": "subscriptionType",
-          "args": []
-        },
-        {
-          "name": "directives",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        }
-      ]
-    },
-    "type": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "kind",
-          "args": []
-        },
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "fields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Schema",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "types",
+              "args": []
+            },
+            {
+              "name": "queryType",
+              "args": []
+            },
+            {
+              "name": "mutationType",
+              "args": []
+            },
+            {
+              "name": "subscriptionType",
+              "args": []
+            },
+            {
+              "name": "directives",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
             }
           ]
         },
         {
-          "name": "interfaces",
-          "args": []
-        },
-        {
-          "name": "possibleTypes",
-          "args": []
-        },
-        {
-          "name": "enumValues",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Type",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "kind",
+              "args": []
+            },
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "fields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "interfaces",
+              "args": []
+            },
+            {
+              "name": "possibleTypes",
+              "args": []
+            },
+            {
+              "name": "enumValues",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "inputFields",
+              "args": []
+            },
+            {
+              "name": "ofType",
+              "args": []
+            },
+            {
+              "name": "specifiedByURL",
+              "args": []
             }
           ]
         },
         {
-          "name": "inputFields",
-          "args": []
+          "__typename": "__Type",
+          "name": "__Directive",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "locations",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": []
+            },
+            {
+              "name": "isRepeatable",
+              "args": []
+            }
+          ]
         },
         {
-          "name": "ofType",
-          "args": []
+          "__typename": "__Type",
+          "name": "__Field",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
+            }
+          ]
         },
         {
-          "name": "specifiedByURL",
-          "args": []
-        }
-      ]
-    },
-    "directive": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "locations",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": []
-        },
-        {
-          "name": "isRepeatable",
-          "args": []
-        }
-      ]
-    },
-    "field": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        }
-      ]
-    },
-    "inputValue": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "defaultValue",
-          "args": []
+          "__typename": "__Type",
+          "name": "__InputValue",
+          "fields": [
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "defaultValue",
+              "args": []
+            }
+          ]
         }
       ]
     }

--- a/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-oneOf.json
+++ b/libraries/apollo-tooling/src/test/fixtures/pre-introspection-response-oneOf.json
@@ -1,183 +1,193 @@
 {
   "data": {
-    "schema": {
-      "__typename": "__Type",
-      "fields": [
+    "__schema": {
+      "__typename": "__Schema",
+      "types": [
         {
-          "name": "types",
-          "args": []
-        },
-        {
-          "name": "queryType",
-          "args": []
-        },
-        {
-          "name": "mutationType",
-          "args": []
-        },
-        {
-          "name": "subscriptionType",
-          "args": []
-        },
-        {
-          "name": "directives",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        }
-      ]
-    },
-    "type": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "kind",
-          "args": []
-        },
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "fields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Schema",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "types",
+              "args": []
+            },
+            {
+              "name": "queryType",
+              "args": []
+            },
+            {
+              "name": "mutationType",
+              "args": []
+            },
+            {
+              "name": "subscriptionType",
+              "args": []
+            },
+            {
+              "name": "directives",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
             }
           ]
         },
         {
-          "name": "interfaces",
-          "args": []
-        },
-        {
-          "name": "possibleTypes",
-          "args": []
-        },
-        {
-          "name": "enumValues",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Type",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "kind",
+              "args": []
+            },
+            {
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "fields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "interfaces",
+              "args": []
+            },
+            {
+              "name": "possibleTypes",
+              "args": []
+            },
+            {
+              "name": "enumValues",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "inputFields",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "ofType",
+              "args": []
+            },
+            {
+              "name": "specifiedByURL",
+              "args": []
+            },
+            {
+              "name": "isOneOf",
+              "args": []
             }
           ]
         },
         {
-          "name": "inputFields",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Directive",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "locations",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "isRepeatable",
+              "args": []
             }
           ]
         },
         {
-          "name": "ofType",
-          "args": []
-        },
-        {
-          "name": "specifiedByURL",
-          "args": []
-        },
-        {
-          "name": "isOneOf",
-          "args": []
-        }
-      ]
-    },
-    "directive": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "locations",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": [
+          "__typename": "__Type",
+          "name": "__Field",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "args",
+              "args": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ]
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
             }
           ]
         },
         {
-          "name": "isRepeatable",
-          "args": []
-        }
-      ]
-    },
-    "field": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "args",
-          "args": [
+          "__typename": "__Type",
+          "name": "__InputValue",
+          "fields": [
             {
-              "name": "includeDeprecated"
+              "name": "name",
+              "args": []
+            },
+            {
+              "name": "description",
+              "args": []
+            },
+            {
+              "name": "type",
+              "args": []
+            },
+            {
+              "name": "isDeprecated",
+              "args": []
+            },
+            {
+              "name": "deprecationReason",
+              "args": []
+            },
+            {
+              "name": "defaultValue",
+              "args": []
             }
           ]
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        }
-      ]
-    },
-    "inputValue": {
-      "__typename": "__Type",
-      "fields": [
-        {
-          "name": "name",
-          "args": []
-        },
-        {
-          "name": "description",
-          "args": []
-        },
-        {
-          "name": "type",
-          "args": []
-        },
-        {
-          "name": "isDeprecated",
-          "args": []
-        },
-        {
-          "name": "deprecationReason",
-          "args": []
-        },
-        {
-          "name": "defaultValue",
-          "args": []
         }
       ]
     }


### PR DESCRIPTION
`api.github.com` doesn't like querying too many introspection elements:

```graphql
{
  "errors": [
    {
      "type": "INTROSPECTION_LIMIT_EXCEEDED",
      "message": "Introspection fields may only be used 2 times, but some fields were used more than that: __Type.fields (5), __Field.args (5)"
    }
  ]
}
```

 We can be lenient in that case, and still try to execute the basic introspection query.