### PR TITLE
Add README for Rx support modules

### DIFF
--- a/libraries/apollo-rx2-support/README.md
+++ b/libraries/apollo-rx2-support/README.md
@@ -1,0 +1,4 @@
+# Module apollo-rx3-support
+
+Provides thin wrappers around [`kotlinx-coroutines-rx3`](https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx3).
+Since v4, this module is deprecated and will be removed in a future version.

--- a/libraries/apollo-rx3-support/README.md
+++ b/libraries/apollo-rx3-support/README.md
@@ -1,0 +1,4 @@
+# Module apollo-rx2-support
+
+Provides thin wrappers around [`kotlinx-coroutines-rx2`](https://github.com/Kotlin/kotlinx.coroutines/tree/master/reactive/kotlinx-coroutines-rx2).
+Since v4, this module is deprecated and will be removed in a future version.


### PR DESCRIPTION
Should fix [failing](https://github.com/apollographql/apollo-kotlin/actions/runs/7843110164/job/21402732754) `dokkatooGenerateModuleHtml`.