### PR TITLE
Keep rx-support as DeprecationLevel.Error

### DIFF
--- a/libraries/apollo-rx2-support/api/apollo-rx2-support.api
+++ b/libraries/apollo-rx2-support/api/apollo-rx2-support.api
@@ -1,0 +1,24 @@
+public final class com/apollographql/apollo3/rx2/Rx2Apollo {
+	public static final field Companion Lcom/apollographql/apollo3/rx2/Rx2Apollo$Companion;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+}
+
+public final class com/apollographql/apollo3/rx2/Rx2Apollo$Companion {
+	public final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Flowable;
+	public final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/rx2/Rx2Apollo$Companion;Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
+	public final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/Single;
+	public final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/rx2/Rx2Apollo$Companion;Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
+}
+
+public final class com/apollographql/apollo3/rx2/_Rx2ExtensionsKt {
+	public static final synthetic fun rxFlowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Flowable;
+	public static synthetic fun rxFlowable$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Flowable;
+	public static final synthetic fun rxSingle (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;)Lio/reactivex/Single;
+	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/Scheduler;ILjava/lang/Object;)Lio/reactivex/Single;
+}
+

--- a/libraries/apollo-rx2-support/build.gradle.kts
+++ b/libraries/apollo-rx2-support/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
+
+apolloLibrary(javaModuleName = "com.apollographql.apollo3.rx2")
+
+dependencies {
+  implementation(project(":apollo-api"))
+  api(libs.rx.java2)
+  api(libs.kotlinx.coroutines.rx2)
+
+  api(project(":apollo-runtime"))
+  api(project(":apollo-normalized-cache"))
+}

--- a/libraries/apollo-rx2-support/gradle.properties
+++ b/libraries/apollo-rx2-support/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=apollo-rx2-support
+POM_NAME=Apollo GraphQL Rx2 Support
+POM_DESCRIPTION=Apollo GraphQL RxJava2 bindings
+POM_PACKAGING=jar

