### PR TITLE
[compiler] Add support for @catch on fieldDefinitions, interfaces and objects

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -67,6 +67,8 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
+      <option name="CALL_PARAMETERS_WRAP" value="0" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="false" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloMissingGraphQLDefinitionImport.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloMissingGraphQLDefinitionImport.html
@@ -4,11 +4,11 @@ Reports usages of types and directives that are not imported or imported implici
 <p>
     Before being referenced, directives and types supported by Apollo Kotlin must be imported by your schema using the <code>@link</code> directive<br>.
     For instance, to use the <code>@semanticNonNull</code> directive, import it from the
-    <a href="https://specs.apollo.dev/nullability/v0.2"><code>nullability</code></a> definitions:
+    <a href="https://specs.apollo.dev/nullability/v0.3"><code>nullability</code></a> definitions:
 <pre>
         extend schema
         @link(
-          url: "https://specs.apollo.dev/nullability/v0.2",
+          url: "https://specs.apollo.dev/nullability/v0.3",
           import: ["@semanticNonNull"]
         )
     </pre>

--- a/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-CatchTo-extra.graphqls
+++ b/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-CatchTo-extra.graphqls
@@ -1,5 +1,5 @@
 extend schema
 @link(
-  url: "https://specs.apollo.dev/nullability/v0.2",
+  url: "https://specs.apollo.dev/nullability/v0.3",
   import: ["@catch"]
 )

--- a/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-CatchTo-extra_after.graphqls
+++ b/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-CatchTo-extra_after.graphqls
@@ -1,5 +1,5 @@
 extend schema
 @link(
-  url: "https://specs.apollo.dev/nullability/v0.2",
+  url: "https://specs.apollo.dev/nullability/v0.3",
   import: ["@catch", "CatchTo"]
 )

--- a/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-catch-extra_after.graphqls
+++ b/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-catch-extra_after.graphqls
@@ -1,5 +1,5 @@
 extend schema
 @link(
-  url: "https://specs.apollo.dev/nullability/v0.2",
+  url: "https://specs.apollo.dev/nullability/v0.3",
   import: ["@catch", "CatchTo"]
 )

--- a/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-targetName-extra.graphqls
+++ b/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-targetName-extra.graphqls
@@ -1,6 +1,6 @@
 extend schema
 @link(
-  url: "https://specs.apollo.dev/nullability/v0.2",
+  url: "https://specs.apollo.dev/nullability/v0.3",
   import: ["@catch", "CatchTo"]
 )
 

--- a/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-targetName-extra_after.graphqls
+++ b/intellij-plugin/src/test/testData/inspection/MissingGraphQLDefinitionImport/missing-targetName-extra_after.graphqls
@@ -6,7 +6,7 @@ extend schema
 
 extend schema
 @link(
-  url: "https://specs.apollo.dev/nullability/v0.2",
+  url: "https://specs.apollo.dev/nullability/v0.3",
   import: ["@catch", "CatchTo"]
 )
 

--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -931,6 +931,7 @@ public final class com/apollographql/apollo3/ast/ReservedEnumValueName : com/apo
 
 public final class com/apollographql/apollo3/ast/Schema {
 	public static final field CATCH Ljava/lang/String;
+	public static final field CATCH_FIELD Ljava/lang/String;
 	public static final field Companion Lcom/apollographql/apollo3/ast/Schema$Companion;
 	public static final field FIELD_POLICY Ljava/lang/String;
 	public static final field FIELD_POLICY_FOR_FIELD Ljava/lang/String;

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/Schema.kt
@@ -210,6 +210,8 @@ class Schema internal constructor(
     @ApolloExperimental
     const val CATCH = "catch"
     @ApolloExperimental
+    const val CATCH_FIELD = "catchField"
+    @ApolloExperimental
     const val SEMANTIC_NON_NULL = "semanticNonNull"
     @ApolloExperimental
     const val SEMANTIC_NON_NULL_FIELD = "semanticNonNullField"

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/gqldocument.kt
@@ -92,7 +92,7 @@ fun kotlinLabsDefinitions(version: String): List<GQLDefinition> {
   })
 }
 
