### PR TITLE
Run defer with router tests on linux runner

### DIFF
--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   defer-with-router-tests:
-    runs-on: macos-11
+    runs-on: ubuntu-latest
     if: github.repository == 'apollographql/apollo-kotlin'
     steps:
       - name: Checkout project


### PR DESCRIPTION
Mac x86 binaries of the router are no longer available (https://github.com/apollographql/router/issues/4483).