### PR TITLE
[⚙️compiler] introduce InputFile

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -8,16 +8,20 @@ public final class com/apollographql/apollo3/compiler/AdapterInitializer$Compani
 
 public final class com/apollographql/apollo3/compiler/ApolloCompiler {
 	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/ApolloCompiler;
-	public final fun buildCodegenSchema (Ljava/util/Set;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;)Lcom/apollographql/apollo3/compiler/CodegenSchema;
+	public final fun buildCodegenSchema (Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;)Lcom/apollographql/apollo3/compiler/CodegenSchema;
 	public final fun buildExecutableSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/CodegenMetadata;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
-	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Set;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
-	public final fun buildSchemaAndOperationsSources (Ljava/util/Set;Ljava/util/Set;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
+	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
+	public final fun buildSchemaAndOperationsSources (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public final fun buildSchemaAndOperationsSourcesFromIr (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/util/Map;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public final fun buildSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Map;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/List;Ljava/util/List;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 }
 
 public abstract interface class com/apollographql/apollo3/compiler/ApolloCompiler$Logger {
 	public abstract fun warning (Ljava/lang/String;)V
+}
+
+public final class com/apollographql/apollo3/compiler/ApolloCompilerKt {
+	public static final fun toInputFiles (Ljava/util/Collection;)Ljava/util/List;
 }
 
 public final class com/apollographql/apollo3/compiler/CodegenMetadata$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
@@ -40,7 +44,7 @@ public final class com/apollographql/apollo3/compiler/CodegenMetadataKt {
 
 public final class com/apollographql/apollo3/compiler/CodegenOptions : com/apollographql/apollo3/compiler/OperationsCodegenOptions, com/apollographql/apollo3/compiler/SchemaCodegenOptions {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenOptions$Companion;
-	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public fun <init> (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
 	public fun getAddDefaultArgumentForInputObjects ()Ljava/lang/Boolean;
 	public fun getAddJvmOverloads ()Ljava/lang/Boolean;
 	public fun getAddUnknownForEnums ()Ljava/lang/Boolean;
@@ -57,7 +61,9 @@ public final class com/apollographql/apollo3/compiler/CodegenOptions : com/apoll
 	public fun getGeneratedSchemaName ()Ljava/lang/String;
 	public fun getNullableFieldStyle ()Lcom/apollographql/apollo3/compiler/JavaNullable;
 	public fun getOperationManifestFormat ()Ljava/lang/String;
+	public fun getPackageName ()Ljava/lang/String;
 	public fun getRequiresOptInAnnotation ()Ljava/lang/String;
+	public fun getRootPackageName ()Ljava/lang/String;
 	public fun getSealedClassesForEnumsMatching ()Ljava/util/List;
 	public fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 	public fun getUseSemanticNaming ()Ljava/lang/Boolean;
@@ -81,8 +87,8 @@ public final class com/apollographql/apollo3/compiler/CodegenOptions$Companion {
 public final class com/apollographql/apollo3/compiler/CodegenSchema {
 	public static final field Companion Lcom/apollographql/apollo3/compiler/CodegenSchema$Companion;
 	public fun <init> (Lcom/apollographql/apollo3/ast/Schema;Ljava/lang/String;Ljava/util/Map;Z)V
-	public final fun getFilePath ()Ljava/lang/String;
 	public final fun getGenerateDataBuilders ()Z
+	public final fun getNormalizedPath ()Ljava/lang/String;
 	public final fun getScalarMapping ()Ljava/util/Map;
 	public final fun getSchema ()Lcom/apollographql/apollo3/ast/Schema;
 }
@@ -128,6 +134,8 @@ public abstract interface class com/apollographql/apollo3/compiler/CommonCodegen
 	public abstract fun getDecapitalizeFields ()Ljava/lang/Boolean;
 	public abstract fun getGenerateMethods ()Ljava/util/List;
 	public abstract fun getOperationManifestFormat ()Ljava/lang/String;
+	public abstract fun getPackageName ()Ljava/lang/String;
+	public abstract fun getRootPackageName ()Ljava/lang/String;
 	public abstract fun getTargetLanguage ()Lcom/apollographql/apollo3/compiler/TargetLanguage;
 	public abstract fun getUseSemanticNaming ()Ljava/lang/Boolean;
 }
@@ -187,6 +195,12 @@ public final class com/apollographql/apollo3/compiler/GeneratedMethod : java/lan
 
 public final class com/apollographql/apollo3/compiler/GeneratedMethod$Companion {
 	public final fun fromName (Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/GeneratedMethod;
+}
+
+public final class com/apollographql/apollo3/compiler/InputFile {
+	public fun <init> (Ljava/io/File;Ljava/lang/String;)V
+	public final fun getFile ()Ljava/io/File;
+	public final fun getNormalizedPath ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/compiler/IrOptions {
@@ -310,8 +324,8 @@ public final class com/apollographql/apollo3/compiler/OptionsKt {
 	public static final field MODELS_OPERATION_BASED Ljava/lang/String;
 	public static final field MODELS_OPERATION_BASED_WITH_INTERFACES Ljava/lang/String;
 	public static final field MODELS_RESPONSE_BASED Ljava/lang/String;
-	public static final fun buildCodegenOptions (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lcom/apollographql/apollo3/compiler/CodegenOptions;
-	public static synthetic fun buildCodegenOptions$default (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/CodegenOptions;
+	public static final fun buildCodegenOptions (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/CodegenOptions;
+	public static synthetic fun buildCodegenOptions$default (Lcom/apollographql/apollo3/compiler/TargetLanguage;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/Boolean;Lcom/apollographql/apollo3/compiler/JavaNullable;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/CodegenOptions;
 	public static final fun buildCodegenSchemaOptions (Ljava/util/Map;Ljava/lang/Boolean;)Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;
 	public static synthetic fun buildCodegenSchemaOptions$default (Ljava/util/Map;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;
 	public static final fun buildIrOptions (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Set;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/IrOptions;
@@ -324,13 +338,13 @@ public abstract interface class com/apollographql/apollo3/compiler/PackageNameGe
 	public abstract fun packageName (Ljava/lang/String;)Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/compiler/PackageNameGenerator$FilePathAware : com/apollographql/apollo3/compiler/PackageNameGenerator {
-	public fun <init> (Ljava/util/Set;)V
+public final class com/apollographql/apollo3/compiler/PackageNameGenerator$Flat : com/apollographql/apollo3/compiler/PackageNameGenerator {
+	public fun <init> (Ljava/lang/String;)V
 	public fun getVersion ()Ljava/lang/String;
 	public fun packageName (Ljava/lang/String;)Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/compiler/PackageNameGenerator$Flat : com/apollographql/apollo3/compiler/PackageNameGenerator {
+public final class com/apollographql/apollo3/compiler/PackageNameGenerator$NormalizedPathAware : com/apollographql/apollo3/compiler/PackageNameGenerator {
 	public fun <init> (Ljava/lang/String;)V
 	public fun getVersion ()Ljava/lang/String;
 	public fun packageName (Ljava/lang/String;)Ljava/lang/String;

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenSchema.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
 class CodegenSchema(
     @Serializable(with = SchemaSerializer::class)
     val schema: Schema,
-    val filePath: String?,
+    val normalizedPath: String,
     val scalarMapping: Map<String, ScalarInfo>,
     val generateDataBuilders: Boolean
 )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -214,6 +214,17 @@ interface CommonCodegenOpt {
    * The target language to use to generate the sources
    */
   val targetLanguage: TargetLanguage?
+
+  /**
+   * The packageName to use for generated sources. To avoid name clashes, the compiler might use sub packages.
+   */
+  val packageName: String?
+
+  /**
+   * If non-null, get the package names from the normalized file paths and prepend [rootPackageName]
+   */
+  val rootPackageName: String?
+
   /**
    * Whether to decapitalize fields. This is useful if your schema has fields starting with an uppercase as
    * it may create name clashes with models that use PascalCase
@@ -373,6 +384,8 @@ interface OperationsCodegenOptions : JavaOperationsCodegenOptions, KotlinOperati
 @Serializable
 class CodegenOptions(
     override val targetLanguage: TargetLanguage?,
+    override val packageName: String?,
+    override val rootPackageName: String?,
     override val decapitalizeFields: Boolean?,
     override val useSemanticNaming: Boolean?,
     override val generateMethods: List<GeneratedMethod>?,
@@ -393,7 +406,7 @@ class CodegenOptions(
     override val generatePrimitiveTypes: Boolean?,
     override val nullableFieldStyle: JavaNullable?,
     override val generateFragmentImplementations: Boolean?,
-    override val generateQueryDocument: Boolean?
+    override val generateQueryDocument: Boolean?,
 ): SchemaCodegenOptions, OperationsCodegenOptions
 
 fun buildCodegenOptions(
@@ -419,6 +432,8 @@ fun buildCodegenOptions(
     nullableFieldStyle: JavaNullable? = null,
     generateFragmentImplementations: Boolean? = null,
     generateQueryDocument: Boolean? = null,
+    packageName: String? = null,
+    rootPackageName: String? = null,
 ): CodegenOptions = CodegenOptions(
     targetLanguage = targetLanguage,
     decapitalizeFields = decapitalizeFields,
@@ -442,6 +457,8 @@ fun buildCodegenOptions(
     nullableFieldStyle = nullableFieldStyle,
     generateFragmentImplementations = generateFragmentImplementations,
     generateQueryDocument = generateQueryDocument,
+    packageName = packageName,
+    rootPackageName = rootPackageName,
 )
 
 fun CodegenOptions.validate() {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/PackageNameGenerator.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/PackageNameGenerator.kt
@@ -35,54 +35,12 @@ interface PackageNameGenerator {
       get() = error("this should only be called from the Gradle Plugin")
   }
 
-  class FilePathAware(private val sourceRoots: Set<String>): PackageNameGenerator {
+  class NormalizedPathAware(private val rootPackageName: String?): PackageNameGenerator {
     override fun packageName(filePath: String): String {
-      return filePackageName(sourceRoots, filePath)
+      return "${rootPackageName}.${filePath.toPackageName()}".removePrefix(".")
     }
 
     override val version: String
       get() = error("this should only be called from the Gradle Plugin")
-
   }
 }
-
-
-/**
- * A helper class to get a package name from a list of root folders
- *
- * Given:
- * - a list of root folders like "src/main/graphql/", "src/debug/graphql/", etc...
- * - an absolute file path like "/User/lee/projects/app/src/main/graphql/com/example/Query.graphql
- * will return "com.example"
- */
-private fun relativeToRoots(roots: Set<String>, filePath: String): String {
-  val file = File(File(filePath).absolutePath).normalize()
-  roots.map { File(it).normalize() }.forEach { sourceDir ->
-    try {
-      val relative = file.toRelativeString(sourceDir)
-      if (relative.startsWith(".."))
-        return@forEach
-
-      return relative
-    } catch (e: IllegalArgumentException) {
-
-    }
-  }
-  // Be robust if the file is not found.
-  // This is for compatibility reasons mainly.
-  return ""
-}
-
-/**
- * Return the packageName if this file is in these roots or throw else
- */
-internal fun filePackageName(roots: Set<String>, filePath: String): String {
-  val relative = relativeToRoots(roots, filePath)
-
-  return relative
-      .split(File.separator)
-      .filter { it.isNotBlank() }
-      .dropLast(1)
-      .joinToString(".")
-}
-

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Strings.kt
@@ -82,3 +82,15 @@ internal fun String.maybeAddSuffix(suffix: String): String {
     "$this$suffix"
   }
 }
+
+
+/**
+ * Return the packageName if this file is in these roots or throw else
+ */
+internal fun String.toPackageName(): String {
+  return split('/')
+      .filter { it.isNotBlank() }
+      .dropLast(1)
+      .joinToString(".")
+}
+

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayoutImpl.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayoutImpl.kt
@@ -27,7 +27,7 @@ internal class SchemaAndOperationsLayoutImpl(
     private val useSemanticNaming: Boolean,
     private val decapitalizeFields: Boolean
 ) : SchemaAndOperationsLayout {
-  private val schemaPackageName = executableDocumentPackageName(codegenSchema.filePath ?: "")
+  private val schemaPackageName = executableDocumentPackageName(codegenSchema.normalizedPath ?: "")
   private val schemaTypeToClassName: Map<String, String> = mutableMapOf<String, String>().apply {
     val usedNames = mutableSetOf<String>()
     val allTypes = codegenSchema.allTypes()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationBuilder.kt
@@ -48,7 +48,7 @@ internal class OperationBuilder(
     flatten: Boolean,
 ) : JavaClassBuilder {
   private val layout = context.layout
-  private val packageName = layout.executableDocumentPackageName(operation.filePath)
+  private val packageName = layout.executableDocumentPackageName(operation.normalizedFilePath)
   private val simpleName = layout.operationName(operation)
 
   private val dataSuperClassName = when (operation.operationType) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationResponseAdapterBuilder.kt
@@ -17,7 +17,7 @@ internal class OperationResponseAdapterBuilder(
     val operation: IrOperation,
     val flatten: Boolean,
 ) : JavaClassBuilder {
-  private val packageName = context.layout.operationAdapterPackageName(operation.filePath)
+  private val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)
   private val simpleName = context.layout.operationName(operation).responseAdapter()
 
   private val responseAdapterBuilders = operation.dataModelGroup.maybeFlatten(flatten).map {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationSelectionsBuilder.kt
@@ -13,7 +13,7 @@ internal class OperationSelectionsBuilder(
     val context: JavaContext,
     val operation: IrOperation,
 ) : JavaClassBuilder {
-  private val packageName = context.layout.operationResponseFieldsPackageName(operation.filePath)
+  private val packageName = context.layout.operationResponseFieldsPackageName(operation.normalizedFilePath)
   private val simpleName = context.layout.operationName(operation).selections()
 
   override fun prepare() {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationVariablesAdapterBuilder.kt
@@ -15,7 +15,7 @@ internal class OperationVariablesAdapterBuilder(
     val context: JavaContext,
     val operation: IrOperation,
 ) : JavaClassBuilder {
-  val packageName = context.layout.operationAdapterPackageName(operation.filePath)
+  val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)
   val simpleName = context.layout.operationName(operation).variablesAdapter()
   override fun prepare() {
     context.resolver.registerOperationVariablesAdapter(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationBuilder.kt
@@ -45,7 +45,7 @@ internal class OperationBuilder(
     val generateInputBuilders: Boolean
 ) : CgFileBuilder {
   private val layout = context.layout
-  private val packageName = layout.executableDocumentPackageName(operation.filePath)
+  private val packageName = layout.executableDocumentPackageName(operation.normalizedFilePath)
   private val simpleName = layout.operationName(operation)
 
   private val dataSuperClassName = when (operation.operationType) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationResponseAdapterBuilder.kt
@@ -16,7 +16,7 @@ internal class OperationResponseAdapterBuilder(
     val operation: IrOperation,
     val flatten: Boolean,
 ) : CgFileBuilder {
-  private val packageName = context.layout.operationAdapterPackageName(operation.filePath)
+  private val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)
   private val simpleName = context.layout.operationName(operation).responseAdapter()
 
   private val responseAdapterBuilders = operation.dataModelGroup.maybeFlatten(flatten).map {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationSelectionsBuilder.kt
@@ -13,7 +13,7 @@ internal class OperationSelectionsBuilder(
     val context: KotlinContext,
     val operation: IrOperation,
 ) : CgFileBuilder {
-  private val packageName = context.layout.operationResponseFieldsPackageName(operation.filePath)
+  private val packageName = context.layout.operationResponseFieldsPackageName(operation.normalizedFilePath)
   private val simpleName = context.layout.operationName(operation).selections()
 
   override fun prepare() {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationVariablesAdapterBuilder.kt
@@ -15,7 +15,7 @@ internal class OperationVariablesAdapterBuilder(
     val context: KotlinContext,
     val operation: IrOperation,
 ) : CgFileBuilder {
-  val packageName = context.layout.operationAdapterPackageName(operation.filePath)
+  val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)
   val simpleName = context.layout.operationName(operation).variablesAdapter()
   override fun prepare() {
     context.resolver.registerOperationVariablesAdapter(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperations.kt
@@ -58,7 +58,7 @@ internal data class IrOperation(
      * the executableDocument sent to the server
      */
     val sourceWithFragments: String,
-    val filePath: String,
+    val normalizedFilePath: String,
     val responseBasedDataModelGroup: IrModelGroup?,
     val dataProperty: IrProperty,
     val dataModelGroup: IrModelGroup,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -54,7 +54,9 @@ import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
 internal class IrOperationsBuilder(
     private val schema: Schema,
     private val operationDefinitions: List<GQLOperationDefinition>,
+    private val operationNameToNormalizedPath: Map<String, String>,
     private val fragmentDefinitions: List<GQLFragmentDefinition>,
+    private val fragmentNameToNormalizedPath: Map<String, String>,
     private val allFragmentDefinitions: Map<String, GQLFragmentDefinition>,
     private val codegenModels: String,
     private val generateOptionalOperationVariables: Boolean,
@@ -308,7 +310,7 @@ internal class IrOperationsBuilder(
         variables = variableDefinitions.map { it.toIr() },
         selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selections, typeDefinition.name),
         sourceWithFragments = sourceWithFragments,
-        filePath = sourceLocation!!.filePath!!,
+        normalizedFilePath = operationNameToNormalizedPath.get(name!!) ?: "",
         dataProperty = dataProperty,
         dataModelGroup = dataModelGroup,
         responseBasedDataModelGroup = responseBasedModelGroup,
@@ -343,7 +345,7 @@ internal class IrOperationsBuilder(
     return IrFragmentDefinition(
         name = name,
         description = description,
-        filePath = sourceLocation!!.filePath!!,
+        filePath = fragmentNameToNormalizedPath[name] ?: "",
         typeCondition = typeDefinition.name,
         variables = inferredVariables.map { it.toIr() },
         selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selections, typeCondition.name),

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -401,8 +401,8 @@ class CodegenTest {
       )
 
       ApolloCompiler.buildSchemaAndOperationsSources(
-          schemaFiles = setOf(schemaFile),
-          executableFiles = graphqlFiles,
+          schemaFiles = setOf(schemaFile).toInputFiles(),
+          executableFiles = graphqlFiles.toInputFiles(),
           codegenSchemaOptions = buildCodegenSchemaOptions(
               scalarMapping = scalarMapping,
               generateDataBuilders = generateDataBuilders

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -43,14 +43,14 @@ class MetadataTest {
     }
 
     ApolloCompiler.buildCodegenSchema(
-        schemaFiles = setOf(File("src/test/metadata/schema.graphqls")),
+        schemaFiles = setOf(File("src/test/metadata/schema.graphqls")).toInputFiles(),
         logger = null,
         codegenSchemaOptions = codegenSchemaOptionsFile.toCodegenSchemaOptions(),
     ).writeTo(codegenSchemaFile)
 
     ApolloCompiler.buildIrOperations(
         codegenSchema = codegenSchemaFile.toCodegenSchema(),
-        executableFiles = setOf(rootGraphQLFile(directory)),
+        executableFiles = setOf(rootGraphQLFile(directory)).toInputFiles(),
         upstreamCodegenModels = emptyList(),
         upstreamFragmentDefinitions = emptyList(),
         options = irOptionsFile.toIrOptions(),
@@ -59,7 +59,7 @@ class MetadataTest {
 
     ApolloCompiler.buildIrOperations(
         codegenSchema = codegenSchemaFile.toCodegenSchema(),
-        executableFiles = setOf(leafGraphQLFile(directory)),
+        executableFiles = setOf(leafGraphQLFile(directory)).toInputFiles(),
         upstreamCodegenModels = rootIrOperationsFile.toIrOperations().codegenModels.let { listOf(it) },
         upstreamFragmentDefinitions = rootIrOperationsFile.toIrOperations().fragmentDefinitions,
         options = irOptionsFile.toIrOptions(),

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.buildCodegenOptions
 import com.apollographql.apollo3.compiler.buildCodegenSchemaOptions
 import com.apollographql.apollo3.compiler.buildIrOptions
+import com.apollographql.apollo3.compiler.toInputFiles
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import org.junit.Test
@@ -26,8 +27,8 @@ class ConditionalFragmentsTest {
   fun `responseBased codegen fails with conditional fragments`(@TestParameter(valuesProvider = ParametersProvider::class) fileName: String) {
     val throwable = assertFails {
       ApolloCompiler.buildSchemaAndOperationsSources(
-          executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")),
-          schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")),
+          executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")).toInputFiles(),
+          schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")).toInputFiles(),
           codegenSchemaOptions = buildCodegenSchemaOptions(),
           irOptions = buildIrOptions(flattenModels = false, codegenModels = MODELS_RESPONSE_BASED),
           packageNameGenerator = PackageNameGenerator.Flat(""),
@@ -46,8 +47,8 @@ class ConditionalFragmentsTest {
   @Test
   fun `operationBased codegen succeeds with conditional fragments`(@TestParameter(valuesProvider = ParametersProvider::class) fileName: String) {
     ApolloCompiler.buildSchemaAndOperationsSources(
-        executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")),
-        schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")),
+        executableFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/$fileName")).toInputFiles(),
+        schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")).toInputFiles(),
         codegenSchemaOptions = buildCodegenSchemaOptions(),
         irOptions = buildIrOptions(flattenModels = false, codegenModels = MODELS_OPERATION_BASED),
         packageNameGenerator = PackageNameGenerator.Flat(""),

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -9,17 +9,22 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import com.apollographql.apollo3.compiler.InputFile as ApolloInputFile
 
 @CacheableTask
 abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val schemaFiles: ConfigurableFileCollection
+
+  @Internal
+  var sourceRoots: Set<String>? = null
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -50,8 +55,13 @@ abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
       return
     }
 
+    val normalizedSchemaFiles = (schemaFiles.files.takeIf { it.isNotEmpty() }?: fallbackSchemaFiles.files).map {
+      // this may produce wrong cache results as that computation is not the same as the Gradle normalization
+      ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
+    }
+
     ApolloCompiler.buildCodegenSchema(
-        schemaFiles = schemaFiles.files.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles.files,
+        schemaFiles = normalizedSchemaFiles,
         logger = logger(),
         codegenSchemaOptions = codegenSchemaOptionsFile.get().asFile.toCodegenSchemaOptions(),
     ).writeTo(codegenSchemaFile.get().asFile)

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
@@ -109,7 +109,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
 
   @get:Input
   @get:Optional
-  abstract val packageNamesFromFilePaths: Property<Boolean>
+  abstract val rootPackageName: Property<String>
 
   @get:Input
   @get:Optional
@@ -219,7 +219,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
   @TaskAction
   fun taskAction() {
     check(
-        packageName.isPresent || hasPackageNameGenerator || packageNamesFromFilePaths.isPresent
+        packageName.isPresent || rootPackageName.isPresent || hasPackageNameGenerator
     ) {
       """
             |Apollo: specify 'packageName':
@@ -278,7 +278,9 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
         generateInputBuilders = generateInputBuilders.orNull,
         decapitalizeFields = decapitalizeFields.orNull,
         addDefaultArgumentForInputObjects = true,
-        addUnknownForEnums = true
+        addUnknownForEnums = true,
+        packageName = packageName.orNull,
+        rootPackageName = rootPackageName.orNull
     ).writeTo(codegenOptions.get().asFile)
 
     OtherOptions(targetLanguage, codegenModels).writeTo(otherOptions.get().asFile)

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
@@ -5,13 +5,10 @@ import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -20,24 +17,9 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 
 abstract class ApolloGenerateSourcesBaseTask : DefaultTask() {
-  @get:InputFiles
-  @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val graphqlFiles: ConfigurableFileCollection
-
   @get:InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val codegenOptionsFile: RegularFileProperty
-
-  @get:Input
-  @get:Optional
-  abstract val packageName: Property<String>
-
-  @get:Input
-  @get:Optional
-  abstract val packageNamesFromFilePaths: Property<Boolean>
-
-  @Internal
-  var packageNameRoots: Set<String>? = null
 
   @Internal
   var packageNameGenerator: PackageNameGenerator? = null
@@ -69,26 +51,6 @@ abstract class ApolloGenerateSourcesBaseTask : DefaultTask() {
 
   @get:OutputDirectory
   abstract val outputDir: DirectoryProperty
-
-  internal fun packageNameGenerator(): PackageNameGenerator {
-    return when {
-      packageNameGenerator != null -> packageNameGenerator!!
-      packageName.isPresent -> PackageNameGenerator.Flat(packageName.get())
-      packageNamesFromFilePaths.orNull == true -> PackageNameGenerator.FilePathAware(packageNameRoots!!)
-      else -> {
-        error(
-            """
-            |Apollo: specify 'packageName':
-            |apollo {
-            |  service("service") {
-            |    packageName.set("com.example")
-            |  }
-            |}
-          """.trimMargin()
-        )
-      }
-    }
-  }
 }
 
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -51,7 +51,7 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
         downstreamUsedCoordinates = downstreamUsedCoordinates.get(),
         upstreamCodegenMetadata = upstreamMetadata.files.map { it.toCodegenMetadata() },
         codegenOptions = codegenOptionsFile.get().asFile.toCodegenOptions(),
-        packageNameGenerator = packageNameGenerator(),
+        packageNameGenerator = packageNameGenerator,
         compilerKotlinHooks = compilerKotlinHooks,
         compilerJavaHooks = compilerJavaHooks,
         operationManifestFile = operationManifestFile.orNull?.asFile,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -8,11 +8,12 @@ import com.apollographql.apollo3.compiler.toIrOptions
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import com.apollographql.apollo3.compiler.InputFile as ApolloInputFile
 
 @CacheableTask
 abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
@@ -22,26 +23,41 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
+  abstract val graphqlFiles: ConfigurableFileCollection
+
+  @Internal
+  var sourceRoots: Set<String>? = null
+
+  @get:InputFiles
+  @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val fallbackSchemaFiles: ConfigurableFileCollection
 
-  @get:InputFile
+  @get:org.gradle.api.tasks.InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val codegenSchemaOptionsFile: RegularFileProperty
 
-  @get:InputFile
+  @get:org.gradle.api.tasks.InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val irOptionsFile: RegularFileProperty
 
   @TaskAction
   fun taskAction() {
+    val normalizedSchemaFiles = (schemaFiles.files.takeIf { it.isNotEmpty() }?: fallbackSchemaFiles.files).map {
+      // this may produce wrong cache results as that computation is not the same as the Gradle normalization
+      ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
+    }
+    val normalizedExecutableFiles = graphqlFiles.files.map {
+      ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
+    }
+
     ApolloCompiler.buildSchemaAndOperationsSources(
-        schemaFiles = schemaFiles.files.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles.files,
-        executableFiles = graphqlFiles.files,
+        schemaFiles = normalizedSchemaFiles,
+        executableFiles = normalizedExecutableFiles,
         codegenSchemaOptions = codegenSchemaOptionsFile.get().asFile.toCodegenSchemaOptions(),
         codegenOptions = codegenOptionsFile.get().asFile.toCodegenOptions(),
         irOptions = irOptionsFile.get().asFile.toIrOptions(),
         logger = logger(),
-        packageNameGenerator = packageNameGenerator(),
+        packageNameGenerator = packageNameGenerator,
         operationOutputGenerator = operationOutputGenerator,
         compilerJavaHooks = compilerJavaHooks,
         compilerKotlinHooks = compilerKotlinHooks,
@@ -49,3 +65,5 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
     ).writeTo(outputDir.get().asFile, true, null)
   }
 }
+
+

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultService.kt
@@ -24,7 +24,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
   private val objects = project.objects
   internal var registered = false
-  internal var packageNamesFromFilePaths: Boolean = false
+  internal var rootPackageName: String? = null
 
   init {
     @Suppress("LeakingThis", "NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")
@@ -150,7 +150,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   }
 
   override fun packageNamesFromFilePaths(rootPackageName: String?) {
-    packageNamesFromFilePaths = true
+    this.rootPackageName = rootPackageName ?: ""
   }
 
   val scalarTypeMapping = mutableMapOf<String, String>()

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
@@ -8,16 +8,6 @@ import org.gradle.api.provider.Provider
 import java.io.File
 
 
-internal fun ApolloGenerateSourcesBaseTask.setPackageNameProperties(service: DefaultService) {
-  packageName.set(service.packageName)
-  packageNamesFromFilePaths.set(service.packageNamesFromFilePaths)
-  if (service.packageNamesFromFilePaths) {
-    packageNameRoots = service.graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.toSet()
-  }
-  packageNameGenerator = service.packageNameGenerator.orNull
-}
-
-
 /**
  * Resolves the operation manifest and formats.
  */

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/normalization.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/normalization.kt
@@ -1,0 +1,34 @@
+package com.apollographql.apollo3.gradle.internal
+
+import java.io.File
+
+/**
+ * A helper class to get a package name from a list of root folders. This tries to mimic Gradle normalization behaviour for PathSensitivity.RELATIVE
+ *
+ * Given:
+ * - a list of root folders like "src/main/graphql/", "src/debug/graphql/", etc...
+ * - an absolute file path like "/User/lee/projects/app/src/main/graphql/com/example/Query.graphql
+ * will return "com.example"
+ *
+ * See also https://github.com/gradle/gradle/issues/27836
+ *
+ */
+internal fun File.normalizedPath(roots: Set<String>): String {
+  val file = this.normalize()
+  roots.map { File(it).normalize() }.forEach { sourceDir ->
+    try {
+      val relative = file.toRelativeString(sourceDir)
+      if (relative.startsWith(".."))
+        return@forEach
+
+      // Make sure the normalized path is the same on all hosts
+      return relative.replace(File.pathSeparatorChar, '/')
+    } catch (e: IllegalArgumentException) {
+
+    }
+  }
+
+  // Be robust if the file is not found.
+  // This is for compatibility reasons mainly.
+  return ""
+}

--- a/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
+++ b/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
@@ -180,7 +180,7 @@ class ApolloProcessor(
 
     codegenSchema = CodegenSchema(
         schema = schema,
-        filePath = null,
+        normalizedPath = "",
         scalarMapping = scalarMapping,
         generateDataBuilders = false
     )


### PR DESCRIPTION
Our `packageNamesFromFilePaths()` require the normalized path (as in [PathSensitivy.RELATIVE](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/PathSensitivity.html#RELATIVE) normalization) in order to compute the package name.

I tried working around this for a while but I came to the conclusion that the proper solution is to make the normalized path a proper input to the compiler. Users that don't need to support `packageNamesFromFilePaths()` (like tests) can always use `files.toInputFiles()` to get a list of input files with empty normalized paths.