### PR TITLE
[🤖 CI] Upload diagnostics on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -38,7 +38,7 @@ jobs:
         if: always()
         with:
           name: push.zip
-          path: push.zip
+          path: diagnostics.zip
       - name: Deploy Kdoc to github pages
         uses: JamesIves/github-pages-deploy-action@65b5dfd4f5bcd3a7403bbc2959c144256167464e #v4.5.0
         with:


### PR DESCRIPTION
The file name was wrong. The diagnostics.zip file is helpful to investigate CI failures