### PR TITLE
[🐘gradle-plugin] Fix a regression in alwaysGenerateTypesMatching

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateOptionsTask.kt
@@ -205,10 +205,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
   abstract var isKmp: Boolean
 
   @get:Input
-  abstract var isMultiModule: Boolean
-
-  @get:Input
-  abstract var hasDownstreamDependencies: Boolean
+  abstract var generateAllTypes: Boolean
 
   @get:Internal
   var hasPackageNameGenerator: Boolean = false
@@ -235,7 +232,7 @@ abstract class ApolloGenerateOptionsTask : DefaultTask() {
     val upstreamTargetLanguage = upstreamOtherOptions?.targetLanguage
     val targetLanguage = targetLanguage(generateKotlinModels.orNull, languageVersion.orNull, isJavaPluginApplied, kgpVersion, upstreamTargetLanguage)
     val generateFilterNotNull = generateFilterNotNull(targetLanguage, isKmp)
-    val alwaysGenerateTypesMatching = alwaysGenerateTypesMatching(alwaysGenerateTypesMatching.orNull, isMultiModule, hasDownstreamDependencies)
+    val alwaysGenerateTypesMatching = alwaysGenerateTypesMatching(alwaysGenerateTypesMatching.orNull, generateAllTypes)
     val upstreamCodegenModels = upstreamOtherOptions?.codegenModels
     val codegenModels = codegenModels(codegenModels.orNull, upstreamCodegenModels)
 
@@ -362,29 +359,6 @@ private fun scalarMapping(
   return scalarTypeMapping.getOrElse(emptyMap()).mapValues { (graphQLName, targetName) ->
     val adapterInitializerExpression = scalarAdapterMapping.getOrElse(emptyMap())[graphQLName]
     ScalarInfo(targetName, if (adapterInitializerExpression == null) RuntimeAdapterInitializer else ExpressionAdapterInitializer(adapterInitializerExpression))
-  }
-}
-
-private fun generateFilterNotNull(targetLanguage: TargetLanguage, isKmp: Boolean): Boolean? {
-  return if (targetLanguage == TargetLanguage.JAVA) {
-    null
-  } else {
-    isKmp
-  }
-}
-
-private fun alwaysGenerateTypesMatching(alwaysGenerateTypesMatching: Set<String>?, isMultiModule: Boolean, hasDownstreamDependencies: Boolean): Set<String> {
-  if (alwaysGenerateTypesMatching != null) {
-    // The user specified something, use this
-    return alwaysGenerateTypesMatching
-  }
-
-  if (isMultiModule && !hasDownstreamDependencies) {
-    // No downstream dependency, generate everything because we don't know what types are going to be used downstream
-    return setOf(".*")
-  } else {
-    // get the used coordinates from the downstream dependencies
-    return emptySet()
   }
 }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -712,8 +712,8 @@ abstract class DefaultApolloExtension(
       task.isJavaPluginApplied = project.hasJavaPlugin()
       task.kgpVersion = project.apolloGetKotlinPluginVersion()
       task.isKmp = project.isKotlinMultiplatform
-      task.isMultiModule = service.isMultiModule()
-      task.hasDownstreamDependencies = service.downstreamDependencies.isNotEmpty()
+      // If there is no downstream dependency, generate everything because we don't know what types are going to be used downstream
+      task.generateAllTypes = service.isSchemaModule() && service.isMultiModule() && service.downstreamDependencies.isEmpty()
 
       task.otherOptions.set(BuildDirLayout.otherOptions(project, service))
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/defaults.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.compiler.MANIFEST_PERSISTED_QUERY
 import com.apollographql.apollo3.compiler.OperationIdGenerator
 import com.apollographql.apollo3.compiler.OperationOutputGenerator
 import com.apollographql.apollo3.compiler.Plugin
+import com.apollographql.apollo3.compiler.TargetLanguage
 import com.apollographql.apollo3.compiler.operationoutput.OperationDescriptor
 import com.apollographql.apollo3.compiler.operationoutput.OperationId
 import com.apollographql.apollo3.compiler.operationoutput.OperationOutput
@@ -99,5 +100,27 @@ internal fun Plugin.toOperationOutputGenerator(): OperationOutputGenerator {
         operationId.id
       }
     }
+  }
+}
+
+internal fun generateFilterNotNull(targetLanguage: TargetLanguage, isKmp: Boolean): Boolean? {
+  return if (targetLanguage == TargetLanguage.JAVA) {
+    null
+  } else {
+    isKmp
+  }
+}
+
+internal fun alwaysGenerateTypesMatching(alwaysGenerateTypesMatching: Set<String>?, generateAllTypes: Boolean): Set<String> {
+  if (alwaysGenerateTypesMatching != null) {
+    // The user specified something, use this
+    return alwaysGenerateTypesMatching
+  }
+
+  if (generateAllTypes) {
+    return setOf(".*")
+  } else {
+    // get the used coordinates from the downstream dependencies
+    return emptySet()
   }
 }


### PR DESCRIPTION
We were setting the default to `.*` for leaf modules which doesn't really make sense since the types are only generated in the schema module but had the unfortunate side effect of generating all types.