### PR TITLE
Cache lock changes

### DIFF
--- a/benchmark/app/src/main/AndroidManifest.xml
+++ b/benchmark/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-permission android:name="INTERNET" />
+  <uses-permission android:name="android.permission.INTERNET" />
   <!-- Storage permissions required to run the macrobenchmark on my Pixel 3, not sure why -->
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/benchmark/microbenchmark/build.gradle.kts
+++ b/benchmark/microbenchmark/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
 
   androidTestImplementation(libs.benchmark.junit4)
   androidTestImplementation(libs.androidx.test.core)
+  androidTestImplementation("com.apollographql.apollo3:apollo-mockserver")
+  androidTestImplementation("com.apollographql.apollo3:apollo-testing-support")
 }
 
 configure<com.android.build.gradle.LibraryExtension> {

--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/ApolloStoreIncubatingTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/ApolloStoreIncubatingTests.kt
@@ -1,0 +1,98 @@
+package com.apollographql.apollo3.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.platform.app.InstrumentationRegistry
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.benchmark.Utils.dbName
+import com.apollographql.apollo3.benchmark.Utils.operationBasedQuery
+import com.apollographql.apollo3.benchmark.Utils.resource
+import com.apollographql.apollo3.benchmark.test.R
+import com.apollographql.apollo3.cache.normalized.incubating.ApolloStore
+import com.apollographql.apollo3.cache.normalized.incubating.api.CacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.incubating.api.CacheResolver
+import com.apollographql.apollo3.cache.normalized.incubating.api.FieldPolicyCacheResolver
+import com.apollographql.apollo3.cache.normalized.incubating.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.incubating.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.incubating.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.incubating.sql.SqlNormalizedCacheFactory
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.lang.reflect.Method
+import java.util.concurrent.Executors
+
+class ApolloStoreIncubatingTests {
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  @Test
+  fun concurrentReadWritesMemory() {
+    concurrentReadWrites(MemoryCacheFactory())
+  }
+
+  @Test
+  fun concurrentReadWritesSql() {
+    Utils.dbFile.delete()
+    // Pass context explicitly here because androidx.startup fails due to relocation
+    val cacheFactory = SqlNormalizedCacheFactory(InstrumentationRegistry.getInstrumentation().context, dbName)
+    concurrentReadWrites(cacheFactory)
+  }
+
+  @Test
+  fun concurrentReadWritesMemoryThenSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = MemoryCacheFactory().chain(SqlNormalizedCacheFactory(InstrumentationRegistry.getInstrumentation().context, dbName))
+    concurrentReadWrites(cacheFactory)
+  }
+
+  private fun concurrentReadWrites(cacheFactory: NormalizedCacheFactory) {
+    val apolloStore = createApolloStore(cacheFactory)
+    val query = operationBasedQuery
+    val data = query.parseJsonResponse(resource(R.raw.calendar_response_simple).jsonReader()).data!!
+    val threadPool = Executors.newFixedThreadPool(CONCURRENCY)
+    benchmarkRule.measureRepeated {
+      val futures = (1..CONCURRENCY).map {
+        threadPool.submit {
+          // Let each thread execute a few writes/reads
+          repeat(WORK_LOAD) {
+            apolloStore.writeOperation(query, data)
+            val data2 = apolloStore.readOperation(query)
+            Assert.assertEquals(data, data2)
+          }
+        }
+      }
+      // Wait for all threads to finish
+      futures.forEach { it.get() }
+    }
+  }
+
+  private fun createApolloStore(cacheFactory: NormalizedCacheFactory): ApolloStore {
+    return createApolloStoreMethod.invoke(
+        null,
+        cacheFactory,
+        TypePolicyCacheKeyGenerator,
+        FieldPolicyCacheResolver,
+    ) as ApolloStore
+  }
+
+
+  companion object {
+    private const val CONCURRENCY = 10
+    private const val WORK_LOAD = 5
+
+    /**
+     * There doesn't seem to be a way to relocate Kotlin metadata and kotlin_module files so we rely on reflection to call top-level
+     * methods
+     * See https://discuss.kotlinlang.org/t/what-is-the-proper-way-to-repackage-shade-kotlin-dependencies/10869
+     */
+    private val apolloStoreKtClass = Class.forName("com.apollographql.apollo3.cache.normalized.incubating.ApolloStoreKt")
+    private val createApolloStoreMethod: Method = apolloStoreKtClass.getMethod(
+        "ApolloStore",
+        NormalizedCacheFactory::class.java,
+        CacheKeyGenerator::class.java,
+        CacheResolver::class.java,
+    )
+  }
+}

