### PR TITLE
[3.x backport] Allow buildPostBody to write operation extensions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,7 +7,6 @@
       </value>
     </option>
     <option name="RIGHT_MARGIN" value="140" />
-    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <JavaCodeStyleSettings>
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="50" />
@@ -62,7 +61,6 @@
       </indentOptions>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
       <indentOptions>
         <option name="INDENT_SIZE" value="2" />
         <option name="CONTINUATION_INDENT_SIZE" value="4" />

--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -21,6 +21,7 @@ public final class com/apollographql/apollo3/annotations/ApolloDeprecatedSince$V
 	public static final field v3_6_3 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_7_2 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static final field v3_7_5 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
+	public static final field v3_8_3 Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 	public static fun values ()[Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 }

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloDeprecatedSince.kt
@@ -28,5 +28,6 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v3_6_3,
     v3_7_2,
     v3_7_5,
+    v3_8_3,
   }
 }

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -957,6 +957,7 @@ public final class com/apollographql/apollo3/api/http/DefaultHttpRequestComposer
 public final class com/apollographql/apollo3/api/http/DefaultHttpRequestComposer$Companion {
 	public final fun appendQueryParameters (Ljava/lang/String;Ljava/util/Map;)Ljava/lang/String;
 	public final fun buildParamsMap (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZZ)Lokio/ByteString;
+	public final fun buildPostBody (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/api/http/HttpBody;
 	public final fun buildPostBody (Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/CustomScalarAdapters;ZLjava/lang/String;)Lcom/apollographql/apollo3/api/http/HttpBody;
 	public final fun composePayload (Lcom/apollographql/apollo3/api/ApolloRequest;)Ljava/util/Map;
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
@@ -2,16 +2,16 @@ package test
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
-import com.apollographql.apollo3.api.http.ByteStringHttpBody
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpRequestComposer
-import com.apollographql.apollo3.api.json.buildJsonByteString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.json.writeObject
-import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
+import com.apollographql.apollo3.integration.fullstack.LaunchDetailsQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueue
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
@@ -23,51 +23,51 @@ import kotlin.test.assertEquals
 class WithExtensionsHttpRequestComposer(private val serverUrl: String) : HttpRequestComposer {
   override fun <D : Operation.Data> compose(apolloRequest: ApolloRequest<D>): HttpRequest {
 
-    return HttpRequest.Builder(HttpMethod.Post, serverUrl)
-        .body(
-            ByteStringHttpBody(
-                "application/json",
-                buildJsonByteString {
-                  writeObject {
-                    name("query")
-                    value(apolloRequest.operation.document())
-                    name("operationName")
-                    value(apolloRequest.operation.name())
-                    name("extensions")
-                    value("extension value")
-                  }
-                }
-            )
-        )
-        .build()
+    val request = HttpRequest.Builder(HttpMethod.Post, serverUrl)
+      .body(
+        DefaultHttpRequestComposer.buildPostBody(
+          apolloRequest.operation,
+          apolloRequest.executionContext[CustomScalarAdapters]!!,
+          apolloRequest.operation.document(),
+        ) {
+          name("extensions")
+          writeObject {
+            name("key")
+            value("value")
+          }
+        }
+      )
+      .build()
+
+    return request
   }
 }
 
 class BodyExtensionsTest {
+  @Suppress("UNCHECKED_CAST")
   @Test
   fun bodyExtensions() = runTest {
     val mockServer = MockServer()
-    val serverUrl = mockServer.url()
 
     val apolloClient = ApolloClient.Builder()
-        .networkTransport(
-            HttpNetworkTransport.Builder()
-                .httpRequestComposer(WithExtensionsHttpRequestComposer(serverUrl))
-                .build()
-        )
-        .build()
+      .networkTransport(
+        HttpNetworkTransport.Builder()
+          .httpRequestComposer(WithExtensionsHttpRequestComposer(mockServer.url()))
+          .build()
+      )
+      .build()
 
     mockServer.enqueue(statusCode = 500)
     kotlin.runCatching {
-      apolloClient.query(HeroNameQuery())
-          .execute()
+      apolloClient.query(LaunchDetailsQuery("42")).execute()
     }
 
     val request = mockServer.takeRequest()
 
     @Suppress("UNCHECKED_CAST")
     val asMap = Buffer().write(request.body).jsonReader().readAny() as Map<String, Any>
-    assertEquals(asMap["extensions"], "extension value")
+    assertEquals((asMap["extensions"] as Map<String, Any>).get("key"), "value")
+    assertEquals((asMap["variables"] as Map<String, Any>).get("id"), "42")
 
     apolloClient.dispose()
     mockServer.stop()


### PR DESCRIPTION
Backport of  https://github.com/apollographql/apollo-kotlin/issues/5627