### PR TITLE
[compiler] Extract the `Layout` interface

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
@@ -74,3 +74,11 @@ internal fun uniqueName(name: String, usedNames: Set<String>): String {
 }
 
 internal fun String.withUnderscorePrefix(): String = if (this == "__typename") this else "_$this"
+
+internal fun String.maybeAddSuffix(suffix: String): String {
+  return if (this.endsWith(suffix)) {
+    this
+  } else {
+    "$this$suffix"
+  }
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/CodegenLayout.kt
@@ -25,8 +25,7 @@ internal class CodegenLayout(
     codegenSchema: CodegenSchema,
     private val packageNameGenerator: PackageNameGenerator,
     private val useSemanticNaming: Boolean,
-    private val decapitalizeFields: Boolean,
-    private val prefix: Boolean
+    private val decapitalizeFields: Boolean
 ) : Layout {
   private val schemaPackageName = executableDocumentPackageName(codegenSchema.filePath ?: "")
   private val schemaTypeToClassName: Map<String, String> = mutableMapOf<String, String>().apply {
@@ -82,7 +81,7 @@ internal class CodegenLayout(
   }
 
   override fun topLevelName(name: String): String {
-    return "${prefix}${name.capitalizeFirstLetter()}"
+    return name.capitalizeFirstLetter()
   }
 
   override fun propertyName(name: String) = if (decapitalizeFields) name.decapitalizeFirstLetter() else name

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Layout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Layout.kt
@@ -1,11 +1,13 @@
 package com.apollographql.apollo3.compiler.codegen
 
-import com.apollographql.apollo3.compiler.PackageNameGenerator
-
 internal interface Layout {
-  val packageNameGenerator: PackageNameGenerator
-  fun schemaTypeName(schemaTypeName: String): String
-  fun basePackageName(): String
+  fun schemaPackageName(): String
+  fun executableDocumentPackageName(filePath: String?): String
+
   fun operationName(name: String, capitalizedOperationType: String): String
+  fun fragmentName(name: String): String
+  fun schemaTypeName(schemaTypeName: String): String
+  fun topLevelName(name: String): String
+
   fun propertyName(name: String): String
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Layout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/Layout.kt
@@ -1,0 +1,11 @@
+package com.apollographql.apollo3.compiler.codegen
+
+import com.apollographql.apollo3.compiler.PackageNameGenerator
+
+internal interface Layout {
+  val packageNameGenerator: PackageNameGenerator
+  fun schemaTypeName(schemaTypeName: String): String
+  fun basePackageName(): String
+  fun operationName(name: String, capitalizedOperationType: String): String
+  fun propertyName(name: String): String
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodeGen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodeGen.kt
@@ -127,9 +127,9 @@ internal object JavaCodeGen {
 
     val layout = CodegenLayout(
         codegenSchema = codegenSchema,
-        useSemanticNaming = useSemanticNaming,
         packageNameGenerator = packageNameGenerator,
-        decapitalizeFields = decapitalizeFields,
+        useSemanticNaming = useSemanticNaming,
+        decapitalizeFields = decapitalizeFields
     )
 
     val context = JavaContext(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentBuilder.kt
@@ -28,7 +28,7 @@ internal class FragmentBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.fragmentPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl()
 
   private val modelBuilders = if (fragment.interfaceModelGroup != null) {
     fragment.dataModelGroup.maybeFlatten(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentDataAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentDataAdapterBuilder.kt
@@ -19,7 +19,7 @@ internal class FragmentDataAdapterBuilder(
     val flatten: Boolean,
 ) : JavaClassBuilder {
   private val packageName = context.layout.fragmentPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl().responseAdapter()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl().responseAdapter()
 
   private val responseAdapterBuilders = fragment.dataModelGroup.maybeFlatten(flatten).map {
     ResponseAdapterBuilder.create(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentSelectionsBuilder.kt
@@ -14,7 +14,7 @@ internal class FragmentSelectionsBuilder(
     val fragment: IrFragmentDefinition,
 ) : JavaClassBuilder {
   private val packageName = context.layout.fragmentResponseFieldsPackageName(fragment.filePath)
-  private val simpleName = fragment.name.selections()
+  private val simpleName = context.layout.fragmentName(fragment.name).selections()
 
   override fun prepare() {
     context.resolver.registerFragmentSelections(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/FragmentVariablesAdapterBuilder.kt
@@ -17,7 +17,7 @@ internal class FragmentVariablesAdapterBuilder(
     val fragment: IrFragmentDefinition,
 ) : JavaClassBuilder {
   private val packageName = context.layout.fragmentAdapterPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl().variablesAdapter()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl().variablesAdapter()
 
   override fun prepare() {
     context.resolver.registerFragmentVariablesAdapter(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
@@ -11,7 +11,6 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.document
 import com.apollographql.apollo3.compiler.codegen.Identifier.id
 import com.apollographql.apollo3.compiler.codegen.Identifier.name
 import com.apollographql.apollo3.compiler.codegen.Identifier.root
-import com.apollographql.apollo3.compiler.codegen.filePackageName
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
@@ -49,7 +48,7 @@ internal class OperationBuilder(
     flatten: Boolean,
 ) : JavaClassBuilder {
   private val layout = context.layout
-  private val packageName = layout.filePackageName(operation.filePath)
+  private val packageName = layout.executableDocumentPackageName(operation.filePath)
   private val simpleName = layout.operationName(operation)
 
   private val dataSuperClassName = when (operation.operationType) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationBuilder.kt
@@ -26,6 +26,7 @@ import com.apollographql.apollo3.compiler.codegen.java.helpers.toParameterSpec
 import com.apollographql.apollo3.compiler.codegen.java.javaPropertyName
 import com.apollographql.apollo3.compiler.codegen.java.model.ModelBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrOperation

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationResponseAdapterBuilder.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.adapter.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.javapoet.TypeSpec

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationSelectionsBuilder.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.selections.CompiledSelectionsBuilder
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.operationResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.selections
 import com.apollographql.apollo3.compiler.ir.IrOperation

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/OperationVariablesAdapterBuilder.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.adapter.variableAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.javapoet.ClassName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
@@ -37,9 +37,10 @@ internal class SchemaBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.schemaSubPackageName()
+  private val simpleName = layout.topLevelName(generatedSchemaName)
 
   override fun prepare() {
-    context.resolver.registerSchema(ClassName.get(packageName, generatedSchemaName))
+    context.resolver.registerSchema(ClassName.get(packageName, simpleName))
   }
 
   override fun build(): CodegenJavaFile {
@@ -66,7 +67,7 @@ internal class SchemaBuilder(
   }
 
   private fun typeSpec(): TypeSpec {
-    return TypeSpec.classBuilder(generatedSchemaName)
+    return TypeSpec.classBuilder(simpleName)
         .addJavadoc(L, "A Schema object containing all the composite types and a possibleTypes helper function")
         .addModifiers(Modifier.PUBLIC)
         .addField(customScalarAdaptersFieldSpec())

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/SchemaBuilder.kt
@@ -13,7 +13,7 @@ import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.java.helpers.toListInitializerCodeblock
-import com.apollographql.apollo3.compiler.codegen.schemaPackageName
+import com.apollographql.apollo3.compiler.codegen.schemaSubPackageName
 import com.apollographql.apollo3.compiler.ir.IrEnum
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.apollographql.apollo3.compiler.ir.IrObject
@@ -36,7 +36,7 @@ internal class SchemaBuilder(
     private val enums: List<IrEnum>
 ) : JavaClassBuilder {
   private val layout = context.layout
-  private val packageName = layout.schemaPackageName()
+  private val packageName = layout.schemaSubPackageName()
 
   override fun prepare() {
     context.resolver.registerSchema(ClassName.get(packageName, generatedSchemaName))

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/UtilAssertionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/file/UtilAssertionsBuilder.kt
@@ -19,7 +19,7 @@ internal class UtilAssertionsBuilder(val context: JavaContext) : JavaClassBuilde
     return CodegenJavaFile(
         packageName = context.layout.typeUtilPackageName(),
         typeSpec = TypeSpec
-            .classBuilder("Assertions")
+            .classBuilder(context.layout.topLevelName("Assertions"))
             .addModifiers(Modifier.PUBLIC)
             .addMethod(
                 MethodSpec.methodBuilder("assertOneOf")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodeGen.kt
@@ -216,8 +216,8 @@ internal object KotlinCodeGen {
 
     val layout = CodegenLayout(
         codegenSchema = codegenSchema,
-        useSemanticNaming = useSemanticNaming,
         packageNameGenerator = packageNameGenerator,
+        useSemanticNaming = useSemanticNaming,
         decapitalizeFields = decapitalizeFields,
     )
 
@@ -333,8 +333,8 @@ internal object KotlinCodeGen {
   ): Pair<CodegenMetadata, List<FileSpec>> {
     val layout = CodegenLayout(
         codegenSchema = codegenSchema,
-        useSemanticNaming = false,
         packageNameGenerator = PackageNameGenerator.Flat(packageName),
+        useSemanticNaming = false,
         decapitalizeFields = false,
     )
 
@@ -391,8 +391,8 @@ internal object KotlinCodeGen {
   ): List<FileSpec> {
     val layout = CodegenLayout(
         codegenSchema = codegenSchema,
-        useSemanticNaming = false,
         packageNameGenerator = PackageNameGenerator.Flat(packageName),
+        useSemanticNaming = false,
         decapitalizeFields = false,
     )
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentBuilder.kt
@@ -33,7 +33,7 @@ internal class FragmentBuilder(
 ) : CgFileBuilder {
   private val layout = context.layout
   private val packageName = layout.fragmentPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl()
 
   private val modelBuilders = if (fragment.interfaceModelGroup != null) {
     fragment.dataModelGroup.maybeFlatten(flatten).flatMap { it.models }.map {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentModelsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentModelsBuilder.kt
@@ -50,7 +50,7 @@ internal class FragmentModelsBuilder(
   override fun build(): CgFile {
     return CgFile(
         packageName = packageName,
-        fileName = fragment.name.capitalizeFirstLetter(),
+        fileName = context.layout.fragmentName(fragment.name),
         typeSpecs = modelBuilders.map { it.build() }
     )
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentResponseAdapterBuilder.kt
@@ -18,7 +18,7 @@ internal class FragmentResponseAdapterBuilder(
     val flatten: Boolean,
 ) : CgFileBuilder {
   private val packageName = context.layout.fragmentPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl().responseAdapter()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl().responseAdapter()
 
   private val responseAdapterBuilders = fragment.dataModelGroup.maybeFlatten(flatten).map {
     ResponseAdapterBuilder.create(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentSelectionsBuilder.kt
@@ -14,7 +14,7 @@ internal class FragmentSelectionsBuilder(
     val fragment: IrFragmentDefinition,
 ) : CgFileBuilder {
   private val packageName = context.layout.fragmentResponseFieldsPackageName(fragment.filePath)
-  private val simpleName = fragment.name.selections()
+  private val simpleName = context.layout.fragmentName(fragment.name).selections()
 
   override fun prepare() {
     context.resolver.registerFragmentSelections(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/FragmentVariablesAdapterBuilder.kt
@@ -1,6 +1,5 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
-import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.fragmentAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
@@ -17,7 +16,7 @@ internal class FragmentVariablesAdapterBuilder(
     val fragment: IrFragmentDefinition,
 ) : CgFileBuilder {
   private val packageName = context.layout.fragmentAdapterPackageName(fragment.filePath)
-  private val simpleName = fragment.name.capitalizeFirstLetter().impl().variablesAdapter()
+  private val simpleName = context.layout.fragmentName(fragment.name).impl().variablesAdapter()
 
   override fun prepare() {
     context.resolver.registerFragmentVariablesAdapter(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.file
 
 import com.apollographql.apollo3.ast.QueryDocumentMinifier
-import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_DOCUMENT
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_ID
@@ -21,6 +20,8 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toNamedType
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toParameterSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.model.ModelBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
+import com.apollographql.apollo3.compiler.codegen.operationName
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrOperationType
 import com.squareup.kotlinpoet.ClassName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationBuilder.kt
@@ -9,7 +9,6 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_NAME
 import com.apollographql.apollo3.compiler.codegen.Identifier.document
 import com.apollographql.apollo3.compiler.codegen.Identifier.id
 import com.apollographql.apollo3.compiler.codegen.Identifier.name
-import com.apollographql.apollo3.compiler.codegen.filePackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgImport
@@ -44,7 +43,7 @@ internal class OperationBuilder(
     val generateInputBuilders: Boolean
 ) : CgFileBuilder {
   private val layout = context.layout
-  private val packageName = layout.filePackageName(operation.filePath)
+  private val packageName = layout.executableDocumentPackageName(operation.filePath)
   private val simpleName = layout.operationName(operation)
 
   private val dataSuperClassName = when (operation.operationType) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationResponseAdapterBuilder.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.kotlinpoet.TypeSpec

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationSelectionsBuilder.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.selections.CompiledSelectionsBuilder
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.operationResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.selections
 import com.apollographql.apollo3.compiler.ir.IrOperation

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/OperationVariablesAdapterBuilder.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.variablesAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
+import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.kotlinpoet.ClassName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/PaginationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/PaginationBuilder.kt
@@ -18,7 +18,7 @@ internal class PaginationBuilder(
 ) : CgFileBuilder {
   private val layout = context.layout
   private val packageName = layout.paginationPackageName()
-  private val simpleName = "Pagination"
+  private val simpleName = layout.topLevelName("Pagination")
 
   override fun prepare() {
     context.resolver.register(ResolverKeyKind.Pagination, "", ClassName(packageName, simpleName))

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
-import com.apollographql.apollo3.compiler.codegen.schemaPackageName
+import com.apollographql.apollo3.compiler.codegen.schemaSubPackageName
 import com.apollographql.apollo3.compiler.ir.IrEnum
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.apollographql.apollo3.compiler.ir.IrObject
@@ -28,7 +28,7 @@ internal class SchemaBuilder(
     private val enums: List<IrEnum>
 ) : CgFileBuilder {
   private val layout = context.layout
-  private val packageName = layout.schemaPackageName()
+  private val packageName = layout.schemaSubPackageName()
 
   override fun prepare() {
     context.resolver.registerSchema(ClassName(packageName, generatedSchemaName))

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/file/SchemaBuilder.kt
@@ -61,7 +61,7 @@ internal class SchemaBuilder(
   }
 
   private fun typeSpec(): TypeSpec {
-    return TypeSpec.objectBuilder(generatedSchemaName)
+    return TypeSpec.objectBuilder(layout.topLevelName(generatedSchemaName))
         .addKdoc("A __Schema object containing all the composite types and a possibleTypes helper function")
         .addProperty(typesPropertySpec())
         .addFunction(possibleTypesFunSpec())

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections;
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections;
 import com.example.fragment_with_multiple_fieldsets.type.I;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class IFragmentImpl implements Fragment<IFragment> {
       "data",
       I.type
     )
-    .selections(iFragmentSelections.__root)
+    .selections(IFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.java.expected
@@ -13,7 +13,7 @@ import com.example.fragment_with_multiple_fieldsets.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class iFragmentSelections {
+public class IFragmentSelections {
   private static List<CompiledSelection> __onA = Arrays.asList(
     new CompiledField.Builder("fieldA", GraphQLString.type).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.java.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledFragment;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections;
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections;
 import com.example.fragment_with_multiple_fieldsets.type.GraphQLString;
 import com.example.fragment_with_multiple_fieldsets.type.I;
 import java.util.Arrays;
@@ -18,7 +18,7 @@ import java.util.List;
 public class TestQuerySelections {
   private static List<CompiledSelection> __i = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("I", Arrays.asList("A", "B")).selections(iFragmentSelections.__root).build()
+    new CompiledFragment.Builder("I", Arrays.asList("A", "B")).selections(IFragmentSelections.__root).build()
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections
 import com.example.fragment_with_multiple_fieldsets.type.I
 import kotlin.Any
 import kotlin.Boolean
@@ -38,6 +38,6 @@ public class IFragmentImpl() : Fragment<IFragment> {
     name = "data",
     type = I.type
   )
-  .selections(selections = iFragmentSelections.__root)
+  .selections(selections = IFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.fragment_with_multiple_fieldsets.type.GraphQLString
 import kotlin.collections.List
 
-public object iFragmentSelections {
+public object IFragmentSelections {
   private val __onA: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "fieldA",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections
 import com.example.fragment_with_multiple_fieldsets.type.GraphQLString
 import com.example.fragment_with_multiple_fieldsets.type.I
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "I",
           possibleTypes = listOf("A", "B")
-        ).selections(iFragmentSelections.__root)
+        ).selections(IFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/IFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections
 import com.example.fragment_with_multiple_fieldsets.type.I
 import kotlin.Any
 import kotlin.Boolean
@@ -40,7 +40,7 @@ public class IFragmentImpl() : Fragment<IFragmentImpl.Data> {
     name = "data",
     type = I.type
   )
-  .selections(selections = iFragmentSelections.__root)
+  .selections(selections = IFragmentSelections.__root)
   .build()
 
   public sealed interface Data : IFragment, Fragment.Data {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.fragment_with_multiple_fieldsets.type.GraphQLString
 import kotlin.collections.List
 
-public object iFragmentSelections {
+public object IFragmentSelections {
   private val __onA: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "fieldA",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.fragment_with_multiple_fieldsets.fragment.selections.iFragmentSelections
+import com.example.fragment_with_multiple_fieldsets.fragment.selections.IFragmentSelections
 import com.example.fragment_with_multiple_fieldsets.type.GraphQLString
 import com.example.fragment_with_multiple_fieldsets.type.I
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "I",
           possibleTypes = listOf("A", "B")
-        ).selections(iFragmentSelections.__root)
+        ).selections(IFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/AFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/AFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections;
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections;
 import com.example.multiple_fragments.type.A;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class AFragmentImpl implements Fragment<AFragment> {
       "data",
       A.type
     )
-    .selections(aFragmentSelections.__root)
+    .selections(AFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/Fragment1Impl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/Fragment1Impl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.multiple_fragments.fragment.selections.fragment1Selections;
+import com.example.multiple_fragments.fragment.selections.Fragment1Selections;
 import com.example.multiple_fragments.type.ANode;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class Fragment1Impl implements Fragment<Fragment1> {
       "data",
       ANode.type
     )
-    .selections(fragment1Selections.__root)
+    .selections(Fragment1Selections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/Fragment2Impl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/Fragment2Impl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.multiple_fragments.fragment.selections.fragment2Selections;
+import com.example.multiple_fragments.fragment.selections.Fragment2Selections;
 import com.example.multiple_fragments.type.ANode;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class Fragment2Impl implements Fragment<Fragment2> {
       "data",
       ANode.type
     )
-    .selections(fragment2Selections.__root)
+    .selections(Fragment2Selections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.java.expected
@@ -14,11 +14,11 @@ import com.example.multiple_fragments.type.Node;
 import java.util.Arrays;
 import java.util.List;
 
-public class aFragmentSelections {
+public class AFragmentSelections {
   private static List<CompiledSelection> __node = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("ANode", Arrays.asList("ANode")).selections(fragment1Selections.__root).build(),
-    new CompiledFragment.Builder("ANode", Arrays.asList("ANode")).selections(fragment2Selections.__root).build()
+    new CompiledFragment.Builder("ANode", Arrays.asList("ANode")).selections(Fragment1Selections.__root).build(),
+    new CompiledFragment.Builder("ANode", Arrays.asList("ANode")).selections(Fragment2Selections.__root).build()
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/fragment1Selections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/fragment1Selections.java.expected
@@ -11,7 +11,7 @@ import com.example.multiple_fragments.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class fragment1Selections {
+public class Fragment1Selections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("field1", GraphQLString.type).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/fragment2Selections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/fragment/selections/fragment2Selections.java.expected
@@ -11,7 +11,7 @@ import com.example.multiple_fragments.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class fragment2Selections {
+public class Fragment2Selections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("field2", GraphQLString.type).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/selections/TestQuerySelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/selections/TestQuerySelections.java.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledFragment;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections;
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections;
 import com.example.multiple_fragments.type.A;
 import com.example.multiple_fragments.type.GraphQLString;
 import java.util.Arrays;
@@ -18,7 +18,7 @@ import java.util.List;
 public class TestQuerySelections {
   private static List<CompiledSelection> __a = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("A", Arrays.asList("A")).selections(aFragmentSelections.__root).build()
+    new CompiledFragment.Builder("A", Arrays.asList("A")).selections(AFragmentSelections.__root).build()
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections
 import com.example.multiple_fragments.type.A
 import kotlin.Any
 import kotlin.Boolean
@@ -38,6 +38,6 @@ public class AFragmentImpl() : Fragment<AFragment> {
     name = "data",
     type = A.type
   )
-  .selections(selections = aFragmentSelections.__root)
+  .selections(selections = AFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/Fragment1Impl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/Fragment1Impl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.fragment1Selections
+import com.example.multiple_fragments.fragment.selections.Fragment1Selections
 import com.example.multiple_fragments.type.ANode
 import kotlin.Any
 import kotlin.Boolean
@@ -38,6 +38,6 @@ public class Fragment1Impl() : Fragment<Fragment1> {
     name = "data",
     type = ANode.type
   )
-  .selections(selections = fragment1Selections.__root)
+  .selections(selections = Fragment1Selections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/Fragment2Impl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/Fragment2Impl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.fragment2Selections
+import com.example.multiple_fragments.fragment.selections.Fragment2Selections
 import com.example.multiple_fragments.type.ANode
 import kotlin.Any
 import kotlin.Boolean
@@ -38,6 +38,6 @@ public class Fragment2Impl() : Fragment<Fragment2> {
     name = "data",
     type = ANode.type
   )
-  .selections(selections = fragment2Selections.__root)
+  .selections(selections = Fragment2Selections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
@@ -13,7 +13,7 @@ import com.example.multiple_fragments.type.GraphQLString
 import com.example.multiple_fragments.type.Node
 import kotlin.collections.List
 
-public object aFragmentSelections {
+public object AFragmentSelections {
   private val __node: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -22,12 +22,12 @@ public object aFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "ANode",
           possibleTypes = listOf("ANode")
-        ).selections(fragment1Selections.__root)
+        ).selections(Fragment1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
           possibleTypes = listOf("ANode")
-        ).selections(fragment2Selections.__root)
+        ).selections(Fragment2Selections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/fragment1Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/fragment1Selections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object fragment1Selections {
+public object Fragment1Selections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "field1",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/fragment2Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/fragment2Selections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object fragment2Selections {
+public object Fragment2Selections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "field2",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections
 import com.example.multiple_fragments.type.A
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "A",
           possibleTypes = listOf("A")
-        ).selections(aFragmentSelections.__root)
+        ).selections(AFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/AFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections
 import com.example.multiple_fragments.type.A
 import kotlin.Any
 import kotlin.Boolean
@@ -40,7 +40,7 @@ public class AFragmentImpl() : Fragment<AFragmentImpl.Data> {
     name = "data",
     type = A.type
   )
-  .selections(selections = aFragmentSelections.__root)
+  .selections(selections = AFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/Fragment1Impl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/Fragment1Impl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.fragment1Selections
+import com.example.multiple_fragments.fragment.selections.Fragment1Selections
 import com.example.multiple_fragments.type.ANode
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class Fragment1Impl() : Fragment<Fragment1Impl.Data> {
     name = "data",
     type = ANode.type
   )
-  .selections(selections = fragment1Selections.__root)
+  .selections(selections = Fragment1Selections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/Fragment2Impl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/Fragment2Impl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.multiple_fragments.fragment.selections.fragment2Selections
+import com.example.multiple_fragments.fragment.selections.Fragment2Selections
 import com.example.multiple_fragments.type.ANode
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class Fragment2Impl() : Fragment<Fragment2Impl.Data> {
     name = "data",
     type = ANode.type
   )
-  .selections(selections = fragment2Selections.__root)
+  .selections(selections = Fragment2Selections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
@@ -13,7 +13,7 @@ import com.example.multiple_fragments.type.GraphQLString
 import com.example.multiple_fragments.type.Node
 import kotlin.collections.List
 
-public object aFragmentSelections {
+public object AFragmentSelections {
   private val __node: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -22,12 +22,12 @@ public object aFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "ANode",
           possibleTypes = listOf("ANode")
-        ).selections(fragment1Selections.__root)
+        ).selections(Fragment1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
           possibleTypes = listOf("ANode")
-        ).selections(fragment2Selections.__root)
+        ).selections(Fragment2Selections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/fragment1Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/fragment1Selections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object fragment1Selections {
+public object Fragment1Selections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "field1",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/fragment2Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/fragment2Selections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object fragment2Selections {
+public object Fragment2Selections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "field2",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.multiple_fragments.fragment.selections.aFragmentSelections
+import com.example.multiple_fragments.fragment.selections.AFragmentSelections
 import com.example.multiple_fragments.type.A
 import com.example.multiple_fragments.type.GraphQLString
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "A",
           possibleTypes = listOf("A")
-        ).selections(aFragmentSelections.__root)
+        ).selections(AFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections;
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections;
 import com.example.named_fragment_inside_inline_fragment.type.Character;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class CharacterAppearsInImpl implements Fragment<CharacterAppearsIn> {
       "data",
       Character.type
     )
-    .selections(characterAppearsInSelections.__root)
+    .selections(CharacterAppearsInSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections;
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections;
 import com.example.named_fragment_inside_inline_fragment.type.Character;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class CharacterNameImpl implements Fragment<CharacterName> {
       "data",
       Character.type
     )
-    .selections(characterNameSelections.__root)
+    .selections(CharacterNameSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.java.expected
@@ -13,7 +13,7 @@ import com.example.named_fragment_inside_inline_fragment.type.Episode;
 import java.util.Arrays;
 import java.util.List;
 
-public class characterAppearsInSelections {
+public class CharacterAppearsInSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("appearsIn", new CompiledNotNullType(new CompiledListType(Episode.type))).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.java.expected
@@ -12,7 +12,7 @@ import com.example.named_fragment_inside_inline_fragment.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class characterNameSelections {
+public class CharacterNameSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("name", new CompiledNotNullType(GraphQLString.type)).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.java.expected
@@ -10,8 +10,8 @@ import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledFragment;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections;
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections;
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections;
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections;
 import com.example.named_fragment_inside_inline_fragment.type.Character;
 import com.example.named_fragment_inside_inline_fragment.type.GraphQLString;
 import java.util.Arrays;
@@ -20,8 +20,8 @@ import java.util.List;
 public class GetHeroSelections {
   private static List<CompiledSelection> __onCharacter = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(characterNameSelections.__root).build(),
-    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(characterAppearsInSelections.__root).build()
+    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(CharacterNameSelections.__root).build(),
+    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(CharacterAppearsInSelections.__root).build()
   );
 
   private static List<CompiledSelection> __hero = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class CharacterAppearsInImpl() : Fragment<CharacterAppearsIn> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = characterAppearsInSelections.__root)
+  .selections(selections = CharacterAppearsInSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class CharacterNameImpl() : Fragment<CharacterName> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = characterNameSelections.__root)
+  .selections(selections = CharacterNameSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.kt.expected
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.named_fragment_inside_inline_fragment.type.Episode
 import kotlin.collections.List
 
-public object characterAppearsInSelections {
+public object CharacterAppearsInSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "appearsIn",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.named_fragment_inside_inline_fragment.type.GraphQLString
 import kotlin.collections.List
 
-public object characterNameSelections {
+public object CharacterNameSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
@@ -10,8 +10,8 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import com.example.named_fragment_inside_inline_fragment.type.GraphQLString
 import kotlin.collections.List
@@ -25,12 +25,12 @@ public object GetHeroSelections {
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(characterNameSelections.__root)
+        ).selections(CharacterNameSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(characterAppearsInSelections.__root)
+        ).selections(CharacterAppearsInSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/CharacterAppearsInImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import com.example.named_fragment_inside_inline_fragment.type.Episode
 import kotlin.Any
@@ -40,7 +40,7 @@ public class CharacterAppearsInImpl() : Fragment<CharacterAppearsInImpl.Data> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = characterAppearsInSelections.__root)
+  .selections(selections = CharacterAppearsInSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/CharacterNameImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class CharacterNameImpl() : Fragment<CharacterNameImpl.Data> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = characterNameSelections.__root)
+  .selections(selections = CharacterNameSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/selections/characterAppearsInSelections.kt.expected
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.named_fragment_inside_inline_fragment.type.Episode
 import kotlin.collections.List
 
-public object characterAppearsInSelections {
+public object CharacterAppearsInSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "appearsIn",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/fragment/selections/characterNameSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.named_fragment_inside_inline_fragment.type.GraphQLString
 import kotlin.collections.List
 
-public object characterNameSelections {
+public object CharacterNameSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
@@ -10,8 +10,8 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterAppearsInSelections
-import com.example.named_fragment_inside_inline_fragment.fragment.selections.characterNameSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterAppearsInSelections
+import com.example.named_fragment_inside_inline_fragment.fragment.selections.CharacterNameSelections
 import com.example.named_fragment_inside_inline_fragment.type.Character
 import com.example.named_fragment_inside_inline_fragment.type.GraphQLString
 import kotlin.collections.List
@@ -25,12 +25,12 @@ public object GetHeroSelections {
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(characterNameSelections.__root)
+        ).selections(CharacterNameSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(characterAppearsInSelections.__root)
+        ).selections(CharacterAppearsInSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/PilotFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/PilotFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.nested_named_fragments.fragment.selections.pilotFragmentSelections;
+import com.example.nested_named_fragments.fragment.selections.PilotFragmentSelections;
 import com.example.nested_named_fragments.type.Person;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class PilotFragmentImpl implements Fragment<PilotFragment> {
       "data",
       Person.type
     )
-    .selections(pilotFragmentSelections.__root)
+    .selections(PilotFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/PlanetFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/PlanetFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.nested_named_fragments.fragment.selections.planetFragmentSelections;
+import com.example.nested_named_fragments.fragment.selections.PlanetFragmentSelections;
 import com.example.nested_named_fragments.type.Planet;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class PlanetFragmentImpl implements Fragment<PlanetFragment> {
       "data",
       Planet.type
     )
-    .selections(planetFragmentSelections.__root)
+    .selections(PlanetFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/StarshipFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/StarshipFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections;
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections;
 import com.example.nested_named_fragments.type.Starship;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class StarshipFragmentImpl implements Fragment<StarshipFragment> {
       "data",
       Starship.type
     )
-    .selections(starshipFragmentSelections.__root)
+    .selections(StarshipFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.java.expected
@@ -14,10 +14,10 @@ import com.example.nested_named_fragments.type.Planet;
 import java.util.Arrays;
 import java.util.List;
 
-public class pilotFragmentSelections {
+public class PilotFragmentSelections {
   private static List<CompiledSelection> __homeworld = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Planet", Arrays.asList("Planet")).selections(planetFragmentSelections.__root).build()
+    new CompiledFragment.Builder("Planet", Arrays.asList("Planet")).selections(PlanetFragmentSelections.__root).build()
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/planetFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/planetFragmentSelections.java.expected
@@ -11,7 +11,7 @@ import com.example.nested_named_fragments.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class planetFragmentSelections {
+public class PlanetFragmentSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("name", GraphQLString.type).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.java.expected
@@ -19,10 +19,10 @@ import com.example.nested_named_fragments.type.StarshipPilotsEdge;
 import java.util.Arrays;
 import java.util.List;
 
-public class starshipFragmentSelections {
+public class StarshipFragmentSelections {
   private static List<CompiledSelection> __node = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Person", Arrays.asList("Person")).selections(pilotFragmentSelections.__root).build()
+    new CompiledFragment.Builder("Person", Arrays.asList("Person")).selections(PilotFragmentSelections.__root).build()
   );
 
   private static List<CompiledSelection> __edges = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/selections/AllStarshipsSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/selections/AllStarshipsSelections.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CompiledFragment;
 import com.apollographql.apollo3.api.CompiledListType;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections;
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections;
 import com.example.nested_named_fragments.type.GraphQLString;
 import com.example.nested_named_fragments.type.Starship;
 import com.example.nested_named_fragments.type.StarshipsConnection;
@@ -22,7 +22,7 @@ import java.util.List;
 public class AllStarshipsSelections {
   private static List<CompiledSelection> __node = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Starship", Arrays.asList("Starship")).selections(starshipFragmentSelections.__root).build()
+    new CompiledFragment.Builder("Starship", Arrays.asList("Starship")).selections(StarshipFragmentSelections.__root).build()
   );
 
   private static List<CompiledSelection> __edges = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/PilotFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/PilotFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.pilotFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.PilotFragmentSelections
 import com.example.nested_named_fragments.type.Person
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class PilotFragmentImpl() : Fragment<PilotFragment> {
     name = "data",
     type = Person.type
   )
-  .selections(selections = pilotFragmentSelections.__root)
+  .selections(selections = PilotFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/PlanetFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/PlanetFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.planetFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.PlanetFragmentSelections
 import com.example.nested_named_fragments.type.Planet
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class PlanetFragmentImpl() : Fragment<PlanetFragment> {
     name = "data",
     type = Planet.type
   )
-  .selections(selections = planetFragmentSelections.__root)
+  .selections(selections = PlanetFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/StarshipFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/StarshipFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections
 import com.example.nested_named_fragments.type.Starship
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class StarshipFragmentImpl() : Fragment<StarshipFragment> {
     name = "data",
     type = Starship.type
   )
-  .selections(selections = starshipFragmentSelections.__root)
+  .selections(selections = StarshipFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
@@ -13,7 +13,7 @@ import com.example.nested_named_fragments.type.GraphQLString
 import com.example.nested_named_fragments.type.Planet
 import kotlin.collections.List
 
-public object pilotFragmentSelections {
+public object PilotFragmentSelections {
   private val __homeworld: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -22,7 +22,7 @@ public object pilotFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Planet",
           possibleTypes = listOf("Planet")
-        ).selections(planetFragmentSelections.__root)
+        ).selections(PlanetFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/planetFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/planetFragmentSelections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.nested_named_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object planetFragmentSelections {
+public object PlanetFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
@@ -18,7 +18,7 @@ import com.example.nested_named_fragments.type.StarshipPilotsConnection
 import com.example.nested_named_fragments.type.StarshipPilotsEdge
 import kotlin.collections.List
 
-public object starshipFragmentSelections {
+public object StarshipFragmentSelections {
   private val __node: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -27,7 +27,7 @@ public object starshipFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Person",
           possibleTypes = listOf("Person")
-        ).selections(pilotFragmentSelections.__root)
+        ).selections(PilotFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.list
 import com.apollographql.apollo3.api.notNull
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections
 import com.example.nested_named_fragments.type.GraphQLString
 import com.example.nested_named_fragments.type.Starship
 import com.example.nested_named_fragments.type.StarshipsConnection
@@ -27,7 +27,7 @@ public object AllStarshipsSelections {
         CompiledFragment.Builder(
           typeCondition = "Starship",
           possibleTypes = listOf("Starship")
-        ).selections(starshipFragmentSelections.__root)
+        ).selections(StarshipFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/PilotFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/PilotFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.pilotFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.PilotFragmentSelections
 import com.example.nested_named_fragments.type.Person
 import kotlin.Any
 import kotlin.Boolean
@@ -40,7 +40,7 @@ public class PilotFragmentImpl() : Fragment<PilotFragmentImpl.Data> {
     name = "data",
     type = Person.type
   )
-  .selections(selections = pilotFragmentSelections.__root)
+  .selections(selections = PilotFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/PlanetFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/PlanetFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.planetFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.PlanetFragmentSelections
 import com.example.nested_named_fragments.type.Planet
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class PlanetFragmentImpl() : Fragment<PlanetFragmentImpl.Data> {
     name = "data",
     type = Planet.type
   )
-  .selections(selections = planetFragmentSelections.__root)
+  .selections(selections = PlanetFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/StarshipFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/StarshipFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections
 import com.example.nested_named_fragments.type.Starship
 import kotlin.Any
 import kotlin.Boolean
@@ -41,7 +41,7 @@ public class StarshipFragmentImpl() : Fragment<StarshipFragmentImpl.Data> {
     name = "data",
     type = Starship.type
   )
-  .selections(selections = starshipFragmentSelections.__root)
+  .selections(selections = StarshipFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
@@ -13,7 +13,7 @@ import com.example.nested_named_fragments.type.GraphQLString
 import com.example.nested_named_fragments.type.Planet
 import kotlin.collections.List
 
-public object pilotFragmentSelections {
+public object PilotFragmentSelections {
   private val __homeworld: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -22,7 +22,7 @@ public object pilotFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Planet",
           possibleTypes = listOf("Planet")
-        ).selections(planetFragmentSelections.__root)
+        ).selections(PlanetFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/planetFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/planetFragmentSelections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.nested_named_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object planetFragmentSelections {
+public object PlanetFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
@@ -18,7 +18,7 @@ import com.example.nested_named_fragments.type.StarshipPilotsConnection
 import com.example.nested_named_fragments.type.StarshipPilotsEdge
 import kotlin.collections.List
 
-public object starshipFragmentSelections {
+public object StarshipFragmentSelections {
   private val __node: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "__typename",
@@ -27,7 +27,7 @@ public object starshipFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Person",
           possibleTypes = listOf("Person")
-        ).selections(pilotFragmentSelections.__root)
+        ).selections(PilotFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.list
 import com.apollographql.apollo3.api.notNull
-import com.example.nested_named_fragments.fragment.selections.starshipFragmentSelections
+import com.example.nested_named_fragments.fragment.selections.StarshipFragmentSelections
 import com.example.nested_named_fragments.type.GraphQLString
 import com.example.nested_named_fragments.type.Starship
 import com.example.nested_named_fragments.type.StarshipsConnection
@@ -27,7 +27,7 @@ public object AllStarshipsSelections {
         CompiledFragment.Builder(
           typeCondition = "Starship",
           possibleTypes = listOf("Starship")
-        ).selections(starshipFragmentSelections.__root)
+        ).selections(StarshipFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/fragment/BFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/fragment/BFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections;
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections;
 import com.example.not_all_combinations_are_needed.type.B;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class BFragmentImpl implements Fragment<BFragment> {
       "data",
       B.type
     )
-    .selections(bFragmentSelections.__root)
+    .selections(BFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.java.expected
@@ -11,7 +11,7 @@ import com.example.not_all_combinations_are_needed.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class bFragmentSelections {
+public class BFragmentSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("fieldB1", GraphQLString.type).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.java.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField;
 import com.apollographql.apollo3.api.CompiledFragment;
 import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections;
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections;
 import com.example.not_all_combinations_are_needed.type.C;
 import com.example.not_all_combinations_are_needed.type.GraphQLString;
 import java.util.Arrays;
@@ -18,7 +18,7 @@ import java.util.List;
 public class TestQuerySelections {
   private static List<CompiledSelection> __onB = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("B", Arrays.asList("ABC", "SomeBC")).selections(bFragmentSelections.__root).build()
+    new CompiledFragment.Builder("B", Arrays.asList("ABC", "SomeBC")).selections(BFragmentSelections.__root).build()
   );
 
   private static List<CompiledSelection> __onA = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/fragment/BFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/fragment/BFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections
 import com.example.not_all_combinations_are_needed.type.B
 import kotlin.Any
 import kotlin.Boolean
@@ -38,6 +38,6 @@ public class BFragmentImpl() : Fragment<BFragment> {
     name = "data",
     type = B.type
   )
-  .selections(selections = bFragmentSelections.__root)
+  .selections(selections = BFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.not_all_combinations_are_needed.type.GraphQLString
 import kotlin.collections.List
 
-public object bFragmentSelections {
+public object BFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "fieldB1",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections
 import com.example.not_all_combinations_are_needed.type.C
 import com.example.not_all_combinations_are_needed.type.GraphQLString
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "B",
           possibleTypes = listOf("ABC", "SomeBC")
-        ).selections(bFragmentSelections.__root)
+        ).selections(BFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/fragment/BFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/fragment/BFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections
 import com.example.not_all_combinations_are_needed.type.B
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class BFragmentImpl() : Fragment<BFragmentImpl.Data> {
     name = "data",
     type = B.type
   )
-  .selections(selections = bFragmentSelections.__root)
+  .selections(selections = BFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/fragment/selections/bFragmentSelections.kt.expected
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.example.not_all_combinations_are_needed.type.GraphQLString
 import kotlin.collections.List
 
-public object bFragmentSelections {
+public object BFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "fieldB1",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.api.CompiledField
 import com.apollographql.apollo3.api.CompiledFragment
 import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.notNull
-import com.example.not_all_combinations_are_needed.fragment.selections.bFragmentSelections
+import com.example.not_all_combinations_are_needed.fragment.selections.BFragmentSelections
 import com.example.not_all_combinations_are_needed.type.C
 import com.example.not_all_combinations_are_needed.type.GraphQLString
 import kotlin.collections.List
@@ -23,7 +23,7 @@ public object TestQuerySelections {
         CompiledFragment.Builder(
           typeCondition = "B",
           possibleTypes = listOf("ABC", "SomeBC")
-        ).selections(bFragmentSelections.__root)
+        ).selections(BFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.droidFragmentSelections;
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.DroidFragmentSelections;
 import com.example.root_query_fragment_with_nested_fragments.type.Droid;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class DroidFragmentImpl implements Fragment<DroidFragment> {
       "data",
       Droid.type
     )
-    .selections(droidFragmentSelections.__root)
+    .selections(DroidFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.java.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Fragment;
 import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.heroFragmentSelections;
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.HeroFragmentSelections;
 import com.example.root_query_fragment_with_nested_fragments.type.Character;
 import java.io.IOException;
 import java.lang.Object;
@@ -76,7 +76,7 @@ public class HeroFragmentImpl implements Fragment<HeroFragment> {
       "data",
       Character.type
     )
-    .selections(heroFragmentSelections.__root)
+    .selections(HeroFragmentSelections.__root)
     .build();
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.java.expected
@@ -20,12 +20,12 @@ import java.util.List;
 public class QueryFragmentSelections {
   private static List<CompiledSelection> __hero = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(heroFragmentSelections.__root).build()
+    new CompiledFragment.Builder("Character", Arrays.asList("Droid", "Human")).selections(HeroFragmentSelections.__root).build()
   );
 
   private static List<CompiledSelection> __droid = Arrays.asList(
     new CompiledField.Builder("__typename", new CompiledNotNullType(GraphQLString.type)).build(),
-    new CompiledFragment.Builder("Droid", Arrays.asList("Droid")).selections(droidFragmentSelections.__root).build()
+    new CompiledFragment.Builder("Droid", Arrays.asList("Droid")).selections(DroidFragmentSelections.__root).build()
   );
 
   private static List<CompiledSelection> __onHuman = Arrays.asList(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.java.expected
@@ -12,7 +12,7 @@ import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class droidFragmentSelections {
+public class DroidFragmentSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("name", new CompiledNotNullType(GraphQLString.type)).build(),
     new CompiledField.Builder("primaryFunction", GraphQLString.type).build()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.java.expected
@@ -12,7 +12,7 @@ import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString;
 import java.util.Arrays;
 import java.util.List;
 
-public class heroFragmentSelections {
+public class HeroFragmentSelections {
   public static List<CompiledSelection> __root = Arrays.asList(
     new CompiledField.Builder("name", new CompiledNotNullType(GraphQLString.type)).build()
   );

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.droidFragmentSelections
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.DroidFragmentSelections
 import com.example.root_query_fragment_with_nested_fragments.type.Droid
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class DroidFragmentImpl() : Fragment<DroidFragment> {
     name = "data",
     type = Droid.type
   )
-  .selections(selections = droidFragmentSelections.__root)
+  .selections(selections = DroidFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.heroFragmentSelections
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.HeroFragmentSelections
 import com.example.root_query_fragment_with_nested_fragments.type.Character
 import kotlin.Any
 import kotlin.Boolean
@@ -39,6 +39,6 @@ public class HeroFragmentImpl() : Fragment<HeroFragment> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = heroFragmentSelections.__root)
+  .selections(selections = HeroFragmentSelections.__root)
   .build()
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object QueryFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(heroFragmentSelections.__root)
+        ).selections(HeroFragmentSelections.__root)
         .build()
       )
 
@@ -37,7 +37,7 @@ public object QueryFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).selections(droidFragmentSelections.__root)
+        ).selections(DroidFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object droidFragmentSelections {
+public object DroidFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object heroFragmentSelections {
+public object HeroFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/DroidFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.droidFragmentSelections
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.DroidFragmentSelections
 import com.example.root_query_fragment_with_nested_fragments.type.Droid
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class DroidFragmentImpl() : Fragment<DroidFragmentImpl.Data> {
     name = "data",
     type = Droid.type
   )
-  .selections(selections = droidFragmentSelections.__root)
+  .selections(selections = DroidFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/HeroFragmentImpl.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Fragment
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.obj
-import com.example.root_query_fragment_with_nested_fragments.fragment.selections.heroFragmentSelections
+import com.example.root_query_fragment_with_nested_fragments.fragment.selections.HeroFragmentSelections
 import com.example.root_query_fragment_with_nested_fragments.type.Character
 import kotlin.Any
 import kotlin.Boolean
@@ -39,7 +39,7 @@ public class HeroFragmentImpl() : Fragment<HeroFragmentImpl.Data> {
     name = "data",
     type = Character.type
   )
-  .selections(selections = heroFragmentSelections.__root)
+  .selections(selections = HeroFragmentSelections.__root)
   .build()
 
   public data class Data(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object QueryFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Character",
           possibleTypes = listOf("Droid", "Human")
-        ).selections(heroFragmentSelections.__root)
+        ).selections(HeroFragmentSelections.__root)
         .build()
       )
 
@@ -37,7 +37,7 @@ public object QueryFragmentSelections {
         CompiledFragment.Builder(
           typeCondition = "Droid",
           possibleTypes = listOf("Droid")
-        ).selections(droidFragmentSelections.__root)
+        ).selections(DroidFragmentSelections.__root)
         .build()
       )
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/droidFragmentSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object droidFragmentSelections {
+public object DroidFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/heroFragmentSelections.kt.expected
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.api.notNull
 import com.example.root_query_fragment_with_nested_fragments.type.GraphQLString
 import kotlin.collections.List
 
-public object heroFragmentSelections {
+public object HeroFragmentSelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "name",

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/TestQuery.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/TestQuery.java.expected
@@ -15,8 +15,8 @@ import com.apollographql.apollo3.api.json.JsonWriter;
 import com.example.target_name.adapter.TestQuery_ResponseAdapter;
 import com.example.target_name.adapter.TestQuery_VariablesAdapter;
 import com.example.target_name.selections.TestQuerySelections;
-import com.example.target_name.type.renamedEnum;
-import com.example.target_name.type.renamedInput;
+import com.example.target_name.type.RenamedEnum;
+import com.example.target_name.type.RenamedInput;
 import java.io.IOException;
 import java.lang.Override;
 import java.lang.String;
@@ -49,11 +49,11 @@ public class TestQuery implements Query<TestQuery.Data> {
 
   public static final String OPERATION_NAME = "TestQuery";
 
-  public final Optional<renamedInput> input;
+  public final Optional<RenamedInput> input;
 
   public final Optional<java.lang.Object> scalar;
 
-  public final Optional<renamedEnum> enum_;
+  public final Optional<RenamedEnum> enum_;
 
   private transient volatile int $hashCode;
 
@@ -61,8 +61,8 @@ public class TestQuery implements Query<TestQuery.Data> {
 
   private transient volatile String $toString;
 
-  public TestQuery(Optional<renamedInput> input, Optional<java.lang.Object> scalar,
-      Optional<renamedEnum> enum_) {
+  public TestQuery(Optional<RenamedInput> input, Optional<java.lang.Object> scalar,
+      Optional<RenamedEnum> enum_) {
     this.input = input;
     this.scalar = scalar;
     this.enum_ = enum_;
@@ -156,16 +156,16 @@ public class TestQuery implements Query<TestQuery.Data> {
   }
 
   public static final class Builder {
-    private Optional<renamedInput> input = Optional.absent();
+    private Optional<RenamedInput> input = Optional.absent();
 
     private Optional<java.lang.Object> scalar = Optional.absent();
 
-    private Optional<renamedEnum> enum_ = Optional.absent();
+    private Optional<RenamedEnum> enum_ = Optional.absent();
 
     Builder() {
     }
 
-    public Builder input(renamedInput input) {
+    public Builder input(RenamedInput input) {
       this.input = Optional.present(input);
       return this;
     }
@@ -175,7 +175,7 @@ public class TestQuery implements Query<TestQuery.Data> {
       return this;
     }
 
-    public Builder enum_(renamedEnum enum_) {
+    public Builder enum_(RenamedEnum enum_) {
       this.enum_ = Optional.present(enum_);
       return this;
     }
@@ -194,7 +194,7 @@ public class TestQuery implements Query<TestQuery.Data> {
 
     public java.lang.Object scalar;
 
-    public renamedEnum enum_;
+    public RenamedEnum enum_;
 
     private transient volatile int $hashCode;
 
@@ -203,7 +203,7 @@ public class TestQuery implements Query<TestQuery.Data> {
     private transient volatile String $toString;
 
     public Data(Object object, Interface interface_, Union union, java.lang.Object scalar,
-        renamedEnum enum_) {
+        RenamedEnum enum_) {
       this.object = object;
       this.interface_ = interface_;
       this.union = union;

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/adapter/TestQuery_ResponseAdapter.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/adapter/TestQuery_ResponseAdapter.java.expected
@@ -18,8 +18,8 @@ import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
 import com.example.target_name.TestQuery;
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter;
-import com.example.target_name.type.renamedEnum;
+import com.example.target_name.type.RenamedEnum;
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter;
 import java.io.IOException;
 import java.lang.Override;
 import java.lang.String;
@@ -39,7 +39,7 @@ public class TestQuery_ResponseAdapter {
       TestQuery.Interface _interface = null;
       TestQuery.Union _union = null;
       java.lang.Object _scalar = null;
-      renamedEnum _enum = null;
+      RenamedEnum _enum = null;
 
       loop:
       while(true) {
@@ -48,7 +48,7 @@ public class TestQuery_ResponseAdapter {
           case 1: _interface = new NullableAdapter<>(new ObjectAdapter<TestQuery.Interface>(Interface.INSTANCE, false)).fromJson(reader, customScalarAdapters); break;
           case 2: _union = new NullableAdapter<>(new ObjectAdapter<TestQuery.Union>(Union.INSTANCE, true)).fromJson(reader, customScalarAdapters); break;
           case 3: _scalar = Adapters.NullableAnyAdapter.fromJson(reader, customScalarAdapters); break;
-          case 4: _enum = new NullableAdapter<>(renamedEnum_ResponseAdapter.INSTANCE).fromJson(reader, customScalarAdapters); break;
+          case 4: _enum = new NullableAdapter<>(RenamedEnum_ResponseAdapter.INSTANCE).fromJson(reader, customScalarAdapters); break;
           default: break loop;
         }
       }
@@ -78,7 +78,7 @@ public class TestQuery_ResponseAdapter {
       Adapters.NullableAnyAdapter.toJson(writer, customScalarAdapters, value.scalar);
 
       writer.name("enum");
-      new NullableAdapter<>(renamedEnum_ResponseAdapter.INSTANCE).toJson(writer, customScalarAdapters, value.enum_);
+      new NullableAdapter<>(RenamedEnum_ResponseAdapter.INSTANCE).toJson(writer, customScalarAdapters, value.enum_);
     }
   }
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/adapter/TestQuery_VariablesAdapter.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/adapter/TestQuery_VariablesAdapter.java.expected
@@ -13,9 +13,9 @@ import com.apollographql.apollo3.api.ObjectAdapter;
 import com.apollographql.apollo3.api.Optional;
 import com.apollographql.apollo3.api.json.JsonWriter;
 import com.example.target_name.TestQuery;
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter;
-import com.example.target_name.type.adapter.renamedInput_InputAdapter;
-import com.example.target_name.type.renamedInput;
+import com.example.target_name.type.RenamedInput;
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter;
+import com.example.target_name.type.adapter.RenamedInput_InputAdapter;
 import java.io.IOException;
 
 public enum TestQuery_VariablesAdapter {
@@ -25,7 +25,7 @@ public enum TestQuery_VariablesAdapter {
       CustomScalarAdapters customScalarAdapters, boolean withDefaultValues) throws IOException {
     if (value.input instanceof Optional.Present) {
       writer.name("input");
-      new ApolloOptionalAdapter<>(new NullableAdapter<>(new ObjectAdapter<renamedInput>(renamedInput_InputAdapter.INSTANCE, false))).toJson(writer, customScalarAdapters, value.input);
+      new ApolloOptionalAdapter<>(new NullableAdapter<>(new ObjectAdapter<RenamedInput>(RenamedInput_InputAdapter.INSTANCE, false))).toJson(writer, customScalarAdapters, value.input);
     }
     if (value.scalar instanceof Optional.Present) {
       writer.name("scalar");
@@ -33,7 +33,7 @@ public enum TestQuery_VariablesAdapter {
     }
     if (value.enum_ instanceof Optional.Present) {
       writer.name("enum");
-      new ApolloOptionalAdapter<>(new NullableAdapter<>(renamedEnum_ResponseAdapter.INSTANCE)).toJson(writer, customScalarAdapters, value.enum_);
+      new ApolloOptionalAdapter<>(new NullableAdapter<>(RenamedEnum_ResponseAdapter.INSTANCE)).toJson(writer, customScalarAdapters, value.enum_);
     }
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/selections/TestQuerySelections.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/selections/TestQuerySelections.java.expected
@@ -12,11 +12,11 @@ import com.apollographql.apollo3.api.CompiledNotNullType;
 import com.apollographql.apollo3.api.CompiledSelection;
 import com.apollographql.apollo3.api.CompiledVariable;
 import com.example.target_name.type.GraphQLString;
-import com.example.target_name.type.renamedEnum;
-import com.example.target_name.type.renamedInterface;
-import com.example.target_name.type.renamedObject;
-import com.example.target_name.type.renamedScalar;
-import com.example.target_name.type.renamedUnion;
+import com.example.target_name.type.RenamedEnum;
+import com.example.target_name.type.RenamedInterface;
+import com.example.target_name.type.RenamedObject;
+import com.example.target_name.type.RenamedScalar;
+import com.example.target_name.type.RenamedUnion;
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,10 +39,10 @@ public class TestQuerySelections {
   );
 
   public static List<CompiledSelection> __root = Arrays.asList(
-    new CompiledField.Builder("object", renamedObject.type).arguments(Arrays.asList(new CompiledArgument.Builder("input").value(new CompiledVariable("input")).build())).selections(__object).build(),
-    new CompiledField.Builder("interface", renamedInterface.type).selections(__interface).build(),
-    new CompiledField.Builder("union", renamedUnion.type).selections(__union).build(),
-    new CompiledField.Builder("scalar", renamedScalar.type).arguments(Arrays.asList(new CompiledArgument.Builder("scalar").value(new CompiledVariable("scalar")).build())).build(),
-    new CompiledField.Builder("enum", renamedEnum.type).arguments(Arrays.asList(new CompiledArgument.Builder("enum").value(new CompiledVariable("enum")).build())).build()
+    new CompiledField.Builder("object", RenamedObject.type).arguments(Arrays.asList(new CompiledArgument.Builder("input").value(new CompiledVariable("input")).build())).selections(__object).build(),
+    new CompiledField.Builder("interface", RenamedInterface.type).selections(__interface).build(),
+    new CompiledField.Builder("union", RenamedUnion.type).selections(__union).build(),
+    new CompiledField.Builder("scalar", RenamedScalar.type).arguments(Arrays.asList(new CompiledArgument.Builder("scalar").value(new CompiledVariable("scalar")).build())).build(),
+    new CompiledField.Builder("enum", RenamedEnum.type).arguments(Arrays.asList(new CompiledArgument.Builder("enum").value(new CompiledVariable("enum")).build())).build()
   );
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/adapter/renamedEnum_ResponseAdapter.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/adapter/renamedEnum_ResponseAdapter.java.expected
@@ -9,23 +9,23 @@ import com.apollographql.apollo3.api.Adapter;
 import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.target_name.type.renamedEnum;
+import com.example.target_name.type.RenamedEnum;
 import java.io.IOException;
 import java.lang.Override;
 
-public enum renamedEnum_ResponseAdapter implements Adapter<renamedEnum> {
+public enum RenamedEnum_ResponseAdapter implements Adapter<RenamedEnum> {
   INSTANCE;
 
   @Override
-  public renamedEnum fromJson(JsonReader reader, CustomScalarAdapters customScalarAdapters) throws
+  public RenamedEnum fromJson(JsonReader reader, CustomScalarAdapters customScalarAdapters) throws
       IOException {
     String rawValue = reader.nextString();
-    return renamedEnum.safeValueOf(rawValue);
+    return RenamedEnum.safeValueOf(rawValue);
   }
 
   @Override
   public void toJson(JsonWriter writer, CustomScalarAdapters customScalarAdapters,
-      renamedEnum value) throws IOException {
+      RenamedEnum value) throws IOException {
     writer.value(value.rawValue);
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/adapter/renamedInput_InputAdapter.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/adapter/renamedInput_InputAdapter.java.expected
@@ -12,23 +12,23 @@ import com.apollographql.apollo3.api.CustomScalarAdapters;
 import com.apollographql.apollo3.api.Optional;
 import com.apollographql.apollo3.api.json.JsonReader;
 import com.apollographql.apollo3.api.json.JsonWriter;
-import com.example.target_name.type.renamedInput;
+import com.example.target_name.type.RenamedInput;
 import java.io.IOException;
 import java.lang.IllegalStateException;
 import java.lang.Override;
 
-public enum renamedInput_InputAdapter implements Adapter<renamedInput> {
+public enum RenamedInput_InputAdapter implements Adapter<RenamedInput> {
   INSTANCE;
 
   @Override
-  public renamedInput fromJson(JsonReader reader, CustomScalarAdapters customScalarAdapters) throws
+  public RenamedInput fromJson(JsonReader reader, CustomScalarAdapters customScalarAdapters) throws
       IOException {
     throw new IllegalStateException("Input type used in output position");
   }
 
   @Override
   public void toJson(JsonWriter writer, CustomScalarAdapters customScalarAdapters,
-      renamedInput value) throws IOException {
+      RenamedInput value) throws IOException {
     if (value.field instanceof Optional.Present) {
       writer.name("field");
       new ApolloOptionalAdapter<>(Adapters.NullableStringAdapter).toJson(writer, customScalarAdapters, value.field);

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedEnum.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedEnum.java.expected
@@ -11,28 +11,28 @@ import java.lang.Override;
 import java.lang.String;
 import java.util.Arrays;
 
-public class renamedEnum {
+public class RenamedEnum {
   public static EnumType type = new EnumType("ReservedEnum", Arrays.asList("VALUE"));
 
-  public static renamedEnum VALUE = new renamedEnum("VALUE");
+  public static RenamedEnum VALUE = new RenamedEnum("VALUE");
 
   public String rawValue;
 
-  public renamedEnum(String rawValue) {
+  public RenamedEnum(String rawValue) {
     this.rawValue = rawValue;
   }
 
-  public static renamedEnum safeValueOf(String rawValue) {
+  public static RenamedEnum safeValueOf(String rawValue) {
     switch(rawValue) {
-      case "VALUE": return renamedEnum.VALUE;
-      default: return new renamedEnum.UNKNOWN__(rawValue);
+      case "VALUE": return RenamedEnum.VALUE;
+      default: return new RenamedEnum.UNKNOWN__(rawValue);
     }
   }
 
   /**
    * An enum value that wasn't known at compile time.
    */
-  public static class UNKNOWN__ extends renamedEnum {
+  public static class UNKNOWN__ extends RenamedEnum {
     private transient volatile int $hashCode;
 
     private transient volatile boolean $hashCodeMemoized;

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedInput.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedInput.java.expected
@@ -10,7 +10,7 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 
-public class renamedInput {
+public class RenamedInput {
   public final Optional<String> field;
 
   private transient volatile int $hashCode;
@@ -19,7 +19,7 @@ public class renamedInput {
 
   private transient volatile String $toString;
 
-  public renamedInput(Optional<String> field) {
+  public RenamedInput(Optional<String> field) {
     this.field = field;
   }
 
@@ -28,8 +28,8 @@ public class renamedInput {
     if (o == this) {
       return true;
     }
-    if (o instanceof renamedInput) {
-      renamedInput that = (renamedInput) o;
+    if (o instanceof RenamedInput) {
+      RenamedInput that = (RenamedInput) o;
       return ((this.field == null) ? (that.field == null) : this.field.equals(that.field));
     }
     return false;
@@ -50,7 +50,7 @@ public class renamedInput {
   @Override
   public String toString() {
     if ($toString == null) {
-      $toString = "renamedInput{"
+      $toString = "RenamedInput{"
         + "field=" + field
         + "}";
     }
@@ -72,8 +72,8 @@ public class renamedInput {
       return this;
     }
 
-    public renamedInput build() {
-      return new renamedInput(field);
+    public RenamedInput build() {
+      return new RenamedInput(field);
     }
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedInterface.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedInterface.java.expected
@@ -7,6 +7,6 @@ package com.example.target_name.type;
 
 import com.apollographql.apollo3.api.InterfaceType;
 
-public class renamedInterface {
+public class RenamedInterface {
   public static InterfaceType type = (new InterfaceType.Builder("ReservedInterface")).build();
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedObject.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedObject.java.expected
@@ -7,6 +7,6 @@ package com.example.target_name.type;
 
 import com.apollographql.apollo3.api.ObjectType;
 
-public class renamedObject {
+public class RenamedObject {
   public static ObjectType type = (new ObjectType.Builder("ReservedObject")).build();
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedScalar.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedScalar.java.expected
@@ -7,6 +7,6 @@ package com.example.target_name.type;
 
 import com.apollographql.apollo3.api.CustomScalarType;
 
-public class renamedScalar {
+public class RenamedScalar {
   public static CustomScalarType type = new CustomScalarType("ReservedScalar", "java.lang.Object");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedUnion.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/renamedUnion.java.expected
@@ -7,6 +7,6 @@ package com.example.target_name.type;
 
 import com.apollographql.apollo3.api.UnionType;
 
-public class renamedUnion {
-  public static UnionType type = new UnionType("ReservedUnion", renamedObject.type);
+public class RenamedUnion {
+  public static UnionType type = new UnionType("ReservedUnion", RenamedObject.type);
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/TestQuery.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/TestQuery.kt.expected
@@ -16,17 +16,17 @@ import com.apollographql.apollo3.api.obj
 import com.example.target_name.adapter.TestQuery_ResponseAdapter
 import com.example.target_name.adapter.TestQuery_VariablesAdapter
 import com.example.target_name.selections.TestQuerySelections
-import com.example.target_name.type.renamedEnum
-import com.example.target_name.type.renamedInput
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.RenamedInput
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
 import com.example.target_name.type.Query as CompiledQuery
 
 public data class TestQuery(
-  public val input: Optional<renamedInput?> = Optional.Absent,
+  public val input: Optional<RenamedInput?> = Optional.Absent,
   public val scalar: Optional<Any?> = Optional.Absent,
-  public val `enum`: Optional<renamedEnum?> = Optional.Absent,
+  public val `enum`: Optional<RenamedEnum?> = Optional.Absent,
 ) : Query<TestQuery.Data> {
   override val ignoreErrors: Boolean = false
 
@@ -60,7 +60,7 @@ public data class TestQuery(
     public val `interface`: Interface?,
     public val union: Union?,
     public val scalar: Any?,
-    public val `enum`: renamedEnum?,
+    public val `enum`: RenamedEnum?,
   ) : Query.Data {
     public data class Object(
       public val `field`: String?,

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/adapter/TestQuery_ResponseAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/adapter/TestQuery_ResponseAdapter.kt.expected
@@ -17,8 +17,8 @@ import com.apollographql.apollo3.api.nullable
 import com.apollographql.apollo3.api.obj
 import com.apollographql.apollo3.api.possibleTypes
 import com.example.target_name.TestQuery
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter
-import com.example.target_name.type.renamedEnum
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter
 import kotlin.Any
 import kotlin.String
 import kotlin.collections.List
@@ -34,7 +34,7 @@ public object TestQuery_ResponseAdapter {
       var _interface: TestQuery.Data.Interface? = null
       var _union: TestQuery.Data.Union? = null
       var _scalar: Any? = null
-      var _enum: renamedEnum? = null
+      var _enum: RenamedEnum? = null
 
       while (true) {
         when (reader.selectName(RESPONSE_NAMES)) {
@@ -42,7 +42,7 @@ public object TestQuery_ResponseAdapter {
           1 -> _interface = Interface.obj().nullable().fromJson(reader, customScalarAdapters)
           2 -> _union = Union.obj(true).nullable().fromJson(reader, customScalarAdapters)
           3 -> _scalar = NullableAnyAdapter.fromJson(reader, customScalarAdapters)
-          4 -> _enum = renamedEnum_ResponseAdapter.nullable().fromJson(reader, customScalarAdapters)
+          4 -> _enum = RenamedEnum_ResponseAdapter.nullable().fromJson(reader, customScalarAdapters)
           else -> break
         }
       }
@@ -74,7 +74,7 @@ public object TestQuery_ResponseAdapter {
       NullableAnyAdapter.toJson(writer, customScalarAdapters, value.scalar)
 
       writer.name("enum")
-      renamedEnum_ResponseAdapter.nullable().toJson(writer, customScalarAdapters, value.`enum`)
+      RenamedEnum_ResponseAdapter.nullable().toJson(writer, customScalarAdapters, value.`enum`)
     }
 
     private object Object : Adapter<TestQuery.Data.Object> {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/adapter/TestQuery_VariablesAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/adapter/TestQuery_VariablesAdapter.kt.expected
@@ -13,8 +13,8 @@ import com.apollographql.apollo3.api.nullable
 import com.apollographql.apollo3.api.obj
 import com.apollographql.apollo3.api.present
 import com.example.target_name.TestQuery
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter
-import com.example.target_name.type.adapter.renamedInput_InputAdapter
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter
+import com.example.target_name.type.adapter.RenamedInput_InputAdapter
 import kotlin.Boolean
 import kotlin.Suppress
 
@@ -31,7 +31,7 @@ public object TestQuery_VariablesAdapter {
   ) {
     if (value.input is Optional.Present) {
       writer.name("input")
-      renamedInput_InputAdapter.obj().nullable().present().toJson(writer, customScalarAdapters,
+      RenamedInput_InputAdapter.obj().nullable().present().toJson(writer, customScalarAdapters,
           value.input)
     }
     if (value.scalar is Optional.Present) {
@@ -40,7 +40,7 @@ public object TestQuery_VariablesAdapter {
     }
     if (value.`enum` is Optional.Present) {
       writer.name("enum")
-      renamedEnum_ResponseAdapter.nullable().present().toJson(writer, customScalarAdapters,
+      RenamedEnum_ResponseAdapter.nullable().present().toJson(writer, customScalarAdapters,
           value.`enum`)
     }
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/selections/TestQuerySelections.kt.expected
@@ -12,11 +12,11 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.CompiledVariable
 import com.apollographql.apollo3.api.notNull
 import com.example.target_name.type.GraphQLString
-import com.example.target_name.type.renamedEnum
-import com.example.target_name.type.renamedInterface
-import com.example.target_name.type.renamedObject
-import com.example.target_name.type.renamedScalar
-import com.example.target_name.type.renamedUnion
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.RenamedInterface
+import com.example.target_name.type.RenamedObject
+import com.example.target_name.type.RenamedScalar
+import com.example.target_name.type.RenamedUnion
 import kotlin.collections.List
 
 public object TestQuerySelections {
@@ -56,7 +56,7 @@ public object TestQuerySelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "object",
-          type = renamedObject.type
+          type = RenamedObject.type
         ).arguments(listOf(
           CompiledArgument.Builder("input").value(CompiledVariable("input")).build()
         ))
@@ -64,24 +64,24 @@ public object TestQuerySelections {
         .build(),
         CompiledField.Builder(
           name = "interface",
-          type = renamedInterface.type
+          type = RenamedInterface.type
         ).selections(__interface)
         .build(),
         CompiledField.Builder(
           name = "union",
-          type = renamedUnion.type
+          type = RenamedUnion.type
         ).selections(__union)
         .build(),
         CompiledField.Builder(
           name = "scalar",
-          type = renamedScalar.type
+          type = RenamedScalar.type
         ).arguments(listOf(
           CompiledArgument.Builder("scalar").value(CompiledVariable("scalar")).build()
         ))
         .build(),
         CompiledField.Builder(
           name = "enum",
-          type = renamedEnum.type
+          type = RenamedEnum.type
         ).arguments(listOf(
           CompiledArgument.Builder("enum").value(CompiledVariable("enum")).build()
         ))

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/adapter/renamedEnum_ResponseAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/adapter/renamedEnum_ResponseAdapter.kt.expected
@@ -9,19 +9,19 @@ import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.example.target_name.type.renamedEnum
+import com.example.target_name.type.RenamedEnum
 
-public object renamedEnum_ResponseAdapter : Adapter<renamedEnum> {
+public object RenamedEnum_ResponseAdapter : Adapter<RenamedEnum> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
-      renamedEnum {
+      RenamedEnum {
     val rawValue = reader.nextString()!!
-    return renamedEnum.safeValueOf(rawValue)
+    return RenamedEnum.safeValueOf(rawValue)
   }
 
   override fun toJson(
     writer: JsonWriter,
     customScalarAdapters: CustomScalarAdapters,
-    `value`: renamedEnum,
+    `value`: RenamedEnum,
   ) {
     writer.value(value.rawValue)
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/adapter/renamedInput_InputAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/adapter/renamedInput_InputAdapter.kt.expected
@@ -12,17 +12,17 @@ import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.present
-import com.example.target_name.type.renamedInput
+import com.example.target_name.type.RenamedInput
 import kotlin.IllegalStateException
 
-public object renamedInput_InputAdapter : Adapter<renamedInput> {
+public object RenamedInput_InputAdapter : Adapter<RenamedInput> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
-      renamedInput = throw IllegalStateException("Input type used in output position")
+      RenamedInput = throw IllegalStateException("Input type used in output position")
 
   override fun toJson(
     writer: JsonWriter,
     customScalarAdapters: CustomScalarAdapters,
-    `value`: renamedInput,
+    `value`: RenamedInput,
   ) {
     if (value.`field` is Optional.Present) {
       writer.name("field")

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedEnum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedEnum.kt.expected
@@ -11,7 +11,7 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.collections.List
 
-public enum class renamedEnum(
+public enum class RenamedEnum(
   public val rawValue: String,
 ) {
   VALUE("VALUE"),
@@ -25,22 +25,22 @@ public enum class renamedEnum(
     public val type: EnumType = EnumType("ReservedEnum", listOf("VALUE"))
 
     /**
-     * All [renamedEnum] known at compile time
+     * All [RenamedEnum] known at compile time
      */
-    public val knownEntries: List<renamedEnum>
+    public val knownEntries: List<RenamedEnum>
       get() = listOf(
         VALUE)
 
     /**
-     * Returns all [renamedEnum] known at compile time
+     * Returns all [RenamedEnum] known at compile time
      */
     @Deprecated(
       message = "Use knownEntries instead",
       replaceWith = ReplaceWith("this.knownEntries"),
     )
-    public fun knownValues(): Array<renamedEnum> = knownEntries.toTypedArray()
+    public fun knownValues(): Array<RenamedEnum> = knownEntries.toTypedArray()
 
-    public fun safeValueOf(rawValue: String): renamedEnum =
+    public fun safeValueOf(rawValue: String): RenamedEnum =
         values().find { it.rawValue == rawValue } ?: UNKNOWN__
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedInput.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedInput.kt.expected
@@ -8,6 +8,6 @@ package com.example.target_name.type
 import com.apollographql.apollo3.api.Optional
 import kotlin.String
 
-public data class renamedInput(
+public data class RenamedInput(
   public val `field`: Optional<String?> = Optional.Absent,
 )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedInterface.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedInterface.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.InterfaceType
 
-public class renamedInterface {
+public class RenamedInterface {
   public companion object {
     public val type: InterfaceType = InterfaceType.Builder(name = "ReservedInterface").build()
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedObject.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedObject.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.ObjectType
 
-public class renamedObject {
+public class RenamedObject {
   public companion object {
     public val type: ObjectType = ObjectType.Builder(name = "ReservedObject").build()
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedScalar.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedScalar.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.CustomScalarType
 
-public class renamedScalar {
+public class RenamedScalar {
   public companion object {
     public val type: CustomScalarType = CustomScalarType("ReservedScalar", "kotlin.Any")
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedUnion.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedUnion.kt.expected
@@ -7,8 +7,8 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.UnionType
 
-public class renamedUnion {
+public class RenamedUnion {
   public companion object {
-    public val type: UnionType = UnionType("ReservedUnion", renamedObject.type)
+    public val type: UnionType = UnionType("ReservedUnion", RenamedObject.type)
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/TestQuery.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/TestQuery.kt.expected
@@ -16,8 +16,8 @@ import com.apollographql.apollo3.api.obj
 import com.example.target_name.adapter.TestQuery_ResponseAdapter
 import com.example.target_name.adapter.TestQuery_VariablesAdapter
 import com.example.target_name.selections.TestQuerySelections
-import com.example.target_name.type.renamedEnum
-import com.example.target_name.type.renamedInput
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.RenamedInput
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.String
@@ -25,9 +25,9 @@ import kotlin.Suppress
 import com.example.target_name.type.Query as CompiledQuery
 
 public data class TestQuery(
-  public val input: Optional<renamedInput?> = Optional.Absent,
+  public val input: Optional<RenamedInput?> = Optional.Absent,
   public val scalar: Optional<Any?> = Optional.Absent,
-  public val `enum`: Optional<renamedEnum?> = Optional.Absent,
+  public val `enum`: Optional<RenamedEnum?> = Optional.Absent,
 ) : Query<TestQuery.Data> {
   override val ignoreErrors: Boolean = false
 
@@ -61,7 +61,7 @@ public data class TestQuery(
     public val `interface`: Interface?,
     public val union: Union?,
     public val scalar: Any?,
-    public val `enum`: renamedEnum?,
+    public val `enum`: RenamedEnum?,
   ) : Query.Data {
     public data class Object(
       public val `field`: String?,

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/adapter/TestQuery_ResponseAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/adapter/TestQuery_ResponseAdapter.kt.expected
@@ -17,8 +17,8 @@ import com.apollographql.apollo3.api.missingField
 import com.apollographql.apollo3.api.nullable
 import com.apollographql.apollo3.api.obj
 import com.example.target_name.TestQuery
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter
-import com.example.target_name.type.renamedEnum
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter
 import kotlin.Any
 import kotlin.String
 import kotlin.Suppress
@@ -35,7 +35,7 @@ public object TestQuery_ResponseAdapter {
       var _interface: TestQuery.Data.Interface? = null
       var _union: TestQuery.Data.Union? = null
       var _scalar: Any? = null
-      var _enum: renamedEnum? = null
+      var _enum: RenamedEnum? = null
 
       while (true) {
         when (reader.selectName(RESPONSE_NAMES)) {
@@ -43,7 +43,7 @@ public object TestQuery_ResponseAdapter {
           1 -> _interface = Interface.obj().nullable().fromJson(reader, customScalarAdapters)
           2 -> _union = Union.obj().nullable().fromJson(reader, customScalarAdapters)
           3 -> _scalar = NullableAnyAdapter.fromJson(reader, customScalarAdapters)
-          4 -> _enum = renamedEnum_ResponseAdapter.nullable().fromJson(reader, customScalarAdapters)
+          4 -> _enum = RenamedEnum_ResponseAdapter.nullable().fromJson(reader, customScalarAdapters)
           else -> break
         }
       }
@@ -75,7 +75,7 @@ public object TestQuery_ResponseAdapter {
       NullableAnyAdapter.toJson(writer, customScalarAdapters, value.scalar)
 
       writer.name("enum")
-      renamedEnum_ResponseAdapter.nullable().toJson(writer, customScalarAdapters, value.`enum`)
+      RenamedEnum_ResponseAdapter.nullable().toJson(writer, customScalarAdapters, value.`enum`)
     }
 
     private object Object : Adapter<TestQuery.Data.Object> {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/adapter/TestQuery_VariablesAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/adapter/TestQuery_VariablesAdapter.kt.expected
@@ -13,8 +13,8 @@ import com.apollographql.apollo3.api.nullable
 import com.apollographql.apollo3.api.obj
 import com.apollographql.apollo3.api.present
 import com.example.target_name.TestQuery
-import com.example.target_name.type.adapter.renamedEnum_ResponseAdapter
-import com.example.target_name.type.adapter.renamedInput_InputAdapter
+import com.example.target_name.type.adapter.RenamedEnum_ResponseAdapter
+import com.example.target_name.type.adapter.RenamedInput_InputAdapter
 import kotlin.Boolean
 import kotlin.Suppress
 
@@ -31,7 +31,7 @@ public object TestQuery_VariablesAdapter {
   ) {
     if (value.input is Optional.Present) {
       writer.name("input")
-      renamedInput_InputAdapter.obj().nullable().present().toJson(writer, customScalarAdapters,
+      RenamedInput_InputAdapter.obj().nullable().present().toJson(writer, customScalarAdapters,
           value.input)
     }
     if (value.scalar is Optional.Present) {
@@ -40,7 +40,7 @@ public object TestQuery_VariablesAdapter {
     }
     if (value.`enum` is Optional.Present) {
       writer.name("enum")
-      renamedEnum_ResponseAdapter.nullable().present().toJson(writer, customScalarAdapters,
+      RenamedEnum_ResponseAdapter.nullable().present().toJson(writer, customScalarAdapters,
           value.`enum`)
     }
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/selections/TestQuerySelections.kt.expected
@@ -12,11 +12,11 @@ import com.apollographql.apollo3.api.CompiledSelection
 import com.apollographql.apollo3.api.CompiledVariable
 import com.apollographql.apollo3.api.notNull
 import com.example.target_name.type.GraphQLString
-import com.example.target_name.type.renamedEnum
-import com.example.target_name.type.renamedInterface
-import com.example.target_name.type.renamedObject
-import com.example.target_name.type.renamedScalar
-import com.example.target_name.type.renamedUnion
+import com.example.target_name.type.RenamedEnum
+import com.example.target_name.type.RenamedInterface
+import com.example.target_name.type.RenamedObject
+import com.example.target_name.type.RenamedScalar
+import com.example.target_name.type.RenamedUnion
 import kotlin.collections.List
 
 public object TestQuerySelections {
@@ -56,7 +56,7 @@ public object TestQuerySelections {
   public val __root: List<CompiledSelection> = listOf(
         CompiledField.Builder(
           name = "object",
-          type = renamedObject.type
+          type = RenamedObject.type
         ).arguments(listOf(
           CompiledArgument.Builder("input").value(CompiledVariable("input")).build()
         ))
@@ -64,24 +64,24 @@ public object TestQuerySelections {
         .build(),
         CompiledField.Builder(
           name = "interface",
-          type = renamedInterface.type
+          type = RenamedInterface.type
         ).selections(__interface)
         .build(),
         CompiledField.Builder(
           name = "union",
-          type = renamedUnion.type
+          type = RenamedUnion.type
         ).selections(__union)
         .build(),
         CompiledField.Builder(
           name = "scalar",
-          type = renamedScalar.type
+          type = RenamedScalar.type
         ).arguments(listOf(
           CompiledArgument.Builder("scalar").value(CompiledVariable("scalar")).build()
         ))
         .build(),
         CompiledField.Builder(
           name = "enum",
-          type = renamedEnum.type
+          type = RenamedEnum.type
         ).arguments(listOf(
           CompiledArgument.Builder("enum").value(CompiledVariable("enum")).build()
         ))

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/adapter/renamedEnum_ResponseAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/adapter/renamedEnum_ResponseAdapter.kt.expected
@@ -9,19 +9,19 @@ import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
-import com.example.target_name.type.renamedEnum
+import com.example.target_name.type.RenamedEnum
 
-public object renamedEnum_ResponseAdapter : Adapter<renamedEnum> {
+public object RenamedEnum_ResponseAdapter : Adapter<RenamedEnum> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
-      renamedEnum {
+      RenamedEnum {
     val rawValue = reader.nextString()!!
-    return renamedEnum.safeValueOf(rawValue)
+    return RenamedEnum.safeValueOf(rawValue)
   }
 
   override fun toJson(
     writer: JsonWriter,
     customScalarAdapters: CustomScalarAdapters,
-    `value`: renamedEnum,
+    `value`: RenamedEnum,
   ) {
     writer.value(value.rawValue)
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/adapter/renamedInput_InputAdapter.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/adapter/renamedInput_InputAdapter.kt.expected
@@ -12,17 +12,17 @@ import com.apollographql.apollo3.api.Optional
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
 import com.apollographql.apollo3.api.present
-import com.example.target_name.type.renamedInput
+import com.example.target_name.type.RenamedInput
 import kotlin.IllegalStateException
 
-public object renamedInput_InputAdapter : Adapter<renamedInput> {
+public object RenamedInput_InputAdapter : Adapter<RenamedInput> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters):
-      renamedInput = throw IllegalStateException("Input type used in output position")
+      RenamedInput = throw IllegalStateException("Input type used in output position")
 
   override fun toJson(
     writer: JsonWriter,
     customScalarAdapters: CustomScalarAdapters,
-    `value`: renamedInput,
+    `value`: RenamedInput,
   ) {
     if (value.`field` is Optional.Present) {
       writer.name("field")

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedEnum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedEnum.kt.expected
@@ -11,7 +11,7 @@ import kotlin.Deprecated
 import kotlin.String
 import kotlin.collections.List
 
-public enum class renamedEnum(
+public enum class RenamedEnum(
   public val rawValue: String,
 ) {
   VALUE("VALUE"),
@@ -25,22 +25,22 @@ public enum class renamedEnum(
     public val type: EnumType = EnumType("ReservedEnum", listOf("VALUE"))
 
     /**
-     * All [renamedEnum] known at compile time
+     * All [RenamedEnum] known at compile time
      */
-    public val knownEntries: List<renamedEnum>
+    public val knownEntries: List<RenamedEnum>
       get() = listOf(
         VALUE)
 
     /**
-     * Returns all [renamedEnum] known at compile time
+     * Returns all [RenamedEnum] known at compile time
      */
     @Deprecated(
       message = "Use knownEntries instead",
       replaceWith = ReplaceWith("this.knownEntries"),
     )
-    public fun knownValues(): Array<renamedEnum> = knownEntries.toTypedArray()
+    public fun knownValues(): Array<RenamedEnum> = knownEntries.toTypedArray()
 
-    public fun safeValueOf(rawValue: String): renamedEnum =
+    public fun safeValueOf(rawValue: String): RenamedEnum =
         values().find { it.rawValue == rawValue } ?: UNKNOWN__
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedInput.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedInput.kt.expected
@@ -8,6 +8,6 @@ package com.example.target_name.type
 import com.apollographql.apollo3.api.Optional
 import kotlin.String
 
-public data class renamedInput(
+public data class RenamedInput(
   public val `field`: Optional<String?> = Optional.Absent,
 )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedInterface.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedInterface.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.InterfaceType
 
-public class renamedInterface {
+public class RenamedInterface {
   public companion object {
     public val type: InterfaceType = InterfaceType.Builder(name = "ReservedInterface").build()
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedObject.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedObject.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.ObjectType
 
-public class renamedObject {
+public class RenamedObject {
   public companion object {
     public val type: ObjectType = ObjectType.Builder(name = "ReservedObject").build()
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedScalar.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedScalar.kt.expected
@@ -7,7 +7,7 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.CustomScalarType
 
-public class renamedScalar {
+public class RenamedScalar {
   public companion object {
     public val type: CustomScalarType = CustomScalarType("ReservedScalar", "kotlin.Any")
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedUnion.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedUnion.kt.expected
@@ -7,8 +7,8 @@ package com.example.target_name.type
 
 import com.apollographql.apollo3.api.UnionType
 
-public class renamedUnion {
+public class RenamedUnion {
   public companion object {
-    public val type: UnionType = UnionType("ReservedUnion", renamedObject.type)
+    public val type: UnionType = UnionType("ReservedUnion", RenamedObject.type)
   }
 }


### PR DESCRIPTION
Add `Layout.fragmentName()` and `Layout.topLevelName()`. 

This will allow to prefix classes in the `Layout` in a future PR.

Note: this changes the generated code for fragment selections to be uppercase, aligned with other selections.