### PR TITLE
Use expect funs instead of expect classes for DefaultHttpEngine

### DIFF
--- a/docs/source/advanced/http-engine.mdx
+++ b/docs/source/advanced/http-engine.mdx
@@ -14,7 +14,9 @@ You can use a different HTTP client with Apollo Kotlin by creating a custom clas
 
 ## The `HttpEngine` interface
 
-The [HttpEngine interface](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-runtime/com.apollographql.apollo3.network.http/-http-engine/index.html) defines two functions: `execute` and `dispose`. Here's an example implementation that also includes a couple of helper methods:
+The [HttpEngine interface](https://apollographql.github.io/apollo-kotlin/kdoc/apollo-runtime/com.apollographql.apollo3.network.http/-http-engine/index.html)
+defines two functions: `execute` and `close`. Here's an example implementation that also includes a couple of helper
+methods:
 
 ```kotlin
 class MyHttpEngine(val wrappedClient: MyClient) : HttpEngine {
@@ -53,7 +55,7 @@ class MyHttpEngine(val wrappedClient: MyClient) : HttpEngine {
     )
   }
 
-  override fun dispose() {
+  override fun close() {
     // Dispose any resources here
   }
 }

--- a/docs/source/migration/4.0.mdx
+++ b/docs/source/migration/4.0.mdx
@@ -163,6 +163,10 @@ val call = client.query(MyQuery())
   .execute()
 ```
 
+### `HttpEngine` now implements `Closeable`
+
+`HttpEngine` now implements `Closeable` and has its `dispose` method renamed to `close`. If you have a custom `HttpEngine`, you need to implement `close` instead of `dispose`.
+
 ## Apollo Gradle Plugin
 
 ### Multi-module `dependsOn`

--- a/libraries/apollo-engine-ktor/src/commonMain/kotlin/com/apollographql/apollo3/network/http/KtorHttpEngine.kt
+++ b/libraries/apollo-engine-ktor/src/commonMain/kotlin/com/apollographql/apollo3/network/http/KtorHttpEngine.kt
@@ -76,7 +76,7 @@ class KtorHttpEngine(
     }
   }
 