--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/ApolloStoreTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/ApolloStoreTests.kt
@@ -1,0 +1,73 @@
+package com.apollographql.apollo3.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.benchmark.Utils.dbName
+import com.apollographql.apollo3.benchmark.Utils.operationBasedQuery
+import com.apollographql.apollo3.benchmark.Utils.resource
+import com.apollographql.apollo3.benchmark.test.R
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.Executors
+
+class ApolloStoreTests {
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  @Test
+  fun concurrentReadWritesMemory() {
+    concurrentReadWrites(MemoryCacheFactory())
+  }
+
+  @Test
+  fun concurrentReadWritesSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = SqlNormalizedCacheFactory(dbName)
+    concurrentReadWrites(cacheFactory)
+  }
+
+  @Test
+  fun concurrentReadWritesMemoryThenSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = MemoryCacheFactory().chain(SqlNormalizedCacheFactory(dbName))
+    concurrentReadWrites(cacheFactory)
+  }
+
+  private fun concurrentReadWrites(cacheFactory: NormalizedCacheFactory) {
+    val apolloStore = createApolloStore(cacheFactory)
+    val query = operationBasedQuery
+    val data = query.parseJsonResponse(resource(R.raw.calendar_response_simple).jsonReader()).data!!
+    val threadPool = Executors.newFixedThreadPool(CONCURRENCY)
+    benchmarkRule.measureRepeated {
+      val futures = (1..CONCURRENCY).map {
+        threadPool.submit {
+          // Let each thread execute a few writes/reads
+          repeat(WORK_LOAD) {
+            apolloStore.writeOperation(query, data)
+            val data2 = apolloStore.readOperation(query)
+            Assert.assertEquals(data, data2)
+          }
+        }
+      }
+      // Wait for all threads to finish
+      futures.forEach { it.get() }
+    }
+  }
+
+  private fun createApolloStore(cacheFactory: NormalizedCacheFactory): ApolloStore {
+    return ApolloStore(cacheFactory)
+  }
+
+
+  companion object {
+    private const val CONCURRENCY = 10
+    private const val WORK_LOAD = 5
+  }
+}

