### PR TITLE
Flakiness: increase the default timeout for receiveOrTimeout

### DIFF
--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
@@ -5,6 +5,6 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 
 @ApolloExperimental
-suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 1000) = withTimeout(timeoutMillis) {
+suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 2000) = withTimeout(timeoutMillis) {
   receive()
 }


### PR DESCRIPTION
Hopefully can reduce flakiness (e.g. [this one](https://github.com/apollographql/apollo-kotlin/actions/runs/8061801564/job/22020244018?pr=5657#step:5:5471)).