### PR TITLE
[compiler] move targetLanguage, codegenModels and generateFilterNotNull to `generateServiceApolloOptions`

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -11,7 +11,7 @@ public final class com/apollographql/apollo3/compiler/ApolloCompiler {
 	public final fun buildCodegenSchema (Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;)V
 	public static synthetic fun buildCodegenSchema$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
 	public final fun buildExecutableSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/CodegenMetadata;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
-	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Set;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
+	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
 	public final fun buildSchemaAndOperationSources (Ljava/util/Set;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public final fun buildSchemaAndOperationSourcesFromIr (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/util/Map;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public static synthetic fun buildSchemaAndOperationSourcesFromIr$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/util/Map;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Ljava/io/File;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
@@ -34,7 +34,6 @@ public final class com/apollographql/apollo3/compiler/CodegenMetadata$$serialize
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenMetadata$Companion {
-	public final fun getEmpty ()Lcom/apollographql/apollo3/compiler/CodegenMetadata;
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -494,6 +493,7 @@ public final class com/apollographql/apollo3/compiler/codegen/SourceOutput {
 }
 
 public final class com/apollographql/apollo3/compiler/codegen/SourceOutputKt {
+	public static final fun plus (Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public static final fun writeTo (Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;Ljava/io/File;ZLjava/io/File;)V
 }
 
@@ -625,6 +625,7 @@ public final class com/apollographql/apollo3/compiler/ir/IrObjectType$Companion 
 }
 
 public abstract interface class com/apollographql/apollo3/compiler/ir/IrOperations {
+	public abstract fun getCodegenModels ()Ljava/lang/String;
 	public abstract fun getFragmentDefinitions ()Ljava/util/List;
 	public abstract fun getUsedFields ()Ljava/util/Map;
 }

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -68,13 +68,11 @@ public final class com/apollographql/apollo3/compiler/CodegenOptions$Companion {
 
 public final class com/apollographql/apollo3/compiler/CodegenSchema {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenSchema$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/ast/Schema;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/apollographql/apollo3/compiler/TargetLanguage;Z)V
-	public final fun getCodegenModels ()Ljava/lang/String;
+	public fun <init> (Lcom/apollographql/apollo3/ast/Schema;Ljava/lang/String;Ljava/util/Map;Z)V
 	public final fun getFilePath ()Ljava/lang/String;
 	public final fun getGenerateDataBuilders ()Z
 	public final fun getScalarMapping ()Ljava/util/Map;
 	public final fun getSchema ()Lcom/apollographql/apollo3/ast/Schema;
-	public final fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenSchema$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -94,12 +92,11 @@ public final class com/apollographql/apollo3/compiler/CodegenSchema$Companion {
 
 public final class com/apollographql/apollo3/compiler/CodegenSchemaOptions {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getCodegenModels ()Ljava/lang/String;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getGenerateDataBuilders ()Ljava/lang/Boolean;
 	public final fun getScalarMapping ()Ljava/util/Map;
-	public final fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenSchemaOptions$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -120,8 +117,8 @@ public final class com/apollographql/apollo3/compiler/CodegenSchemaOptions$Compa
 public final class com/apollographql/apollo3/compiler/CommonCodegenOptions {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/CommonCodegenOptions$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDecapitalizeFields ()Ljava/lang/Boolean;
 	public final fun getGenerateFragmentImplementations ()Ljava/lang/Boolean;
 	public final fun getGenerateMethods ()Ljava/util/List;
@@ -129,6 +126,7 @@ public final class com/apollographql/apollo3/compiler/CommonCodegenOptions {
 	public final fun getGenerateSchema ()Ljava/lang/Boolean;
 	public final fun getGeneratedSchemaName ()Ljava/lang/String;
 	public final fun getOperationManifestFormat ()Ljava/lang/String;
+	public final fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 	public final fun getUseSemanticNaming ()Ljava/lang/Boolean;
 }
 
@@ -207,10 +205,11 @@ public final class com/apollographql/apollo3/compiler/GeneratedMethod$Companion 
 public final class com/apollographql/apollo3/compiler/IrOptions {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/IrOptions$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;)V
-	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAddTypename ()Ljava/lang/String;
 	public final fun getAlwaysGenerateTypesMatching ()Ljava/util/Set;
+	public final fun getCodegenModels ()Ljava/lang/String;
 	public final fun getDecapitalizeFields ()Ljava/lang/Boolean;
 	public final fun getFailOnWarnings ()Ljava/lang/Boolean;
 	public final fun getFieldsOnDisjointTypesMustMerge ()Ljava/lang/Boolean;
@@ -344,7 +343,7 @@ public final class com/apollographql/apollo3/compiler/OptionsKt {
 	public static final field MODELS_OPERATION_BASED Ljava/lang/String;
 	public static final field MODELS_OPERATION_BASED_WITH_INTERFACES Ljava/lang/String;
 	public static final field MODELS_RESPONSE_BASED Ljava/lang/String;
-	public static final fun validate (Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/TargetLanguage;)V
+	public static final fun validate (Lcom/apollographql/apollo3/compiler/CodegenOptions;)V
 }
 
 public abstract interface class com/apollographql/apollo3/compiler/PackageNameGenerator {

--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -8,8 +8,7 @@ public final class com/apollographql/apollo3/compiler/AdapterInitializer$Compani
 
 public final class com/apollographql/apollo3/compiler/ApolloCompiler {
 	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ApolloCompiler;
-	public final fun buildCodegenSchema (Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;)V
-	public static synthetic fun buildCodegenSchema$default (Lcom/apollographql/apollo3/compiler/ApolloCompiler;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;Ljava/io/File;ILjava/lang/Object;)V
+	public final fun buildCodegenSchema (Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;)Lcom/apollographql/apollo3/compiler/CodegenSchema;
 	public final fun buildExecutableSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/CodegenMetadata;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
 	public final fun buildSchemaAndOperationSources (Ljava/util/Set;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
@@ -31,10 +31,6 @@ class CodegenMetadata internal constructor(
         entries = entries + other.entries
     )
   }
-
-  companion object {
-    val Empty = CodegenMetadata(TargetLanguage.JAVA, emptyList())
-  }
 }
 
 private val emptyTargetLanguage = "emptyTargetLanguage"

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
@@ -14,10 +14,8 @@ class CodegenSchema(
     @Serializable(with = SchemaSerializer::class)
     val schema: Schema,
     val filePath: String?,
-    val codegenModels: String,
     val scalarMapping: Map<String, ScalarInfo>,
-    val targetLanguage: TargetLanguage,
-    val generateDataBuilders: Boolean,
+    val generateDataBuilders: Boolean
 )
 
 internal class CodegenType(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -129,13 +129,7 @@ enum class GeneratedMethod {
 
 @Serializable
 class CodegenSchemaOptions(
-    /**
-     * This isn't needed to build the [CodegenSchema] but this ensures targetLanguage is the same
-     * in all modules
-     */
-    val targetLanguage: TargetLanguage,
     val scalarMapping: Map<String, ScalarInfo> = emptyMap(),
-    val codegenModels: String? = null,
     val generateDataBuilders: Boolean? = null,
 )
 
@@ -181,10 +175,13 @@ class IrOptions(
      * For input types, this will recursively add all input fields types/enums.
      */
     val alwaysGenerateTypesMatching: Set<String>? = null,
+
+    val codegenModels: String? = null,
 )
 
 @Serializable
 class CommonCodegenOptions(
+    val targetLanguage: TargetLanguage? = null,
     val decapitalizeFields: Boolean? = null,
 
     val useSemanticNaming: Boolean? = null,
@@ -238,8 +235,8 @@ class CodegenOptions(
     val kotlin: KotlinCodegenOptions = KotlinCodegenOptions(),
 )
 
-fun CodegenOptions.validate(targetLanguage: TargetLanguage) {
-  if (targetLanguage == TargetLanguage.JAVA) {
+fun CodegenOptions.validate() {
+  if (common.targetLanguage == TargetLanguage.JAVA) {
     if (kotlin.generateAsInternal != null) {
       error("Apollo: generateAsInternal is not used in Java")
     }
@@ -441,6 +438,8 @@ internal val defaultCompilerJavaHooks = emptyList<ApolloCompilerJavaHooks>()
 internal val defaultOperationManifestFormat = MANIFEST_NONE
 internal val defaultAddUnkownForEnums = true
 internal val defaultAddDefaultArgumentForInputObjects = true
+internal val defaultCodegenModels = "operationBased"
+internal val defaultTargetLanguage = TargetLanguage.KOTLIN_1_9
 
 internal fun codegenModels(codegenModels: String?, targetLanguage: TargetLanguage): String {
   return when (targetLanguage) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SourceOutput.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SourceOutput.kt
@@ -17,6 +17,14 @@ class SourceOutput(
   }
 }
 
+infix fun SourceOutput?.plus(other: SourceOutput): SourceOutput {
+  if (this == null) {
+    return other
+  }
+
+  return this + other
+}
+
 fun SourceOutput.writeTo(directory: File?, deleteDirectoryFirst: Boolean, codegenSymbolsFile: File?) {
   if (directory != null) {
     if (deleteDirectoryFirst) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegen.kt
@@ -247,7 +247,7 @@ internal object JavaCodegen {
     }
 
     val flatten = irOperations.flattenModels
-    val generateDataBuilders = irOperations.generateDataBuilders
+    val generateDataBuilders = codegenSchema.generateDataBuilders
     val decapitalizeFields = irOperations.decapitalizeFields
 
     val generateFragmentImplementations = commonCodegenOptions.generateFragmentImplementations ?: defaultGenerateFragmentImplementations

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
@@ -142,12 +142,14 @@ private fun buildOutput(
 internal object KotlinCodegen {
   fun buildSchemaSources(
       codegenSchema: CodegenSchema,
+      targetLanguage: TargetLanguage,
       irSchema: IrSchema?,
       commonCodegenOptions: CommonCodegenOptions,
       kotlinCodegenOptions: KotlinCodegenOptions,
       packageNameGenerator: PackageNameGenerator,
       compilerKotlinHooks: List<ApolloCompilerKotlinHooks>,
   ): KotlinOutput {
+    check(irSchema is DefaultIrSchema)
 
     val generateDataBuilders = codegenSchema.generateDataBuilders
     val generateMethods = generateMethodsKotlin(commonCodegenOptions.generateMethods)
@@ -165,7 +167,6 @@ internal object KotlinCodegen {
     val addDefaultArgumentForInputObjects = kotlinCodegenOptions.addDefaultArgumentForInputObjects
         ?: defaultAddDefaultArgumentForInputObjects
 
-    val targetLanguage = codegenSchema.targetLanguage
     val scalarMapping = codegenSchema.scalarMapping
 
     return buildOutput(
@@ -174,7 +175,7 @@ internal object KotlinCodegen {
         requiresOptInAnnotation = requiresOptInAnnotation,
         targetLanguage = targetLanguage,
         hooks = compilerKotlinHooks,
-        generateAsInternal = generateAsInternal
+        generateAsInternal = generateAsInternal,
     ) { resolver ->
 
       val layout = CodegenLayout(
@@ -192,7 +193,6 @@ internal object KotlinCodegen {
           targetLanguage = targetLanguage,
       )
 
-      check(irSchema is DefaultIrSchema)
       irSchema.irScalars.forEach { irScalar ->
         builders.add(ScalarBuilder(context, irScalar, scalarMapping.get(irScalar.name)?.targetName))
       }
@@ -226,11 +226,11 @@ internal object KotlinCodegen {
         builders.add(PaginationBuilder(context, irSchema.connectionTypes))
       }
     }
-
   }
 
   fun buildOperationSources(
       codegenSchema: CodegenSchema,
+      targetLanguage: TargetLanguage,
       irOperations: IrOperations,
       operationOutput: OperationOutput,
       upstreamCodegenMetadata: List<CodegenMetadata>,
@@ -256,8 +256,6 @@ internal object KotlinCodegen {
     val generateInputBuilders = kotlinCodegenOptions.generateInputBuilders ?: defaultGenerateInputBuilders
     val jsExport = kotlinCodegenOptions.jsExport ?: defaultJsExport
     val requiresOptInAnnotation = kotlinCodegenOptions.requiresOptInAnnotation ?: defaultRequiresOptInAnnotation
-
-    val targetLanguage = codegenSchema.targetLanguage
 
     return buildOutput(
         codegenSchema = codegenSchema,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
@@ -78,6 +78,11 @@ private fun buildOutput(
   @Suppress("NAME_SHADOWING")
   val hooks = compilerKotlinHooks(hooks, generateAsInternal)
 
+  upstreamCodegenMetadatas.forEach {
+    check(it.targetLanguage == targetLanguage) {
+      "Apollo: Cannot depend on '${it.targetLanguage}' generated models (expected: '$targetLanguage')."
+    }
+  }
   val resolver = KotlinResolver(
       entries = upstreamCodegenMetadatas.flatMap { it.entries },
       next = null,
@@ -241,7 +246,7 @@ internal object KotlinCodegen {
   ): KotlinOutput {
     check(irOperations is DefaultIrOperations)
 
-    val generateDataBuilders = irOperations.generateDataBuilders
+    val generateDataBuilders = codegenSchema.generateDataBuilders
     val flatten = irOperations.flattenModels
     val decapitalizeFields = irOperations.decapitalizeFields
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
@@ -35,8 +35,7 @@ internal data class DefaultIrOperations(
 
     val flattenModels: Boolean,
     val decapitalizeFields: Boolean,
-    val generateDataBuilders: Boolean,
-    val codegenModels: String,
+    override val codegenModels: String,
 
     override val fragmentDefinitions: List<@Serializable(with = GQLFragmentDefinitionSerializer::class) GQLFragmentDefinition>,
 ) : IrOperations
@@ -44,6 +43,7 @@ internal data class DefaultIrOperations(
 interface IrOperations {
   val fragmentDefinitions: List<GQLFragmentDefinition>
   val usedFields: Map<String, Set<String>>
+  val codegenModels: String
 }
 
 @Serializable

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
@@ -3,8 +3,8 @@ package com.apollographql.apollo3.compiler.ir
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLType
 import com.apollographql.apollo3.compiler.internal.BooleanExpressionSerializer
-import com.apollographql.apollo3.compiler.internal.GQLTypeSerializer
 import com.apollographql.apollo3.compiler.internal.GQLFragmentDefinitionSerializer
+import com.apollographql.apollo3.compiler.internal.GQLTypeSerializer
 import kotlinx.serialization.Contextual
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -36,6 +36,7 @@ internal data class DefaultIrOperations(
     val flattenModels: Boolean,
     val decapitalizeFields: Boolean,
     val generateDataBuilders: Boolean,
+    val codegenModels: String,
 
     override val fragmentDefinitions: List<@Serializable(with = GQLFragmentDefinitionSerializer::class) GQLFragmentDefinition>,
 ) : IrOperations

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -250,7 +250,6 @@ internal class IrOperationsBuilder(
         flattenModels = flattenModels,
         decapitalizeFields = decapitalizeFields,
         fragmentDefinitions = fragmentDefinitions,
-        generateDataBuilders = generateDataBuilders,
         codegenModels = codegenModels
     )
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -251,6 +251,7 @@ internal class IrOperationsBuilder(
         decapitalizeFields = decapitalizeFields,
         fragmentDefinitions = fragmentDefinitions,
         generateDataBuilders = generateDataBuilders,
+        codegenModels = codegenModels
     )
   }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchema.kt
@@ -31,7 +31,6 @@ internal class DefaultIrSchema(
     val irUnions: List<IrUnion>,
     val irInterfaces: List<IrInterface>,
     val irObjects: List<IrObject>,
-
     val connectionTypes: List<String>,
 ) : IrSchema
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrSchemaBuilder.kt
@@ -12,7 +12,7 @@ internal object IrSchemaBuilder {
   fun build(
       schema: Schema,
       usedFields: Map<String, Set<String>>,
-      alreadyVisitedTypes: Set<String>
+      alreadyVisitedTypes: Set<String>,
   ): IrSchema {
 
     val irEnums = mutableListOf<IrEnum>()
@@ -62,7 +62,7 @@ internal object IrSchemaBuilder {
         irUnions = irUnions,
         irInterfaces = irInterfaces,
         irObjects = irObjects,
-        connectionTypes = schema.connectionTypes.toList()
+        connectionTypes = schema.connectionTypes.toList(),
     )
   }
 }

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -340,6 +340,7 @@ class CodegenTest {
       }
 
       val commonCodegenOptions = CommonCodegenOptions(
+          targetLanguage = targetLanguage,
           useSemanticNaming = useSemanticNaming,
           generateFragmentImplementations = generateFragmentImplementations,
           generateSchema = generateSchema,
@@ -349,12 +350,11 @@ class CodegenTest {
           schemaFiles = setOf(schemaFile),
           executableFiles = graphqlFiles,
           codegenSchemaOptions = CodegenSchemaOptions(
-              targetLanguage = targetLanguage,
               scalarMapping = scalarMapping,
-              codegenModels = codegenModels,
               generateDataBuilders = generateDataBuilders
           ),
           irOptions = IrOptions(
+              codegenModels = codegenModels,
               flattenModels = flattenModels,
               decapitalizeFields = decapitalizeFields,
           ),

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -43,9 +43,9 @@ class MetadataTest {
 
     ApolloCompiler.buildCodegenSchema(
         schemaFiles = setOf(File("src/test/metadata/schema.graphqls")),
-        codegenSchemaOptionsFile = codegenSchemaOptionsFile,
-        codegenSchemaFile = codegenSchemaFile
-    )
+        logger = null,
+        codegenSchemaOptions = codegenSchemaOptionsFile.toCodegenSchemaOptions(),
+    ).writeTo(codegenSchemaFile)
 
     ApolloCompiler.buildIrOperations(
         codegenSchema = codegenSchemaFile.toCodegenSchema(),

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -36,7 +36,7 @@ class MetadataTest {
 
 
   private fun compileRoot(directory: String) {
-    CodegenSchemaOptions(targetLanguage = TargetLanguage.KOTLIN_1_9).writeTo(codegenSchemaOptionsFile)
+    CodegenSchemaOptions().writeTo(codegenSchemaOptionsFile)
     IrOptions().writeTo(irOptionsFile)
     CodegenOptions(common = CommonCodegenOptions()).writeTo(rootCodegenOptionsFile)
     CodegenOptions(common = CommonCodegenOptions()).writeTo(leafCodegenOptionsFile)

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -50,6 +50,7 @@ class MetadataTest {
     ApolloCompiler.buildIrOperations(
         codegenSchema = codegenSchemaFile.toCodegenSchema(),
         executableFiles = setOf(rootGraphQLFile(directory)),
+        upstreamCodegenModels = emptyList(),
         upstreamFragmentDefinitions = emptyList(),
         options = irOptionsFile.toIrOptions(),
         logger = null
@@ -58,6 +59,7 @@ class MetadataTest {
     ApolloCompiler.buildIrOperations(
         codegenSchema = codegenSchemaFile.toCodegenSchema(),
         executableFiles = setOf(leafGraphQLFile(directory)),
+        upstreamCodegenModels = rootIrOperationsFile.toIrOperations().codegenModels.let { listOf(it) },
         upstreamFragmentDefinitions = rootIrOperationsFile.toIrOperations().fragmentDefinitions,
         options = irOptionsFile.toIrOptions(),
         logger = null

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
@@ -7,7 +7,6 @@ import com.apollographql.apollo3.compiler.IrOptions
 import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED
 import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
 import com.apollographql.apollo3.compiler.PackageNameGenerator
-import com.apollographql.apollo3.compiler.TargetLanguage
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Test
@@ -29,8 +28,8 @@ class ConditionalFragmentsTest {
       ApolloCompiler.buildSchemaAndOperationSources(
           executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")),
           schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")),
-          codegenSchemaOptions = CodegenSchemaOptions(targetLanguage = TargetLanguage.KOTLIN_1_9, codegenModels = MODELS_RESPONSE_BASED),
-          irOptions = IrOptions(flattenModels = false),
+          codegenSchemaOptions = CodegenSchemaOptions(),
+          irOptions = IrOptions(flattenModels = false, codegenModels = MODELS_RESPONSE_BASED),
           packageNameGenerator = PackageNameGenerator.Flat(""),
           codegenOptions = CodegenOptions(),
           compilerKotlinHooks = null,
@@ -49,8 +48,8 @@ class ConditionalFragmentsTest {
     ApolloCompiler.buildSchemaAndOperationSources(
         executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")),
         schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")),
-        codegenSchemaOptions = CodegenSchemaOptions(targetLanguage = TargetLanguage.KOTLIN_1_9, codegenModels = MODELS_OPERATION_BASED),
-        irOptions = IrOptions(flattenModels = false),
+        codegenSchemaOptions = CodegenSchemaOptions(),
+        irOptions = IrOptions(flattenModels = false, codegenModels = MODELS_OPERATION_BASED),
         packageNameGenerator = PackageNameGenerator.Flat(""),
         codegenOptions = CodegenOptions(),
         compilerKotlinHooks = null,

--- a/libraries/apollo-gradle-plugin-external/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin-external/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
   id("org.jetbrains.kotlin.jvm")
   id("java-gradle-plugin")
   id("com.gradleup.gr8") // Only used for removeGradleApiFromApi()
+  id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 apolloLibrary(

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -1,13 +1,10 @@
 package com.apollographql.apollo3.gradle.internal
 
 import com.apollographql.apollo3.compiler.ApolloCompiler
-import com.apollographql.apollo3.compiler.toCodegenSchemaOptions
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
@@ -30,20 +27,6 @@ abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val codegenSchemaOptionsFile: RegularFileProperty
 
-  /**
-   * Only used for checks
-   */
-  @get:Input
-  @get:Optional
-  abstract val userGenerateKotlinModels: Property<Boolean>
-
-  /**
-   * Only used for checks
-   */
-  @get:Input
-  @get:Optional
-  abstract val userCodegenModels: Property<String>
-
   @get:OutputFile
   @get:Optional
   abstract val codegenSchemaFile: RegularFileProperty
@@ -51,26 +34,6 @@ abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
   @TaskAction
   fun taskAction() {
     if (upstreamSchemaFiles.files.isNotEmpty()) {
-      val options = codegenSchemaOptionsFile.get().asFile.toCodegenSchemaOptions()
-      /**
-       * We already have a schema
-       */
-      check(schemaFiles.isEmpty) {
-        "Apollo: this module depends on another one that already has a schema. Double check that no schema file is present in this module and/or that schemaFile(s) is not specified in Gradle configuration"
-      }
-      check(options.generateDataBuilders == null) {
-        "Apollo: generateDataBuilders cannot be used because this module depends on another one that has already set generateDataBuilders"
-      }
-      check(options.scalarMapping.isEmpty()) {
-        "Apollo: scalarTypeMapping is not used because this module depends on another one that has already set scalarTypeMapping"
-      }
-      check(!userCodegenModels.isPresent) {
-        "Apollo: codegenModels is not used because this module depends on another one that has already set codegenModels"
-      }
-      check(!userGenerateKotlinModels.isPresent) {
-        "Apollo: generateKotlinModels is not used because this module depends on another one that has already set targetLanguage"
-      }
-
       /**
        * Output an empty file
        */

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -1,6 +1,8 @@
 package com.apollographql.apollo3.gradle.internal
 
 import com.apollographql.apollo3.compiler.ApolloCompiler
+import com.apollographql.apollo3.compiler.toCodegenSchemaOptions
+import com.apollographql.apollo3.compiler.writeTo
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
@@ -47,8 +49,7 @@ abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
     ApolloCompiler.buildCodegenSchema(
         schemaFiles = schemaFiles.files,
         logger = logger(),
-        codegenSchemaOptionsFile = codegenSchemaOptionsFile.get().asFile,
-        codegenSchemaFile = codegenSchemaFile.get().asFile,
-    )
+        codegenSchemaOptions = codegenSchemaOptionsFile.get().asFile.toCodegenSchemaOptions(),
+    ).writeTo(codegenSchemaFile.get().asFile)
   }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateIrOperationsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateIrOperationsTask.kt
@@ -38,10 +38,12 @@ abstract class ApolloGenerateIrOperationsTask: DefaultTask() {
 
   @TaskAction
   fun taskAction() {
+    val irOperations = upstreamIrFiles.files.map { it.toIrOperations() }
     ApolloCompiler.buildIrOperations(
         executableFiles = graphqlFiles.files,
         codegenSchema = codegenSchemaFiles.files.findCodegenSchemaFile().toCodegenSchema(),
-        upstreamFragmentDefinitions = upstreamIrFiles.files.flatMap { it.toIrOperations().fragmentDefinitions },
+        upstreamCodegenModels = irOperations.map { it.codegenModels },
+        upstreamFragmentDefinitions = irOperations.flatMap { it.fragmentDefinitions },
         options = irOptionsFile.get().asFile.toIrOptions(),
         logger = logger(),
     ).writeTo(irOperationsFile.get().asFile)

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
@@ -200,13 +200,12 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
     }
 
     CodegenSchemaOptions(
-        targetLanguage = targetLanguage.get(),
         scalarMapping = scalarMapping(scalarTypeMapping, scalarAdapterMapping),
-        codegenModels = codegenModels.orNull,
         generateDataBuilders = generateDataBuilders.orNull,
     ).writeTo(codegenSchemaOptionsFile.get().asFile)
 
     IrOptions(
+        codegenModels = codegenModels.orNull,
         addTypename = addTypename.orNull,
         fieldsOnDisjointTypesMustMerge = fieldsOnDisjointTypesMustMerge.orNull,
         decapitalizeFields = decapitalizeFields.orNull,
@@ -218,6 +217,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
     ).writeTo(irOptionsFile.get().asFile)
 
     val common = CommonCodegenOptions(
+        targetLanguage = targetLanguage.get(),
         useSemanticNaming = useSemanticNaming.orNull,
         generateFragmentImplementations = generateFragmentImplementations.orNull,
         generateMethods = generateMethods.orNull,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
@@ -9,28 +9,43 @@ import com.apollographql.apollo3.compiler.IrOptions
 import com.apollographql.apollo3.compiler.JavaCodegenOptions
 import com.apollographql.apollo3.compiler.JavaNullable
 import com.apollographql.apollo3.compiler.KotlinCodegenOptions
+import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED
+import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED_WITH_INTERFACES
+import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
 import com.apollographql.apollo3.compiler.RuntimeAdapterInitializer
 import com.apollographql.apollo3.compiler.ScalarInfo
 import com.apollographql.apollo3.compiler.TargetLanguage
+import com.apollographql.apollo3.compiler.validate
 import com.apollographql.apollo3.compiler.writeTo
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 abstract class ApolloGenerateOptionsTask : DefaultTask() {
   /**
    * CodegenSchemaOptions
    */
   @get:Input
-  abstract val targetLanguage: Property<TargetLanguage>
+  @get:Optional
+  abstract val generateKotlinModels: Property<Boolean>
+
+  @get:Input
+  @get:Optional
+  abstract val languageVersion: Property<String>
 
   @get:Input
   @get:Optional
@@ -160,10 +175,6 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val generateFilterNotNull: Property<Boolean>
-
-  @get:Input
-  @get:Optional
   abstract val generateInputBuilders: Property<Boolean>
 
   @get:Input
@@ -181,8 +192,33 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
   @get:OutputFile
   abstract val codegenOptions: RegularFileProperty
 
+  /**
+   * Gradle model
+   */
+  @get:InputFiles
+  abstract val upstreamOtherOptions: ConfigurableFileCollection
+
+  @get:Input
+  abstract var isJavaPluginApplied: Boolean
+
+  @get:Input
+  @get:Optional
+  abstract var kgpVersion: String?
+
+  @get:Input
+  abstract var isKmp: Boolean
+
+  @get:Input
+  abstract var isMultiModule: Boolean
+
+  @get:Input
+  abstract var hasDownstreamDependencies: Boolean
+
   @get:Internal
   var hasPackageNameGenerator: Boolean = false
+
+  @get:OutputFile
+  abstract val otherOptions: RegularFileProperty
 
   @TaskAction
   fun taskAction() {
@@ -199,13 +235,21 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
           """.trimMargin()
     }
 
+    val upstreamOtherOptions = upstreamOtherOptions.firstOrNull()?.toOtherOptions()
+    val upstreamTargetLanguage = upstreamOtherOptions?.targetLanguage
+    val targetLanguage = targetLanguage(generateKotlinModels.orNull, languageVersion.orNull, isJavaPluginApplied, kgpVersion, upstreamTargetLanguage)
+    val generateFilterNotNull = generateFilterNotNull(targetLanguage, isKmp)
+    val alwaysGenerateTypesMatching = alwaysGenerateTypesMatching(alwaysGenerateTypesMatching.orNull, isMultiModule, hasDownstreamDependencies)
+    val upstreamCodegenModels = upstreamOtherOptions?.codegenModels
+    val codegenModels = codegenModels(codegenModels.orNull, upstreamCodegenModels)
+
     CodegenSchemaOptions(
         scalarMapping = scalarMapping(scalarTypeMapping, scalarAdapterMapping),
         generateDataBuilders = generateDataBuilders.orNull,
     ).writeTo(codegenSchemaOptionsFile.get().asFile)
 
     IrOptions(
-        codegenModels = codegenModels.orNull,
+        codegenModels = codegenModels,
         addTypename = addTypename.orNull,
         fieldsOnDisjointTypesMustMerge = fieldsOnDisjointTypesMustMerge.orNull,
         decapitalizeFields = decapitalizeFields.orNull,
@@ -213,11 +257,11 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
         warnOnDeprecatedUsages = warnOnDeprecatedUsages.orNull,
         failOnWarnings = failOnWarnings.orNull,
         generateOptionalOperationVariables = generateOptionalOperationVariables.orNull,
-        alwaysGenerateTypesMatching = alwaysGenerateTypesMatching.orNull
+        alwaysGenerateTypesMatching = alwaysGenerateTypesMatching
     ).writeTo(irOptionsFile.get().asFile)
 
     val common = CommonCodegenOptions(
-        targetLanguage = targetLanguage.get(),
+        targetLanguage = targetLanguage,
         useSemanticNaming = useSemanticNaming.orNull,
         generateFragmentImplementations = generateFragmentImplementations.orNull,
         generateMethods = generateMethods.orNull,
@@ -236,7 +280,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
 
     val kotlin = KotlinCodegenOptions(
         generateAsInternal = generateAsInternal.orNull,
-        generateFilterNotNull = generateFilterNotNull.orNull,
+        generateFilterNotNull = generateFilterNotNull,
         sealedClassesForEnumsMatching = sealedClassesForEnumsMatching.orNull,
         addJvmOverloads = addJvmOverloads.orNull,
         requiresOptInAnnotation = requiresOptInAnnotation.orNull,
@@ -248,9 +292,82 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
         common = common,
         java = java,
         kotlin = kotlin
-    ).writeTo(codegenOptions.get().asFile)
+    ).apply {
+      validate()
+      writeTo(codegenOptions.get().asFile)
+    }
+
+    OtherOptions(targetLanguage, codegenModels).writeTo(otherOptions.get().asFile)
+  }
+
+  private fun codegenModels(codegenModels: String?, upstreamCodegenModels: String?): String {
+    if (codegenModels != null) {
+      setOf(MODELS_OPERATION_BASED, MODELS_RESPONSE_BASED, MODELS_OPERATION_BASED_WITH_INTERFACES).apply {
+        check(contains(codegenModels)) {
+          "Apollo: unknown codegenModels '$codegenModels'. Valid values: $this"
+        }
+      }
+
+      check(upstreamCodegenModels == null || codegenModels == upstreamCodegenModels) {
+        "Apollo: Expected '$upstreamCodegenModels', got '$codegenModels'. Check your codegenModels setting."
+      }
+      return codegenModels
+    }
+    if (upstreamCodegenModels != null) {
+      return upstreamCodegenModels
+    }
+
+    return MODELS_OPERATION_BASED
   }
 }
+
+private fun targetLanguage(generateKotlinModels: Boolean?,
+                           languageVersion: String?,
+                           javaPluginApplied: Boolean,
+                           kgpVersion: String?,
+                           upstreamTargetLanguage: TargetLanguage?): TargetLanguage {
+    return when {
+      generateKotlinModels != null -> {
+        if (generateKotlinModels) {
+          check(kgpVersion != null) {
+            "Apollo: generateKotlinModels.set(true) requires to apply a Kotlin plugin"
+          }
+          val targetLanguage = getKotlinTargetLanguage(kgpVersion, languageVersion)
+
+          check(upstreamTargetLanguage == null || targetLanguage == upstreamTargetLanguage) {
+            "Apollo: Expected '$upstreamTargetLanguage', got '$targetLanguage'. Check your generateKotlinModels and languageVersion settings."
+          }
+          targetLanguage
+        } else {
+          check(javaPluginApplied) {
+            "Apollo: generateKotlinModels.set(false) requires to apply the Java plugin"
+          }
+
+          check(upstreamTargetLanguage == null || TargetLanguage.JAVA == upstreamTargetLanguage) {
+            "Apollo: Expected '$upstreamTargetLanguage', got '${TargetLanguage.JAVA}'. Check your generateKotlinModels settings."
+          }
+
+          TargetLanguage.JAVA
+        }
+      }
+
+      upstreamTargetLanguage != null -> {
+        upstreamTargetLanguage
+      }
+      kgpVersion != null -> {
+        getKotlinTargetLanguage(kgpVersion, languageVersion)
+      }
+
+      javaPluginApplied -> {
+        TargetLanguage.JAVA
+      }
+      else -> {
+        error("Apollo: No Java or Kotlin plugin found")
+      }
+    }
+}
+
+
 
 private fun scalarMapping(
     scalarTypeMapping: MapProperty<String, String>,
@@ -260,4 +377,41 @@ private fun scalarMapping(
     val adapterInitializerExpression = scalarAdapterMapping.getOrElse(emptyMap())[graphQLName]
     ScalarInfo(targetName, if (adapterInitializerExpression == null) RuntimeAdapterInitializer else ExpressionAdapterInitializer(adapterInitializerExpression))
   }
+}
+
+private fun generateFilterNotNull(targetLanguage: TargetLanguage, isKmp: Boolean): Boolean? {
+  return if (targetLanguage == TargetLanguage.JAVA) {
+    null
+  } else {
+    isKmp
+  }
+}
+
+private fun alwaysGenerateTypesMatching(alwaysGenerateTypesMatching: Set<String>?, isMultiModule: Boolean, hasDownstreamDependencies: Boolean): Set<String> {
+  if (alwaysGenerateTypesMatching != null) {
+    // The user specified something, use this
+    return alwaysGenerateTypesMatching
+  }
+
+  if (isMultiModule && !hasDownstreamDependencies) {
+    // No downstream dependency, generate everything because we don't know what types are going to be used downstream
+    return setOf(".*")
+  } else {
+    // get the used coordinates from the downstream dependencies
+    return emptySet()
+  }
+}
+
+@Serializable
+internal class OtherOptions(
+    val targetLanguage: TargetLanguage,
+    val codegenModels: String
+)
+
+internal fun OtherOptions.writeTo(file: File) {
+  file.writeText(Json.encodeToString(this))
+}
+
+internal fun File.toOtherOptions(): OtherOptions {
+  return Json.decodeFromString(readText())
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
@@ -44,6 +44,12 @@ object BuildDirLayout {
     )
   }
 
+  internal fun otherOptions(project: Project, service: Service): Provider<RegularFile> {
+    return project.layout.buildDirectory.file(
+        "generated/options/apollo/${service.name}/otherOptions.json"
+    )
+  }
+
   internal fun codegenSchemaOptions(project: Project, service: Service): Provider<RegularFile> {
     return project.layout.buildDirectory.file(
         "generated/options/apollo/${service.name}/codegenSchemaOptions.json"

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/BuildDirLayout.kt
@@ -49,9 +49,9 @@ object BuildDirLayout {
         "generated/options/apollo/${service.name}/codegenSchemaOptions.json"
     )
   }
-  internal fun schema(project: Project, service: Service): Provider<RegularFile> {
+  internal fun codegenSchema(project: Project, service: Service): Provider<RegularFile> {
     return project.layout.buildDirectory.file(
-        "generated/schema/apollo/${service.name}/schema.graphqls"
+        "generated/schema/apollo/${service.name}/codegenSchema.json"
     )
   }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -691,8 +691,6 @@ abstract class DefaultApolloExtension(
       task.schemaFiles.from(project.provider { service.lazySchemaFiles(project) })
       task.upstreamSchemaFiles.from(schemaConsumerConfiguration)
       task.codegenSchemaOptionsFile.set(optionsTaskProvider.flatMap { it.codegenSchemaOptionsFile })
-      task.userGenerateKotlinModels.set(service.generateKotlinModels)
-      task.userCodegenModels.set(service.codegenModels)
       task.codegenSchemaFile.set(BuildDirLayout.schema(project, service))
     }
   }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -691,7 +691,7 @@ abstract class DefaultApolloExtension(
       task.schemaFiles.from(project.provider { service.lazySchemaFiles(project) })
       task.upstreamSchemaFiles.from(schemaConsumerConfiguration)
       task.codegenSchemaOptionsFile.set(optionsTaskProvider.flatMap { it.codegenSchemaOptionsFile })
-      task.codegenSchemaFile.set(BuildDirLayout.schema(project, service))
+      task.codegenSchemaFile.set(BuildDirLayout.codegenSchema(project, service))
     }
   }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/KotlinPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/KotlinPluginFacade.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.gradle.api.Service
 import com.apollographql.apollo3.gradle.api.kotlinMultiplatformExtension
 import com.apollographql.apollo3.gradle.api.kotlinProjectExtensionOrThrow
+import com.apollographql.apollo3.gradle.internal.DefaultApolloExtension.Companion.hasKotlinPlugin
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
@@ -15,14 +16,14 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
  * For a non-Kotlin project, this class will never be loaded so that no runtime
  * exception is thrown
  */
-fun getKotlinTargetLanguage(project: Project, userSpecified: String?): TargetLanguage {
+fun getKotlinTargetLanguage(kgpVersion: String, userSpecified: String?): TargetLanguage {
   @Suppress("DEPRECATION_ERROR")
   return when (userSpecified) {
     "1.5" -> TargetLanguage.KOTLIN_1_5
     "1.9" -> TargetLanguage.KOTLIN_1_9
     null -> {
       // User didn't specify a version: default to the Kotlin plugin version
-      val kotlinPluginVersion = project.getKotlinPluginVersion().split("-")[0]
+      val kotlinPluginVersion = kgpVersion.split("-")[0]
       val versionNumbers = kotlinPluginVersion.split(".").map { it.toInt() }
       val version = KotlinVersion(versionNumbers[0], versionNumbers[1])
       if (version.isAtLeast(1, 9)) {
@@ -34,6 +35,14 @@ fun getKotlinTargetLanguage(project: Project, userSpecified: String?): TargetLan
 
     else -> error("Apollo: languageVersion '$userSpecified' is not supported, Supported values: '1.5', '1.9'")
   }
+}
+
+fun Project.apolloGetKotlinPluginVersion(): String? {
+  if (!project.hasKotlinPlugin()) {
+    return null
+  }
+
+  return project.getKotlinPluginVersion()
 }
 
 internal fun linkSqlite(project: Project) {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ModelNames.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ModelNames.kt
@@ -20,7 +20,6 @@ object ModelNames {
   fun generateApolloSourcesFromIr(service: Service) = camelCase("generate", service.name, "ApolloSourcesFromIr")
   fun generateApolloCodegenSchema(service: Service) = camelCase("generate", service.name, "ApolloCodegenSchema")
   fun generateApolloIrOperations(service: Service) = camelCase("generate", service.name, "ApolloIrOperations")
-  fun generateApolloIrSchema(service: Service) = camelCase("generate", service.name, "ApolloIrSchema")
   fun generateApolloOptions(service: Service) = camelCase("generate", service.name, "ApolloOptions")
   fun downloadApolloSchema() = camelCase("downloadApolloSchema")
   fun downloadApolloSchemaIntrospection(service: Service) = camelCase("download", service.name, "ApolloSchemaFromIntrospection")
@@ -40,4 +39,6 @@ object ModelNames {
   fun downstreamIrConsumerConfiguration(service: Service) = camelCase("apollo", service.name, "DownStreamIrConsumer")
   fun codegenSchemaProducerConfiguration(service: Service) = camelCase("apollo", service.name, "CodegenSchemaProducer")
   fun codegenSchemaConsumerConfiguration(service: Service) = camelCase("apollo", service.name, "CodegenSchemaConsumer")
+  fun otherOptionsProducerConfiguration(service: Service) = camelCase("apollo", service.name, "OtherOptionsProducer")
+  fun otherOptionsConsumerConfiguration(service: Service) = camelCase("apollo", service.name, "OtherOptionsConsumer")
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
@@ -3,65 +3,10 @@ package com.apollographql.apollo3.gradle.internal
 import com.apollographql.apollo3.compiler.MANIFEST_NONE
 import com.apollographql.apollo3.compiler.MANIFEST_OPERATION_OUTPUT
 import com.apollographql.apollo3.compiler.MANIFEST_PERSISTED_QUERY
-import com.apollographql.apollo3.compiler.TargetLanguage
-import com.apollographql.apollo3.gradle.api.isKotlinMultiplatform
-import com.apollographql.apollo3.gradle.internal.DefaultApolloExtension.Companion.hasJavaPlugin
-import com.apollographql.apollo3.gradle.internal.DefaultApolloExtension.Companion.hasKotlinPlugin
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Provider
 import java.io.File
 
-internal fun DefaultService.alwaysGenerateTypesMatching(): Set<String> {
-  if (alwaysGenerateTypesMatching.isPresent) {
-    // The user specified something, use this!
-    return alwaysGenerateTypesMatching.get()
-  }
-
-  if (isMultiModule() && downstreamDependencies.isEmpty()) {
-    // No downstream dependency, generate everything because we don't know what types are going to be used downstream
-    return setOf(".*")
-  } else {
-    // get the used coordinates from the downstream dependencies
-    return emptySet()
-  }
-}
-
-
-internal fun DefaultService.targetLanguage(): TargetLanguage {
-  val generateKotlinModels: Boolean
-  when {
-    this.generateKotlinModels.isPresent -> {
-      generateKotlinModels = this.generateKotlinModels.get()
-      if (generateKotlinModels) {
-        check(project.hasKotlinPlugin()) {
-          "Apollo: generateKotlinModels.set(true) requires to apply a Kotlin plugin"
-        }
-      } else {
-        check(project.hasJavaPlugin()) {
-          "Apollo: generateKotlinModels.set(false) requires to apply the Java plugin"
-        }
-      }
-    }
-
-    project.hasKotlinPlugin() -> {
-      generateKotlinModels = true
-    }
-
-    project.hasJavaPlugin() -> {
-      generateKotlinModels = false
-    }
-
-    else -> {
-      error("Apollo: No Java or Kotlin plugin found")
-    }
-  }
-
-  return if (generateKotlinModels) {
-    getKotlinTargetLanguage(project, this.languageVersion.orNull)
-  } else {
-    TargetLanguage.JAVA
-  }
-}
 
 internal fun ApolloGenerateSourcesBaseTask.setPackageNameProperties(service: DefaultService) {
   packageName.set(service.packageName)
@@ -144,12 +89,3 @@ internal fun DefaultService.operationManifestFormat(): Provider<String> {
   }
 }
 
-internal fun DefaultService.generateFilterNotNull(): Provider<Boolean> {
-  return project.provider {
-    if (targetLanguage() == TargetLanguage.JAVA) {
-      null
-    } else {
-      project.isKotlinMultiplatform
-    }
-  }
-}

--- a/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test-java11/kotlin/com/apollographql/apollo3/gradle/test/MultiModulesTests.kt
@@ -126,4 +126,14 @@ class MultiModulesTests {
       )
     }
   }
+
+  @Test
+  fun `schema module targetLanguage propagates`() {
+    TestUtils.withTestProject("multi-modules-badconfig") { dir ->
+      TestUtils.executeTaskAndAssertSuccess(
+          ":leaf:build",
+          dir
+      )
+    }
+  }
 }

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
@@ -39,7 +39,7 @@ object TestUtils {
       block(dest)
     } finally {
       // Comment this line if you want to keep the directory around during development
-      // dest.deleteRecursively()
+      dest.deleteRecursively()
     }
   }
 

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/util/TestUtils.kt
@@ -21,6 +21,7 @@ object TestUtils {
 
   fun <T> withDirectory(testDir: String? = null, block: (File) -> T): T {
     val dest = if (testDir == null) {
+      // Because we run tests in parallel, we need different folders
       File.createTempFile("testProject", "", File(System.getProperty("user.dir")).resolve("build"))
     } else {
       File(System.getProperty("user.dir")).resolve("build/$testDir")
@@ -38,7 +39,7 @@ object TestUtils {
       block(dest)
     } finally {
       // Comment this line if you want to keep the directory around during development
-      dest.deleteRecursively()
+      // dest.deleteRecursively()
     }
   }
 

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm).apply(false)
+  alias(libs.plugins.apollo).apply(false)
+}

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  alias(libs.plugins.apollo)
+}
+
+dependencies {
+  implementation(libs.apollo.api)
+  implementation(project(":root"))
+}
+
+apollo {
+  service("service") {
+    // PLACEHOLDER
+    packageNamesFromFilePaths()
+    dependsOn(project(":root"))
+  }
+}

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/src/main/graphql/com/library/operations.graphql
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/src/main/graphql/com/library/operations.graphql
@@ -1,0 +1,3 @@
+query GetDetails {
+  ...queryDetails
+}

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    generateKotlinModels.set(false)
+    // PLACEHOLDER
     generateApolloMetadata.set(true)
     isADependencyOf(project(":leaf"))
     mapScalar("Date", "java.util.Date")

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  alias(libs.plugins.apollo)
+  id("maven-publish")
+}
+
+dependencies {
+  implementation(kotlin("stdlib"))
+  implementation(libs.apollo.api)
+
+  testImplementation(libs.kotlin.test.junit)
+}
+
+apollo {
+  service("service") {
+    packageNamesFromFilePaths()
+    generateKotlinModels.set(false)
+    generateApolloMetadata.set(true)
+    isADependencyOf(project(":leaf"))
+    mapScalar("Date", "java.util.Date")
+  }
+}

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/src/main/graphql/com/library/operations.graphql
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/src/main/graphql/com/library/operations.graphql
@@ -1,0 +1,3 @@
+fragment queryDetails on Query {
+  foo
+}

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/src/main/graphql/com/library/schema.graphqls
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/src/main/graphql/com/library/schema.graphqls
@@ -1,0 +1,6 @@
+type Query {
+  foo: Int!
+  date: Date
+}
+
+scalar Date

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/settings.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/settings.gradle.kts
@@ -1,0 +1,3 @@
+apply(from = "../../../../gradle/test.settings.gradle.kts")
+
+include(":root",  "leaf")

--- a/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
+++ b/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
@@ -15,7 +15,6 @@ import com.apollographql.apollo3.compiler.ExpressionAdapterInitializer
 import com.apollographql.apollo3.compiler.KotlinCodegenOptions
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.ScalarInfo
-import com.apollographql.apollo3.compiler.TargetLanguage
 import com.apollographql.apollo3.compiler.codegen.SourceOutput
 import com.apollographql.apollo3.compiler.ir.IrClassName
 import com.apollographql.apollo3.compiler.ir.IrExecutionContextTargetArgument
@@ -183,9 +182,7 @@ class ApolloProcessor(
     codegenSchema = CodegenSchema(
         schema = schema,
         filePath = null,
-        codegenModels = "operationBased",
         scalarMapping = scalarMapping,
-        targetLanguage = TargetLanguage.KOTLIN_1_9,
         generateDataBuilders = false
     )
 


### PR DESCRIPTION
Because `targetLanguage` depends on upstream modules (for upstream default values), it can't get computed during task configuration so move it to task execution. 

`codegenModels` and `generateFilterNotNull` depend on `targetLanguage` so move it there as well. 