### PR TITLE
[🐘gradle-plugin] bump minimum required Gradle version

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Some platforms have specific runtime requirements:
 
 At build time, it requires:
 
-* Gradle 6.8+
+* Gradle 8.0+
 * Kotlin 1.8+ for JVM projects
 * Kotlin 1.9+ for native projects
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -143,7 +143,7 @@ Some platforms have specific runtime requirements:
 
 At build time, it requires:
 
-* Gradle 6.8+
+* Gradle 8.0+
 * Kotlin 1.8+ for JVM projects
 * Kotlin 1.9+ for native projects
 

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -102,7 +102,7 @@ gr8 = { group = "com.gradleup", name = "gr8-plugin", version = "0.8" }
 # to avoid leaking the Kotlin stdlib on the classpath
 #
 # Keep in sync with MIN_GRADLE_VERSION
-gradle-api-min = { group = "dev.gradleplugins", name = "gradle-api", version = "6.8" }
+gradle-api-min = { group = "dev.gradleplugins", name = "gradle-api", version = "8.0" }
 gradle-japicmp-plugin = { group = "me.champeau.gradle", name = "japicmp-gradle-plugin", version = "0.2.8" }
 gradle-publish-plugin = { group = "com.gradle.publish", name = "plugin-publish-plugin", version = "1.1.0" }
 guava-jre = { group = "com.google.guava", name = "guava", version.ref = "guava" }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -56,9 +56,11 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   }
 
   @Deprecated("Not supported any more, use dependsOn() instead", level = DeprecationLevel.ERROR)
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   override fun usedCoordinates(file: File) = TODO()
 
   @Deprecated("Not supported any more, use dependsOn() instead", level = DeprecationLevel.ERROR)
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   override fun usedCoordinates(file: String) = TODO()
 
   var introspection: DefaultIntrospection? = null

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -10,7 +10,6 @@ import com.apollographql.apollo3.gradle.api.Service
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
-import org.gradle.util.GradleVersion
 import java.io.File
 import javax.inject.Inject
 
@@ -26,27 +25,16 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
   init {
     @Suppress("LeakingThis", "NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
-    if (GradleVersion.current() >= GradleVersion.version("6.2")) {
-      // This allows users to call includes.put("Date", "java.util.Date")
-      // see https://github.com/gradle/gradle/issues/7485
-      includes.convention(null as List<String>?)
-      excludes.convention(null as List<String>?)
-      alwaysGenerateTypesMatching.convention(null as List<String>?)
-      sealedClassesForEnumsMatching.convention(null as List<String>?)
-      classesForEnumsMatching.convention(null as List<String>?)
-      generateMethods.convention(null as List<String>?)
-      compilerJavaHooks.convention(null as List<ApolloCompilerJavaHooks>?)
-      compilerKotlinHooks.convention(null as List<ApolloCompilerKotlinHooks>?)
-    } else {
-      includes.set(null as List<String>?)
-      excludes.set(null as List<String>?)
-      alwaysGenerateTypesMatching.set(null as List<String>?)
-      sealedClassesForEnumsMatching.set(null as List<String>?)
-      classesForEnumsMatching.set(null as List<String>?)
-      generateMethods.set(null as List<String>?)
-      compilerJavaHooks.set(null as List<ApolloCompilerJavaHooks>?)
-      compilerKotlinHooks.set(null as List<ApolloCompilerKotlinHooks>?)
-    }
+    // This allows users to call includes.put("Date", "java.util.Date")
+    // see https://github.com/gradle/gradle/issues/7485
+    includes.convention(null as List<String>?)
+    excludes.convention(null as List<String>?)
+    alwaysGenerateTypesMatching.convention(null as List<String>?)
+    sealedClassesForEnumsMatching.convention(null as List<String>?)
+    classesForEnumsMatching.convention(null as List<String>?)
+    generateMethods.convention(null as List<String>?)
+    compilerJavaHooks.convention(null as List<ApolloCompilerJavaHooks>?)
+    compilerKotlinHooks.convention(null as List<ApolloCompilerKotlinHooks>?)
   }
 
   val graphqlSourceDirectorySet = objects.sourceDirectorySet("graphql", "graphql")


### PR DESCRIPTION
[AGP 8 requires Gradle 8](https://developer.android.com/build/releases/gradle-plugin) so go ahead and bump that version for Apollo Kotlin. It's not stricly required but moves the ecosystem and since v4 is going to stick around, will give us a bit of headroom.