--- a/libraries/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/-Rx2Extensions.kt
+++ b/libraries/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/-Rx2Extensions.kt
@@ -1,0 +1,29 @@
+package com.apollographql.apollo3.rx2
+
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import io.reactivex.Flowable
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.annotations.CheckReturnValue
+import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.rx2.asCoroutineDispatcher
+import kotlinx.coroutines.rx2.asFlowable
+
+@JvmSynthetic
+@CheckReturnValue
+@Deprecated("use kotlinx-coroutines-rx2 directly", ReplaceWith("toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+fun <D: Operation.Data> ApolloCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()): Single<ApolloResponse<D>>{
+  return toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()
+}
+
+@JvmSynthetic
+@CheckReturnValue
+@Deprecated("use kotlinx-coroutines-rx2 directly", ReplaceWith("toFlow().asFlowable(scheduler.asCoroutineDispatcher()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+fun <D: Operation.Data> ApolloCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()): Flowable<ApolloResponse<D>> {
+  return toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+}

--- a/libraries/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/Rx2Apollo.kt
+++ b/libraries/apollo-rx2-support/src/main/java/com/apollographql/apollo3/rx2/Rx2Apollo.kt
@@ -1,0 +1,39 @@
+package com.apollographql.apollo3.rx2
+
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import io.reactivex.Flowable
+import io.reactivex.Scheduler
+import io.reactivex.Single
+import io.reactivex.annotations.CheckReturnValue
+import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.rx2.asCoroutineDispatcher
+import kotlinx.coroutines.rx2.asFlowable
+
+class Rx2Apollo private constructor() {
+  init {
+    throw AssertionError("This class cannot be instantiated")
+  }
+
+  companion object {
+    @JvmStatic
+    @CheckReturnValue
+    @JvmOverloads
+    @Deprecated("use kotlinx-coroutines-rx2 directly", ReplaceWith("call.toFlow().asFlowable(scheduler.asCoroutineDispatcher())"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+    fun <D : Operation.Data> flowable(call: ApolloCall<D>, scheduler: Scheduler = Schedulers.io()): Flowable<ApolloResponse<D>> {
+      return call.toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+    }
+
+    @JvmStatic
+    @CheckReturnValue
+    @JvmOverloads
+    @Deprecated("use kotlinx-coroutines-rx2 directly", ReplaceWith("call.toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+    fun <D : Operation.Data> single(call: ApolloCall<D>, scheduler: Scheduler = Schedulers.io()): Single<ApolloResponse<D>> {
+      return call.toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()
+    }
+  }
+}

--- a/libraries/apollo-rx3-support/api/apollo-rx3-support.api
+++ b/libraries/apollo-rx3-support/api/apollo-rx3-support.api
@@ -1,0 +1,24 @@
+public final class com/apollographql/apollo3/rx3/Rx3Apollo {
+	public static final field Companion Lcom/apollographql/apollo3/rx3/Rx3Apollo$Companion;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Single;
+	public static final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+}
+
+public final class com/apollographql/apollo3/rx3/Rx3Apollo$Companion {
+	public final fun flowable (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Flowable;
+	public final fun flowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
+	public static synthetic fun flowable$default (Lcom/apollographql/apollo3/rx3/Rx3Apollo$Companion;Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
+	public final fun single (Lcom/apollographql/apollo3/ApolloCall;)Lio/reactivex/rxjava3/core/Single;
+	public final fun single (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+	public static synthetic fun single$default (Lcom/apollographql/apollo3/rx3/Rx3Apollo$Companion;Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+}
+
+public final class com/apollographql/apollo3/rx3/_Rx3ExtensionsKt {
+	public static final synthetic fun rxFlowable (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Flowable;
+	public static synthetic fun rxFlowable$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Flowable;
+	public static final synthetic fun rxSingle (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;)Lio/reactivex/rxjava3/core/Single;
+	public static synthetic fun rxSingle$default (Lcom/apollographql/apollo3/ApolloCall;Lio/reactivex/rxjava3/core/Scheduler;ILjava/lang/Object;)Lio/reactivex/rxjava3/core/Single;
+}
+

--- a/libraries/apollo-rx3-support/build.gradle.kts
+++ b/libraries/apollo-rx3-support/build.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+ */
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
+
+apolloLibrary(javaModuleName = "com.apollographql.apollo3.rx3")
+
+dependencies {
+  implementation(project(":apollo-api"))
+  api(libs.rx.java3)
+  api(libs.kotlinx.coroutines.rx3)
+
+  api(project(":apollo-runtime"))
+  api(project(":apollo-normalized-cache"))
+}

--- a/libraries/apollo-rx3-support/gradle.properties
+++ b/libraries/apollo-rx3-support/gradle.properties
@@ -1,0 +1,7 @@
+#
+# This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+#
+POM_ARTIFACT_ID=apollo-rx3-support
+POM_NAME=Apollo GraphQL Rx3 Support
+POM_DESCRIPTION=Apollo GraphQL RxJava3 bindings
+POM_PACKAGING=jar

--- a/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/-Rx3Extensions.kt
+++ b/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/-Rx3Extensions.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+ */
+package com.apollographql.apollo3.rx3
+
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import io.reactivex.rxjava3.annotations.CheckReturnValue
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.rx3.asCoroutineDispatcher
+import kotlinx.coroutines.rx3.asFlowable
+
+@JvmSynthetic
+@CheckReturnValue
+@Deprecated("use kotlinx-coroutines-rx3 directly", ReplaceWith("toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+fun <D: Operation.Data> ApolloCall<D>.rxSingle(scheduler: Scheduler = Schedulers.io()): Single<ApolloResponse<D>>{
+  return toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()
+}
+
+@JvmSynthetic
+@CheckReturnValue
+@Deprecated("use kotlinx-coroutines-rx3 directly", ReplaceWith("toFlow.asFlowable(scheduler.asCoroutineDispatcher())"), level = DeprecationLevel.ERROR)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+fun <D: Operation.Data> ApolloCall<D>.rxFlowable(scheduler: Scheduler = Schedulers.io()): Flowable<ApolloResponse<D>> {
+  return toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+}
+

--- a/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/Rx3Apollo.kt
+++ b/libraries/apollo-rx3-support/src/main/java/com/apollographql/apollo3/rx3/Rx3Apollo.kt
@@ -1,0 +1,42 @@
+/*
+ * This file is auto generated from apollo-rx2-support by rxjava3.main.kts, do not edit manually.
+ */
+package com.apollographql.apollo3.rx3
+
+import com.apollographql.apollo3.ApolloCall
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import io.reactivex.rxjava3.annotations.CheckReturnValue
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Scheduler
+import io.reactivex.rxjava3.core.Single
+import io.reactivex.rxjava3.schedulers.Schedulers
+import kotlinx.coroutines.rx3.asCoroutineDispatcher
+import kotlinx.coroutines.rx3.asFlowable
+
+class Rx3Apollo private constructor() {
+  init {
+    throw AssertionError("This class cannot be instantiated")
+  }
+
+  companion object {
+    @JvmStatic
+    @CheckReturnValue
+    @JvmOverloads
+    @Deprecated("use kotlinx-coroutines-rx3 directly", ReplaceWith("call.toFlow().asFlowable(scheduler.asCoroutineDispatcher())"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+    fun <D : Operation.Data> flowable(call: ApolloCall<D>, scheduler: Scheduler = Schedulers.io()): Flowable<ApolloResponse<D>> {
+      return call.toFlow().asFlowable(scheduler.asCoroutineDispatcher())
+    }
+
+    @JvmStatic
+    @CheckReturnValue
+    @JvmOverloads
+    @Deprecated("use kotlinx-coroutines-rx3 directly", ReplaceWith("call.toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()"), level = DeprecationLevel.ERROR)
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+    fun <D : Operation.Data> single(call: ApolloCall<D>, scheduler: Scheduler = Schedulers.io()): Single<ApolloResponse<D>> {
+      return call.toFlow().asFlowable(scheduler.asCoroutineDispatcher()).firstOrError()
+    }
+  }
+}


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/issues/5609, keep the symbols around until the next major to help with the migration