-  override fun dispose() {
+  override fun close() {
     if (!disposed) {
       client.close()
       disposed = true

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -209,21 +209,12 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpIntercepto
 	public final fun getRequest ()Lcom/apollographql/apollo3/api/http/HttpRequest;
 }
 
-public final class com/apollographql/apollo3/network/http/DefaultHttpEngine : com/apollographql/apollo3/network/http/HttpEngine {
-	public static final field Companion Lcom/apollographql/apollo3/network/http/DefaultHttpEngine$Companion;
-	public fun <init> (J)V
-	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (JJ)V
-	public fun <init> (Lokhttp3/Call$Factory;)V
-	public fun <init> (Lokhttp3/OkHttpClient;)V
-	public fun dispose ()V
-	public fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class com/apollographql/apollo3/network/http/DefaultHttpEngine$Companion {
-	public final fun execute (Lokhttp3/Call$Factory;Lokhttp3/Request;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun toApolloHttpResponse (Lokhttp3/Response;)Lcom/apollographql/apollo3/api/http/HttpResponse;
-	public final fun toOkHttpRequest (Lcom/apollographql/apollo3/api/http/HttpRequest;)Lokhttp3/Request;
+public final class com/apollographql/apollo3/network/http/DefaultHttpEngine {
+	public static final fun DefaultHttpEngine (J)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static final fun DefaultHttpEngine (JJ)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static final fun DefaultHttpEngine (Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static final fun DefaultHttpEngine (Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static synthetic fun DefaultHttpEngine$default (JILjava/lang/Object;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 }
 
 public final class com/apollographql/apollo3/network/http/HeadersInterceptor : com/apollographql/apollo3/network/http/HttpInterceptor {
@@ -241,8 +232,9 @@ public final class com/apollographql/apollo3/network/http/HttpCall {
 	public final fun headers (Ljava/util/List;)Lcom/apollographql/apollo3/network/http/HttpCall;
 }
 
-public abstract interface class com/apollographql/apollo3/network/http/HttpEngine {
-	public abstract fun dispose ()V
+public abstract interface class com/apollographql/apollo3/network/http/HttpEngine : java/io/Closeable {
+	public fun close ()V
+	public fun dispose ()V
 	public abstract fun execute (Lcom/apollographql/apollo3/api/http/HttpRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpEngine.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo3.network.http
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince.Version.v4_0_0
 import com.apollographql.apollo3.api.ExecutionContext
 import com.apollographql.apollo3.api.http.HttpBody
 import com.apollographql.apollo3.api.http.HttpHeader
@@ -7,11 +9,12 @@ import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import okio.Closeable
 
 /**
  * A wrapper around platform specific engines
  */
-interface HttpEngine {
+interface HttpEngine : Closeable {
 
   /**
    * Executes the given HttpRequest
@@ -22,12 +25,18 @@ interface HttpEngine {
    */
   suspend fun execute(request: HttpRequest): HttpResponse
 
+  @ApolloDeprecatedSince(v4_0_0)
+  @Deprecated("Use close", ReplaceWith("close()"), level = DeprecationLevel.ERROR)
+  fun dispose() {
+  }
+
   /**
    * Disposes any resources used by the [HttpEngine]
    *
    * Use this to dispose a connection pool for an example. Must be idemptotent
    */
-  fun dispose()
+  @Suppress("DEPRECATION_ERROR")
+  override fun close() = dispose()
 }
 
 /**
@@ -37,11 +46,7 @@ interface HttpEngine {
  * - on Android (OkHttp), it is used to set both `OkHttpClient.connectTimeout` and `OkHttpClient.readTimeout`
  * - on Js (Ktor), it is used to set both `HttpTimeoutCapabilityConfiguration.connectTimeoutMillis` and `HttpTimeoutCapabilityConfiguration.requestTimeoutMillis`
  */
-expect class DefaultHttpEngine(timeoutMillis: Long = 60_000): HttpEngine {
-  override suspend fun execute(request: HttpRequest): HttpResponse
-
-  override fun dispose()
-}
+expect fun DefaultHttpEngine(timeoutMillis: Long = 60_000): HttpEngine
 
 fun HttpEngine.get(url: String) = HttpCall(this, HttpMethod.Get, url)
 fun HttpEngine.post(url: String) = HttpCall(this, HttpMethod.Post, url)
@@ -64,6 +69,7 @@ class HttpCall(private val engine: HttpEngine, method: HttpMethod, url: String) 
   fun addExecutionContext(executionContext: ExecutionContext) = apply {
     requestBuilder.addExecutionContext(executionContext)
   }
+
   fun headers(headers: List<HttpHeader>) = apply {
     requestBuilder.headers(headers)
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -257,7 +257,7 @@ private constructor(
 
   override fun dispose() {
     interceptors.forEach { it.dispose() }
-    engine.dispose()
+    engine.close()
   }
 
 

--- a/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.js.kt
+++ b/libraries/apollo-runtime/src/jsMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.js.kt
@@ -17,29 +17,34 @@ import io.ktor.util.flattenEntries
 import io.ktor.utils.io.CancellationException
 import okio.Buffer
 
+actual fun DefaultHttpEngine(timeoutMillis: Long): HttpEngine = JsHttpEngine(timeoutMillis)
+
+fun DefaultHttpEngine(connectTimeoutMillis: Long, readTimeoutMillis: Long): HttpEngine =
+    JsHttpEngine(connectTimeoutMillis, readTimeoutMillis)
+
 /**
  * @param connectTimeoutMillis The connection timeout in milliseconds. The connection timeout is the time period in which a client should establish a connection with a server.
  * @param readTimeoutMillis The request timeout in milliseconds. The request timeout is the time period required to process an HTTP call: from sending a request to receiving a response.
  */
-actual class DefaultHttpEngine constructor(private val connectTimeoutMillis: Long, private val readTimeoutMillis: Long) : HttpEngine {
+private class JsHttpEngine constructor(private val connectTimeoutMillis: Long, private val readTimeoutMillis: Long) : HttpEngine {
   var disposed = false
 
   /**
    * @param timeoutMillis: The timeout in milliseconds used both for the connection and the request.
    */
-  actual constructor(timeoutMillis: Long) : this(timeoutMillis, timeoutMillis)
+  constructor(timeoutMillis: Long) : this(timeoutMillis, timeoutMillis)
 
   private val client = HttpClient(Js) {
     expectSuccess = false
     install(HttpTimeout) {
-      this.connectTimeoutMillis = this@DefaultHttpEngine.connectTimeoutMillis
+      this.connectTimeoutMillis = this@JsHttpEngine.connectTimeoutMillis
 
       // socketTimeoutMillis would make more sense but doesn't seem to work on JS. See https://youtrack.jetbrains.com/issue/KTOR-6211
-      this.requestTimeoutMillis = this@DefaultHttpEngine.readTimeoutMillis
+      this.requestTimeoutMillis = this@JsHttpEngine.readTimeoutMillis
     }
   }
 
-  actual override suspend fun execute(request: HttpRequest): HttpResponse {
+  override suspend fun execute(request: HttpRequest): HttpResponse {
     try {
       val response = client.request(request.url) {
         method = when (request.method) {
@@ -71,7 +76,7 @@ actual class DefaultHttpEngine constructor(private val connectTimeoutMillis: Lon
     }
   }
 
-  actual override fun dispose() {
+  override fun close() {
     if (!disposed) {
       client.close()
       disposed = true

--- a/tests/engine/src/commonTest/kotlin/GzipTest.kt
+++ b/tests/engine/src/commonTest/kotlin/GzipTest.kt
@@ -47,7 +47,7 @@ class GzipTest {
     }
 
     mockServer.close()
-    engine.dispose()
+    engine.close()
   }
 
   @Test


### PR DESCRIPTION
Also rename `HttpEngine.dispose()` -> `HttpEngine.close()`

Would it be worth it to also rename `NetworkTransport.dispose()`?