### PR TITLE
Add --admin to gh pr merge to bypass waiting for approval

### DIFF
--- a/scripts/increment-ij-plugin-snapshot.main.kts
+++ b/scripts/increment-ij-plugin-snapshot.main.kts
@@ -37,7 +37,7 @@ fun runCommand(vararg args: String): String {
 }
 
 fun mergeAndWait(branchName: String) {
-  runCommand("gh", "pr", "merge", branchName, "--squash", "--auto", "--delete-branch")
+  runCommand("gh", "pr", "merge", branchName, "--squash", "--admin", "--delete-branch")
   println("Waiting for the PR to be merged...")
   while (true) {
     val state = runCommand("gh", "pr", "view", branchName, "--json", "state", "--jq", ".state")


### PR DESCRIPTION
We recently changed the project's settings so PR need approval to be merged, this broke that script. Not 100% sure --admin will work from a gh action, we'll see.