### PR TITLE
Introduce `SchemaLayout`, `OperationsLayout` and `ExecutableSchemaLayout`

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -11,9 +11,9 @@ public final class com/apollographql/apollo3/compiler/ApolloCompiler {
 	public final fun buildCodegenSchema (Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;)Lcom/apollographql/apollo3/compiler/CodegenSchema;
 	public final fun buildExecutableSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/CodegenMetadata;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 	public final fun buildIrOperations (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo3/compiler/ir/IrOperations;
-	public final fun buildSchemaAndOperationsSources (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
-	public final fun buildSchemaAndOperationsSourcesFromIr (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/util/Map;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
-	public final fun buildSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Map;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/PackageNameGenerator;Ljava/util/List;Ljava/util/List;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
+	public final fun buildSchemaAndOperationsSources (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo3/compiler/IrOptions;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayout;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo3/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
+	public final fun buildSchemaAndOperationsSourcesFromIr (Lcom/apollographql/apollo3/compiler/CodegenSchema;Lcom/apollographql/apollo3/compiler/ir/IrOperations;Ljava/util/Map;Ljava/util/List;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayout;Lcom/apollographql/apollo3/compiler/OperationOutputGenerator;Ljava/util/List;Ljava/util/List;Ljava/io/File;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
+	public final fun buildSchemaSources (Lcom/apollographql/apollo3/compiler/CodegenSchema;Ljava/util/Map;Lcom/apollographql/apollo3/compiler/CodegenOptions;Lcom/apollographql/apollo3/compiler/codegen/SchemaLayout;Ljava/util/List;Ljava/util/List;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 }
 
 public abstract interface class com/apollographql/apollo3/compiler/ApolloCompiler$Logger {
@@ -409,6 +409,20 @@ public final class com/apollographql/apollo3/compiler/VersionKt {
 	public static final field APOLLO_VERSION Ljava/lang/String;
 }
 
+public abstract interface class com/apollographql/apollo3/compiler/codegen/CommonLayout {
+	public abstract fun propertyName (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun topLevelName (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract interface class com/apollographql/apollo3/compiler/codegen/ExecutableSchemaLayout : com/apollographql/apollo3/compiler/codegen/SchemaLayout {
+}
+
+public abstract interface class com/apollographql/apollo3/compiler/codegen/OperationsLayout : com/apollographql/apollo3/compiler/codegen/CommonLayout {
+	public abstract fun executableDocumentPackageName (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun fragmentName (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun operationName (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+}
+
 public final class com/apollographql/apollo3/compiler/codegen/ResolverClassName$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/apollographql/apollo3/compiler/codegen/ResolverClassName$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
@@ -475,6 +489,14 @@ public final class com/apollographql/apollo3/compiler/codegen/ResolverKeyKind : 
 	public static fun values ()[Lcom/apollographql/apollo3/compiler/codegen/ResolverKeyKind;
 }
 
+public abstract interface class com/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayout : com/apollographql/apollo3/compiler/codegen/OperationsLayout, com/apollographql/apollo3/compiler/codegen/SchemaLayout {
+}
+
+public abstract interface class com/apollographql/apollo3/compiler/codegen/SchemaLayout : com/apollographql/apollo3/compiler/codegen/CommonLayout {
+	public abstract fun schemaPackageName ()Ljava/lang/String;
+	public abstract fun schemaTypeName (Ljava/lang/String;)Ljava/lang/String;
+}
+
 public abstract interface class com/apollographql/apollo3/compiler/codegen/SourceFile {
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getPackageName ()Ljava/lang/String;
@@ -521,7 +543,7 @@ public final class com/apollographql/apollo3/compiler/codegen/java/JavaOutputKt 
 	public static final fun toSourceOutput (Lcom/apollographql/apollo3/compiler/codegen/java/JavaOutput;)Lcom/apollographql/apollo3/compiler/codegen/SourceOutput;
 }
 
-public final class com/apollographql/apollo3/compiler/codegen/java/adapter/AdapterCommonKt {
+public final class com/apollographql/apollo3/compiler/codegen/java/helpers/AdapterCommonKt {
 	public static final fun singletonAdapterInitializer (Lcom/squareup/javapoet/TypeName;Lcom/squareup/javapoet/TypeName;Z)Lcom/squareup/javapoet/CodeBlock;
 	public static synthetic fun singletonAdapterInitializer$default (Lcom/squareup/javapoet/TypeName;Lcom/squareup/javapoet/TypeName;ZILjava/lang/Object;)Lcom/squareup/javapoet/CodeBlock;
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/Options.kt
@@ -643,3 +643,11 @@ internal fun compilerKotlinHooks(compilerKotlinHooks: List<ApolloCompilerKotlinH
 internal fun compilerJavaHooks(compilerJavaHooks: List<ApolloCompilerJavaHooks>?): List<ApolloCompilerJavaHooks> {
   return compilerJavaHooks.orEmpty()
 }
+
+internal fun packageNameGenerator(packageName: String?, rootPackageName: String?): PackageNameGenerator {
+  return when {
+    packageName != null -> PackageNameGenerator.Flat(packageName)
+    rootPackageName != null -> PackageNameGenerator.NormalizedPathAware(rootPackageName)
+    else -> error("Apollo: missing 'packageName'")
+  }
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/LayoutImpl.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/LayoutImpl.kt
@@ -21,13 +21,13 @@ import com.apollographql.apollo3.compiler.withUnderscorePrefix
  *
  * Inputs should always be GraphQL identifiers and outputs are valid Kotlin/Java identifiers.
  */
-internal class SchemaAndOperationsLayoutImpl(
+internal class LayoutImpl(
     codegenSchema: CodegenSchema,
     private val packageNameGenerator: PackageNameGenerator,
     private val useSemanticNaming: Boolean,
     private val decapitalizeFields: Boolean
-) : SchemaAndOperationsLayout {
-  private val schemaPackageName = executableDocumentPackageName(codegenSchema.normalizedPath ?: "")
+) : SchemaAndOperationsLayout, ExecutableSchemaLayout {
+  private val schemaPackageName = executableDocumentPackageName(codegenSchema.normalizedPath)
   private val schemaTypeToClassName: Map<String, String> = mutableMapOf<String, String>().apply {
     val usedNames = mutableSetOf<String>()
     val allTypes = codegenSchema.allTypes()
@@ -127,23 +127,23 @@ internal fun modelName(info: IrFieldInfo): String {
 }
 
 
-internal fun SchemaAndOperationsLayoutImpl.typePackageName() = "${schemaPackageName()}.type"
-internal fun SchemaAndOperationsLayoutImpl.typeBuilderPackageName() = "${schemaPackageName()}.type.builder"
-internal fun SchemaAndOperationsLayoutImpl.typeAdapterPackageName() = "${schemaPackageName()}.type.adapter"
-internal fun SchemaAndOperationsLayoutImpl.typeUtilPackageName() = "${schemaPackageName()}.type.util"
+internal fun SchemaLayout.typePackageName() = "${schemaPackageName()}.type"
+internal fun SchemaLayout.typeBuilderPackageName() = "${schemaPackageName()}.type.builder"
+internal fun SchemaLayout.typeAdapterPackageName() = "${schemaPackageName()}.type.adapter"
+internal fun SchemaLayout.typeUtilPackageName() = "${schemaPackageName()}.type.util"
 
-internal fun SchemaAndOperationsLayoutImpl.paginationPackageName() = "${schemaPackageName()}.pagination"
-internal fun SchemaAndOperationsLayoutImpl.schemaSubPackageName() = "${schemaPackageName()}.schema"
-internal fun SchemaAndOperationsLayoutImpl.executionPackageName() = "${schemaPackageName()}.execution"
+internal fun SchemaLayout.paginationPackageName() = "${schemaPackageName()}.pagination"
+internal fun SchemaLayout.schemaSubPackageName() = "${schemaPackageName()}.schema"
+internal fun ExecutableSchemaLayout.executionPackageName() = "${schemaPackageName()}.execution"
 
-internal fun SchemaAndOperationsLayoutImpl.operationAdapterPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.adapter"
-internal fun SchemaAndOperationsLayoutImpl.operationResponseFieldsPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.selections"
+internal fun OperationsLayout.operationAdapterPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.adapter"
+internal fun OperationsLayout.operationResponseFieldsPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.selections"
 
-internal fun SchemaAndOperationsLayoutImpl.fragmentPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment"
-internal fun SchemaAndOperationsLayoutImpl.fragmentAdapterPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment.adapter"
-internal fun SchemaAndOperationsLayoutImpl.fragmentResponseFieldsPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment.selections"
+internal fun OperationsLayout.fragmentPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment"
+internal fun OperationsLayout.fragmentAdapterPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment.adapter"
+internal fun OperationsLayout.fragmentResponseFieldsPackageName(filePath: String) = "${executableDocumentPackageName(filePath)}.fragment.selections"
 
-internal fun SchemaAndOperationsLayoutImpl.operationName(operation: IrOperation) = operationName(operation.name, operation.operationType.name)
+internal fun OperationsLayout.operationName(operation: IrOperation) = operationName(operation.name, operation.operationType.name)
 
 internal fun String.responseAdapter(): String = "${this}_ResponseAdapter"
 internal fun String.inputAdapter(): String = "${this}_InputAdapter"

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayout.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/SchemaAndOperationsLayout.kt
@@ -1,19 +1,20 @@
 package com.apollographql.apollo3.compiler.codegen
 
-internal interface CommonLayout {
+interface CommonLayout {
   fun topLevelName(name: String): String
   fun propertyName(name: String): String
 }
 
-internal interface SchemaLayout : CommonLayout {
+interface SchemaLayout : CommonLayout {
   fun schemaPackageName(): String
   fun schemaTypeName(schemaTypeName: String): String
 }
 
-internal interface OperationsLayout {
+interface OperationsLayout: CommonLayout {
   fun executableDocumentPackageName(filePath: String?): String
   fun operationName(name: String, capitalizedOperationType: String): String
   fun fragmentName(name: String): String
 }
 
-internal interface SchemaAndOperationsLayout : SchemaLayout, OperationsLayout
+interface SchemaAndOperationsLayout : SchemaLayout, OperationsLayout
+interface ExecutableSchemaLayout : SchemaLayout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaContext.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaContext.kt
@@ -2,15 +2,33 @@ package com.apollographql.apollo3.compiler.codegen.java
 
 import com.apollographql.apollo3.compiler.GeneratedMethod
 import com.apollographql.apollo3.compiler.JavaNullable
-import com.apollographql.apollo3.compiler.codegen.SchemaAndOperationsLayoutImpl
+import com.apollographql.apollo3.compiler.codegen.CommonLayout
+import com.apollographql.apollo3.compiler.codegen.OperationsLayout
+import com.apollographql.apollo3.compiler.codegen.SchemaLayout
 import com.apollographql.apollo3.compiler.internal.escapeJavaReservedWord
 
-internal class JavaContext(
-    val layout: SchemaAndOperationsLayoutImpl,
-    val resolver: JavaResolver,
-    val generateMethods: List<GeneratedMethod>,
-    val generateModelBuilders: Boolean,
-    val nullableFieldStyle: JavaNullable,
-)
+internal interface JavaContext {
+  val layout: CommonLayout
+  val resolver: JavaResolver
+  val generateMethods: List<GeneratedMethod>
+  val generateModelBuilders: Boolean
+  val nullableFieldStyle: JavaNullable
+}
 
-internal fun SchemaAndOperationsLayoutImpl.javaPropertyName(name: String) = propertyName(name).escapeJavaReservedWord()
+internal class JavaSchemaContext(
+    override val layout: SchemaLayout,
+    override val resolver: JavaResolver,
+    override val generateMethods: List<GeneratedMethod>,
+    override val generateModelBuilders: Boolean,
+    override val nullableFieldStyle: JavaNullable,
+): JavaContext
+
+internal class JavaOperationsContext(
+    override val layout: OperationsLayout,
+    override val resolver: JavaResolver,
+    override val generateMethods: List<GeneratedMethod>,
+    override val generateModelBuilders: Boolean,
+    override val nullableFieldStyle: JavaNullable,
+): JavaContext
+
+internal fun CommonLayout.javaPropertyName(name: String) = propertyName(name).escapeJavaReservedWord()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaResolver.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.compiler.codegen.ResolverClassName
 import com.apollographql.apollo3.compiler.codegen.ResolverEntry
 import com.apollographql.apollo3.compiler.codegen.ResolverKey
 import com.apollographql.apollo3.compiler.codegen.ResolverKeyKind
-import com.apollographql.apollo3.compiler.codegen.java.adapter.singletonAdapterInitializer
+import com.apollographql.apollo3.compiler.codegen.java.helpers.singletonAdapterInitializer
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.ir.IrCatchTo
 import com.apollographql.apollo3.compiler.ir.IrCompositeType2
@@ -390,6 +390,7 @@ internal class JavaResolver(
   }
 
   fun registerMapType(name: String, className: ClassName) = register(ResolverKeyKind.MapType, name, className)
+  fun resolveMapType(name: String): ClassName = resolveAndAssert(ResolverKeyKind.MapType, name)
 
   private fun nonNullableAdapterInitializer2(type: IrType2): CodeBlock? {
     return when (type) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/AdapterCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/AdapterCommon.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.helpers
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.RESPONSE_NAMES
@@ -17,12 +17,6 @@ import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
-import com.apollographql.apollo3.compiler.codegen.java.helpers.absentOptionalInitializer
-import com.apollographql.apollo3.compiler.codegen.java.helpers.codeBlock
-import com.apollographql.apollo3.compiler.codegen.java.helpers.testOptionalValuePresence
-import com.apollographql.apollo3.compiler.codegen.java.helpers.toListInitializerCodeblock
-import com.apollographql.apollo3.compiler.codegen.java.helpers.unwrapOptionalValue
-import com.apollographql.apollo3.compiler.codegen.java.helpers.wrapValueInOptional
 import com.apollographql.apollo3.compiler.codegen.java.isNotEmpty
 import com.apollographql.apollo3.compiler.codegen.java.javaPropertyName
 import com.apollographql.apollo3.compiler.codegen.java.joinToCode

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/BuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/BuilderBuilder.kt
@@ -1,10 +1,10 @@
 package com.apollographql.apollo3.compiler.codegen.java.helpers
 
-import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.T
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.FieldSpec

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/InputAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/helpers/InputAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * Generates ResponseAdapters for input
  */
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.helpers
 
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
 import com.apollographql.apollo3.compiler.codegen.Identifier.fromJson
@@ -11,12 +11,10 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.value
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
-import com.apollographql.apollo3.compiler.codegen.java.helpers.NamedType
-import com.apollographql.apollo3.compiler.codegen.java.helpers.beginOptionalControlFlow
-import com.apollographql.apollo3.compiler.codegen.java.helpers.suppressDeprecatedAnnotation
 import com.apollographql.apollo3.compiler.codegen.java.javaPropertyName
 import com.squareup.javapoet.CodeBlock
 import com.squareup.javapoet.MethodSpec
@@ -27,7 +25,7 @@ import javax.lang.model.element.Modifier
 
 
 internal fun List<NamedType>.inputAdapterTypeSpec(
-    context: JavaContext,
+    context: JavaSchemaContext,
     adapterName: String,
     adaptedTypeName: TypeName,
 ): TypeSpec {
@@ -57,7 +55,7 @@ private fun notImplementedFromResponseMethodSpec(adaptedTypeName: TypeName) = Me
 
 
 private fun List<NamedType>.writeToResponseMethodSpec(
-    context: JavaContext,
+    context: JavaSchemaContext,
     adaptedTypeName: TypeName,
 ): MethodSpec {
   return MethodSpec.methodBuilder(toJson)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/CompiledSelectionsBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -22,7 +22,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class CompiledSelectionsBuilder(
-    private val context: JavaContext,
+    private val context: JavaOperationsContext,
 ) {
 
   fun build(selectionSets: List<IrSelectionSet>, rootName: String): TypeSpec {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/ExecutableCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/ExecutableCommon.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.serializeVariables
 import com.apollographql.apollo3.compiler.codegen.Identifier.withDefaultValues
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.java.JavaResolver
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
@@ -69,7 +69,7 @@ internal fun adapterMethodSpec(
       .build()
 }
 
-internal fun rootFieldMethodSpec(context: JavaContext, parentType: String, selectionsClassName: ClassName): MethodSpec {
+internal fun rootFieldMethodSpec(context: JavaOperationsContext, parentType: String, selectionsClassName: ClassName): MethodSpec {
   return MethodSpec.methodBuilder(rootField)
       .addModifiers(Modifier.PUBLIC)
       .addAnnotation(JavaClassNames.Override)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentBuilder.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.makeClassFromParameters
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.java.helpers.toNamedType
@@ -20,7 +20,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class FragmentBuilder(
-    private val context: JavaContext,
+    private val context: JavaOperationsContext,
     private val fragment: IrFragmentDefinition,
     flatten: Boolean,
 ) : JavaClassBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentDataAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentDataAdapterBuilder.kt
@@ -1,12 +1,11 @@
 package com.apollographql.apollo3.compiler.codegen.java.operations
 
-import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.fragmentPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.ResponseAdapterBuilder
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
+import com.apollographql.apollo3.compiler.codegen.java.operations.util.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
@@ -14,7 +13,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class FragmentDataAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val fragment: IrFragmentDefinition,
     val flatten: Boolean,
 ) : JavaClassBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentModelsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentModelsBuilder.kt
@@ -4,13 +4,13 @@ import com.apollographql.apollo3.compiler.codegen.fragmentPackageName
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
-import com.apollographql.apollo3.compiler.ir.IrModelGroup
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
+import com.apollographql.apollo3.compiler.ir.IrModelGroup
 
 internal class FragmentModelsBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val fragment: IrFragmentDefinition,
     modelGroup: IrModelGroup,
     private val addSuperInterface: Boolean,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentSelectionsBuilder.kt
@@ -3,13 +3,13 @@ package com.apollographql.apollo3.compiler.codegen.java.operations
 import com.apollographql.apollo3.compiler.codegen.fragmentResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.selections
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.squareup.javapoet.ClassName
 
 internal class FragmentSelectionsBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val fragment: IrFragmentDefinition,
 ) : JavaClassBuilder {
   private val packageName = context.layout.fragmentResponseFieldsPackageName(fragment.filePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/FragmentVariablesAdapterBuilder.kt
@@ -1,19 +1,18 @@
 package com.apollographql.apollo3.compiler.codegen.java.operations
 
-import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.fragmentAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.variableAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
+import com.apollographql.apollo3.compiler.codegen.java.operations.util.variableAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeSpec
 
 internal class FragmentVariablesAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val fragment: IrFragmentDefinition,
 ) : JavaClassBuilder {
   private val packageName = context.layout.fragmentAdapterPackageName(fragment.filePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/ModelBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/ModelBuilder.kt
@@ -1,12 +1,12 @@
 package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.toClassName
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.BuilderBuilder
 import com.apollographql.apollo3.compiler.codegen.java.helpers.makeClassFromProperties
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
+import com.apollographql.apollo3.compiler.codegen.java.helpers.toClassName
 import com.apollographql.apollo3.compiler.codegen.java.javaPropertyName
 import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
 import com.apollographql.apollo3.compiler.internal.applyIf
@@ -26,7 +26,7 @@ import javax.lang.model.element.Modifier
  * @param path: the path leading to this model but not including the model name
  */
 internal class ModelBuilder(
-    private val context: JavaContext,
+    private val context: JavaOperationsContext,
     private val model: IrModel,
     private val superClassName: ClassName?,
     private val path: List<String>,
@@ -118,7 +118,7 @@ internal class ModelBuilder(
     }
   }
 
-  private fun TypeSpec.addBuilder(context: JavaContext): TypeSpec {
+  private fun TypeSpec.addBuilder(context: JavaOperationsContext): TypeSpec {
     val fields = fieldSpecs.filter { !it.modifiers.contains(Modifier.STATIC) }
         .filterNot { it.name.startsWith(prefix = "$") }
     if (fields.isEmpty()) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationBuilder.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.ast.QueryDocumentMinifier
-import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_DOCUMENT
 import com.apollographql.apollo3.compiler.codegen.Identifier.OPERATION_ID
@@ -14,7 +13,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.root
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -26,7 +25,6 @@ import com.apollographql.apollo3.compiler.codegen.java.helpers.toParameterSpec
 import com.apollographql.apollo3.compiler.codegen.java.javaPropertyName
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationName
-import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.apollographql.apollo3.compiler.ir.IrOperationType
@@ -40,7 +38,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class OperationBuilder(
-    private val context: JavaContext,
+    private val context: JavaOperationsContext,
     private val operationId: String,
     private val generateQueryDocument: Boolean,
     private val operation: IrOperation,
@@ -160,7 +158,7 @@ internal class OperationBuilder(
   private fun buildDataMethod(): MethodSpec {
     return MethodSpec.methodBuilder(Identifier.buildData)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addParameter(ClassName.get(layout.typeBuilderPackageName(), "${operation.operationType.typeName.capitalizeFirstLetter()}Map"), Identifier.map)
+        .addParameter(context.resolver.resolveMapType(operation.operationType.typeName), Identifier.map)
         .addParameter(JavaClassNames.FakeResolver, Identifier.resolver)
         .returns(context.resolver.resolveModel(operation.dataModelGroup.baseModelId))
         .addCode(
@@ -183,7 +181,7 @@ internal class OperationBuilder(
   private fun buildDataOverloadMethod(): MethodSpec {
     return MethodSpec.methodBuilder(Identifier.buildData)
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addParameter(ClassName.get(layout.typeBuilderPackageName(), "${operation.operationType.typeName.capitalizeFirstLetter()}Map"), Identifier.map)
+        .addParameter(context.resolver.resolveMapType(operation.operationType.typeName), Identifier.map)
         .returns(context.resolver.resolveModel(operation.dataModelGroup.baseModelId))
         .addStatement(
             "return buildData(${Identifier.map}, new $T($T.types))",
@@ -257,7 +255,7 @@ internal class OperationBuilder(
     )
   }
 
-  private fun TypeSpec.Builder.addBuilder(context: JavaContext): TypeSpec.Builder {
+  private fun TypeSpec.Builder.addBuilder(context: JavaOperationsContext): TypeSpec.Builder {
     addMethod(BuilderBuilder.builderFactoryMethod())
 
     val operationClassName = context.resolver.resolveOperation(operation.name)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationResponseAdapterBuilder.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.ResponseAdapterBuilder
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
+import com.apollographql.apollo3.compiler.codegen.java.operations.util.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.operationName
@@ -13,7 +13,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class OperationResponseAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val operation: IrOperation,
     val flatten: Boolean,
 ) : JavaClassBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationSelectionsBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
 import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.operationResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.selections
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.javapoet.ClassName
 
 internal class OperationSelectionsBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val operation: IrOperation,
 ) : JavaClassBuilder {
   private val packageName = context.layout.operationResponseFieldsPackageName(operation.normalizedFilePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/OperationVariablesAdapterBuilder.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.compiler.codegen.java.operations
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.variableAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.java.JavaOperationsContext
+import com.apollographql.apollo3.compiler.codegen.java.operations.util.variableAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
@@ -12,7 +12,7 @@ import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeSpec
 
 internal class OperationVariablesAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaOperationsContext,
     val operation: IrOperation,
 ) : JavaClassBuilder {
   val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/MonomorphicFieldResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/MonomorphicFieldResponseAdapterBuilder.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.operations.util
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
@@ -7,6 +7,10 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.reader
 import com.apollographql.apollo3.compiler.codegen.Identifier.toJson
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.helpers.readFromResponseCodeBlock
+import com.apollographql.apollo3.compiler.codegen.java.helpers.responseNamesFieldSpec
+import com.apollographql.apollo3.compiler.codegen.java.helpers.toClassName
+import com.apollographql.apollo3.compiler.codegen.java.helpers.writeToResponseCodeBlock
 import com.apollographql.apollo3.compiler.ir.IrModel
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.ParameterizedTypeName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/ResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/ResponseAdapterBuilder.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.operations.util
 
 import com.apollographql.apollo3.compiler.codegen.java.JavaContext
 import com.apollographql.apollo3.compiler.ir.IrModelGroup

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/VariablesAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/operations/util/VariablesAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * Generates ResponseAdapters for variables
  */
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.operations.util
 
 import com.apollographql.apollo3.compiler.codegen.Identifier.Empty
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/BuilderFactoryBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/BuilderFactoryBuilder.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
@@ -22,7 +22,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class BuilderFactoryBuilder(
-    context: JavaContext,
+    context: JavaSchemaContext,
     private val objs: List<IrObject>,
     private val ifaces: List<IrInterface>,
     private val unions: List<IrUnion>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAdapterBuilder.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.java.adapter
+package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.rawValue
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.codegen.typeAdapterPackageName
@@ -24,7 +24,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class EnumResponseAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaSchemaContext,
     val enum: IrEnum,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAsClassBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAsClassBuilder.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.safeValueOf
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -26,7 +26,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class EnumAsClassBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val enum: IrEnum,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAsEnumBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/EnumAsEnumBuilder.kt
@@ -6,7 +6,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.safeValueOf
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -26,7 +26,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class EnumAsEnumBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val enum: IrEnum,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InputObjectAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InputObjectAdapterBuilder.kt
@@ -3,8 +3,8 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 import com.apollographql.apollo3.compiler.codegen.inputAdapter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
-import com.apollographql.apollo3.compiler.codegen.java.adapter.inputAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
+import com.apollographql.apollo3.compiler.codegen.java.helpers.inputAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.java.helpers.toNamedType
 import com.apollographql.apollo3.compiler.codegen.typeAdapterPackageName
 import com.apollographql.apollo3.compiler.ir.IrInputObject
@@ -12,7 +12,7 @@ import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeSpec
 
 internal class InputObjectAdapterBuilder(
-    val context: JavaContext,
+    val context: JavaSchemaContext,
     val inputObject: IrInputObject,
 ) : JavaClassBuilder {
   val packageName = context.layout.typeAdapterPackageName()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InputObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InputObjectBuilder.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.compiler.JavaNullable
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.java.helpers.BuilderBuilder
 import com.apollographql.apollo3.compiler.codegen.java.helpers.NamedType
@@ -23,7 +23,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class InputObjectBuilder(
-    val context: JavaContext,
+    val context: JavaSchemaContext,
     val inputObject: IrInputObject,
 ) : JavaClassBuilder {
   private val packageName = context.layout.typePackageName()
@@ -91,7 +91,7 @@ internal class InputObjectBuilder(
   }
 }
 
-private fun List<NamedType>.assertOneOfBlock(context: JavaContext): CodeBlock {
+private fun List<NamedType>.assertOneOfBlock(context: JavaSchemaContext): CodeBlock {
   val assertionsClassName: ClassName = if (context.nullableFieldStyle == JavaNullable.GUAVA_OPTIONAL) {
     // When using the Guava optionals, use the method generated in the project, as apollo-api doesn't depend on Guava
     ClassName.get(context.layout.typeUtilPackageName(), "Assertions")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.typePackageName
@@ -12,7 +12,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class InterfaceBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val iface: IrInterface,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceBuilderBuilder.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -24,7 +24,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class InterfaceBuilderBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val iface: IrInterface,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceMapBuilder.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.squareup.javapoet.ClassName
@@ -11,7 +11,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class InterfaceMapBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val iface: IrInterface,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceUnknownMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/InterfaceUnknownMapBuilder.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.__fields
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.squareup.javapoet.ClassName
@@ -14,7 +14,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class InterfaceUnknownMapBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val iface: IrInterface,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.typePackageName
@@ -12,7 +12,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class ObjectBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val obj: IrObject,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectBuilderBuilder.kt
@@ -7,7 +7,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.S
 import com.apollographql.apollo3.compiler.codegen.java.T
@@ -23,7 +23,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class ObjectBuilderBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val obj: IrObject,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ObjectMapBuilder.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.__fields
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrObject
 import com.squareup.javapoet.ClassName
@@ -14,7 +14,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class ObjectMapBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val obj: IrObject,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ScalarBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/ScalarBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.typePackageName
@@ -12,7 +12,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class ScalarBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val scalar: IrScalar,
     private val targetTypeName: String?,
 ) : JavaClassBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/SchemaBuilder.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.types
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.L
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.java.helpers.toListInitializerCodeblock
@@ -27,7 +27,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class SchemaBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val generatedSchemaName: String,
     private val scalarMapping: Map<String, ScalarInfo>,
     private val objects: List<IrObject>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.java.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.typePackageName
@@ -12,7 +12,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class UnionBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val union: IrUnion,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionBuilderBuilder.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.java.T
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrUnion
@@ -20,7 +20,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class UnionBuilderBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val union: IrUnion,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionMapBuilder.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrUnion
 import com.squareup.javapoet.ClassName
@@ -11,7 +11,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class UnionMapBuilder(
-    val context: JavaContext,
+    val context: JavaSchemaContext,
     val union: IrUnion,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionUnknownMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UnionUnknownMapBuilder.kt
@@ -5,7 +5,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.__fields
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassNames
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeBuilderPackageName
 import com.apollographql.apollo3.compiler.ir.IrUnion
 import com.squareup.javapoet.ClassName
@@ -14,7 +14,7 @@ import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Modifier
 
 internal class UnionUnknownMapBuilder(
-    private val context: JavaContext,
+    private val context: JavaSchemaContext,
     private val union: IrUnion,
 ) : JavaClassBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UtilAssertionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/UtilAssertionsBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.java.schema
 
 import com.apollographql.apollo3.compiler.codegen.java.CodegenJavaFile
 import com.apollographql.apollo3.compiler.codegen.java.JavaClassBuilder
-import com.apollographql.apollo3.compiler.codegen.java.JavaContext
+import com.apollographql.apollo3.compiler.codegen.java.JavaSchemaContext
 import com.apollographql.apollo3.compiler.codegen.typeUtilPackageName
 import com.squareup.javapoet.ArrayTypeName
 import com.squareup.javapoet.ClassName
@@ -12,7 +12,7 @@ import com.squareup.javapoet.TypeSpec
 import com.squareup.javapoet.WildcardTypeName
 import javax.lang.model.element.Modifier
 
-internal class UtilAssertionsBuilder(val context: JavaContext) : JavaClassBuilder {
+internal class UtilAssertionsBuilder(val context: JavaSchemaContext) : JavaClassBuilder {
   override fun prepare() {}
 
   override fun build(): CodegenJavaFile {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinContext.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinContext.kt
@@ -2,17 +2,43 @@ package com.apollographql.apollo3.compiler.codegen.kotlin
 
 import com.apollographql.apollo3.compiler.GeneratedMethod
 import com.apollographql.apollo3.compiler.TargetLanguage
-import com.apollographql.apollo3.compiler.codegen.SchemaAndOperationsLayoutImpl
+import com.apollographql.apollo3.compiler.codegen.CommonLayout
+import com.apollographql.apollo3.compiler.codegen.ExecutableSchemaLayout
+import com.apollographql.apollo3.compiler.codegen.OperationsLayout
+import com.apollographql.apollo3.compiler.codegen.SchemaLayout
 
-internal class KotlinContext(
-    val generateMethods: List<GeneratedMethod>,
-    val jsExport: Boolean,
-    val layout: SchemaAndOperationsLayoutImpl,
-    val resolver: KotlinResolver,
-    val targetLanguage: TargetLanguage,
-) {
+internal interface KotlinContext {
+  val layout: CommonLayout
+  val generateMethods: List<GeneratedMethod>
+  val jsExport: Boolean
+  val resolver: KotlinResolver
+  val targetLanguage: TargetLanguage
+
   fun isTargetLanguageVersionAtLeast(targetLanguage: TargetLanguage): Boolean {
     // Assumes TargetLanguage.KOTLIN_X_Y values are declared in increasing order
     return this.targetLanguage.ordinal >= targetLanguage.ordinal
   }
 }
+internal class KotlinSchemaContext(
+    override val layout: SchemaLayout,
+    override val generateMethods: List<GeneratedMethod>,
+    override val jsExport: Boolean,
+    override val resolver: KotlinResolver,
+    override val targetLanguage: TargetLanguage,
+): KotlinContext
+
+internal class KotlinOperationsContext(
+    override val layout: OperationsLayout,
+    override val generateMethods: List<GeneratedMethod>,
+    override val jsExport: Boolean,
+    override val resolver: KotlinResolver,
+    override val targetLanguage: TargetLanguage,
+): KotlinContext
+
+internal class KotlinExecutableSchemaContext(
+    override val layout: ExecutableSchemaLayout,
+    override val generateMethods: List<GeneratedMethod>,
+    override val jsExport: Boolean,
+    override val resolver: KotlinResolver,
+    override val targetLanguage: TargetLanguage,
+): KotlinContext

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinResolver.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.compiler.codegen.ResolverClassName
 import com.apollographql.apollo3.compiler.codegen.ResolverEntry
 import com.apollographql.apollo3.compiler.codegen.ResolverKey
 import com.apollographql.apollo3.compiler.codegen.ResolverKeyKind
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.obj
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.obj
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
 import com.apollographql.apollo3.compiler.ir.IrCatchTo
 import com.apollographql.apollo3.compiler.ir.IrCompositeType2

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/AdapterRegistryBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/AdapterRegistryBuilder.kt
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.executionPackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinExecutableSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrEnumType
 import com.apollographql.apollo3.compiler.ir.IrInputObjectType
@@ -22,7 +22,7 @@ import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.PropertySpec
 
 internal class AdapterRegistryBuilder(
-    val context: KotlinContext,
+    val context: KotlinExecutableSchemaContext,
     val serviceName: String,
     val codegenSchema: CodegenSchema
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/ExecutableSchemaBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/ExecutableSchemaBuilderBuilder.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.executionPackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinExecutableSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.ir.IrTargetObject
 import com.apollographql.apollo3.compiler.ir.asKotlinPoet
@@ -17,7 +17,7 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.joinToCode
 
 internal class ExecutableSchemaBuilderBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinExecutableSchemaContext,
     private val serviceName: String,
     private val mainResolver: ClassName,
     private val adapterRegistry: MemberName,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/MainResolverBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/executableschema/MainResolverBuilder.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.executionPackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinExecutableSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
 import com.apollographql.apollo3.compiler.internal.applyIf
@@ -27,7 +27,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 
 internal class MainResolverBuilder(
-    val context: KotlinContext,
+    val context: KotlinExecutableSchemaContext,
     val serviceName: String,
     val irTargetObjects: List<IrTargetObject>,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/AdapterCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/AdapterCommon.kt
@@ -1,6 +1,5 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.helpers
 
-import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.RESPONSE_NAMES
 import com.apollographql.apollo3.compiler.codegen.Identifier.__path
 import com.apollographql.apollo3.compiler.codegen.Identifier.__typename
@@ -14,7 +13,8 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.value
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.codeBlock
+import com.apollographql.apollo3.compiler.codegen.variableName
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.BLabel
 import com.apollographql.apollo3.compiler.ir.BooleanExpression
 import com.apollographql.apollo3.compiler.ir.IrCatchTo
@@ -23,7 +23,6 @@ import com.apollographql.apollo3.compiler.ir.IrModelType
 import com.apollographql.apollo3.compiler.ir.IrProperty
 import com.apollographql.apollo3.compiler.ir.IrType
 import com.apollographql.apollo3.compiler.ir.firstElementOfType
-import com.apollographql.apollo3.compiler.codegen.variableName
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.MemberName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/InputAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/InputAdapter.kt
@@ -1,7 +1,7 @@
 /*
  * Generates ResponseAdapters for input
  */
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.helpers
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
@@ -11,9 +11,6 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.value
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.NamedType
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.requiresOptInAnnotation
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/CompiledSelectionsBuilder.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 
 import com.apollographql.apollo3.compiler.codegen.Identifier
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.codeBlock
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toListInitializerCodeblock
@@ -21,7 +21,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 
 internal class CompiledSelectionsBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinOperationsContext,
 ) {
   fun build(selectionSets: List<IrSelectionSet>, rootName: String): TypeSpec {
     return TypeSpec.objectBuilder(rootName)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentBuilder.kt
@@ -4,8 +4,9 @@ import com.apollographql.apollo3.compiler.codegen.fragmentPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.builderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.dataBuilderCtor
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.makeClassFromParameters
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
@@ -17,7 +18,6 @@ import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.ignoreE
 import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.maybeAddFilterNotNull
 import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.rootFieldFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.serializeVariablesFunSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.schema.builderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
@@ -28,7 +28,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class FragmentBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinOperationsContext,
     private val generateFilterNotNull: Boolean,
     private val fragment: IrFragmentDefinition,
     flatten: Boolean,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentModelsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentModelsBuilder.kt
@@ -3,14 +3,14 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 import com.apollographql.apollo3.compiler.codegen.fragmentPackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.flattenFragmentModels
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.apollographql.apollo3.compiler.ir.IrModelGroup
 
 internal class FragmentModelsBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val fragment: IrFragmentDefinition,
     modelGroup: IrModelGroup,
     private val addSuperInterface: Boolean,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentResponseAdapterBuilder.kt
@@ -4,15 +4,15 @@ import com.apollographql.apollo3.compiler.codegen.fragmentPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.ResponseAdapterBuilder
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class FragmentResponseAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val fragment: IrFragmentDefinition,
     val flatten: Boolean,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentSelectionsBuilder.kt
@@ -3,13 +3,13 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 import com.apollographql.apollo3.compiler.codegen.fragmentResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.selections
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.squareup.kotlinpoet.ClassName
 
 internal class FragmentSelectionsBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val fragment: IrFragmentDefinition,
 ) : CgFileBuilder {
   private val packageName = context.layout.fragmentResponseFieldsPackageName(fragment.filePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/FragmentVariablesAdapterBuilder.kt
@@ -4,15 +4,15 @@ import com.apollographql.apollo3.compiler.codegen.fragmentAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.impl
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.variablesAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.variablesAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
 import com.apollographql.apollo3.compiler.ir.IrFragmentDefinition
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class FragmentVariablesAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val fragment: IrFragmentDefinition,
 ) : CgFileBuilder {
   private val packageName = context.layout.fragmentAdapterPackageName(fragment.filePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/ModelBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/ModelBuilder.kt
@@ -1,8 +1,8 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.from
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.from
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.makeClassFromProperties
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
@@ -24,7 +24,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class ModelBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinOperationsContext,
     private val model: IrModel,
     private val superClassName: ClassName?,
     private val path: List<String>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationBuilder.kt
@@ -6,20 +6,20 @@ import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgImport
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.builderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.dataBuilderCtor
-import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.adapterFunSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.ignoreErrorsPropertySpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.maybeAddFilterNotNull
-import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.rootFieldFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.makeClassFromParameters
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddJsExport
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toNamedType
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toParameterSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.adapterFunSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.ignoreErrorsPropertySpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.maybeAddFilterNotNull
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.rootFieldFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.serializeVariablesFunSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.schema.builderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.internal.applyIf
@@ -34,7 +34,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class OperationBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinOperationsContext,
     private val generateFilterNotNull: Boolean,
     private val operationId: String,
     private val generateQueryDocument: Boolean,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationResponseAdapterBuilder.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.ResponseAdapterBuilder
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.ResponseAdapterBuilder
 import com.apollographql.apollo3.compiler.codegen.maybeFlatten
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.operationName
@@ -12,7 +12,7 @@ import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class OperationResponseAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val operation: IrOperation,
     val flatten: Boolean,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationSelectionsBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.operationResponseFieldsPackageName
 import com.apollographql.apollo3.compiler.codegen.selections
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.compiler.ir.IrOperation
 import com.squareup.kotlinpoet.ClassName
 
 internal class OperationSelectionsBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val operation: IrOperation,
 ) : CgFileBuilder {
   private val packageName = context.layout.operationResponseFieldsPackageName(operation.normalizedFilePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationVariablesAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/OperationVariablesAdapterBuilder.kt
@@ -2,8 +2,8 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.operations
 
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.variablesAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.operations.util.variablesAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.operationAdapterPackageName
 import com.apollographql.apollo3.compiler.codegen.operationName
 import com.apollographql.apollo3.compiler.codegen.variablesAdapter
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class OperationVariablesAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinOperationsContext,
     val operation: IrOperation,
 ) : CgFileBuilder {
   val packageName = context.layout.operationAdapterPackageName(operation.normalizedFilePath)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ExecutableCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ExecutableCommon.kt
@@ -8,7 +8,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.selections
 import com.apollographql.apollo3.compiler.codegen.Identifier.serializeVariables
 import com.apollographql.apollo3.compiler.codegen.Identifier.withDefaultValues
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.patchKotlinNativeOptionalArrayProperties
 import com.apollographql.apollo3.compiler.ir.IrProperty
@@ -53,7 +53,7 @@ internal fun ignoreErrorsPropertySpec(value: Boolean): PropertySpec {
 }
 
 internal fun adapterFunSpec(
-    context: KotlinContext,
+    context: KotlinOperationsContext,
     property: IrProperty,
 ): FunSpec {
   val type = property.info.type
@@ -70,7 +70,7 @@ internal fun adapterFunSpec(
     .build()
 }
 
-internal fun rootFieldFunSpec(context: KotlinContext, parentType: String, selectionsClassName: ClassName): FunSpec {
+internal fun rootFieldFunSpec(context: KotlinOperationsContext, parentType: String, selectionsClassName: ClassName): FunSpec {
   return FunSpec.builder(rootField)
       .addModifiers(KModifier.OVERRIDE)
       .returns(KotlinSymbols.CompiledField)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ImplementationAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ImplementationAdapterBuilder.kt
@@ -1,10 +1,13 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.operations.util
 
-import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.from
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.readFromResponseCodeBlock
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.writeToResponseCodeBlock
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrModel
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/PolymorphicFieldResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/PolymorphicFieldResponseAdapterBuilder.kt
@@ -1,6 +1,5 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.operations.util
 
-import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.codegen.Identifier.__typename
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
 import com.apollographql.apollo3.compiler.codegen.Identifier.fromJson
@@ -10,6 +9,9 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.value
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.from
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.typenameFromReaderCodeBlock
+import com.apollographql.apollo3.compiler.internal.applyIf
 import com.apollographql.apollo3.compiler.ir.IrModelGroup
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ResponseAdapterBuilder.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.operations.util
 
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.ir.IrModelGroup

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/VariablesAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/VariablesAdapter.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.adapter
+package com.apollographql.apollo3.compiler.codegen.kotlin.operations.util
 
 import com.apollographql.apollo3.compiler.codegen.Identifier.customScalarAdapters
 import com.apollographql.apollo3.compiler.codegen.Identifier.serializeVariables
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.compiler.codegen.Identifier.withDefaultValues
 import com.apollographql.apollo3.compiler.codegen.Identifier.writer
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSerializeStatement
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.codeBlock
 import com.apollographql.apollo3.compiler.ir.IrVariable
 import com.squareup.kotlinpoet.AnnotationSpec

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/CustomScalarAdaptersBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/CustomScalarAdaptersBuilder.kt
@@ -1,10 +1,10 @@
-package com.apollographql.apollo3.compiler.codegen.kotlin.executableschema
+package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 
 import com.apollographql.apollo3.compiler.ExpressionAdapterInitializer
 import com.apollographql.apollo3.compiler.ScalarInfo
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.typePackageName
 import com.squareup.kotlinpoet.ClassName
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.PropertySpec
 
 internal class CustomScalarAdaptersBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val scalarMapping: Map<String, ScalarInfo>,
 ) : CgFileBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsEnumBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsEnumBuilder.kt
@@ -4,7 +4,7 @@ import com.apollographql.apollo3.compiler.TargetLanguage
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.deprecatedAnnotation
@@ -25,7 +25,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 
 internal class EnumAsEnumBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val enum: IrEnum,
     private val withUnknown: Boolean
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.addSuppressions
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
@@ -26,7 +26,7 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.joinToCode
 
 internal class EnumAsSealedBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val enum: IrEnum,
 ) : CgFileBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumResponseAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumResponseAdapterBuilder.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.codegen.Identifier
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.responseAdapter
 import com.apollographql.apollo3.compiler.codegen.typeAdapterPackageName
@@ -17,7 +17,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class EnumResponseAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinSchemaContext,
     val enum: IrEnum,
 ) : CgFileBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/InputObjectAdapterBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/InputObjectAdapterBuilder.kt
@@ -3,8 +3,8 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.codegen.inputAdapter
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
-import com.apollographql.apollo3.compiler.codegen.kotlin.adapter.inputAdapterTypeSpec
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.inputAdapterTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.toNamedType
 import com.apollographql.apollo3.compiler.codegen.typeAdapterPackageName
 import com.apollographql.apollo3.compiler.ir.IrInputObject
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class InputObjectAdapterBuilder(
-    val context: KotlinContext,
+    val context: KotlinSchemaContext,
     val inputObject: IrInputObject,
 ) : CgFileBuilder {
   val packageName = context.layout.typeAdapterPackageName()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/InterfaceBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/InterfaceBuilder.kt
@@ -3,14 +3,14 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.abstractMapTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteBuilderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteMapTypeSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.schema.util.typePropertySpec
 import com.apollographql.apollo3.compiler.codegen.typePackageName
 import com.apollographql.apollo3.compiler.ir.IrInterface
@@ -19,7 +19,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class InterfaceBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val iface: IrInterface,
     private val generateDataBuilders: Boolean,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/ObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/ObjectBuilder.kt
@@ -3,13 +3,13 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteBuilderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteMapTypeSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.schema.util.typePropertySpec
 import com.apollographql.apollo3.compiler.codegen.typePackageName
 import com.apollographql.apollo3.compiler.ir.IrObject
@@ -19,7 +19,7 @@ import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class ObjectBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val obj: IrObject,
     private val generateDataBuilders: Boolean,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/PaginationBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/PaginationBuilder.kt
@@ -3,7 +3,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.codegen.ResolverKeyKind
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.paginationPackageName
 import com.squareup.kotlinpoet.ClassName
@@ -13,7 +13,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class PaginationBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val connectionTypes: List<String>,
 ) : CgFileBuilder {
   private val layout = context.layout

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/ScalarBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/ScalarBuilder.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
 import com.apollographql.apollo3.compiler.codegen.kotlin.schema.util.typePropertySpec
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class ScalarBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val scalar: IrScalar,
     private val targetTypeName: String?,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
@@ -4,7 +4,7 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.codegen.Identifier.type
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.schemaSubPackageName
 import com.apollographql.apollo3.compiler.ir.IrEnum
@@ -20,7 +20,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class SchemaBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val generatedSchemaName: String,
     private val objects: List<IrObject>,
     private val interfaces: List<IrInterface>,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/UnionBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/UnionBuilder.kt
@@ -3,14 +3,14 @@ package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
-import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinContext
+import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.abstractMapTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteBuilderTypeSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.concreteMapTypeSpec
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
-import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDeprecation
 import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeAddDescription
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.maybeImplementBuilderFactory
+import com.apollographql.apollo3.compiler.codegen.kotlin.helpers.topLevelBuildFunSpec
 import com.apollographql.apollo3.compiler.codegen.kotlin.schema.util.typePropertySpec
 import com.apollographql.apollo3.compiler.codegen.typePackageName
 import com.apollographql.apollo3.compiler.ir.IrUnion
@@ -19,7 +19,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal class UnionBuilder(
-    private val context: KotlinContext,
+    private val context: KotlinSchemaContext,
     private val union: IrUnion,
     private val generateDataBuilders: Boolean,
 ) : CgFileBuilder {

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -316,7 +316,6 @@ class CodegenTest {
         else -> false
       }
 
-      val packageNameGenerator = PackageNameGenerator.Flat(packageName)
       val generateMethods = when (targetLanguage) {
         JAVA -> null
         else -> {
@@ -385,6 +384,7 @@ class CodegenTest {
       val codegenOptions = buildCodegenOptions(
           targetLanguage = targetLanguage,
           useSemanticNaming = useSemanticNaming,
+          packageName = packageName,
           generateFragmentImplementations = generateFragmentImplementations,
           generateSchema = generateSchema,
           generateMethods = generateMethods,
@@ -398,6 +398,7 @@ class CodegenTest {
           requiresOptInAnnotation = requiresOptInAnnotation.takeIf { targetLanguage != JAVA },
           generateAsInternal = generateAsInternal.takeIf { targetLanguage != JAVA },
           generateFilterNotNull = true.takeIf { targetLanguage != JAVA },
+          decapitalizeFields = decapitalizeFields
       )
 
       ApolloCompiler.buildSchemaAndOperationsSources(
@@ -414,10 +415,10 @@ class CodegenTest {
           ),
           codegenOptions = codegenOptions,
           operationOutputGenerator = operationOutputGenerator,
-          packageNameGenerator = packageNameGenerator,
           compilerKotlinHooks = null,
           compilerJavaHooks = null,
           logger = null,
+          layout = null,
           operationManifestFile = null,
 
       ).writeTo(outputDir, true, null)

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/MetadataTest.kt
@@ -37,10 +37,8 @@ class MetadataTest {
   private fun compileRoot(directory: String) {
     buildCodegenSchemaOptions().writeTo(codegenSchemaOptionsFile)
     buildIrOptions().writeTo(irOptionsFile)
-    buildCodegenOptions().apply {
-      writeTo(rootCodegenOptionsFile)
-      writeTo(leafCodegenOptionsFile)
-    }
+    buildCodegenOptions(packageName = rootPackageName).writeTo(rootCodegenOptionsFile)
+    buildCodegenOptions(packageName = leafPackageName).writeTo(leafCodegenOptionsFile)
 
     ApolloCompiler.buildCodegenSchema(
         schemaFiles = setOf(File("src/test/metadata/schema.graphqls")).toInputFiles(),
@@ -72,7 +70,7 @@ class MetadataTest {
         upstreamCodegenMetadata = emptyList(),
         downstreamUsedCoordinates = leafIrOperationsFile.toIrOperations().usedFields,
         codegenOptions = rootCodegenOptionsFile.toCodegenOptions(),
-        packageNameGenerator = PackageNameGenerator.Flat(rootPackageName),
+        layout = null,
         compilerJavaHooks = null,
         compilerKotlinHooks = null,
         operationManifestFile = null,
@@ -85,7 +83,7 @@ class MetadataTest {
         upstreamCodegenMetadata = setOf(rootCodegenMetadata).map { it.toCodegenMetadata() },
         downstreamUsedCoordinates = emptyMap(),
         codegenOptions = leafCodegenOptionsFile.toCodegenOptions(),
-        packageNameGenerator = PackageNameGenerator.Flat(leafPackageName),
+        layout = null,
         compilerJavaHooks = null,
         compilerKotlinHooks = null,
         operationManifestFile = null,

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/ConditionalFragmentsTest.kt
@@ -3,7 +3,6 @@ package com.apollographql.apollo3.compiler.conditionalFragments
 import com.apollographql.apollo3.compiler.ApolloCompiler
 import com.apollographql.apollo3.compiler.MODELS_OPERATION_BASED
 import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
-import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.buildCodegenOptions
 import com.apollographql.apollo3.compiler.buildCodegenSchemaOptions
 import com.apollographql.apollo3.compiler.buildIrOptions
@@ -31,11 +30,11 @@ class ConditionalFragmentsTest {
           schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")).toInputFiles(),
           codegenSchemaOptions = buildCodegenSchemaOptions(),
           irOptions = buildIrOptions(flattenModels = false, codegenModels = MODELS_RESPONSE_BASED),
-          packageNameGenerator = PackageNameGenerator.Flat(""),
-          codegenOptions = buildCodegenOptions(),
+          codegenOptions = buildCodegenOptions(packageName = ""),
           compilerKotlinHooks = null,
           compilerJavaHooks = null,
           logger = null,
+          layout = null,
           operationManifestFile = null,
           operationOutputGenerator = null,
       )
@@ -51,11 +50,11 @@ class ConditionalFragmentsTest {
         schemaFiles = setOf(File("src/test/kotlin/com/apollographql/apollo3/compiler/conditionalFragments/schema.graphqls")).toInputFiles(),
         codegenSchemaOptions = buildCodegenSchemaOptions(),
         irOptions = buildIrOptions(flattenModels = false, codegenModels = MODELS_OPERATION_BASED),
-        packageNameGenerator = PackageNameGenerator.Flat(""),
-        codegenOptions = buildCodegenOptions(),
+        codegenOptions = buildCodegenOptions(packageName = ""),
         compilerKotlinHooks = null,
         compilerJavaHooks = null,
         logger = null,
+        layout = null,
         operationManifestFile = null,
         operationOutputGenerator = null,
     )

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.gradle.internal
 
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
-import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerJavaHooks
 import com.apollographql.apollo3.compiler.hooks.ApolloCompilerKotlinHooks
 import org.gradle.api.DefaultTask
@@ -20,12 +19,6 @@ abstract class ApolloGenerateSourcesBaseTask : DefaultTask() {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val codegenOptionsFile: RegularFileProperty
-
-  @Internal
-  var packageNameGenerator: PackageNameGenerator? = null
-
-  @Input
-  fun getPackageNameGeneratorVersion() = packageNameGenerator?.version ?: ""
 
   @get:Internal
   var operationOutputGenerator: OperationOutputGenerator? = null

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -51,7 +51,7 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
         downstreamUsedCoordinates = downstreamUsedCoordinates.get(),
         upstreamCodegenMetadata = upstreamMetadata.files.map { it.toCodegenMetadata() },
         codegenOptions = codegenOptionsFile.get().asFile.toCodegenOptions(),
-        packageNameGenerator = packageNameGenerator,
+        layout = null,
         compilerKotlinHooks = compilerKotlinHooks,
         compilerJavaHooks = compilerJavaHooks,
         operationManifestFile = operationManifestFile.orNull?.asFile,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -57,7 +57,7 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
         codegenOptions = codegenOptionsFile.get().asFile.toCodegenOptions(),
         irOptions = irOptionsFile.get().asFile.toIrOptions(),
         logger = logger(),
-        packageNameGenerator = packageNameGenerator,
+        layout = null,
         operationOutputGenerator = operationOutputGenerator,
         compilerJavaHooks = compilerJavaHooks,
         compilerKotlinHooks = compilerKotlinHooks,

--- a/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
+++ b/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ApolloProcessor.kt
@@ -11,7 +11,6 @@ import com.apollographql.apollo3.compiler.ApolloCompiler
 import com.apollographql.apollo3.compiler.CodegenMetadata
 import com.apollographql.apollo3.compiler.CodegenSchema
 import com.apollographql.apollo3.compiler.ExpressionAdapterInitializer
-import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.ScalarInfo
 import com.apollographql.apollo3.compiler.buildCodegenOptions
 import com.apollographql.apollo3.compiler.codegen.SourceOutput
@@ -191,9 +190,10 @@ class ApolloProcessor(
             codegenOptions = buildCodegenOptions(
                 addUnknownForEnums = false,
                 addDefaultArgumentForInputObjects = false,
-                generateAsInternal = true
+                generateAsInternal = true,
+                packageName = packageName
             ),
-            packageNameGenerator = PackageNameGenerator.Flat(packageName),
+        null,
             null,
             null
         )

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -24,7 +24,7 @@ apollo {
     packageName.set("com.example.two")
   }
   service("3") {
-    sourceFolder.set("3")
+    srcDir("src/main/graphql/3")
     packageName.set("com.example.three")
   }
 }


### PR DESCRIPTION
Instead of the all-in-one codegen layout, expose specialized interfaces to different codegen packages. 

* `codegen.[java|kotlin].schema` uses `SchemaLayout`
* `codegen.[java|kotlin].executableschema` uses `ExecutableSchemaLayout`
* `codegen.[java|kotlin].operations` uses `OperationsLayout`

For convenience, `LayoutImpl` is unchanged and implements all 3 interfaces but it's internal only and doesn't leak in public API.

`ApolloCompiler.buildFoo()` now have 2 kind of options:

1. the "declarative" ones (`IrOptions`, `CodegenOptions`, etc...) are scalars that can be serialized in JSON option files.
1. the "turing complete" ones (`Layout`, `OperationOutputGenerator`, `ApolloCompilerHooks`, etc...) are code that are serialized as classpaths.

Note: this temporarily breaks passing a custom `packageNameGenerator` but turns out we have no test for this. I'll re-introduce that in a follow up PR