-@ApolloInternal const val NULLABILITY_VERSION = "v0.2"
+@ApolloInternal const val NULLABILITY_VERSION = "v0.3"
 
 /**
  * Extra nullability definitions from https://specs.apollo.dev/nullability/<[version]>

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExecutableValidationScope.kt
@@ -501,8 +501,10 @@ internal class ExecutableValidationScope(
     val fieldA = fieldWithParentA.field
     val fieldB = fieldWithParentB.field
 
-    val typeA = fieldA.definitionFromScope(schema, parentTypeDefinitionA)?.type
-    val typeB = fieldB.definitionFromScope(schema, parentTypeDefinitionB)?.type
+    val fieldDefinitionA = fieldA.definitionFromScope(schema, parentTypeDefinitionA)
+    val fieldDefinitionB = fieldB.definitionFromScope(schema, parentTypeDefinitionB)
+    val typeA = fieldDefinitionA?.type
+    val typeB = fieldDefinitionB?.type
     if (typeA == null || typeB == null) {
       // will be caught by other validation rules
       return
@@ -512,7 +514,7 @@ internal class ExecutableValidationScope(
       addFieldMergingIssue(fieldWithParentA.field, fieldWithParentB.field, "they have different types")
       return
     }
-    if (hasCatch && !areCatchesEqual(fieldA.directives.findCatch(schema), fieldB.directives.findCatch(schema))) {
+    if (hasCatch && !areCatchesEqual(fieldA.findCatch(fieldDefinitionA, schema), fieldB.findCatch(fieldDefinitionB, schema))) {
       addFieldMergingIssue(fieldWithParentA.field, fieldWithParentB.field, "they have different `@catch` directives")
       return
     }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
@@ -341,12 +341,7 @@ private fun ExtensionsMerger.mergeFields(
       }
 
       if (!newFieldDefinition.type.isCompatibleWith(existingFieldDefinition.type)) {
-        issues.add(
-            OtherValidationIssue(
-                "Cannot merge field directives`${newFieldDefinition.name}`: its type is not compatible with the original type`",
-                newFieldDefinition.sourceLocation
-            )
-        )
+        issues.add(OtherValidationIssue("Cannot merge field directives`${newFieldDefinition.name}`: its type is not compatible with the original type`", newFieldDefinition.sourceLocation))
         return@forEach
       }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
@@ -57,54 +57,13 @@ internal class ExtensionsMerger(private val definitions: List<GQLDefinition>, in
       when (definition) {
         is GQLTypeSystemExtension -> {
           when (definition) {
-            is GQLSchemaExtension -> mergeTypedDefinition(
-                GQLSchemaDefinition::class,
-                newDefinitions,
-                definition,
-                "schema"
-            ) { mergeSchema(it, definition) }
-
-            is GQLScalarTypeExtension -> mergeNamedDefinition(
-                GQLScalarTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "scalar"
-            ) { mergeScalar(it, definition) }
-
-            is GQLInterfaceTypeExtension -> mergeNamedDefinition(
-                GQLInterfaceTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "interface"
-            ) { mergeInterface(it, definition) }
-
-            is GQLObjectTypeExtension -> mergeNamedDefinition(
-                GQLObjectTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "object"
-            ) { mergeObject(it, definition) }
-
-            is GQLInputObjectTypeExtension -> mergeNamedDefinition(
-                GQLInputObjectTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "input"
-            ) { mergeInputObject(it, definition) }
-
-            is GQLEnumTypeExtension -> mergeNamedDefinition(
-                GQLEnumTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "enum"
-            ) { mergeEnum(it, definition) }
-
-            is GQLUnionTypeExtension -> mergeNamedDefinition(
-                GQLUnionTypeDefinition::class,
-                newDefinitions,
-                definition,
-                "union"
-            ) { mergeUnion(it, definition) }
+            is GQLSchemaExtension -> mergeTypedDefinition(GQLSchemaDefinition::class, newDefinitions, definition, "schema") { mergeSchema(it, definition) }
+            is GQLScalarTypeExtension -> mergeNamedDefinition(GQLScalarTypeDefinition::class, newDefinitions, definition, "scalar") { mergeScalar(it, definition) }
+            is GQLInterfaceTypeExtension -> mergeNamedDefinition(GQLInterfaceTypeDefinition::class, newDefinitions, definition, "interface") { mergeInterface(it, definition) }
+            is GQLObjectTypeExtension -> mergeNamedDefinition(GQLObjectTypeDefinition::class, newDefinitions, definition, "object") { mergeObject(it, definition) }
+            is GQLInputObjectTypeExtension -> mergeNamedDefinition(GQLInputObjectTypeDefinition::class, newDefinitions, definition, "input") { mergeInputObject(it, definition) }
+            is GQLEnumTypeExtension -> mergeNamedDefinition(GQLEnumTypeDefinition::class, newDefinitions, definition, "enum") { mergeEnum(it, definition) }
+            is GQLUnionTypeExtension -> mergeNamedDefinition(GQLUnionTypeDefinition::class, newDefinitions, definition, "union") { mergeUnion(it, definition) }
           }
         }
 
@@ -357,7 +316,7 @@ private fun ExtensionsMerger.mergeUniqueInterfacesOrThrow(
 private fun ExtensionsMerger.mergeFields(
     list: List<GQLFieldDefinition>,
     others: List<GQLFieldDefinition>,
-    extraDirectives: Map<String, List<GQLDirective>> = emptyMap()
+    extraDirectives: Map<String, List<GQLDirective>> = emptyMap(),
 ): List<GQLFieldDefinition> {
 
   val result = list.toMutableList()
@@ -414,7 +373,7 @@ private fun ExtensionsMerger.mergeFields(
   }
 
   return result.map {
-    it.copy(directives = mergeDirectives(it.directives,  extraDirectives.get(it.name).orEmpty()))
+    it.copy(directives = mergeDirectives(it.directives, extraDirectives.get(it.name).orEmpty()))
   }
 }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/ExtensionsMerger.kt
@@ -210,10 +210,7 @@ private fun ExtensionsMerger.mergeSchema(
 ): GQLSchemaDefinition = with(schemaDefinition) {
   return copy(
       directives = mergeDirectives(directives, extension.directives),
-      rootOperationTypeDefinitions = mergeUniquesOrThrow(
-          rootOperationTypeDefinitions,
-          extension.operationTypeDefinitions
-      ) { it.operationType }
+      rootOperationTypeDefinitions = mergeUniquesOrThrow(rootOperationTypeDefinitions, extension.operationTypeDefinitions) { it.operationType }
   )
 }
 
@@ -329,32 +326,17 @@ private fun ExtensionsMerger.mergeFields(
     } else {
       val existingFieldDefinition = result[index]
       if (!mergeOptions.allowFieldNullabilityModification) {
-        issues.add(
-            OtherValidationIssue(
-                "There is already a field definition named `${newFieldDefinition.name}` for this type",
-                newFieldDefinition.sourceLocation
-            )
-        )
+        issues.add(OtherValidationIssue("There is already a field definition named `${newFieldDefinition.name}` for this type", newFieldDefinition.sourceLocation))
         return@forEach
       }
 
       if (!areEqual(newFieldDefinition.arguments, existingFieldDefinition.arguments)) {
-        issues.add(
-            OtherValidationIssue(
-                "Cannot merge field definition `${newFieldDefinition.name}`: its arguments do not match the arguments of the original field definition",
-                newFieldDefinition.sourceLocation
-            )
-        )
+        issues.add(OtherValidationIssue("Cannot merge field definition `${newFieldDefinition.name}`: its arguments do not match the arguments of the original field definition", newFieldDefinition.sourceLocation))
         return@forEach
       }
 
       if (newFieldDefinition.directives.isNotEmpty()) {
-        issues.add(
-            OtherValidationIssue(
-                "Cannot add directives to existing field definition `${newFieldDefinition.name}`",
-                newFieldDefinition.sourceLocation
-            )
-        )
+        issues.add(OtherValidationIssue("Cannot add directives to existing field definition `${newFieldDefinition.name}`", newFieldDefinition.sourceLocation))
         return@forEach
       }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/definitions.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo3/ast/internal/definitions.kt
@@ -350,7 +350,22 @@ Passing a negative level or a level greater than the list dimension is an error.
 
 See `CatchTo` for more details.
 ""${'"'}
-directive @catch(to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD | SCHEMA
+directive @catch(to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD | FIELD_DEFINITION | SCHEMA
+
+""${'"'}
+Indicates how clients should handle errors on a given position.
+
+`@catchField` is the same as `@catch` but can be used on type system extensions for services
+that do not own the schema like client services:
+
+```graphql
+# extend the schema to catch User.email to `RESULT`.
+extend type User @catchField(name: "email", to: RESULT)
+```
+
+See `@catch`.
+""${'"'}
+directive @catchField(to: CatchTo! = RESULT, levels: [Int] = [0]) repeatable on INTERFACE | OBJECT
 
 enum CatchTo {
     ""${'"'}

--- a/libraries/apollo-compiler/src/test/validation/operation/catch/schema.graphqls
+++ b/libraries/apollo-compiler/src/test/validation/operation/catch/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/nullability/v0.2", import: ["@semanticNonNull", "@catch", "CatchTo"])
+extend schema @link(url: "https://specs.apollo.dev/nullability/v0.3", import: ["@semanticNonNull", "@catch", "CatchTo"])
 
 extend schema @catch(to: THROW)
 

--- a/libraries/apollo-compiler/src/test/validation/schema/unexpected-definitions.expected
+++ b/libraries/apollo-compiler/src/test/validation/schema/unexpected-definitions.expected
@@ -1,5 +1,5 @@
 IncompatibleDefinition (2:1)
-Unexpected 'catch' definition. Expecting 'directive @catch (to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD|SCHEMA'.
+Unexpected 'catch' definition. Expecting 'directive @catch (to: CatchTo! = RESULT, levels: [Int] = [0]) on FIELD|FIELD_DEFINITION|SCHEMA'.
 ------------
 IncompatibleDefinition (3:1)
 Unexpected 'CatchTo' definition. Expecting 'enum CatchTo { RESULT NULL THROW }'.

--- a/tests/catch/build.gradle.kts
+++ b/tests/catch/build.gradle.kts
@@ -29,4 +29,9 @@ apollo {
     srcDir("src/main/graphql/result")
     packageName.set("result")
   }
+  service("extensions") {
+    srcDir("src/main/graphql/shared")
+    srcDir("src/main/graphql/extensions")
+    packageName.set("extensions")
+  }
 }

--- a/tests/catch/src/main/graphql/extensions/extra.graphqls
+++ b/tests/catch/src/main/graphql/extensions/extra.graphqls
@@ -1,0 +1,5 @@
+extend schema @catch(to: RESULT)
+
+extend type Query
+@catchField(name: "nullable", to: RESULT)
+@catchField(name: "list", to: RESULT, levels: [1])

--- a/tests/catch/src/main/graphql/extensions/operations.graphql
+++ b/tests/catch/src/main/graphql/extensions/operations.graphql
@@ -1,0 +1,8 @@
+
+query ExtensionsNullable {
+  nullable
+}
+
+query ExtensionsList {
+  list
+}

--- a/tests/catch/src/main/graphql/shared/schema.graphqls
+++ b/tests/catch/src/main/graphql/shared/schema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/nullability/v0.2", import: ["@semanticNonNullField", "@semanticNonNull", "@catch", "CatchTo", "@ignoreErrors"])
+extend schema @link(url: "https://specs.apollo.dev/nullability/v0.3", import: ["@semanticNonNullField", "@semanticNonNull", "@catch", "CatchTo", "@ignoreErrors"])
 
 type Query {
   nullable: Int

--- a/tests/catch/src/test/kotlin/test/ExtensionsTest.kt
+++ b/tests/catch/src/test/kotlin/test/ExtensionsTest.kt
@@ -1,0 +1,53 @@
+package test
+
+import com.apollographql.apollo3.api.graphQLErrorOrNull
+import extensions.ExtensionsListQuery
+import extensions.ExtensionsNullableQuery
+import junit.framework.TestCase.assertTrue
+import org.intellij.lang.annotations.Language
+import kotlin.test.Test
+import kotlin.test.assertNull
+
+class ExtensionsTest {
+  @Test
+  fun scalarCatchToExtension() {
+    @Language("json")
+    val jsonResponse = """
+    {
+      "errors": [
+         { "path": ["nullable"], "message": "resolve error" }   
+      ], 
+      "data": {
+        "nullable": null
+      }
+    }
+  """.trimIndent()
+
+    ExtensionsNullableQuery().parseResponse(jsonResponse).apply {
+      // List items are non-null
+      assertTrue(data!!.nullable.graphQLErrorOrNull()?.message?.contains("resolve error") == true)
+      assertNull(exception)
+    }
+  }
+
+  @Test
+  fun listCatchToExtension() {
+    @Language("json")
+    val jsonResponse = """
+    {
+      "errors": [
+         { "path": ["list", 0], "message": "resolve error" }   
+      ], 
+      "data": {
+        "list": [null]
+      }
+    }
+  """.trimIndent()
+
+    ExtensionsListQuery().parseResponse(jsonResponse).apply {
+      // List items are non-null
+      assertTrue(data!!.list?.get(0)?.graphQLErrorOrNull()?.message?.contains("resolve error") == true)
+      assertNull(exception)
+    }
+  }
+}


### PR DESCRIPTION
Implementation of https://github.com/apollographql/specs/pull/48
See https://github.com/apollographql/specs/issues/47

`@catch` can now be set, by order or precedence:

At the schema level

```graphql
// All fields are modeled as FieldResult in Kotlin
extend schema @catch(to: RESULT)
```

At the field definition level

```graphql
type User {
  // email is modeled as FieldResult in Kotlin
  email @catch(to: RESULT)
}

// or if you don't own the schema
extend type User @catchField(name: "email", to: RESULT)
```

At the field level

```graphql
query GetEmail {
  user {
    // email is modeled as FieldResult in Kotlin for this query only
    email @catch(to: RESULT)
  }
}
```

Also took this opportunity to factor in the `@semanticNonNullField` handling in schema merging so that it's done in a central place.
