### PR TITLE
[build] Compile build-logic to Java17 bytecode

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
   runtimeOnly(libs.kotlinx.binarycompatibilityvalidator)
 }
 
+// Keep in sync with CompilerOptions.kt
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -50,16 +50,15 @@ dependencies {
   runtimeOnly(libs.kotlinx.binarycompatibilityvalidator)
 }
 
-// Keep in sync with CompilerOptions.kt
 java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 tasks.withType<JavaCompile>().configureEach {
-  options.release.set(11)
+  options.release.set(17)
 }
 tasks.withType(KotlinJvmCompile::class.java).configureEach {
-  kotlinOptions.jvmTarget = "11"
+  kotlinOptions.jvmTarget = "17"
 }
 
 gradlePlugin {


### PR DESCRIPTION
Fixes 


```
:build-logic:test: Could not resolve app.cash.sqldelight:gradle-plugin:2.0.1.
Required by:
    project :build-logic
```