### PR TITLE
Add CacheResolver tests with lists and pagination

### DIFF
--- a/docs/source/caching/programmatic-ids.mdx
+++ b/docs/source/caching/programmatic-ids.mdx
@@ -74,9 +74,9 @@ val cacheKeyResolver = object: CacheKeyResolver() {
     // Even though we call leafType() here, we're guaranteed that the type is a composite type and not a list
     val typename = field.type.leafType().name
 
-    // resolveArgument returns the runtime value of the "id" argument
+    // argumentValue returns the runtime value of the "id" argument
     // from either the variables or as a literal value
-    val id = field.resolveArgument("id", variables)
+    val id = field.argumentValue("id", variables).getOrNull()
 
     if (id is String) {
       // This field has an id argument, so we can use it to compute a cache ID
@@ -127,9 +127,9 @@ override fun listOfCacheKeysForField(field: CompiledField, variables: Executable
   // Note that the field *can* be a list type here
   val typename = field.type.leafType().name
 
-  // resolveArgument returns the runtime value of the "id" argument
+  // argumentValue returns the runtime value of the "id" argument
   // from either the variables or as a literal value
-  val ids = field.resolveArgument("ids", variables)
+  val ids = field.argumentValue("ids", variables).getOrNull()
 
   if (ids is List<*>) {
     // This field has an id argument, so we can use it to compute a cache key

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -23,4 +23,8 @@ apollo {
     sourceFolder.set("2")
     packageName.set("com.example.two")
   }
+  service("3") {
+    sourceFolder.set("3")
+    packageName.set("com.example.three")
+  }
 }

--- a/tests/normalization-tests/src/main/graphql/3/extra.graphqls
+++ b/tests/normalization-tests/src/main/graphql/3/extra.graphqls
@@ -1,0 +1,9 @@
+extend type Query @fieldPolicy(forField: "country" keyArgs: "code")
+
+extend type Book @typePolicy(keyFields: "id")
+
+extend type Library @typePolicy(keyFields: "id")
+
+extend type Author @typePolicy(keyFields: "id")
+
+extend type Country @typePolicy(keyFields: "code")

--- a/tests/normalization-tests/src/main/graphql/3/operations.graphql
+++ b/tests/normalization-tests/src/main/graphql/3/operations.graphql
@@ -43,3 +43,22 @@ query GetBooksByIdsPaginatedNoCursors($bookIds: [ID!]!, $after: String) {
     }
   }
 }
+
+query GetBooksByIdsPaginatedNoCursorsWithFragment($bookIds: [ID!]!, $after: String) {
+  viewer {
+    libraries(limit: 1) {
+      booksPaginated(bookIds: $bookIds, after: $after) {
+        edges {
+          ...BookEdge
+        }
+      }
+    }
+  }
+}
+
+fragment BookEdge on BookEdge {
+  node {
+    name
+    year
+  }
+}

--- a/tests/normalization-tests/src/main/graphql/3/operations.graphql
+++ b/tests/normalization-tests/src/main/graphql/3/operations.graphql
@@ -1,0 +1,45 @@
+query GetBooksByIds($bookIds: [ID!]!) {
+  viewer {
+    libraries(limit: 1) {
+      books(bookIds: $bookIds) {
+        name
+        year
+      }
+    }
+  }
+}
+
+query GetBooksByIdsPaginated($bookIds: [ID!]!, $after: String) {
+  viewer {
+    libraries(limit: 1) {
+      booksPaginated(bookIds: $bookIds, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        edges {
+          cursor
+          node {
+            name
+            year
+          }
+        }
+      }
+    }
+  }
+}
+
+query GetBooksByIdsPaginatedNoCursors($bookIds: [ID!]!, $after: String) {
+  viewer {
+    libraries(limit: 1) {
+      booksPaginated(bookIds: $bookIds, after: $after) {
+        edges {
+          node {
+            name
+            year
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/normalization-tests/src/main/graphql/3/schema.graphqls
+++ b/tests/normalization-tests/src/main/graphql/3/schema.graphqls
@@ -1,0 +1,52 @@
+type Query {
+  viewer: Viewer!
+  home: Home!
+  country(code: ID!): Country
+}
+
+type Viewer {
+  libraries(limit: Int): [Library!]!
+}
+
+type Book {
+  id: String!
+  name: String!
+  year: Int!
+  author: Author!
+}
+
+type Library {
+  id: String!
+  name: String!
+  books(bookIds: [ID!]!): [Book]!
+  booksPaginated(bookIds: [ID!]!, first: Int = 10, after: String): BookConnection!
+}
+
+type BookConnection {
+  edges: [BookEdge!]!
+  pageInfo: PageInfo!
+}
+
+type BookEdge {
+  node: Book!
+  cursor: String!
+}
+
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String!
+}
+
+type Author {
+  id: String!
+  name: String!
+}
+
+type Home {
+  address: String
+}
+
+type Country {
+  code: ID!
+  name: String!
+}

--- a/tests/normalization-tests/src/test/kotlin/com/example/NormalizationTest.kt
+++ b/tests/normalization-tests/src/test/kotlin/com/example/NormalizationTest.kt
@@ -7,25 +7,37 @@ import com.apollographql.apollo3.api.Executable
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.toApolloResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.CacheKey
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.api.CacheKeyGeneratorContext
+import com.apollographql.apollo3.cache.normalized.api.CacheKeyResolver
 import com.apollographql.apollo3.cache.normalized.api.CacheResolver
 import com.apollographql.apollo3.cache.normalized.api.FieldPolicyCacheResolver
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.apolloStore
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.normalizedCache
+import com.apollographql.apollo3.cache.normalized.store
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import com.example.one.Issue2818Query
 import com.example.one.Issue3672Query
 import com.example.one.fragment.SectionFragment
+import com.example.three.GetBooksByIdsPaginatedNoCursorsQuery
+import com.example.three.GetBooksByIdsPaginatedQuery
+import com.example.three.GetBooksByIdsQuery
+import com.example.three.type.Book
+import com.example.three.type.BookConnection
 import com.example.two.GetCountryQuery
 import com.example.two.NestedFragmentQuery
 import kotlinx.coroutines.runBlocking
 import okio.Buffer
 import org.junit.Test
+import kotlin.test.assertEquals
 
 internal object IdBasedCacheKeyResolver : CacheResolver, CacheKeyGenerator {
 
@@ -125,6 +137,173 @@ class NormalizationTest {
     apolloClient.query(GetCountryQuery("foo")).execute().run {
       check(data?.country?.name == "Foo")
     }
+    apolloClient.close()
+    mockserver.close()
+  }
+
+  @Test
+  fun resolveList() = runTest {
+    val mockserver = MockServer()
+    val apolloClient = ApolloClient.Builder()
+        .serverUrl(mockserver.url())
+        .store(
+            ApolloStore(
+                normalizedCacheFactory = MemoryCacheFactory(),
+                cacheKeyGenerator = TypePolicyCacheKeyGenerator,
+                cacheResolver = object : CacheKeyResolver() {
+                  override fun cacheKeyForField(field: CompiledField, variables: Executable.Variables): CacheKey? {
+                    // Same behavior as FieldPolicyCacheResolver
+                    val keyArgsValues = field.argumentValues(variables) { it.isKey }.values.map { it.toString() }
+                    if (keyArgsValues.isNotEmpty()) {
+                      return CacheKey(field.type.rawType().name, keyArgsValues)
+                    }
+                    return null
+                  }
+
+                  @Suppress("UNCHECKED_CAST")
+                  override fun listOfCacheKeysForField(field: CompiledField, variables: Executable.Variables): List<CacheKey?>? {
+                    return if (field.type.rawType() == Book.type) {
+                      val bookIds = field.argumentValues(variables)["bookIds"] as List<String>
+                      bookIds.map { CacheKey(Book.type.name, it) }
+                    } else {
+                      null
+                    }
+                  }
+                }
+            )
+        )
+        .build()
+
+    mockserver.enqueueString("""
+      {
+        "data": {
+          "viewer": {
+            "libraries": [
+              {
+                "__typename": "Library",
+                "id": "library-1",
+                "books": [
+                  {
+                    "__typename": "Book",
+                    "id": "book-1",
+                    "name": "First book",
+                    "year": 1991
+                  },
+                  {
+                    "__typename": "Book",
+                    "id": "book-2",
+                    "name": "Second book",
+                    "year": 1992
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    """.trimIndent())
+
+    // Fetch from network
+    apolloClient.query(GetBooksByIdsQuery(listOf("book-1", "book-2"))).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+    println(NormalizedCache.prettifyDump(apolloClient.apolloStore.dump()))
+
+
+    // Fetch from the cache
+    val fromCache = apolloClient.query(GetBooksByIdsQuery(listOf("book-1"))).fetchPolicy(FetchPolicy.CacheOnly).execute()
+    assertEquals(fromCache.data?.viewer?.libraries?.first()?.books?.first()?.name, "First book")
+
+    apolloClient.close()
+    mockserver.close()
+  }
+
+  @Test
+  fun resolvePaginatedList() = runTest {
+    val mockserver = MockServer()
+    val apolloClient = ApolloClient.Builder()
+        .serverUrl(mockserver.url())
+        .store(
+            ApolloStore(
+                normalizedCacheFactory = MemoryCacheFactory(),
+                cacheKeyGenerator = TypePolicyCacheKeyGenerator,
+                cacheResolver = object : CacheResolver {
+                  @Suppress("UNCHECKED_CAST")
+                  override fun resolveField(
+                      field: CompiledField,
+                      variables: Executable.Variables,
+                      parent: Map<String, Any?>,
+                      parentId: String,
+                  ): Any? {
+                    if (field.type.rawType() == BookConnection.type) {
+                      val bookIds = field.argumentValues(variables)["bookIds"] as List<String>
+                      return mapOf(
+                          "edges" to bookIds.map {
+                            mapOf("node" to CacheKey(Book.type.name, it))
+                          },
+                          "__typename" to BookConnection.type.name
+                      )
+                    }
+
+                    return FieldPolicyCacheResolver.resolveField(field, variables, parent, parentId)
+                  }
+                }
+
+            )
+        )
+        .build()
+
+    mockserver.enqueueString("""
+      {
+        "data": {
+          "viewer": {
+            "libraries": [
+              {
+                "__typename": "Library",
+                "id": "library-1",
+                "booksPaginated": {
+                  "__typename": "BookConnection",
+                  "pageInfo": {
+                    "__typename": "PageInfo",
+                    "hasNextPage": false,
+                    "endCursor": "book-2"
+                  },
+                  "edges": [
+                    {
+                      "__typename": "BookEdge",
+                      "cursor": "cursor-book-1",
+                      "node": {
+                        "__typename": "Book",
+                        "id": "book-1",
+                        "name": "First book",
+                        "year": 1991
+                      }
+                    },
+                    {
+                      "__typename": "BookEdge",
+                      "cursor": "cursor-book-2",
+                      "node": {
+                        "__typename": "Book",
+                        "id": "book-2",
+                        "name": "Second book",
+                        "year": 1992
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    """.trimIndent())
+
+    // Fetch from network
+    val fromNetwork = apolloClient.query(GetBooksByIdsPaginatedQuery(listOf("book-1", "book-2"))).fetchPolicy(FetchPolicy.NetworkOnly).execute()
+    println(NormalizedCache.prettifyDump(apolloClient.apolloStore.dump()))
+
+    // Fetch from the cache
+    val fromCache = apolloClient.query(GetBooksByIdsPaginatedNoCursorsQuery(listOf("book-1"))).fetchPolicy(FetchPolicy.CacheOnly).execute()
+    assertEquals(fromCache.data?.viewer?.libraries?.first()?.booksPaginated?.edges?.first()?.node?.name, "First book")
+
     apolloClient.close()
     mockserver.close()
   }


### PR DESCRIPTION
Also, handle the Map case in `CacheBatchReader.registerCacheKeys` - turns out it was handled correctly in the incubating version so ended up re-using that.