--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIncubatingIntegrationTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIncubatingIntegrationTests.kt
@@ -1,0 +1,153 @@
+package com.apollographql.apollo3.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.platform.app.InstrumentationRegistry
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.benchmark.Utils.dbName
+import com.apollographql.apollo3.benchmark.Utils.operationBasedQuery
+import com.apollographql.apollo3.benchmark.Utils.resource
+import com.apollographql.apollo3.benchmark.test.R
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.incubating.ApolloStore
+import com.apollographql.apollo3.cache.normalized.incubating.api.CacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.incubating.api.CacheResolver
+import com.apollographql.apollo3.cache.normalized.incubating.api.FieldPolicyCacheResolver
+import com.apollographql.apollo3.cache.normalized.incubating.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.incubating.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.incubating.api.TypePolicyCacheKeyGenerator
+import com.apollographql.apollo3.cache.normalized.incubating.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo3.mockserver.MockRequestBase
+import com.apollographql.apollo3.mockserver.MockResponse
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.MockServerHandler
+import com.apollographql.apollo3.testing.MapTestNetworkTransport
+import com.apollographql.apollo3.testing.registerTestResponse
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import java.lang.reflect.Method
+
+class CacheIncubatingIntegrationTests {
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportMemory() {
+    concurrentQueries(MemoryCacheFactory(), withMockServer = false)
+  }
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = SqlNormalizedCacheFactory(InstrumentationRegistry.getInstrumentation().context, dbName)
+    concurrentQueries(cacheFactory, withMockServer = false)
+  }
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportMemoryThenSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = MemoryCacheFactory().chain(SqlNormalizedCacheFactory(InstrumentationRegistry.getInstrumentation().context, dbName))
+    concurrentQueries(cacheFactory, withMockServer = false)
+  }
+
+
+  private fun concurrentQueries(cacheFactory: NormalizedCacheFactory, withMockServer: Boolean) {
+    val mockServer = MockServer.Builder()
+        .handler(
+            object : MockServerHandler {
+              private val mockResponse = MockResponse.Builder()
+                  .statusCode(200)
+                  .body(resource(R.raw.calendar_response_simple).readByteString())
+                  .build()
+
+              override fun handle(request: MockRequestBase): MockResponse {
+                return mockResponse
+              }
+            }
+        )
+        .build()
+
+    val client = ApolloClient.Builder()
+        .let {
+          if (withMockServer) {
+            it.serverUrl(runBlocking { mockServer.url() })
+          } else {
+            it.networkTransport(MapTestNetworkTransport())
+          }
+        }
+        .store(createApolloStore(cacheFactory))
+        .build()
+    if (!withMockServer) {
+      client.registerTestResponse(operationBasedQuery, operationBasedQuery.parseJsonResponse(resource(R.raw.calendar_response_simple).jsonReader()).data!!)
+    }
+
+    benchmarkRule.measureRepeated {
+      runBlocking {
+        (1..CONCURRENCY).map {
+          launch {
+            // Let each job execute a few queries
+            repeat(WORK_LOAD) {
+              client.query(operationBasedQuery).fetchPolicy(FetchPolicy.NetworkOnly).execute().dataOrThrow()
+              client.query(operationBasedQuery).fetchPolicy(FetchPolicy.CacheOnly).execute().dataOrThrow()
+            }
+          }
+        }
+            // Wait for all jobs to finish
+            .joinAll()
+      }
+    }
+  }
+
+  private fun createApolloStore(cacheFactory: NormalizedCacheFactory): ApolloStore {
+    return createApolloStoreMethod.invoke(
+        null,
+        cacheFactory,
+        TypePolicyCacheKeyGenerator,
+        FieldPolicyCacheResolver,
+    ) as ApolloStore
+  }
+
+
+  companion object {
+    private const val CONCURRENCY = 10
+    private const val WORK_LOAD = 8
+
+    /**
+     * There doesn't seem to be a way to relocate Kotlin metadata and kotlin_module files so we rely on reflection to call top-level
+     * methods
+     * See https://discuss.kotlinlang.org/t/what-is-the-proper-way-to-repackage-shade-kotlin-dependencies/10869
+     */
+    private val apolloStoreKtClass = Class.forName("com.apollographql.apollo3.cache.normalized.incubating.ApolloStoreKt")
+    private val createApolloStoreMethod: Method = apolloStoreKtClass.getMethod(
+        "ApolloStore",
+        NormalizedCacheFactory::class.java,
+        CacheKeyGenerator::class.java,
+        CacheResolver::class.java,
+    )
+
+    private val NormalizedCacheClass = Class.forName("com.apollographql.apollo3.cache.normalized.incubating.NormalizedCache")
+    private val storeMethod: Method = NormalizedCacheClass.getMethod(
+        "store",
+        ApolloClient.Builder::class.java,
+        ApolloStore::class.java,
+        Boolean::class.java,
+    )
+
+    private fun ApolloClient.Builder.store(store: ApolloStore): ApolloClient.Builder {
+      return storeMethod.invoke(
+          null,
+          this,
+          store,
+          false,
+      ) as ApolloClient.Builder
+    }
+  }
+}
+
+

