### PR TITLE
Don't automatically add key fields to union selections

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
@@ -213,21 +213,21 @@ internal fun ValidationScope.extraValidateNonNullDirective(directive: GQLDirecti
  */
 internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDirective, directiveContext: GQLNode) {
   val fieldDefinitions: List<GQLFieldDefinition>
-  val type: String
+  val typeName: String
   when (directiveContext) {
     is GQLInterfaceTypeDefinition -> {
       fieldDefinitions = directiveContext.fields
-      type = directiveContext.name
+      typeName = directiveContext.name
     }
 
     is GQLObjectTypeDefinition -> {
       fieldDefinitions = directiveContext.fields
-      type = directiveContext.name
+      typeName = directiveContext.name
     }
 
     is GQLUnionTypeDefinition -> {
       fieldDefinitions = emptyList()
-      type = directiveContext.name
+      typeName = directiveContext.name
     }
 
     else -> {
@@ -236,7 +236,18 @@ internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDire
     }
   }
 
-  val keyFieldsArg = directive.arguments.firstOrNull { it.name == "keyFields" }
+  validateTypePolicyArgument(directive, "keyFields", typeName, fieldDefinitions)
+  validateTypePolicyArgument(directive, "embeddedFields", typeName, fieldDefinitions)
+  validateTypePolicyArgument(directive, "connectionFields", typeName, fieldDefinitions)
+}
+
+private fun ValidationScope.validateTypePolicyArgument(
+    directive: GQLDirective,
+    argumentName: String,
+    typeName: String,
+    fieldDefinitions: List<GQLFieldDefinition>,
+) {
+  val keyFieldsArg = directive.arguments.firstOrNull { it.name == argumentName }
   if (keyFieldsArg != null) {
     (keyFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
       if (selection !is GQLField) {
@@ -246,39 +257,7 @@ internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDire
       } else {
         val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
         if (definition == null) {
-          registerIssue("Field '${selection.name}' is not a valid key field for type '$type'", keyFieldsArg.sourceLocation)
-        }
-      }
-    }
-  }
-
-  val embeddedFieldsArg = directive.arguments.firstOrNull { it.name == "embeddedFields" }
-  if (embeddedFieldsArg != null) {
-    (embeddedFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
-      if (selection !is GQLField) {
-        registerIssue("Fragments are not supported in @$TYPE_POLICY directives", embeddedFieldsArg.sourceLocation)
-      } else if (selection.selections.isNotEmpty()) {
-        registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", embeddedFieldsArg.sourceLocation)
-      } else {
-        val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
-        if (definition == null) {
-          registerIssue("Field '${selection.name}' is not a valid embedded field for type '$type'", embeddedFieldsArg.sourceLocation)
-        }
-      }
-    }
-  }
-
-  val connectionFieldsArg = directive.arguments.firstOrNull { it.name == "connectionFields" }
-  if (connectionFieldsArg != null) {
-    (connectionFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
-      if (selection !is GQLField) {
-        registerIssue("Fragments are not supported in @$TYPE_POLICY directives", connectionFieldsArg.sourceLocation)
-      } else if (selection.selections.isNotEmpty()) {
-        registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", connectionFieldsArg.sourceLocation)
-      } else {
-        val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
-        if (definition == null) {
-          registerIssue("Field '${selection.name}' is not a valid connection field for type '$type'", connectionFieldsArg.sourceLocation)
+          registerIssue("No such field: '$typeName.${selection.name}'", keyFieldsArg.sourceLocation)
         }
       }
     }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ValidationCommon.kt
@@ -212,11 +212,6 @@ internal fun ValidationScope.extraValidateNonNullDirective(directive: GQLDirecti
  * Extra Apollo-specific validation for @typePolicy
  */
 internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDirective, directiveContext: GQLNode) {
-  val keyFieldsArg = directive.arguments.firstOrNull { it.name == "keyFields" }
-  if (keyFieldsArg == null) {
-    return
-  }
-
   val fieldDefinitions: List<GQLFieldDefinition>
   val type: String
   when (directiveContext) {
@@ -241,15 +236,50 @@ internal fun ValidationScope.extraValidateTypePolicyDirective(directive: GQLDire
     }
   }
 
-  (keyFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
-    if (selection !is GQLField) {
-      registerIssue("Fragments are not supported in @$TYPE_POLICY directives", keyFieldsArg.sourceLocation)
-    } else if (selection.selections.isNotEmpty()) {
-      registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", keyFieldsArg.sourceLocation)
-    } else {
-      val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
-      if (definition == null) {
-        registerIssue("Field '${selection.name}' is not a valid key field for type '$type'", keyFieldsArg.sourceLocation)
+  val keyFieldsArg = directive.arguments.firstOrNull { it.name == "keyFields" }
+  if (keyFieldsArg != null) {
+    (keyFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
+      if (selection !is GQLField) {
+        registerIssue("Fragments are not supported in @$TYPE_POLICY directives", keyFieldsArg.sourceLocation)
+      } else if (selection.selections.isNotEmpty()) {
+        registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", keyFieldsArg.sourceLocation)
+      } else {
+        val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
+        if (definition == null) {
+          registerIssue("Field '${selection.name}' is not a valid key field for type '$type'", keyFieldsArg.sourceLocation)
+        }
+      }
+    }
+  }
+
+  val embeddedFieldsArg = directive.arguments.firstOrNull { it.name == "embeddedFields" }
+  if (embeddedFieldsArg != null) {
+    (embeddedFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
+      if (selection !is GQLField) {
+        registerIssue("Fragments are not supported in @$TYPE_POLICY directives", embeddedFieldsArg.sourceLocation)
+      } else if (selection.selections.isNotEmpty()) {
+        registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", embeddedFieldsArg.sourceLocation)
+      } else {
+        val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
+        if (definition == null) {
+          registerIssue("Field '${selection.name}' is not a valid embedded field for type '$type'", embeddedFieldsArg.sourceLocation)
+        }
+      }
+    }
+  }
+
+  val connectionFieldsArg = directive.arguments.firstOrNull { it.name == "connectionFields" }
+  if (connectionFieldsArg != null) {
+    (connectionFieldsArg.value as GQLStringValue).value.parseAsGQLSelections().getOrThrow().forEach { selection ->
+      if (selection !is GQLField) {
+        registerIssue("Fragments are not supported in @$TYPE_POLICY directives", connectionFieldsArg.sourceLocation)
+      } else if (selection.selections.isNotEmpty()) {
+        registerIssue("Composite fields are not supported in @$TYPE_POLICY directives", connectionFieldsArg.sourceLocation)
+      } else {
+        val definition = fieldDefinitions.firstOrNull { it.name == selection.name }
+        if (definition == null) {
+          registerIssue("Field '${selection.name}' is not a valid connection field for type '$type'", connectionFieldsArg.sourceLocation)
+        }
       }
     }
   }

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
@@ -116,8 +116,8 @@ class KeyFieldsTest {
     val (operationDefinitions, schemaDefinitions) = definitions.partition { it is GQLExecutableDefinition }
 
     val issues = GQLDocument(schemaDefinitions, null).validateAsSchema().issues
-    check(issues.any { it.message.contains("Field 'id' is not a valid key field for type 'Animal'") })
-    check(issues.any { it.message.contains("Field 'version' is not a valid key field for type 'Node'") })
-    check(issues.any { it.message.contains("Field 'x' is not a valid key field for type 'Foo'") })
+    check(issues.any { it.message.contains("No such field: 'Animal.id'") })
+    check(issues.any { it.message.contains("No such field: 'Node.version'") })
+    check(issues.any { it.message.contains("No such field: 'Foo.x'") })
   }
 }

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/KeyFieldsTest.kt
@@ -4,7 +4,6 @@ import com.apollographql.apollo3.ast.GQLDocument
 import com.apollographql.apollo3.ast.GQLExecutableDefinition
 import com.apollographql.apollo3.ast.GQLFragmentDefinition
 import com.apollographql.apollo3.ast.GQLOperationDefinition
-import com.apollographql.apollo3.ast.SourceAwareException
 import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toGQLDocument
 import com.apollographql.apollo3.ast.toSchema
@@ -54,15 +53,6 @@ class KeyFieldsTest {
         .toGQLDocument()
         .toSchema()
     assertEquals(setOf("id"), schema.keyFields("Node"))
-  }
-
-  @Test
-  fun testExtendUnionTypePolicyDirective() {
-    val schema = "src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/extendsSchema.graphqls"
-        .toPath()
-        .toGQLDocument()
-        .toSchema()
-    assertEquals(setOf("x"), schema.keyFields("Foo"))
   }
 
   @Test
@@ -125,15 +115,9 @@ class KeyFieldsTest {
 
     val (operationDefinitions, schemaDefinitions) = definitions.partition { it is GQLExecutableDefinition }
 
-    try {
-      val schema = GQLDocument(schemaDefinitions, null).validateAsSchema().getOrThrow()
-      var operation = (operationDefinitions.single() as GQLOperationDefinition)
-      operation = addRequiredFields(operation, "always", schema, emptyMap())
-      checkKeyFields(operation, schema, emptyMap())
-      fail("An exception was expected")
-    } catch (e: SourceAwareException) {
-      check(e.message!!.contains("Field 'id' is not a valid key field for type 'Animal'"))
-      return
-    }
+    val issues = GQLDocument(schemaDefinitions, null).validateAsSchema().issues
+    check(issues.any { it.message.contains("Field 'id' is not a valid key field for type 'Animal'") })
+    check(issues.any { it.message.contains("Field 'version' is not a valid key field for type 'Node'") })
+    check(issues.any { it.message.contains("Field 'x' is not a valid key field for type 'Foo'") })
   }
 }

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/extendsSchema.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/extendsSchema.graphqls
@@ -15,13 +15,3 @@ type Bar {
 }
 
 extend type Bar implements Node
-
-union Foo = A | B
-type A {
-  x: String!
-}
-type B {
-  x: String!
-}
-
-extend union Foo @typePolicy(keyFields: "x")

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/nonexistentKeyField.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/keyfields/nonexistentKeyField.graphqls
@@ -8,6 +8,20 @@ type Animal @typePolicy(keyFields: "id") {
   species: String!
 }
 
+interface Node @typePolicy(keyFields: "id version") {
+  id: ID!
+}
+
+union Foo = A | B
+type A {
+  x: String!
+}
+type B {
+  x: String!
+}
+
+extend union Foo @typePolicy(keyFields: "x")
+
 
 query GetAnimal {
   animal {

--- a/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.expected
+++ b/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.expected
@@ -1,0 +1,44 @@
+OtherValidationIssue (17:35)
+Field 'name' is not a valid key field for type 'Node'
+------------
+OtherValidationIssue (17:87)
+Field 'baz' is not a valid embedded field for type 'Node'
+------------
+OtherValidationIssue (17:56)
+Field 'foo' is not a valid connection field for type 'Node'
+------------
+OtherValidationIssue (17:56)
+Field 'bar' is not a valid connection field for type 'Node'
+------------
+OtherValidationIssue (11:32)
+Field 'name' is not a valid key field for type 'Person'
+------------
+OtherValidationIssue (11:84)
+Field 'baz' is not a valid embedded field for type 'Person'
+------------
+OtherValidationIssue (11:53)
+Field 'foo' is not a valid connection field for type 'Person'
+------------
+OtherValidationIssue (11:53)
+Field 'bar' is not a valid connection field for type 'Person'
+------------
+OtherValidationIssue (24:30)
+Field 'id' is not a valid key field for type 'Foo'
+------------
+OtherValidationIssue (24:30)
+Field 'name' is not a valid key field for type 'Foo'
+------------
+OtherValidationIssue (24:82)
+Field 'id' is not a valid embedded field for type 'Foo'
+------------
+OtherValidationIssue (24:82)
+Field 'baz' is not a valid embedded field for type 'Foo'
+------------
+OtherValidationIssue (24:51)
+Field 'id' is not a valid connection field for type 'Foo'
+------------
+OtherValidationIssue (24:51)
+Field 'foo' is not a valid connection field for type 'Foo'
+------------
+OtherValidationIssue (24:51)
+Field 'bar' is not a valid connection field for type 'Foo'

--- a/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.expected
+++ b/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.expected
@@ -1,44 +1,44 @@
 OtherValidationIssue (17:35)
-Field 'name' is not a valid key field for type 'Node'
+No such field: 'Node.name'
 ------------
 OtherValidationIssue (17:87)
-Field 'baz' is not a valid embedded field for type 'Node'
+No such field: 'Node.baz'
 ------------
 OtherValidationIssue (17:56)
-Field 'foo' is not a valid connection field for type 'Node'
+No such field: 'Node.foo'
 ------------
 OtherValidationIssue (17:56)
-Field 'bar' is not a valid connection field for type 'Node'
+No such field: 'Node.bar'
 ------------
 OtherValidationIssue (11:32)
-Field 'name' is not a valid key field for type 'Person'
+No such field: 'Person.name'
 ------------
 OtherValidationIssue (11:84)
-Field 'baz' is not a valid embedded field for type 'Person'
+No such field: 'Person.baz'
 ------------
 OtherValidationIssue (11:53)
-Field 'foo' is not a valid connection field for type 'Person'
+No such field: 'Person.foo'
 ------------
 OtherValidationIssue (11:53)
-Field 'bar' is not a valid connection field for type 'Person'
+No such field: 'Person.bar'
 ------------
 OtherValidationIssue (24:30)
-Field 'id' is not a valid key field for type 'Foo'
+No such field: 'Foo.id'
 ------------
 OtherValidationIssue (24:30)
-Field 'name' is not a valid key field for type 'Foo'
+No such field: 'Foo.name'
 ------------
 OtherValidationIssue (24:82)
-Field 'id' is not a valid embedded field for type 'Foo'
+No such field: 'Foo.id'
 ------------
 OtherValidationIssue (24:82)
-Field 'baz' is not a valid embedded field for type 'Foo'
+No such field: 'Foo.baz'
 ------------
 OtherValidationIssue (24:51)
-Field 'id' is not a valid connection field for type 'Foo'
+No such field: 'Foo.id'
 ------------
 OtherValidationIssue (24:51)
-Field 'foo' is not a valid connection field for type 'Foo'
+No such field: 'Foo.foo'
 ------------
 OtherValidationIssue (24:51)
-Field 'bar' is not a valid connection field for type 'Foo'
+No such field: 'Foo.bar'

--- a/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.graphql
+++ b/libraries/apollo-compiler/src/test/validation/schema/typepolicy-unknown-fields.graphql
@@ -1,0 +1,24 @@
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.2/", import: ["@typePolicy"])
+
+type Query {
+  x: Int
+}
+
+type Person {
+  id: ID!
+}
+
+extend type Person @typePolicy(keyFields: "id name" connectionFields: "id foo bar" embeddedFields: "id baz")
+
+interface Node {
+  id: ID!
+}
+
+extend interface Node @typePolicy(keyFields: "id name" connectionFields: "id foo bar" embeddedFields: "id baz")
+
+
+union Foo = A | B
+type A { a: String }
+type B { b: String }
+
+extend union Foo @typePolicy(keyFields: "id name" connectionFields: "id foo bar" embeddedFields: "id baz")


### PR DESCRIPTION
Key fields were added to selections of unions, but that's not valid as unions have no fields (except `__typename`), and was crashing later on [here](https://github.com/apollographql/apollo-kotlin/blob/65ab70266f5c8363a20d200a3f16f7192e8e2e2b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/checkKeyFields.kt#L85).

We can still check if selections have the key fields at least.