### PR TITLE
[🐘 gradle-plugin] Use Gradle normalization instead of ours

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -9,22 +9,17 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import com.apollographql.apollo3.compiler.InputFile as ApolloInputFile
 
 @CacheableTask
 abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val schemaFiles: ConfigurableFileCollection
-
-  @Internal
-  var sourceRoots: Set<String>? = null
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -55,10 +50,7 @@ abstract class ApolloGenerateCodegenSchemaTask : DefaultTask() {
       return
     }
 
-    val normalizedSchemaFiles = (schemaFiles.files.takeIf { it.isNotEmpty() }?: fallbackSchemaFiles.files).map {
-      // this may produce wrong cache results as that computation is not the same as the Gradle normalization
-      ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
-    }
+    val normalizedSchemaFiles = (schemaFiles.takeIf { it.files.isNotEmpty() }?: fallbackSchemaFiles).toInputFiles()
 
     ApolloCompiler.buildCodegenSchema(
         schemaFiles = normalizedSchemaFiles,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateIrOperationsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateIrOperationsTask.kt
@@ -11,7 +11,6 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -25,9 +24,6 @@ abstract class ApolloGenerateIrOperationsTask: DefaultTask() {
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val graphqlFiles: ConfigurableFileCollection
-
-  @get:Internal
-  var sourceRoots: Set<String>? = null
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -44,9 +40,7 @@ abstract class ApolloGenerateIrOperationsTask: DefaultTask() {
   fun taskAction() {
     val upstreamIrOperations = upstreamIrFiles.files.map { it.toIrOperations() }
 
-    val normalizedExecutableFiles = graphqlFiles.files.map {
-      com.apollographql.apollo3.compiler.InputFile(it, it.normalizedPath(sourceRoots!!))
-    }
+    val normalizedExecutableFiles = graphqlFiles.toInputFiles()
 
     ApolloCompiler.buildIrOperations(
         executableFiles = normalizedExecutableFiles,

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3.gradle.internal
 
 import com.apollographql.apollo3.compiler.ApolloCompiler
 import com.apollographql.apollo3.compiler.CodegenSchema
+import com.apollographql.apollo3.compiler.InputFile
 import com.apollographql.apollo3.compiler.LayoutFactory
 import com.apollographql.apollo3.compiler.codegen.SchemaAndOperationsLayout
 import com.apollographql.apollo3.compiler.codegen.writeTo
@@ -10,16 +11,15 @@ import com.apollographql.apollo3.compiler.toCodegenSchemaOptions
 import com.apollographql.apollo3.compiler.toIrOptions
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import com.apollographql.apollo3.compiler.InputFile as ApolloInputFile
 
 @CacheableTask
 abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
@@ -29,14 +29,11 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val graphqlFiles: ConfigurableFileCollection
-
-  @Internal
-  var sourceRoots: Set<String>? = null
+  abstract val fallbackSchemaFiles: ConfigurableFileCollection
 
   @get:InputFiles
   @get:PathSensitive(PathSensitivity.RELATIVE)
-  abstract val fallbackSchemaFiles: ConfigurableFileCollection
+  abstract val graphqlFiles: ConfigurableFileCollection
 
   @get:org.gradle.api.tasks.InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
@@ -49,17 +46,12 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
   @TaskAction
   fun taskAction() {
     if (requiresBuildscriptClasspath()) {
-      val normalizedSchemaFiles = (schemaFiles.files.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles.files).map {
-        // this may produce wrong cache results as that computation is not the same as the Gradle normalization
-        ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
-      }
-      val normalizedExecutableFiles = graphqlFiles.files.map {
-        ApolloInputFile(it, it.normalizedPath(sourceRoots!!))
-      }
+      val schemaInputFiles = (schemaFiles.takeIf { it.files.isNotEmpty() } ?: fallbackSchemaFiles).toInputFiles()
+      val executableInputFiles = graphqlFiles.toInputFiles()
 
       ApolloCompiler.buildSchemaAndOperationsSources(
-          schemaFiles = normalizedSchemaFiles,
-          executableFiles = normalizedExecutableFiles,
+          schemaFiles = schemaInputFiles,
+          executableFiles = executableInputFiles,
           codegenSchemaOptions = codegenSchemaOptionsFile.get().asFile.toCodegenSchemaOptions(),
           codegenOptions = codegenOptionsFile.get().asFile.toCodegenOptions(),
           irOptions = irOptionsFile.get().asFile.toIrOptions(),
@@ -80,7 +72,6 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
         it.graphqlFiles.from(graphqlFiles.files)
         it.schemaFiles.from(schemaFiles)
         it.fallbackSchemaFiles.from(fallbackSchemaFiles)
-        it.sourceRoots = sourceRoots!!
         it.codegenSchemaOptions.set(codegenSchemaOptionsFile)
         it.irOptions.set(irOptionsFile)
         it.codegenOptions.set(codegenOptionsFile)
@@ -94,19 +85,13 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
 private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
   override fun execute() {
     with(parameters) {
-      val normalizedSchemaFiles = (schemaFiles.files.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles.files).map {
-        // this may produce wrong cache results as that computation is not the same as the Gradle normalization
-        ApolloInputFile(it, it.normalizedPath(sourceRoots))
-      }
-      val normalizedExecutableFiles = graphqlFiles.files.map {
-        ApolloInputFile(it, it.normalizedPath(sourceRoots))
-      }
-
+      val schemaInputFiles = (schemaFiles.takeIf { it.files.isNotEmpty() } ?: fallbackSchemaFiles).toInputFiles()
+      val executableInputFiles = graphqlFiles.toInputFiles()
       val plugin = apolloCompilerPlugin()
 
       ApolloCompiler.buildSchemaAndOperationsSources(
-          schemaFiles = normalizedSchemaFiles,
-          executableFiles = normalizedExecutableFiles,
+          schemaFiles = schemaInputFiles,
+          executableFiles = executableInputFiles,
           codegenSchemaOptions = codegenSchemaOptions.get().asFile.toCodegenSchemaOptions(),
           codegenOptions = codegenOptions.get().asFile.toCodegenOptions(),
           irOptions = irOptions.get().asFile.toIrOptions(),
@@ -138,3 +123,15 @@ private interface GenerateSourcesParameters : WorkParameters {
   val outputDir: DirectoryProperty
 }
 
+
+fun FileCollection.toInputFiles(): List<InputFile> {
+  val inputFiles = mutableListOf<InputFile>()
+
+  asFileTree.visit {
+    if (it.file.isFile) {
+      inputFiles.add(InputFile(it.file, it.path))
+    }
+  }
+
+  return inputFiles
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -69,7 +69,7 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
       }
 
       workQueue.submit(GenerateSources::class.java) {
-        it.graphqlFiles.from(graphqlFiles.files)
+        it.graphqlFiles.from(graphqlFiles)
         it.schemaFiles.from(schemaFiles)
         it.fallbackSchemaFiles.from(fallbackSchemaFiles)
         it.codegenSchemaOptions.set(codegenSchemaOptionsFile)
@@ -115,7 +115,6 @@ private interface GenerateSourcesParameters : WorkParameters {
   val graphqlFiles: ConfigurableFileCollection
   val schemaFiles: ConfigurableFileCollection
   val fallbackSchemaFiles: ConfigurableFileCollection
-  var sourceRoots: Set<String>
   val codegenSchemaOptions: RegularFileProperty
   val codegenOptions: RegularFileProperty
   val irOptions: RegularFileProperty

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -759,7 +759,6 @@ abstract class DefaultApolloExtension(
         task.codegenSchemaFiles.from(schemaTaskProvider.flatMap { it.codegenSchemaFile })
       }
       task.graphqlFiles.from(service.graphqlSourceDirectorySet)
-      task.sourceRoots = service.graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.toSet()
       task.upstreamIrFiles.from(upstreamIrFiles)
       task.irOptionsFile.set(irOptionsTaskProvider.flatMap { it.irOptionsFile })
 
@@ -779,7 +778,6 @@ abstract class DefaultApolloExtension(
 
       task.schemaFiles.from(service.schemaFiles(project))
       task.fallbackSchemaFiles.from(service.fallbackSchemaFiles(project))
-      task.sourceRoots = service.graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.toSet()
       task.upstreamSchemaFiles.from(schemaConsumerConfiguration)
       task.codegenSchemaOptionsFile.set(optionsTaskProvider.flatMap { it.codegenSchemaOptionsFile })
       task.codegenSchemaFile.set(BuildDirLayout.codegenSchema(project, service))
@@ -866,7 +864,6 @@ abstract class DefaultApolloExtension(
       configureBaseCodegenTask(project, task, optionsTaskProvider, service, classpath)
 
       task.graphqlFiles.from(service.graphqlSourceDirectorySet)
-      task.sourceRoots = service.graphqlSourceDirectorySet.srcDirs.map { it.absolutePath }.toSet()
       task.schemaFiles.from(service.schemaFiles(project))
       task.fallbackSchemaFiles.from(service.fallbackSchemaFiles(project))
       task.codegenSchemaOptionsFile.set(optionsTaskProvider.map { it.codegenSchemaOptionsFile.get() })

--- a/tests/schema-packagename/build.gradle.kts
+++ b/tests/schema-packagename/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.apollographql.apollo3.compiler.OperationIdGenerator
+
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.apollographql.apollo3")
@@ -12,7 +14,19 @@ dependencies {
 
 apollo {
   service("service") {
-    schemaFile.set(file("src/main/graphql/com/example/schema.graphqls"))
+    schemaFiles.from(fileTree("src/main/graphql/").apply {
+      include("com/example/schema.graphqls")
+    })
     packageNamesFromFilePaths()
+
+    // This is to force running without a worker. See https://github.com/gradle/gradle/issues/28147
+    operationIdGenerator.set(object: OperationIdGenerator {
+      override val version: String
+        get() = "v1"
+
+      override fun apply(operationDocument: String, operationName: String): String {
+        return operationName
+      }
+    })
   }
 }

--- a/tests/schema-packagename/build.gradle.kts
+++ b/tests/schema-packagename/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+  id("com.apollographql.apollo3")
+}
+
+apolloTest()
+
+dependencies {
+  implementation(libs.apollo.api)
+  testImplementation(libs.kotlin.test)
+}
+
+apollo {
+  service("service") {
+    schemaFile.set(file("src/main/graphql/com/example/schema.graphqls"))
+    packageNamesFromFilePaths()
+  }
+}

--- a/tests/schema-packagename/src/main/graphql/com/example/operation.graphql
+++ b/tests/schema-packagename/src/main/graphql/com/example/operation.graphql
@@ -1,0 +1,3 @@
+query GetFoo {
+  foo
+}

--- a/tests/schema-packagename/src/main/graphql/com/example/schema.graphqls
+++ b/tests/schema-packagename/src/main/graphql/com/example/schema.graphqls
@@ -1,0 +1,4 @@
+scalar Foo
+type Query {
+  foo: Foo
+}

--- a/tests/schema-packagename/src/test/kotlin/test/SchemaPackageNameTest.kt
+++ b/tests/schema-packagename/src/test/kotlin/test/SchemaPackageNameTest.kt
@@ -1,0 +1,10 @@
+package test
+
+import kotlin.test.Test
+
+class SchemaPackageNameTest {
+  @Test
+  fun userOnUserNameError() {
+    println(com.example.type.Foo)
+  }
+}

--- a/tests/schema-packagename/src/test/kotlin/test/SchemaPackageNameTest.kt
+++ b/tests/schema-packagename/src/test/kotlin/test/SchemaPackageNameTest.kt
@@ -6,5 +6,6 @@ class SchemaPackageNameTest {
   @Test
   fun userOnUserNameError() {
     println(com.example.type.Foo)
+    println(com.example.GetFooQuery)
   }
 }


### PR DESCRIPTION
We don't need internal `sourceRoots` as `FileCollection` rightfully includes the normalized path. 

This simplifies the code quite a bunch but is unfortunately blocked on https://github.com/gradle/gradle/issues/28147

Also this is a behaviour change for users using both `packageNameFromFilePaths` and `schemaFile` that can be mitigated by using `schemaFiles` instead:

```kotlin
    packageNameFromFilePaths()

    // replace
    schemaFile.set("src/main/graphql/com/example/schema.graphqls")

    // with
    schemaFiles.from(fileTree("src/main/graphql/").apply {
      include("com/example/schema.graphqls")
    })
```