--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIntegrationTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo3/benchmark/CacheIntegrationTests.kt
@@ -1,0 +1,113 @@
+package com.apollographql.apollo3.benchmark
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.benchmark.Utils.dbName
+import com.apollographql.apollo3.benchmark.Utils.operationBasedQuery
+import com.apollographql.apollo3.benchmark.Utils.resource
+import com.apollographql.apollo3.benchmark.test.R
+import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.FetchPolicy
+import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
+import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.fetchPolicy
+import com.apollographql.apollo3.cache.normalized.sql.SqlNormalizedCacheFactory
+import com.apollographql.apollo3.cache.normalized.store
+import com.apollographql.apollo3.mockserver.MockRequestBase
+import com.apollographql.apollo3.mockserver.MockResponse
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.MockServerHandler
+import com.apollographql.apollo3.testing.MapTestNetworkTransport
+import com.apollographql.apollo3.testing.registerTestResponse
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class CacheIntegrationTests {
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportMemory() {
+    concurrentQueries(MemoryCacheFactory(), withMockServer = false)
+  }
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = SqlNormalizedCacheFactory(dbName)
+    concurrentQueries(cacheFactory, withMockServer = false)
+  }
+
+  @Test
+  fun concurrentQueriesTestNetworkTransportMemoryThenSql() {
+    Utils.dbFile.delete()
+    val cacheFactory = MemoryCacheFactory().chain(SqlNormalizedCacheFactory(dbName))
+    concurrentQueries(cacheFactory, withMockServer = false)
+  }
+
+
+  private fun concurrentQueries(cacheFactory: NormalizedCacheFactory, withMockServer: Boolean) {
+    val mockServer = MockServer.Builder()
+        .handler(
+            object : MockServerHandler {
+              private val mockResponse = MockResponse.Builder()
+                  .statusCode(200)
+                  .body(resource(R.raw.calendar_response_simple).readByteString())
+                  .build()
+
+              override fun handle(request: MockRequestBase): MockResponse {
+                return mockResponse
+              }
+            }
+        )
+        .build()
+
+    val client = ApolloClient.Builder()
+        .let {
+          if (withMockServer) {
+            it.serverUrl(runBlocking { mockServer.url() })
+          } else {
+            it.networkTransport(MapTestNetworkTransport())
+          }
+        }
+        .store(createApolloStore(cacheFactory))
+        .build()
+    if (!withMockServer) {
+      client.registerTestResponse(operationBasedQuery, operationBasedQuery.parseJsonResponse(resource(R.raw.calendar_response_simple).jsonReader()).data!!)
+    }
+
+    benchmarkRule.measureRepeated {
+      runBlocking {
+        (1..CONCURRENCY).map {
+          launch {
+            // Let each job execute a few queries
+            repeat(WORK_LOAD) {
+              client.query(operationBasedQuery).fetchPolicy(FetchPolicy.NetworkOnly).execute().dataOrThrow()
+              client.query(operationBasedQuery).fetchPolicy(FetchPolicy.CacheOnly).execute().dataOrThrow()
+            }
+          }
+        }
+            // Wait for all jobs to finish
+            .joinAll()
+      }
+    }
+  }
+
+  private fun createApolloStore(cacheFactory: NormalizedCacheFactory): ApolloStore {
+    return ApolloStore(cacheFactory)
+  }
+
+
+  companion object {
+    private const val CONCURRENCY = 10
+    private const val WORK_LOAD = 8
+  }
+}
+
+

