### PR TITLE
[🐘 gradle-plugin] Add overload for dependsOn that tries to do cross project configuration

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -766,10 +766,35 @@ interface Service {
   fun operationManifestConnection(action: Action<in OperationManifestConnection>)
 
   /**
-   * Adds a given dependency for the codegen
+   * Adds a dependency for the codegen. Use this when some types/fragments are generated
+   * in upstream modules.
    */
   fun dependsOn(dependencyNotation: Any)
+
+  /**
+   * Counterpoint of [dependsOn]. [isADependencyOf] allows a schema module to discover
+   * used types in downstream modules automatically without having to specify [alwaysGenerateTypesMatching].
+   *
+   * This works by setting a dependency on the IR in downstream modules.
+   * Because the IR task and the codegen task are separate this does not create a cycle.
+   *
+   * @see [alwaysGenerateTypesMatching]
+   */
   fun isADependencyOf(dependencyNotation: Any)
+
+  /**
+   * Same as [dependsOn] but tries to do automatic cross-project configuration.
+   * This is highly experimental and probably not compatible with most Gradle best practices.
+   *
+   * Use at your own risks!
+   *
+   * @param bidirectional if true and if [dependencyNotation] is a project dependency,
+   * this version of [dependsOn] also calls [isADependencyOf] automatically by using
+   * cross-project configuration. This is experimental and probably not project isolation compatible.
+   *
+   */
+  @ApolloExperimental
+  fun dependsOn(dependencyNotation: Any, bidirectional: Boolean)
 
   class OperationOutputConnection(
       /**

--- a/tests/multi-module-1/bidirectional/build.gradle.kts
+++ b/tests/multi-module-1/bidirectional/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.apollographql.apollo3")
+}
+
+apolloTest()
+
+dependencies {
+  implementation(libs.apollo.runtime)
+  implementation(project(":multi-module-1-root"))
+  testImplementation(libs.kotlin.test.junit)
+}
+
+apollo {
+  service("service") {
+    packageNamesFromFilePaths()
+    dependsOn(project(":multi-module-1-root"), true)
+  }
+}

--- a/tests/multi-module-1/bidirectional/src/main/graphql/com/example/operations.graphql
+++ b/tests/multi-module-1/bidirectional/src/main/graphql/com/example/operations.graphql
@@ -1,0 +1,6 @@
+query GetA {
+  a {
+    foo
+  }
+
+}

--- a/tests/multi-module-1/root/build.gradle.kts
+++ b/tests/multi-module-1/root/build.gradle.kts
@@ -7,6 +7,7 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
+  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/multi-module-1/root/src/main/graphql/schema.graphqls
+++ b/tests/multi-module-1/root/src/main/graphql/schema.graphqls
@@ -1,5 +1,15 @@
 type Query {
   long: Long!
+  a: A
+  b: B
+}
+
+type A {
+  foo: Int
+}
+
+type B {
+  foo: Int
 }
 
 scalar Long

--- a/tests/multi-module-1/root/src/test/kotlin/MainTest.kt
+++ b/tests/multi-module-1/root/src/test/kotlin/MainTest.kt
@@ -1,5 +1,16 @@
+import kotlin.test.Test
+
 class MainTest {
+  @Test
   fun test() {
     println(multimodule1.root.fragment.QueryDetails::class.java)
+    // A is used in the bidirectional module and registered automatically
+    println(multimodule1.root.type.A::class.java)
+    // B is not used at all and must not be generated
+    try {
+      val clazz = Class.forName("multimodule1.root.type.B")
+      error("An exception was expected but got $clazz instead")
+    } catch (e: ClassNotFoundException) {
+    }
   }
 }


### PR DESCRIPTION
This is so that adding `dependsOn`:

```kotlin
apollo {
  service("service") {
    // ..
    dependsOn(project(":schema"))
  }
}
```

automatically adds the matching `isADependencyOf()`

This is all highly experimental but it's working in integration tests.

Also add more KDoc.