### PR TITLE
[🏃runtime] Allow buildPostBody to write operation extensions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -20,6 +20,7 @@
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="50" />
       <option name="CONTINUATION_INDENT_IN_PARAMETER_LISTS" value="true" />
       <option name="CONTINUATION_INDENT_IN_ARGUMENT_LISTS" value="true" />
+      <option name="CONTINUATION_INDENT_FOR_CHAINED_CALLS" value="true" />
       <option name="CONTINUATION_INDENT_IN_IF_CONDITIONS" value="true" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
     </JetCodeStyleSettings>

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -894,6 +894,7 @@ public final class com/apollographql/apollo3/api/http/DefaultHttpRequestComposer
 public final class com/apollographql/apollo3/api/http/DefaultHttpRequestComposer$Companion {
 	public final fun appendQueryParameters (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
 	public final fun buildParamsMap (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZZ)Lokio/ByteString;
+	public final fun buildPostBody (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/api/http/HttpBody;
 	public final fun buildPostBody (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLjava/lang/String;)Lcom/apollographql/apollo3/api/http/HttpBody;
 	public final fun composePayload (Lcom/apollographql/apollo3/api/ApolloRequest;)Ljava/util/Map;
 	public final fun getHEADER_ACCEPT_NAME ()Ljava/lang/String;

--- a/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
@@ -2,16 +2,16 @@ package test
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.http.ByteStringHttpBody
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
-import com.apollographql.apollo3.api.json.buildJsonByteString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.json.writeObject
-import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.integration.fullstack.LaunchDetailsQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
 import com.apollographql.apollo3.mockserver.enqueueString
@@ -24,51 +24,49 @@ import kotlin.test.assertEquals
 class WithExtensionsHttpRequestComposer(private val serverUrl: String) : HttpRequestComposer {
   override fun <D : Operation.Data> compose(apolloRequest: ApolloRequest<D>): HttpRequest {
 
-    return HttpRequest.Builder(HttpMethod.Post, serverUrl)
+    val request = HttpRequest.Builder(HttpMethod.Post, serverUrl)
         .body(
-            ByteStringHttpBody(
-                "application/json",
-                buildJsonByteString {
-                  writeObject {
-                    name("query")
-                    value(apolloRequest.operation.document())
-                    name("operationName")
-                    value(apolloRequest.operation.name())
-                    name("extensions")
-                    value("extension value")
-                  }
-                }
-            )
+            DefaultHttpRequestComposer.buildPostBody(
+                apolloRequest.operation,
+                apolloRequest.executionContext[CustomScalarAdapters]!!,
+                apolloRequest.operation.document(),
+            ) {
+              name("extensions")
+              writeObject {
+                name("key")
+                value("value")
+              }
+            }
         )
         .build()
+
+    return request
   }
 }
 
 class BodyExtensionsTest {
+  @Suppress("UNCHECKED_CAST")
   @Test
   fun bodyExtensions() = runTest {
     val mockServer = MockServer()
-    val serverUrl = mockServer.url()
 
     val apolloClient = ApolloClient.Builder()
         .networkTransport(
             HttpNetworkTransport.Builder()
-                .httpRequestComposer(WithExtensionsHttpRequestComposer(serverUrl))
+                .httpRequestComposer(WithExtensionsHttpRequestComposer(mockServer.url()))
                 .build()
         )
         .build()
 
     mockServer.enqueueString(statusCode = 500)
-    kotlin.runCatching {
-      apolloClient.query(HeroNameQuery())
-          .execute()
-    }
+    apolloClient.query(LaunchDetailsQuery("42")).execute()
 
     val request = mockServer.awaitRequest()
 
     @Suppress("UNCHECKED_CAST")
     val asMap = Buffer().write(request.body).jsonReader().readAny() as Map<String, Any>
-    assertEquals(asMap["extensions"], "extension value")
+    assertEquals((asMap["extensions"] as Map<String, Any>).get("key"), "value")
+    assertEquals((asMap["variables"] as Map<String, Any>).get("id"), "42")
 
     apolloClient.close()
     mockServer.close()


### PR DESCRIPTION
See #5627

Allow custom `HttpRequestComposer`s to write extensions