--- a/benchmark/microbenchmark/src/androidTest/res/raw/calendar_response_simple.json
+++ b/benchmark/microbenchmark/src/androidTest/res/raw/calendar_response_simple.json
@@ -1,0 +1,112 @@
+{
+  "data": {
+    "items": {
+      "edges": [
+        {
+          "id": "a3997cde-a335-4752-b5fe-6cb625066c30",
+          "node": {
+            "__typename": "Item",
+            "id": "a3997cde-a335-4752-b5fe-6cb625066c30",
+            "title": "Holiday - Tom Cruise",
+            "type": {
+              "id": "Event",
+              "node": {
+                "__typename": "ItemType",
+                "id": "Event",
+                "name": "Event",
+                "defaultCategory": {
+                  "id": "General",
+                  "node": {
+                    "__typename": "Category",
+                    "id": "General",
+                    "name": "General",
+                    "icon": {
+                      "id": "General",
+                      "node": {
+                        "__typename": "Icon",
+                        "id": "General",
+                        "name": "General"
+                      }
+                    },
+                    "primaryColor": "Gray400",
+                    "secondaryColor": "Gray200"
+                  }
+                },
+                "defaultIcon": {
+                  "id": "Calendar",
+                  "node": {
+                    "__typename": "Icon",
+                    "id": "Calendar",
+                    "name": "Calendar"
+                  }
+                }
+              }
+            },
+            "icon": {
+              "id": "Beach",
+              "node": {
+                "__typename": "Icon",
+                "id": "Beach",
+                "name": "Beach"
+              }
+            },
+            "category": {
+              "id": "Work",
+              "node": {
+                "__typename": "Category",
+                "id": "Work",
+                "name": "Work",
+                "icon": {
+                  "id": "Suitcase",
+                  "node": {
+                    "__typename": "Icon",
+                    "id": "Suitcase",
+                    "name": "Suitcase"
+                  }
+                },
+                "primaryColor": "BlueMedium",
+                "secondaryColor": "BlueBright"
+              }
+            },
+            "start": {
+              "__typename": "DateTimeInfo",
+              "date": "2022-05-02",
+              "dateTime": null,
+              "timeZone": null
+            },
+            "end": {
+              "__typename": "DateTimeInfo",
+              "date": "2022-05-03",
+              "dateTime": null,
+              "timeZone": null
+            },
+            "series": null,
+            "calendar": {
+              "id": "7eac2ed6-24f6-4fbc-ab30-80effff39ae9",
+              "node": {
+                "__typename": "Calendar",
+                "id": "7eac2ed6-24f6-4fbc-ab30-80effff39ae9",
+                "name": "Team Holidays",
+                "canCreate": false,
+                "provider": {
+                  "node": {
+                    "__typename": "CalendarProvider",
+                    "id": "cc8e4c28-f178-11ec-8ea0-0242ac120002",
+                    "type": "google",
+                    "displayName": "Google",
+                    "username": "someone@somewhere.com"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+      "pageInfo": {
+        "__typename": "PageInfo",
+        "endCursor": "c4d77372-135a-4cfe-8370-81e37d81347b",
+        "hasNextPage": true
+      }
+    }
+  }
+}

--- a/benchmark/microbenchmark/src/main/AndroidManifest.xml
+++ b/benchmark/microbenchmark/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
   <uses-permission
       android:name="android.permission.MANAGE_EXTERNAL_STORAGE"
       tools:ignore="ScopedStorage" />
+  <uses-permission android:name="android.permission.INTERNET" />
+
   <application
       android:allowBackup="false"
       android:debuggable="false"

--- a/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-api-incubating/build.gradle.kts
@@ -15,6 +15,9 @@ kotlin {
         api(project(":apollo-mpp-utils"))
         implementation(libs.okio)
         api(libs.uuid)
+        implementation(libs.atomicfu.get().toString()) {
+          because("Use of ReentrantLock for Apple (we don't use the gradle plugin rewrite)")
+        }
       }
     }
   }

--- a/libraries/apollo-normalized-cache-api-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-apple.kt
@@ -1,5 +1,0 @@
-package com.apollographql.apollo3.cache.normalized.api.internal
-
-internal actual class CacheLock actual constructor() {
-  actual fun <T> lock(block: () -> T): T = block()
-}

--- a/libraries/apollo-normalized-cache-api-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/appleMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
@@ -1,10 +1,10 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized.api.internal
 
 import kotlinx.atomicfu.locks.ReentrantLock
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 
-internal actual class Lock {
+actual class Lock {
   private val lock: ReentrantLock = reentrantLock()
 
   actual fun <T> read(block: () -> T): T {

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.kt
@@ -1,5 +1,0 @@
-package com.apollographql.apollo3.cache.normalized.api.internal
-
-internal expect class CacheLock() {
-  fun <T> lock(block: () -> T): T
-}

--- a/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
@@ -1,6 +1,6 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized.api.internal
 
-import kotlinx.atomicfu.locks.ReentrantLock
+import com.apollographql.apollo3.annotations.ApolloInternal
 
 /**
  * A lock with read/write semantics where possible.
@@ -8,7 +8,8 @@ import kotlinx.atomicfu.locks.ReentrantLock
  * - uses Java's `ReentrantReadWriteLock` on the JVM
  * - uses AtomicFu's [ReentrantLock] on Native (read and write are not distinguished)
  */
-internal expect class Lock() {
+@ApolloInternal
+expect class Lock() {
   fun <T> read(block: () -> T): T
   fun <T> write(block: () -> T): T
 }

--- a/libraries/apollo-normalized-cache-api-incubating/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-js.kt
@@ -1,5 +1,0 @@
-package com.apollographql.apollo3.cache.normalized.api.internal
-
-internal actual class CacheLock actual constructor() {
-  actual fun <T> lock(block: () -> T): T = block()
-}

--- a/libraries/apollo-normalized-cache-api-incubating/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/jsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
@@ -1,6 +1,6 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized.api.internal
 
-internal actual class Lock {
+actual class Lock {
   actual fun <T> read(block: () -> T): T {
     return block()
   }

--- a/libraries/apollo-normalized-cache-api-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock-jvm.kt
@@ -1,9 +1,0 @@
-package com.apollographql.apollo3.cache.normalized.api.internal
-
-internal actual class CacheLock actual constructor() {
-  actual fun <T> lock(block: () -> T): T {
-    return synchronized(this) {
-      block()
-    }
-  }
-}

--- a/libraries/apollo-normalized-cache-api-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
@@ -1,10 +1,10 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized.api.internal
 
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
 
-internal actual class Lock {
+actual class Lock {
   private val lock = ReentrantReadWriteLock()
 
   actual fun <T> read(block: () -> T): T {

--- a/libraries/apollo-normalized-cache-api-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.wasmJs.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/-cache-lock.wasmJs.kt
@@ -1,7 +1,0 @@
-package com.apollographql.apollo3.cache.normalized.api.internal
-
-internal actual class CacheLock actual constructor() {
-  actual fun <T> lock(block: () -> T): T {
-    return block()
-  }
-}

--- a/libraries/apollo-normalized-cache-api-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
+++ b/libraries/apollo-normalized-cache-api-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/cache/normalized/api/internal/Lock.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.cache.normalized.internal
+package com.apollographql.apollo3.cache.normalized.api.internal
 
 /**
  * A lock with read/write semantics where possible.
@@ -6,7 +6,7 @@ package com.apollographql.apollo3.cache.normalized.internal
  * - uses Java's `ReentrantReadWriteLock` on the JVM
  * - uses AtomicFu's [ReentrantLock] on Native (read and write are not distinguished)
  */
-internal actual class Lock actual constructor() {
+actual class Lock actual constructor() {
   actual fun <T> read(block: () -> T): T {
     return block()
   }

--- a/libraries/apollo-normalized-cache-incubating/build.gradle.kts
+++ b/libraries/apollo-normalized-cache-incubating/build.gradle.kts
@@ -14,9 +14,6 @@ kotlin {
         api(project(":apollo-runtime"))
         api(project(":apollo-normalized-cache-api-incubating"))
         api(libs.kotlinx.coroutines)
-        implementation(libs.atomicfu.get().toString()) {
-          because("Use of ReentrantLock in DefaultApolloStore for Apple (we don't use the gradle plugin rewrite)")
-        }
       }
     }
   }

--- a/libraries/apollo-normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCache.kt
+++ b/libraries/apollo-normalized-cache-sqlite-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/sql/SqlNormalizedCache.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.cache.normalized.api.DefaultRecordMerger
 import com.apollographql.apollo3.cache.normalized.api.NormalizedCache
 import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.api.RecordMerger
+import com.apollographql.apollo3.cache.normalized.api.internal.Lock
 import com.apollographql.apollo3.cache.normalized.sql.internal.RecordDatabase
 import com.apollographql.apollo3.exception.apolloExceptionHandler
 import kotlin.reflect.KClass
@@ -16,6 +17,18 @@ import kotlin.reflect.KClass
 class SqlNormalizedCache internal constructor(
     private val recordDatabase: RecordDatabase,
 ) : NormalizedCache() {
+
+  // A lock is only needed if there is a nextCache
+  private val lock = nextCache?.let { Lock() }
+
+  private fun <T> lockWrite(block: () -> T): T {
+    return lock?.write { block() } ?: block()
+  }
+
+  private fun <T> lockRead(block: () -> T): T {
+    return lock?.read { block() } ?: block()
+  }
+
   private fun <T> maybeTransaction(condition: Boolean, block: () -> T): T {
     return if (condition) {
       recordDatabase.transaction {
@@ -28,68 +41,78 @@ class SqlNormalizedCache internal constructor(
 
   override fun loadRecord(key: String, cacheHeaders: CacheHeaders): Record? {
     val evictAfterRead = cacheHeaders.hasHeader(EVICT_AFTER_READ)
-    return maybeTransaction(evictAfterRead) {
-      try {
-        recordDatabase.select(key)
-      } catch (e: Exception) {
-        // Unable to read the record from the database, it is possibly corrupted - treat this as a cache miss
-        apolloExceptionHandler(Exception("Unable to read a record from the database", e))
-        null
-      }?.also {
-        if (evictAfterRead) {
-          recordDatabase.delete(key)
+    return lockWrite {
+      maybeTransaction(evictAfterRead) {
+        try {
+          recordDatabase.select(key)
+        } catch (e: Exception) {
+          // Unable to read the record from the database, it is possibly corrupted - treat this as a cache miss
+          apolloExceptionHandler(Exception("Unable to read a record from the database", e))
+          null
+        }?.also {
+          if (evictAfterRead) {
+            recordDatabase.delete(key)
+          }
         }
-      }
-    } ?: nextCache?.loadRecord(key, cacheHeaders)
+      } ?: nextCache?.loadRecord(key, cacheHeaders)
+    }
   }
 
   override fun loadRecords(keys: Collection<String>, cacheHeaders: CacheHeaders): Collection<Record> {
     val evictAfterRead = cacheHeaders.hasHeader(EVICT_AFTER_READ)
-    val records = maybeTransaction(evictAfterRead) {
-      try {
-        internalGetRecords(keys)
-      } catch (e: Exception) {
-        // Unable to read the records from the database, it is possibly corrupted - treat this as a cache miss
-        apolloExceptionHandler(Exception("Unable to read records from the database", e))
-        emptyList()
-      }.also {
-        if (evictAfterRead) {
-          it.forEach { record ->
-            recordDatabase.delete(record.key)
+    return lockWrite {
+      val records = maybeTransaction(evictAfterRead) {
+        try {
+          internalGetRecords(keys)
+        } catch (e: Exception) {
+          // Unable to read the records from the database, it is possibly corrupted - treat this as a cache miss
+          apolloExceptionHandler(Exception("Unable to read records from the database", e))
+          emptyList()
+        }.also {
+          if (evictAfterRead) {
+            it.forEach { record ->
+              recordDatabase.delete(record.key)
+            }
           }
         }
       }
+      val missRecordKeys = keys - records.map { it.key }.toSet()
+      val missRecords = missRecordKeys.ifEmpty { null }?.let { nextCache?.loadRecords(it, cacheHeaders) }.orEmpty()
+      records + missRecords
     }
-    val missRecordKeys = keys - records.map { it.key }.toSet()
-    val missRecords = missRecordKeys.ifEmpty { null }?.let { nextCache?.loadRecords(it, cacheHeaders) }.orEmpty()
-    return records + missRecords
   }
 
   override fun clearAll() {
-    nextCache?.clearAll()
-    recordDatabase.deleteAll()
+    lockWrite {
+      nextCache?.clearAll()
+      recordDatabase.deleteAll()
+    }
   }
 
   override fun remove(cacheKey: CacheKey, cascade: Boolean): Boolean {
-    val selfRemoved = recordDatabase.transaction {
-      internalDeleteRecord(
-          key = cacheKey.key,
-          cascade = cascade,
-      )
+    return lockWrite {
+      val selfRemoved = recordDatabase.transaction {
+        internalDeleteRecord(
+            key = cacheKey.key,
+            cascade = cascade,
+        )
+      }
+      val chainRemoved = nextCache?.remove(cacheKey, cascade) ?: false
+      selfRemoved || chainRemoved
     }
-    val chainRemoved = nextCache?.remove(cacheKey, cascade) ?: false
-    return selfRemoved || chainRemoved
   }
 
   override fun remove(pattern: String): Int {
-    var selfRemoved = 0
-    recordDatabase.transaction {
-      recordDatabase.deleteMatching(pattern)
-      selfRemoved = recordDatabase.changes().toInt()
-    }
-    val chainRemoved = nextCache?.remove(pattern) ?: 0
+    return lockWrite {
+      var selfRemoved = 0
+      recordDatabase.transaction {
+        recordDatabase.deleteMatching(pattern)
+        selfRemoved = recordDatabase.changes().toInt()
+      }
+      val chainRemoved = nextCache?.remove(pattern) ?: 0
 
-    return selfRemoved + chainRemoved
+      selfRemoved + chainRemoved
+    }
   }
 
   private fun CacheHeaders.date(): Long? {
@@ -109,12 +132,14 @@ class SqlNormalizedCache internal constructor(
     if (cacheHeaders.hasHeader(ApolloCacheHeaders.DO_NOT_STORE)) {
       return emptySet()
     }
-    return try {
-      internalUpdateRecord(record = record, recordMerger = recordMerger, date = cacheHeaders.date()) + nextCache?.merge(record, cacheHeaders).orEmpty()
-    } catch (e: Exception) {
-      // Unable to merge the record in the database, it is possibly corrupted - treat this as a cache miss
-      apolloExceptionHandler(Exception("Unable to merge a record from the database", e))
-      emptySet()
+    return lockWrite {
+      try {
+        internalUpdateRecord(record = record, recordMerger = recordMerger, date = cacheHeaders.date())
+      } catch (e: Exception) {
+        // Unable to merge the record in the database, it is possibly corrupted - treat this as a cache miss
+        apolloExceptionHandler(Exception("Unable to merge a record from the database", e))
+        emptySet()
+      } + nextCache?.merge(record, cacheHeaders).orEmpty()
     }
   }
 
@@ -123,19 +148,21 @@ class SqlNormalizedCache internal constructor(
     if (cacheHeaders.hasHeader(ApolloCacheHeaders.DO_NOT_STORE)) {
       return emptySet()
     }
-    return try {
-      internalUpdateRecords(records = records, recordMerger = recordMerger, date = cacheHeaders.date()) + nextCache?.merge(records, cacheHeaders).orEmpty()
-    } catch (e: Exception) {
-      // Unable to merge the records in the database, it is possibly corrupted - treat this as a cache miss
-      apolloExceptionHandler(Exception("Unable to merge records from the database", e))
-      emptySet()
+    return lockWrite {
+      try {
+        internalUpdateRecords(records = records, recordMerger = recordMerger, date = cacheHeaders.date())
+      } catch (e: Exception) {
+        // Unable to merge the records in the database, it is possibly corrupted - treat this as a cache miss
+        apolloExceptionHandler(Exception("Unable to merge records from the database", e))
+        emptySet()
+      } + nextCache?.merge(records, cacheHeaders).orEmpty()
     }
   }
 
   override fun dump(): Map<KClass<*>, Map<String, Record>> {
-    return mapOf(
-        this@SqlNormalizedCache::class to recordDatabase.selectAll().associateBy { it.key }
-    ) + nextCache?.dump().orEmpty()
+    return lockRead {
+      mapOf(this::class to recordDatabase.selectAll().associateBy { it.key }) + nextCache?.dump().orEmpty()
+    }
   }
 
   /**


### PR DESCRIPTION
The idea: instead of having a lock in `ApolloStore`, let caches handle their own locking, in the hope that this would reduce overall contention (see #4605).

Things to note:
- Each cache still uses a lock to at least ensure consistency between the different caches in the chain
- The access to SQLite appears to be guarded by a lock on its own, so no locking is needed in general. A lock is still used only in case there is a `nextCache`
- In the MemoryCache, the lock guards writes to the LRUCache and access to the next cache
- In incubating only

Added micro-benchmarks that start a few threads performing read and writes through ApolloStore in parallel (memory / sql / memory then sql).

It _looks like_ the bench performance is improved when comparing the results before/after the change (avg of 6 runs on a Samsung S10+):

|             | Memory     | Sql         | Memory then sql |
|-------------|------------|-------------|-----------------|
| Before      | 50,565,308 | 801,852,416 | 1,182,789,288   |
| After       | 45,090,843 | 708,763,083 | 900,559,012     |
| Improvement | 10.8%      | 11.6&       | 23.9%           |


### A few flame charts

Memory, before:
<img width="640" alt="incubating-before-10-100-memory" src="https://github.com/apollographql/apollo-kotlin/assets/372852/6ee53284-7bb0-4f35-9f41-5a24c5e92b1a">

Memory, after:
<img width="640" alt="incubating-after-10-100-memory" src="https://github.com/apollographql/apollo-kotlin/assets/372852/ec5d22db-719c-43ab-a79a-e8dfa4c7c7fe">


Sql, before:
<img width="640" alt="incubating-before-10-100-sql" src="https://github.com/apollographql/apollo-kotlin/assets/372852/5aff3040-aba6-4109-be17-6ef799cc5598">


Sql, after:
<img width="640" alt="incubating-after-10-100-sql" src="https://github.com/apollographql/apollo-kotlin/assets/372852/e1b40e98-ab44-4adb-a878-c23bb5930764">
