### PR TITLE
Fix incorrect file name in tutorial documentation step 6

### DIFF
--- a/docs/source/tutorial/06-add-more-info.mdx
+++ b/docs/source/tutorial/06-add-more-info.mdx
@@ -36,7 +36,7 @@ Any GraphQL field can take arguments like `missionPatch` above, and arguments ca
 
 ## Bind the info
 
-In `LaunchListAdapter.kt`, bind the GraphQL data to the mission name, site, and mission patch using Coil's `AsyncImage`:
+In `LaunchList.kt`, bind the GraphQL data to the mission name, site, and mission patch using Coil's `AsyncImage`:
 
 ```kotlin title="app/src/main/java/com/example/rocketreserver/LaunchList.kt"
 @Composable


### PR DESCRIPTION
There is no file called `LaunchListAdapter.kt`. It should be `LaunchList.kt`.