### PR TITLE
[infra] Unbreak dokkatoo

### DIFF
--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -99,6 +99,12 @@ fun Project.configureDokkaAggregate() {
   dependencies.add(
       "dokkatooPluginHtml",
       dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
+        "org.jetbrains.dokka:all-modules-page-plugin:$dokkaVersion"
+      }
+  )
+  dependencies.add(
+      "dokkatooPluginHtml",
+      dokkatoo.versions.jetbrainsDokka.map { dokkaVersion ->
         "org.jetbrains.dokka:versioning-plugin:$dokkaVersion"
       }
   )

--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -81,7 +81,8 @@ if (relocateJar) {
     configurations.named("testImplementation").configure {
       extendsFrom(shadeConfiguration)
     }
-    replaceOutgoingJar(shadowedJar)
+
+    replaceOutgoingJar2(shadowedJar)
   }
 } else {
   configurations.named("implementation").configure {
@@ -89,6 +90,22 @@ if (relocateJar) {
   }
 }
 
+fun replaceOutgoingJar2(newJar: Any) {
+  project.configurations.configureEach {
+    outgoing {
+      val removed = artifacts.removeIf {
+        it.name == "apollo-gradle-plugin" && it.type == "jar" && it.classifier.isNullOrEmpty()
+      }
+      if (removed) {
+
+        artifact(newJar) {
+          // Pom and maven consumers do not like the `-all` or `-shadowed` classifiers
+          classifier = ""
+        }
+      }
+    }
+  }
+}
 
 gradlePlugin {
   website.set("https://github.com/apollographql/apollo-kotlin")


### PR DESCRIPTION
Our Gradle plugin relocation was overwriting the dokka artifacts, making [publication fail in CI](https://github.com/apollographql/apollo-kotlin/actions/runs/7884352283/job/21521863149)