### PR TITLE
Introduce incubating WebSocketEngine

### DIFF
--- a/build-logic/src/main/kotlin/Mpp.kt
+++ b/build-logic/src/main/kotlin/Mpp.kt
@@ -105,6 +105,9 @@ fun Project.configureMpp(
     if (withWasm) {
       @OptIn(ExperimentalWasmDsl::class)
       wasmJs {
+        /**
+         * See https://youtrack.jetbrains.com/issue/KT-63014
+         */
         nodejs()
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,4 +168,4 @@ tasks.register("rmbuild") {
   }
 }
 
-rootSetup(ciBuild)
+apolloRoot(ciBuild)

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -42,6 +42,7 @@ rx-java3 = "3.1.6"
 sqldelight = "2.0.1"
 truth = "1.1.3"
 moshix = "0.14.1"
+node-ws = "8.14.2"
 
 [libraries]
 android-plugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-plugin" }
@@ -74,6 +75,7 @@ apollo-normalizedcache-sqlite-incubating = { group = "com.apollographql.apollo3"
 apollo-rx2-support-java = { group = "com.apollographql.apollo3", name = "apollo-rx2-support-java", version.ref = "apollo" }
 apollo-plugin = { group = "com.apollographql.apollo3", name = "apollo-gradle-plugin", version.ref = "apollo" }
 apollo-runtime = { group = "com.apollographql.apollo3", name = "apollo-runtime", version.ref = "apollo" }
+apollo-websocket-network-transport-incubating = { group = "com.apollographql.apollo3", name = "apollo-websocket-network-transport-incubating", version.ref = "apollo" }
 apollo-compiler = { group = "com.apollographql.apollo3", name = "apollo-compiler", version.ref = "apollo" }
 apollo-execution = { group = "com.apollographql.apollo3", name = "apollo-execution-incubating", version.ref = "apollo" }
 # Used by the apollo-tooling project which uses a published version of Apollo

--- a/kotlin-js-store-2.0/yarn.lock
+++ b/kotlin-js-store-2.0/yarn.lock
@@ -557,6 +557,11 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
+ws@8.14.2:
+  version "8.14.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.2.tgz#6c249a806eb2db7a20d26d51e7709eab7b2e6c7f"
+  integrity sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==
+
 ws@8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"

--- a/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/internal/runTest.wasmJs.kt
+++ b/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/internal/runTest.wasmJs.kt
@@ -22,5 +22,7 @@ actual fun runTest(
     after: suspend CoroutineScope.() -> Unit,
     block: suspend CoroutineScope.() -> Unit,
 ): ApolloTestResult {
-  TODO()
+  return Promise.resolve(empty)
 }
+
+val empty: JsAny = js("({})")

--- a/libraries/apollo-websocket-network-transport-incubating/README.md
+++ b/libraries/apollo-websocket-network-transport-incubating/README.md
@@ -1,0 +1,4 @@
+# Module apollo-websocket-network-transport-incubating
+
+An incubating network transport for websockets. See https://github.com/apollographql/apollo-kotlin/issues/5648 for more details
+

--- a/libraries/apollo-websocket-network-transport-incubating/build.gradle.kts
+++ b/libraries/apollo-websocket-network-transport-incubating/build.gradle.kts
@@ -1,0 +1,50 @@
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+
+plugins {
+  id("org.jetbrains.kotlin.multiplatform")
+}
+
+apolloLibrary(
+    javaModuleName = "com.apollographql.apollo3.network.websocket",
+    withLinux = false,
+)
+
+kotlin {
+  sourceSets {
+    findByName("commonMain")?.apply {
+      dependencies {
+        api(project(":apollo-runtime"))
+        api(project(":apollo-mpp-utils"))
+        api(libs.atomicfu)
+      }
+    }
+
+    findByName("commonTest")?.apply {
+      dependencies {
+        implementation(project(":apollo-mockserver"))
+        implementation(project(":apollo-testing-support")) {
+          because("runTest")
+        }
+      }
+    }
+
+    findByName("jsMain")?.apply {
+      dependencies {
+        /**
+         * WebSocket implementation for node
+         */
+        api(npm("ws", libs.versions.node.ws.get()))
+        /**
+         * Kotlin Node declarations
+         *
+         * The situation is a bit weird because jsMain has both browser and node dependencies but
+         * there is not much we can do about it
+         * See https://youtrack.jetbrains.com/issue/KT-47038
+         */
+        implementation(libs.kotlin.node)
+      }
+    }
+  }
+}
+
+

--- a/libraries/apollo-websocket-network-transport-incubating/build.gradle.kts
+++ b/libraries/apollo-websocket-network-transport-incubating/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-
 plugins {
   id("org.jetbrains.kotlin.multiplatform")
 }
@@ -7,6 +5,7 @@ plugins {
 apolloLibrary(
     javaModuleName = "com.apollographql.apollo3.network.websocket",
     withLinux = false,
+    publish = false
 )
 
 kotlin {

--- a/libraries/apollo-websocket-network-transport-incubating/gradle.properties
+++ b/libraries/apollo-websocket-network-transport-incubating/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=apollo-websocket-network-transport-incubating
+POM_NAME=apollo-websocket-network-transport-incubating
+POM_DESCRIPTION=apollo-websocket-network-transport-incubating

--- a/libraries/apollo-websocket-network-transport-incubating/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.apple.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.apple.kt
@@ -1,0 +1,161 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.DefaultApolloException
+import com.apollographql.apollo3.network.toNSData
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.cinterop.convert
+import okio.ByteString.Companion.toByteString
+import platform.Foundation.NSData
+import platform.Foundation.NSMutableURLRequest
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLSession
+import platform.Foundation.NSURLSessionConfiguration
+import platform.Foundation.NSURLSessionWebSocketCloseCode
+import platform.Foundation.NSURLSessionWebSocketDelegateProtocol
+import platform.Foundation.NSURLSessionWebSocketMessage
+import platform.Foundation.NSURLSessionWebSocketMessageTypeData
+import platform.Foundation.NSURLSessionWebSocketMessageTypeString
+import platform.Foundation.NSURLSessionWebSocketTask
+import platform.Foundation.setHTTPMethod
+import platform.Foundation.setValue
+import platform.darwin.NSObject
+
+internal class AppleWebSocketEngine : WebSocketEngine {
+  private val delegate = Delegate()
+  private val nsUrlSession = NSURLSession.sessionWithConfiguration(
+      configuration = NSURLSessionConfiguration.defaultSessionConfiguration,
+      delegate = delegate,
+      delegateQueue = null
+  )
+
+  override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {
+    val serverUrl = NSURL(string = url)
+
+    val request = NSMutableURLRequest.requestWithURL(serverUrl).apply {
+      headers.forEach { setValue(it.value, forHTTPHeaderField = it.name) }
+      setHTTPMethod("GET")
+    }
+
+    val task = nsUrlSession.webSocketTaskWithRequest(request)
+    val webSocket = AppleWebSocket(task, listener)
+    delegate.associate(task, webSocket)
+    webSocket.connect()
+
+    return webSocket
+  }
+
+  override fun close() {
+    delegate.close()
+    nsUrlSession.invalidateAndCancel()
+  }
+}
+
+
+private class Delegate: NSObject(), NSURLSessionWebSocketDelegateProtocol {
+  private val lock = reentrantLock()
+  private val map = mutableMapOf<NSURLSessionWebSocketTask, AppleWebSocket>()
+
+  fun associate(webSocketTask: NSURLSessionWebSocketTask, webSocket: AppleWebSocket) {
+    lock.withLock {
+      map.put(webSocketTask, webSocket)
+    }
+  }
+
+  override fun URLSession(session: NSURLSession, webSocketTask: NSURLSessionWebSocketTask, didOpenWithProtocol: String?) {
+    val webSocket = lock.withLock {
+      map.get(webSocketTask)
+    }
+    webSocket?.onOpen()
+  }
+
+  override fun URLSession(
+      session: NSURLSession,
+      webSocketTask: NSURLSessionWebSocketTask,
+      didCloseWithCode: NSURLSessionWebSocketCloseCode,
+      reason: NSData?,
+  ) {
+    val webSocket = lock.withLock {
+      val ws = map.get(webSocketTask)
+
+      map.remove(webSocketTask)
+      ws
+    }
+    webSocket?.onClosed(didCloseWithCode.convert(), reason?.toByteString()?.utf8())
+  }
+
+  fun close() {
+    lock.withLock {
+      map.clear()
+    }
+  }
+}
+
+/**
+ * Peculiarities of NSURLSesssionWebSocketTask:
+ * - cancelWithCloseCode(code) calls didCloseWithCode with the same client code, making it impossible to detect the server close code
+ * - sometimes cancelWithCloseCode(code) doesn't send the close frame to the server (https://developer.apple.com/forums/thread/679446)
+ * - when the server close frame is received, the received completion handler is called first with an error, making it quite difficult
+ * to detect server close
+ */
+internal class AppleWebSocket(
+    private val nsurlSessionWebSocketTask: NSURLSessionWebSocketTask,
+    private val listener: WebSocketListener,
+) : WebSocket {
+  private val disposed = atomic(false)
+
+  internal fun connect() {
+    nsurlSessionWebSocketTask.resume()
+    receiveNext()
+  }
+
+  fun onOpen() {
+    listener.onOpen()
+  }
+
+  fun onClosed(code: Int?, reason: String?) {
+    if (disposed.compareAndSet(expect = false, update = true)) {
+      listener.onClosed(code, reason)
+    }
+  }
+
+  private fun receiveNext() {
+    nsurlSessionWebSocketTask.receiveMessageWithCompletionHandler { message, nsError ->
+      if (nsError != null) {
+        if (disposed.compareAndSet(expect = false, update = true)) {
+          listener.onError(DefaultApolloException("Error reading websocket: ${nsError.localizedDescription}"))
+        }
+      } else if (message != null) {
+        when (message.type) {
+          NSURLSessionWebSocketMessageTypeData -> {
+            listener.onMessage(message.data!!.toByteString().toByteArray())
+          }
+
+          NSURLSessionWebSocketMessageTypeString -> {
+            listener.onMessage(message.string!!)
+          }
+        }
+
+        receiveNext()
+      }
+    }
+  }
+
+  override fun send(data: ByteArray) {
+    nsurlSessionWebSocketTask.sendMessage(NSURLSessionWebSocketMessage(data = data.toNSData())) {}
+  }
+
+  override fun send(text: String) {
+    nsurlSessionWebSocketTask.sendMessage(NSURLSessionWebSocketMessage(string = text)) {}
+  }
+
+  override fun close(code: Int, reason: String) {
+    if (disposed.compareAndSet(expect = false, update = true)) {
+      nsurlSessionWebSocketTask.cancelWithCloseCode(code.convert(), reason.encodeToByteArray().toNSData())
+    }
+  }
+}
+
+actual fun WebSocketEngine(): WebSocketEngine = AppleWebSocketEngine()

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
@@ -7,7 +7,7 @@ interface WebSocketEngine: Closeable {
   /**
    * Creates a new [WebSocket].
    *
-   * The [WebSocket] is be garbage collected when not used anymore. Call [WebSocket.close] to close the websocket and release resources earlier.
+   * The [WebSocket] is garbage collected when not used anymore. Call [WebSocket.close] to close the websocket and release resources earlier.
    * You don't need to call [WebSocket.close] if:
    * - [WebSocketListener.onError] has been called
    * - [WebSocketListener.onClosed] has been called

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
@@ -1,0 +1,87 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.http.HttpHeader
+import okio.Closeable
+
+interface WebSocketEngine: Closeable {
+  /**
+   * Creates a new [WebSocket].
+   *
+   * The [WebSocket] is be garbage collected when not used anymore. Call [WebSocket.close] to close the websocket and release resources earlier.
+   * You don't need to call [WebSocket.close] if:
+   * - [WebSocketListener.onError] has been called
+   * - [WebSocketListener.onClosed] has been called
+   *
+   * @param url: an url starting with one of:
+   * - ws://
+   * - wss://
+   * - http://
+   * - https://
+   *
+   * If the underlying engine requires a ws or wss, http and https are replaced by ws and wss respectively
+   */
+  fun newWebSocket(
+      url: String,
+      headers: List<HttpHeader> = emptyList(),
+      listener: WebSocketListener
+  ): WebSocket
+}
+
+interface WebSocketListener {
+  /**
+   * The HTTP 101 Switching Protocols response has been received and is valid.
+   */
+  fun onOpen()
+
+  /**
+   * A text message has been received.
+   */
+  fun onMessage(text: String)
+
+
+  /**
+   * A data message has been received.
+   */
+  fun onMessage(data: ByteArray)
+
+  /**
+   * An error happened, no more calls to the listener are made.
+   */
+  fun onError(throwable: Throwable)
+
+  /**
+   * The server sent a close frame, no more calls to the listener are made.
+   */
+  fun onClosed(code: Int?, reason: String?)
+}
+
+interface WebSocket {
+  /**
+   * Sends a binary message asynchronously.
+   *
+   * There is no flow control. If the application is sending messages too fast, the connection is closed.
+   */
+  fun send(data: ByteArray)
+
+  /**
+   * Sends a text message asynchronously.
+   *
+   * There is no flow control. If the application is sending messages too fast, the connection is closed.
+   */
+  fun send(text: String)
+
+  /**
+   * Closes the websocket gracefully and asynchronously.
+   *
+   * After this call, no more calls to the listener are made
+   *
+   * Note: there is no API to retrieve the server close code because Apple cancelWithCloseCode calls the
+   * URLSession delegate with the same (client) code.
+   */
+  fun close(code: Int, reason: String)
+}
+
+expect fun WebSocketEngine() : WebSocketEngine
+
+internal const val CLOSE_NORMAL = 1000
+internal const val CLOSE_GOING_AWAY = 1001

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonTest/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngineTest.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonTest/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngineTest.kt
@@ -1,0 +1,199 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.mockserver.CloseFrame
+import com.apollographql.apollo3.mockserver.DataMessage
+import com.apollographql.apollo3.mockserver.MockRequestBase
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.PingFrame
+import com.apollographql.apollo3.mockserver.PongFrame
+import com.apollographql.apollo3.mockserver.TextMessage
+import com.apollographql.apollo3.mockserver.WebSocketBody
+import com.apollographql.apollo3.mockserver.WebSocketMessage
+import com.apollographql.apollo3.mockserver.WebsocketMockRequest
+import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
+import com.apollographql.apollo3.mockserver.enqueueWebSocket
+import com.apollographql.apollo3.mpp.Platform
+import com.apollographql.apollo3.mpp.platform
+import com.apollographql.apollo3.testing.internal.runTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.withTimeout
+import okio.ByteString.Companion.toByteString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+private data class Item(
+    val message: WebSocketMessage? = null,
+    val open: Boolean = false,
+    val throwable: Throwable? = null,
+)
+
+private class Listener(private val channel: Channel<Item>) : WebSocketListener {
+  override fun onOpen() {
+    channel.trySend(Item(open = true))
+  }
+
+  override fun onMessage(text: String) {
+    channel.trySend(TextMessage(text))
+  }
+
+  override fun onMessage(data: ByteArray) {
+    channel.trySend(DataMessage(data))
+  }
+
+  override fun onError(throwable: Throwable) {
+    channel.trySend(Item(throwable = throwable))
+  }
+
+  override fun onClosed(code: Int?, reason: String?) {
+    channel.trySend(CloseFrame(code, reason))
+  }
+}
+
+private fun debug(line: String) {
+  if (false) {
+    println(line)
+  }
+}
+
+internal val mockServerListener = object : MockServer.Listener {
+  override fun onRequest(request: MockRequestBase) {
+    debug("Client: ${request.method} ${request.path}")
+  }
+
+  override fun onMessage(message: WebSocketMessage) {
+    debug("Client: ${message.pretty()}")
+  }
+}
+
+private fun WebSocketMessage.pretty(): String = when (this) {
+  is TextMessage -> {
+    "TextMessage(${this.text})"
+  }
+
+  is DataMessage -> {
+    "BinaryMessage(${this.data.toByteString().hex()})"
+  }
+
+  is CloseFrame -> {
+    "CloseFrame($code, $reason)"
+  }
+
+  PingFrame -> "PingFrame"
+  PongFrame -> "PongFrame"
+}
+
+class WebSocketEngineTest {
+  private class Scope(
+      val clientReader: Channel<Item>,
+      val clientWriter: WebSocket,
+      val serverReader: WebsocketMockRequest,
+      val serverWriter: WebSocketBody,
+  )
+
+  private fun whenHandshakeDone(block: suspend Scope.() -> Unit) = runTest {
+    val mockServer = MockServer.Builder()
+        .listener(mockServerListener)
+        .build()
+
+    val engine = WebSocketEngine()
+
+    val clientReader = Channel<Item>(Channel.UNLIMITED)
+
+    val serverWriter = mockServer.enqueueWebSocket()
+    val clientWriter = engine.newWebSocket(mockServer.url(), emptyList(), Listener(clientReader))
+
+    val serverReader = mockServer.awaitWebSocketRequest()
+
+    clientReader.awaitOpen()
+
+    Scope(clientReader, clientWriter, serverReader, serverWriter).block()
+
+    mockServer.close()
+    engine.close()
+  }
+
+  @Test
+  fun simpleSessionWithClientClose() = whenHandshakeDone {
+    clientWriter.send("Client Text")
+    serverReader.awaitMessage().apply {
+      assertIs<TextMessage>(this)
+      assertEquals("Client Text", this.text)
+    }
+
+    serverWriter.enqueueMessage(TextMessage("Server Text"))
+    clientReader.awaitMessage().apply {
+      assertIs<TextMessage>(this)
+      assertEquals("Server Text", this.text)
+    }
+
+    clientWriter.send("Client Data".encodeToByteArray())
+    serverReader.awaitMessage().apply {
+      assertIs<DataMessage>(this)
+      assertEquals("Client Data", this.data.decodeToString())
+    }
+
+    serverWriter.enqueueMessage(DataMessage("Server Data".encodeToByteArray()))
+    clientReader.awaitMessage().apply {
+      assertIs<DataMessage>(this)
+      assertEquals("Server Data", this.data.decodeToString())
+    }
+
+    clientWriter.close(1003, "Client Bye")
+    if (platform() != Platform.Native) {
+      // Apple sometimes does not send the Close frame. See https://developer.apple.com/forums/thread/679446
+      serverReader.awaitMessage().apply {
+        assertIs<CloseFrame>(this)
+        assertEquals(1003, this.code)
+        assertEquals("Client Bye", this.reason)
+      }
+    }
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun serverClose() = whenHandshakeDone {
+    serverWriter.enqueueMessage(CloseFrame(1002, "Server Bye"))
+
+    val item = clientReader.awaitItem()
+
+    if (item.message != null) {
+      item.message.apply {
+        assertIs<CloseFrame>(this)
+        assertEquals(1002, code)
+        assertEquals("Server Bye", reason)
+      }
+    } else if (item.throwable != null) {
+      // Apple implementation calls onError instead on onClose
+    }
+
+    assertTrue(clientReader.isEmpty)
+  }
+}
+
+private suspend fun Channel<Item>.awaitItem(): Item = withTimeout(1.seconds) {
+  receive()
+}
+
+private suspend fun Channel<Item>.awaitMessage(): WebSocketMessage = withTimeout(1.seconds) {
+  val item = receive()
+  check(item.message != null) {
+    "Expected message item, received $item"
+  }
+  item.message
+}
+
+private suspend fun Channel<Item>.awaitOpen() = withTimeout(1.seconds) {
+  val item = receive()
+  check(item.open) {
+    "Expected open item, received $item"
+  }
+}
+
+private fun Channel<Item>.trySend(message: WebSocketMessage) {
+  debug("Server: ${message.pretty()}")
+  trySend(Item(message = message))
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.js.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.js.kt
@@ -1,0 +1,168 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.DefaultApolloException
+import node.buffer.Buffer
+import org.khronos.webgl.Uint8Array
+import org.w3c.dom.WebSocket as PlatformWebSocket
+
+internal class JsWebSocketEngine: WebSocketEngine {
+  override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {
+    return JsWebSocket(url, headers, listener)
+  }
+
+  override fun close() {
+  }
+}
+
+internal class JsWebSocket(
+    url: String,
+    headers: List<HttpHeader>,
+    private val listener: WebSocketListener,
+) : WebSocket {
+  private val platformWebSocket: PlatformWebSocket?
+  private var disposed = false
+
+  private val actualUrl = when {
+    url.startsWith("http://") -> "ws://${url.substring(7)}"
+    url.startsWith("https://") -> "wss://${url.substring(8)}"
+    else -> url
+  }
+  init {
+    platformWebSocket = createWebSocket(actualUrl, headers, listener)
+    platformWebSocket?.onopen = {
+      listener.onOpen()
+    }
+
+    platformWebSocket?.onmessage = {
+      val data2: dynamic = it.data
+
+      @Suppress("USELESS_CAST")
+      when {
+        data2 is String -> listener.onMessage(data2 as String)
+        Buffer.isBuffer(data2) -> {
+          listener.onMessage((data2 as Buffer).toByteArray())
+        }
+        else -> {
+          val d = JSON.stringify(data2)
+          if (!disposed) {
+            disposed = true
+            listener.onError(DefaultApolloException("The JS WebSocket implementation only support text messages (got $d)"))
+            platformWebSocket?.close(CLOSE_GOING_AWAY.toShort(), "Unsupported message received")
+          }
+          Unit
+        }
+      }
+    }
+
+    platformWebSocket?.onerror = {
+      if (!disposed) {
+        disposed = true
+        listener.onError(DefaultApolloException("Error while reading websocket"))
+      }
+    }
+
+    platformWebSocket?.onclose = {
+      val event: dynamic = it
+      if (!disposed) {
+        disposed = true
+        if (event.wasClean) {
+          listener.onClosed(event.code, event.reason)
+        } else {
+          listener.onError(DefaultApolloException("WebSocket was closed"))
+        }
+      }
+    }
+  }
+
+  override fun send(data: ByteArray) {
+    platformWebSocket?.let {
+      if (it.bufferedAmount.toDouble() > MAX_BUFFERED) {
+        if (!disposed) {
+          disposed = true
+          listener.onError(DefaultApolloException("Too much data queued"))
+        }
+      }
+      it.send(Uint8Array(data.toTypedArray()))
+    }
+  }
+
+  override fun send(text: String) {
+    platformWebSocket?.let {
+      if (it.bufferedAmount.toDouble() > MAX_BUFFERED) {
+        if (!disposed) {
+          disposed = true
+          listener.onError(DefaultApolloException("Too much data queued"))
+        }
+      }
+
+      it.send(text)
+    }
+  }
+
+  override fun close(code: Int, reason: String) {
+    if (!disposed) {
+      disposed = true
+      platformWebSocket?.close(code.toShort(), reason)
+    }
+  }
+}
+
+/**
+ * This is probably far too high and problems will probably appear much sooner but this is used to signal the intent
+ * of this code as well as a last resort
+ */
+private val MAX_BUFFERED = 100_000_000
+
+/**
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * From https://github.com/ktorio/ktor/blob/6cd529b2dcedfcfc4ca2af0f62704764e160d7fd/ktor-utils/js/src/io/ktor/util/PlatformUtilsJs.kt#L16
+ */
+fun isNode(): Boolean {
+  return js(
+      """
+                (typeof process !== 'undefined' 
+                    && process.versions != null 
+                    && process.versions.node != null) ||
+                (typeof window !== 'undefined' 
+                    && typeof window.process !== 'undefined' 
+                    && window.process.versions != null 
+                    && window.process.versions.node != null)
+                """
+  ) as Boolean
+}
+
+/*
+ * The following applies for lines below
+ * Copyright 2014-2019 JetBrains s.r.o and contributors. Use of this source code is governed by the Apache 2.0 license.
+ * Some lines have been added/modified from the original source (https://github.com/ktorio/ktor/blob/f723638afd4d36024c390c5b79108b53ab513943/ktor-client/ktor-client-core/js/src/io/ktor/client/engine/js/JsClientEngine.kt#L62)
+ * in order to fix an issue with subprotocols on Node (https://youtrack.jetbrains.com/issue/KTOR-4001)
+ */
+/**
+ * Adding "_capturingHack" to reduce chances of JS IR backend to rename variable,
+ * so it can be accessed inside js("") function
+ *
+ * May return null if headers are set
+ */
+@Suppress("UNUSED_PARAMETER", "UnsafeCastFromDynamic", "UNUSED_VARIABLE", "LocalVariableName")
+private fun createWebSocket(urlString_capturingHack: String, headers: List<HttpHeader>, listener: WebSocketListener): PlatformWebSocket? {
+  val (protocolHeaders, otherHeaders) = headers.partition { it.name.equals("sec-websocket-protocol", true) }
+  val protocols = protocolHeaders.map { it.value }.toTypedArray()
+  return if (isNode()) {
+    val ws_capturingHack = js("eval('require')('ws')")
+    val headers_capturingHack: dynamic = object {}
+    headers.forEach {
+      headers_capturingHack[it.name] = it.value
+    }
+    js("new ws_capturingHack(urlString_capturingHack, protocols, { headers: headers_capturingHack })")
+  } else {
+    if(otherHeaders.isNotEmpty()) {
+      listener.onError(DefaultApolloException("Apollo: the WebSocket browser API doesn't allow passing headers. Use connectionPayload or other mechanisms."))
+      null
+    } else {
+      js("new WebSocket(urlString_capturingHack, protocols)")
+    }
+  }
+}
+
+actual fun WebSocketEngine(): WebSocketEngine = JsWebSocketEngine()

--- a/libraries/apollo-websocket-network-transport-incubating/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.js.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/jsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.js.kt
@@ -47,7 +47,7 @@ internal class JsWebSocket(
           val d = JSON.stringify(data2)
           if (!disposed) {
             disposed = true
-            listener.onError(DefaultApolloException("The JS WebSocket implementation only support text messages (got $d)"))
+            listener.onError(DefaultApolloException("Apollo: unsupported message received ('$d')"))
             platformWebSocket?.close(CLOSE_GOING_AWAY.toShort(), "Unsupported message received")
           }
           Unit

--- a/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/DefaultOkHttpClientBuilder.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/DefaultOkHttpClientBuilder.kt
@@ -1,0 +1,8 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+
+import okhttp3.OkHttpClient
+
+internal val defaultOkHttpClientBuilder: OkHttpClient.Builder by lazy {
+  OkHttpClient.Builder()
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.jvm.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.jvm.kt
@@ -1,0 +1,98 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.http.HttpHeader
+import okhttp3.Headers
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okio.ByteString
+import okio.ByteString.Companion.toByteString
+import java.util.concurrent.atomic.AtomicBoolean
+import okhttp3.WebSocket as PlatformWebSocket
+import okhttp3.WebSocketListener as PlatformWebSocketListener
+
+internal class JvmWebSocketEngine(private val okHttpClient: OkHttpClient) : WebSocketEngine {
+  override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {
+    return JvmWebSocket(okHttpClient, url, headers, listener)
+  }
+
+  override fun close() {
+
+  }
+}
+
+internal class JvmWebSocket(
+    webSocketFactory: PlatformWebSocket.Factory,
+    url: String,
+    headers: List<HttpHeader>,
+    private val listener: WebSocketListener,
+) : WebSocket, PlatformWebSocketListener() {
+  private val platformWebSocket: PlatformWebSocket
+  private val disposed = AtomicBoolean(false)
+
+  init {
+    val request = Request.Builder()
+        .url(url)
+        .headers(headers.toOkHttpHeaders())
+        .build()
+
+    platformWebSocket = webSocketFactory.newWebSocket(request, this)
+  }
+
+  override fun onOpen(webSocket: PlatformWebSocket, response: Response) {
+    listener.onOpen()
+  }
+
+  override fun onMessage(webSocket: PlatformWebSocket, bytes: ByteString) {
+    listener.onMessage(bytes.toByteArray())
+  }
+
+  override fun onMessage(webSocket: PlatformWebSocket, text: String) {
+    listener.onMessage(text)
+  }
+
+  override fun onFailure(webSocket: PlatformWebSocket, t: Throwable, response: Response?) {
+    if (disposed.compareAndSet(false, true)) {
+      listener.onError(t)
+      platformWebSocket.cancel()
+    }
+  }
+
+  override fun onClosing(webSocket: PlatformWebSocket, code: Int, reason: String) {
+    if (disposed.compareAndSet(false, true)) {
+      listener.onClosed(code, reason)
+      platformWebSocket.cancel()
+    }
+  }
+
+  override fun onClosed(webSocket: PlatformWebSocket, code: Int, reason: String) {
+    /**
+     * Do nothing. When we come here either [close] or [onClosing] has been called and the [WebSocket]
+     * is disposed already.
+     */
+  }
+
+  private fun List<HttpHeader>.toOkHttpHeaders(): Headers =
+      Headers.Builder().also { headers ->
+        this.forEach {
+          headers.add(it.name, it.value)
+        }
+      }.build()
+
+  override fun send(data: ByteArray) {
+    platformWebSocket.send(data.toByteString())
+  }
+
+  override fun send(text: String) {
+    platformWebSocket.send(text)
+  }
+
+  override fun close(code: Int, reason: String) {
+    if (disposed.compareAndSet(false, true)) {
+      platformWebSocket.close(code, reason)
+    }
+  }
+}
+
+
+actual fun WebSocketEngine(): WebSocketEngine = JvmWebSocketEngine(defaultOkHttpClientBuilder.build())

--- a/libraries/apollo-websocket-network-transport-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.wasmJs.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/wasmJsMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.wasmJs.kt
@@ -1,0 +1,5 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+actual fun WebSocketEngine(): WebSocketEngine {
+  TODO("Not yet implemented")
+}


### PR DESCRIPTION
The incubating WebSocketEngine uses events instead of coroutines, making it easier to map to the underlying implementations (OkHttp, NSUrlSession and JS WebSocket are all event-based).

It also fixes a memory leak in the Apple WebSocketEngine (the NSUrlSession wasn't cancelled).

This PR also makes wasm tests "work" again. They are mostly ignored but you can now type `./gradlew build` and the build will pass. They were failing previously because trying to run on a node version that did not support wasm.