### PR TITLE
[3.x] Disable pushing the KDoc

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,9 +43,4 @@ jobs:
         if: always()
         with:
           name: push.zip
-          path: push.zip
-      - name: Deploy Kdoc to github pages
-        uses: JamesIves/github-pages-deploy-action@830e6a4f7c81743c52f3fed0ac67428feff9620a #v4.2.5
-        with:
-          branch: gh-pages # The branch the action should deploy to.
-          folder: build/dokkaHtml # The folder the action should deploy.
+          path: diagnostics.zip


### PR DESCRIPTION
Disable pushing the KDoc as it conflicts with the `main` one