### PR TITLE
Introduce incubating WebSocketNetworkTransport

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -1290,9 +1290,13 @@ public final class com/apollographql/apollo3/exception/RouterError : com/apollog
 	public final fun getErrors ()Ljava/util/List;
 }
 
+public final class com/apollographql/apollo3/exception/SubscriptionConnectionException : com/apollographql/apollo3/exception/ApolloException {
+	public fun <init> (Ljava/lang/Object;)V
+	public final fun getPayload ()Ljava/lang/Object;
+}
+
 public final class com/apollographql/apollo3/exception/SubscriptionOperationException : com/apollographql/apollo3/exception/ApolloException {
 	public fun <init> (Ljava/lang/String;Ljava/lang/Object;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPayload ()Ljava/lang/Object;
 }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/exception/Exceptions.kt
@@ -41,15 +41,20 @@ class ApolloNetworkException(
 /**
  * The server could not process a subscription and sent an error.
  *
- * This typically happens if there is a validation error. This is a terminal event.
+ * This typically happens if there is a validation error.
  *
  * @param operationName the name of the subscription that triggered the error.
  * @param payload the payload returned by the server.
  */
 class SubscriptionOperationException(
     operationName: String,
-    val payload: Any? = null,
+    val payload: Any?,
 ) : ApolloException(message = "Operation error $operationName")
+
+class SubscriptionConnectionException(
+    val payload: Any?,
+) : ApolloException(message = "Websocket error")
+
 
 /**
  * The router sent one or several errors.

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/AppSyncWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/AppSyncWsProtocol.kt
@@ -83,7 +83,7 @@ class AppSyncWsProtocol(
       "error" -> {
         val id = map["id"] as? String
         if (id != null) {
-          OperationErrorServerMessage(id, map["payload"])
+          OperationErrorServerMessage(id, map["payload"], true)
         } else {
           ParseErrorServerMessage("General error: $text")
         }

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/AppSyncWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/AppSyncWsProtocol.kt
@@ -1,0 +1,134 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.NullableAnyAdapter
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer.Companion.appendQueryParameters
+import com.apollographql.apollo3.api.json.buildJsonByteString
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
+import com.apollographql.apollo3.api.json.writeAny
+import com.apollographql.apollo3.api.toJsonString
+import okio.Buffer
+
+class AppSyncWsProtocol(
+    val authorization: suspend () -> Any? = { null },
+) : WsProtocol {
+  override val name: String
+    get() = "graphql-ws"
+
+  override suspend fun connectionInit(): ClientMessage {
+    return mapOf("type" to "connection_init").toClientMessage()
+  }
+
+  override suspend fun <D : Operation.Data> operationStart(request: ApolloRequest<D>): ClientMessage {
+    // AppSync encodes the data as a String
+    val data = NullableAnyAdapter.toJsonString(DefaultHttpRequestComposer.composePayload(request))
+
+
+        return mapOf(
+            "type" to "start",
+            "id" to request.requestUuid.toString(),
+            "payload" to mapOf(
+                "data" to data,
+                "extensions" to mapOf(
+                    "authorization" to authorization()
+                )
+            )
+        ).toClientMessage()
+  }
+
+  override fun <D : Operation.Data> operationStop(request: ApolloRequest<D>): ClientMessage {
+    return mapOf(
+        "type" to "stop",
+        "id" to request.requestUuid.toString(),
+    ).toClientMessage()
+  }
+
+  override fun ping(): ClientMessage? {
+    return mapOf("type" to "ping").toClientMessage()
+  }
+
+  override fun pong(): ClientMessage? {
+    return mapOf("type" to "pong").toClientMessage()
+  }
+
+  override fun parseServerMessage(text: String): ServerMessage {
+    val map = try {
+      @Suppress("UNCHECKED_CAST")
+      Buffer().writeUtf8(text).jsonReader().readAny() as Map<String, Any?>
+    } catch (e: Exception) {
+      return ParseErrorServerMessage("Cannot parse server message: '$this'")
+    }
+
+    val type = map["type"] as? String
+    if (type == null) {
+      return ParseErrorServerMessage("No 'type' found in server message: '$this'")
+    }
+
+    return when (type) {
+      "connection_ack" -> ConnectionAckServerMessage
+      "connection_error" -> ConnectionErrorServerMessage(map["payload"])
+      "ka" -> PingServerMessage
+      "data", "complete" -> {
+        val id = map["id"] as? String
+        when {
+          id == null -> ParseErrorServerMessage("No 'id' found in message: '$text'")
+          type == "data" -> ResponseServerMessage(id, map["payload"], false)
+          type == "complete" -> CompleteServerMessage(id)
+          else -> error("") // make the compiler happy
+        }
+      }
+      "error" -> {
+        val id = map["id"] as? String
+        if (id != null) {
+          OperationErrorServerMessage(id, map["payload"])
+        } else {
+          ParseErrorServerMessage("General error: $text")
+        }
+      }
+
+      else -> ParseErrorServerMessage("Unknown type: '$type' found in server message: '$text'")
+    }
+  }
+
+  companion object {
+    /**
+     * Helper method that builds the final URL. It will append the authorization and payload arguments as query parameters.
+     * This method can be used for both the HTTP URL as well as the WebSocket URL
+     *
+     * Example:
+     * ```
+     * buildUrl(
+     *   baseUrl = "https://example1234567890000.appsync-realtime-api.us-east-1.amazonaws.com/graphql",
+     *   // This example uses an API key. See the AppSync documentation for information on what to pass
+     *   authorization = mapOf(
+     *     "host" to "example1234567890000.appsync-api.us-east-1.amazonaws.com",
+     *     "x-api-key" to "da2-12345678901234567890123456"
+     *   )
+     * )
+     * ```
+     *
+     * @param baseUrl The base web socket URL.
+     * @param authorization The authorization as per the AppSync documentation.
+     * @param payload An optional payload. Defaults to an empty object.
+     */
+    fun buildUrl(
+        baseUrl: String,
+        authorization: Map<String, Any?>,
+        payload: Map<String, Any?> = emptyMap(),
+    ): String =
+        baseUrl
+            .appendQueryParameters(mapOf(
+                "header" to authorization.base64Encode(),
+                "payload" to payload.base64Encode(),
+            ))
+
+    private fun Map<String, Any?>.base64Encode(): String {
+      return buildJsonByteString {
+        writeAny(this@base64Encode)
+      }.base64()
+    }
+  }
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ClientMessage.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ClientMessage.kt
@@ -1,0 +1,14 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.writeAny
+
+sealed interface ClientMessage
+class TextClientMessage(val text: String): ClientMessage
+class DataClientMessage(val data: ByteArray): ClientMessage
+
+internal fun Any?.toClientMessage(): ClientMessage {
+  return buildJsonString {
+    writeAny(this@toClientMessage)
+  }.let { TextClientMessage(it) }
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/GraphQLWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/GraphQLWsProtocol.kt
@@ -1,0 +1,81 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
+import okio.Buffer
+
+class GraphQLWsProtocol(
+    val connectionParams: suspend () -> Any?,
+) : WsProtocol {
+  override val name: String
+    get() = "graphql-transport-ws"
+
+  override suspend fun connectionInit(): ClientMessage {
+    val map = mutableMapOf<String, Any?>()
+    map.put("type", "connection_init")
+    val params = connectionParams()
+    if (params != null) {
+      map.put("payload", params)
+    }
+
+    return map.toClientMessage()
+  }
+
+  override suspend fun <D : Operation.Data> operationStart(request: ApolloRequest<D>): ClientMessage {
+    return mapOf(
+        "type" to "subscribe",
+        "id" to request.requestUuid.toString(),
+        "payload" to DefaultHttpRequestComposer.composePayload(request)
+    ).toClientMessage()
+  }
+
+  override fun <D : Operation.Data> operationStop(request: ApolloRequest<D>): ClientMessage {
+    return mapOf(
+        "type" to "complete",
+        "id" to request.requestUuid.toString(),
+    ).toClientMessage()
+  }
+
+  override fun ping(): ClientMessage? {
+    return mapOf("type" to "ping").toClientMessage()
+  }
+
+  override fun pong(): ClientMessage? {
+    return mapOf("type" to "pong").toClientMessage()
+  }
+
+  override fun parseServerMessage(text: String): ServerMessage {
+    val map = try {
+      @Suppress("UNCHECKED_CAST")
+      Buffer().writeUtf8(text).jsonReader().readAny() as Map<String, Any?>
+    } catch (e: Exception) {
+      return ParseErrorServerMessage("Cannot parse server message: '$text'")
+    }
+
+    val type = map["type"] as? String
+    if (type == null) {
+      return ParseErrorServerMessage("No 'type' found in server message: '$text'")
+    }
+
+    return when (type) {
+      "connection_ack" -> ConnectionAckServerMessage
+      "ping" -> PingServerMessage
+      "pong" -> PongServerMessage
+      "next", "complete", "error" -> {
+        val id = map["id"] as? String
+        when {
+          id == null -> ParseErrorServerMessage("No 'id' found in message: '$text'")
+          type == "next" -> ResponseServerMessage(id, map["payload"], false)
+          type == "complete" -> CompleteServerMessage(id)
+          type == "error" -> ResponseServerMessage(id, mapOf("errors" to map["payload"]), true)
+          else -> error("") // make the compiler happy
+        }
+      }
+
+      else -> ParseErrorServerMessage("Unknown type: '$type' found in server message: '$text'")
+    }
+  }
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/OperationListener.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/OperationListener.kt
@@ -1,0 +1,37 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+import com.apollographql.apollo3.exception.ApolloException
+
+internal interface OperationListener {
+  /**
+   * A response was received
+   *
+   * [response] is the Kotlin representation of a GraphQL response.
+   *
+   * ```kotlin
+   * mapOf(
+   *   "data" to ...
+   *   "errors" to listOf(...)
+   * )
+   * ```
+   */
+  fun onResponse(response: ApolloJsonElement)
+
+  /**
+   * The operation terminated successfully. No future calls to this listener are made.
+   */
+  fun onComplete()
+
+  /**
+   * The server sent an error. That error may be terminal in which case, no future calls to this listener are made.
+   */
+  fun onError(payload: ApolloJsonElement, terminal: Boolean)
+
+  /**
+   * The transport failed. No future calls to this listener are made.
+   */
+  fun onTransportError(cause: ApolloException)
+}
+
+

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
@@ -1,0 +1,37 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+
+sealed interface ServerMessage
+object ConnectionAckServerMessage : ServerMessage
+object ConnectionKeepAliveServerMessage : ServerMessage
+object PingServerMessage : ServerMessage
+object PongServerMessage : ServerMessage
+class ConnectionErrorServerMessage(val payload: Any?) : ServerMessage
+
+/**
+ * A GraphQL response was received
+ *
+ * @param response, a GraphQL response, possibly containing errors.
+ * @param complete, whether this is a terminal message for the given operation.
+ */
+class ResponseServerMessage(val id: String, val response: Any?, val complete: Boolean) : ServerMessage
+
+/**
+ * The subscription completed normally
+ * This is a terminal message for the given operation.
+ */
+class CompleteServerMessage(val id: String) : ServerMessage
+
+/**
+ * There was an error with the operation that cannot be represented by a GraphQL response
+ *
+ * @param payload additional information regarding the error. It may represent a GraphQL error
+ * but it doesn't have to
+ */
+class OperationErrorServerMessage(val id: String, val payload: ApolloJsonElement, val terminal: Boolean) : ServerMessage
+
+/**
+ * Special Server message that indicates a malformed message
+ */
+class ParseErrorServerMessage(val errorMessage: String) : ServerMessage

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscribableWebSocket.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscribableWebSocket.kt
@@ -1,0 +1,262 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.ApolloWebSocketClosedException
+import com.apollographql.apollo3.exception.DefaultApolloException
+import com.apollographql.apollo3.exception.SubscriptionConnectionException
+import com.apollographql.apollo3.mpp.currentTimeMillis
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * A [SubscribableWebSocket] is the link between the lower level [WebSocket] and GraphQL.
+ *
+ * A [SubscribableWebSocket] has its own [CoroutineScope] used for ping/pong messages as well as allowing the underlying [WsProtocol] to
+ * suspend to retrieve a token in init or start
+ *
+ * [startOperation] starts a new operation and calls [OperationListener] when the server sends messages.
+ *
+ */
+internal class SubscribableWebSocket(
+    webSocketEngine: WebSocketEngine,
+    serverUrl: String,
+    httpHeaders: List<HttpHeader>,
+    private val dispatcher: CoroutineDispatcher,
+    private val wsProtocol: WsProtocol,
+    private val pingIntervalMillis: Long,
+    private val connectionAcknowledgeTimeoutMillis: Long,
+) : WebSocketListener {
+
+  private var lock = reentrantLock()
+  private val scope = CoroutineScope(dispatcher)
+
+  private var ackTimeoutJob: Job? = null
+  private var state: SocketState = SocketState.AwaitOpen
+  private var shutdownCause: ApolloException? = null
+  private var activeListeners = mutableMapOf<String, OperationListener>()
+  private var pending = mutableListOf<ApolloRequest<*>>()
+  private var webSocket: WebSocket = webSocketEngine.newWebSocket(serverUrl, httpHeaders, this)
+  private var _lastActiveMillis: Long = 0
+
+  val lastActiveMillis: Long
+    get() = lock.withLock {
+      _lastActiveMillis
+    }
+  val shutdown: Boolean
+    get() = lock.withLock {
+      state == SocketState.ShutDown
+    }
+
+  fun shutdown(cause: ApolloException?, code: Int?, reason: String?) {
+    val listeners = mutableListOf<OperationListener>()
+
+    lock.withLock {
+      if (state == SocketState.ShutDown) {
+        return
+      }
+      scope.cancel()
+
+      state = SocketState.ShutDown
+      shutdownCause = cause
+      listeners.addAll(activeListeners.values)
+      activeListeners.clear()
+    }
+
+    if (code != null && reason != null) {
+      webSocket.close(code, reason)
+    }
+
+    listeners.forEach {
+      if (cause == null) {
+        it.onComplete()
+      } else {
+        it.onTransportError(cause)
+      }
+    }
+  }
+
+  override fun onOpen() {
+    lock.withLock {
+      when (state) {
+        SocketState.AwaitOpen -> {
+          scope.launch(dispatcher) {
+            webSocket.send(wsProtocol.connectionInit())
+          }
+          ackTimeoutJob = scope.launch(dispatcher) {
+            delay(connectionAcknowledgeTimeoutMillis)
+            shutdown(DefaultApolloException("Timeout while waiting for ack"), CLOSE_GOING_AWAY, "Timeout while waiting for connection_ack")
+          }
+          state = SocketState.AwaitAck
+        }
+
+        else -> {
+          // spurious "open" event
+        }
+      }
+    }
+  }
+
+  override fun onMessage(text: String) {
+    when (val message = wsProtocol.parseServerMessage(text)) {
+      ConnectionAckServerMessage -> {
+        ackTimeoutJob?.cancel()
+        ackTimeoutJob = null
+
+        lock.withLock {
+          if (state != SocketState.AwaitAck) {
+            // spurious connection_ack
+            return
+          }
+          state = SocketState.Connected
+
+          if (pingIntervalMillis > 0) {
+            scope.launch {
+              while (true) {
+                delay(pingIntervalMillis)
+                wsProtocol.ping()?.let { webSocket.send(it) }
+              }
+            }
+          }
+
+          scope.launch {
+            pending.forEach {
+              webSocket.send(wsProtocol.operationStart(it))
+            }
+          }
+        }
+      }
+
+      is ConnectionErrorServerMessage -> {
+        shutdown(SubscriptionConnectionException(message.payload), CLOSE_GOING_AWAY, "Connection error")
+      }
+
+      is ResponseServerMessage -> {
+        activeListeners.get(message.id)?.let {
+          it.onResponse(message.response)
+          if (message.complete) {
+            it.onComplete()
+          }
+        }
+      }
+
+      is CompleteServerMessage -> {
+        activeListeners.get(message.id)?.onComplete()
+      }
+
+      is OperationErrorServerMessage -> {
+        activeListeners.get(message.id)?.onError(message.payload, message.terminal)
+      }
+
+      is ParseErrorServerMessage -> {
+        // This is an unknown or malformed message
+        // It's not 100% clear what we should do here. Should we terminate the operation?
+        println("Cannot parse message: '${message.errorMessage}'")
+      }
+
+      PingServerMessage -> {
+        wsProtocol.pong()?.let {
+          webSocket.send(it)
+        }
+      }
+
+      PongServerMessage -> {
+        // nothing to do
+      }
+
+      ConnectionKeepAliveServerMessage -> {
+        // nothing to do
+      }
+    }
+  }
+
+  override fun onMessage(data: ByteArray) {
+    onMessage(data.decodeToString())
+  }
+
+  override fun onError(cause: ApolloException) {
+    shutdown(cause, null, null)
+  }
+
+  override fun onClosed(code: Int?, reason: String?) {
+    shutdown(ApolloWebSocketClosedException(code ?: CLOSE_NORMAL, reason), null, null)
+  }
+
+  fun <D : Operation.Data> startOperation(request: ApolloRequest<D>, listener: OperationListener) {
+    var cause: ApolloException? = null
+    lock.withLock {
+      when (state) {
+        SocketState.AwaitOpen, SocketState.AwaitAck -> {
+          activeListeners.put(request.requestUuid.toString(), listener)
+          pending.add(request)
+        }
+
+        SocketState.Connected -> {
+          activeListeners.put(request.requestUuid.toString(), listener)
+          scope.launch { webSocket.send(wsProtocol.operationStart(request)) }
+        }
+
+        SocketState.ShutDown -> {
+          cause = DefaultApolloException("Apollo: the WebSocket is shut down")
+        }
+      }
+    }
+
+    if (cause != null) {
+      listener.onTransportError(cause!!)
+    }
+  }
+
+  fun <D : Operation.Data> stopOperation(request: ApolloRequest<D>) {
+    val id = request.requestUuid.toString()
+    val removed = lock.withLock {
+      var ret = false
+      if (activeListeners.containsKey(id)) {
+        activeListeners.remove(id)
+        ret = true
+      }
+
+      if (activeListeners.isEmpty()) {
+        _lastActiveMillis = currentTimeMillis()
+      }
+      ret
+    }
+
+    if (!removed) {
+      return
+    }
+
+    scope.launch { webSocket.send(wsProtocol.operationStop(request)) }
+  }
+
+  fun markActive() = lock.withLock {
+    _lastActiveMillis = 0
+  }
+}
+
+private enum class SocketState {
+  AwaitOpen,
+  AwaitAck,
+  Connected,
+  ShutDown
+
+}
+
+private fun WebSocket.send(clientMessage: ClientMessage) {
+  when (clientMessage) {
+    is TextClientMessage -> send(clientMessage.text)
+    is DataClientMessage -> send(clientMessage.data)
+  }
+}
+
+interface StateListener {
+  fun onConnectionLost(cause: ApolloException)
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscribableWebSocket.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscribableWebSocket.kt
@@ -256,7 +256,3 @@ private fun WebSocket.send(clientMessage: ClientMessage) {
     is DataClientMessage -> send(clientMessage.data)
   }
 }
-
-interface StateListener {
-  fun onConnectionLost(cause: ApolloException)
-}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionWsProtocol.kt
@@ -72,7 +72,7 @@ class SubscriptionWsProtocol private constructor(
           /**
            * "error" is followed by "complete" but we send the terminal [OperationErrorServerMessage] right away
            */
-          type == "error" -> OperationErrorServerMessage(id, map["payload"])
+          type == "error" -> OperationErrorServerMessage(id, map["payload"], true)
           else -> error("") // make the compiler happy
         }
       }

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionWsProtocol.kt
@@ -1,0 +1,84 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.DefaultHttpRequestComposer
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
+import okio.Buffer
+
+class SubscriptionWsProtocol private constructor(
+    val connectionParams: suspend () -> Any?,
+) : WsProtocol {
+  override val name: String
+    get() = "graphql-ws"
+
+  override suspend fun connectionInit(): ClientMessage {
+    val map = mutableMapOf<String, Any?>()
+    map.put("type", "connection_init")
+    val params = connectionParams()
+    if (params != null) {
+      map.put("payload", params)
+    }
+
+    return map.toClientMessage()
+  }
+
+  override suspend fun <D : Operation.Data> operationStart(request: ApolloRequest<D>): ClientMessage {
+    return mapOf(
+        "id" to request.requestUuid.toString(),
+        "type" to "start",
+        "payload" to DefaultHttpRequestComposer.composePayload(request)
+    ).toClientMessage()
+  }
+
+  override fun <D : Operation.Data> operationStop(request: ApolloRequest<D>): ClientMessage {
+    return mapOf(
+        "type" to "stop",
+        "id" to request.requestUuid.toString(),
+    ).toClientMessage()
+  }
+
+  override fun ping(): ClientMessage? {
+    return null
+  }
+
+  override fun pong(): ClientMessage? {
+    return null
+  }
+
+  override fun parseServerMessage(text: String): ServerMessage {
+    val map = try {
+      @Suppress("UNCHECKED_CAST")
+      Buffer().writeUtf8(text).jsonReader().readAny() as Map<String, Any?>
+    } catch (e: Exception) {
+      return ParseErrorServerMessage("Cannot parse server message: '$text'")
+    }
+
+    val type = map["type"] as? String
+    if (type == null) {
+      return ParseErrorServerMessage("No 'type' found in server message: '$text'")
+    }
+
+    return when (type) {
+      "connection_ack" -> ConnectionAckServerMessage
+      "connection_error" -> ConnectionErrorServerMessage(map["payload"])
+      "data", "complete", "error" -> {
+        val id = map["id"] as? String
+        when {
+          id == null -> ParseErrorServerMessage("No 'id' found in message: '$text'")
+          type == "data" -> ResponseServerMessage(id, map["payload"], false)
+          type == "complete" -> CompleteServerMessage(id)
+          /**
+           * "error" is followed by "complete" but we send the terminal [OperationErrorServerMessage] right away
+           */
+          type == "error" -> OperationErrorServerMessage(id, map["payload"])
+          else -> error("") // make the compiler happy
+        }
+      }
+
+      else -> ParseErrorServerMessage("Unknown type: '$type' found in server message: '$text'")
+    }
+  }
+}
+

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.network.ws.incubating
 
 import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.ApolloException
 import okio.Closeable
 
 interface WebSocketEngine: Closeable {
@@ -47,7 +48,7 @@ interface WebSocketListener {
   /**
    * An error happened, no more calls to the listener are made.
    */
-  fun onError(throwable: Throwable)
+  fun onError(cause: ApolloException)
 
   /**
    * The server sent a close frame, no more calls to the listener are made.

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
@@ -1,0 +1,99 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.mpp.currentTimeMillis
+import kotlinx.atomicfu.locks.reentrantLock
+import kotlinx.atomicfu.locks.withLock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+internal class WebSocketHolder(
+    private val webSocketEngine: WebSocketEngine,
+    private val serverUrl: String,
+    private val httpHeaders: List<HttpHeader>,
+    private val wsProtocol: WsProtocol,
+    private val connectionAcknowledgeTimeoutMillis: Long,
+    private val pingIntervalMillis: Long,
+    private val idleTimeoutMillis: Long,
+)  {
+  private val dispatcher = Dispatchers.Default
+  private val scope = CoroutineScope(dispatcher)
+  private var idleJob: Job? = null
+  private var subscribableWebSocket: SubscribableWebSocket? = null
+  private var lock = reentrantLock()
+
+  init {
+    triggerCleanup(timeoutMillis = idleTimeoutMillis)
+  }
+
+  private fun triggerCleanup(timeoutMillis: Long): Unit = lock.withLock {
+    idleJob?.cancel()
+    idleJob = scope.launch {
+      delay(timeoutMillis)
+      val next = lock.withLock {
+        cleanupLocked()
+      }
+      triggerCleanup(next)
+    }
+  }
+
+  fun acquire(): SubscribableWebSocket = lock.withLock {
+    cleanupLocked()
+    if (subscribableWebSocket == null) {
+      subscribableWebSocket = SubscribableWebSocket(
+          webSocketEngine,
+          serverUrl,
+          httpHeaders,
+          dispatcher,
+          wsProtocol,
+          connectionAcknowledgeTimeoutMillis,
+          pingIntervalMillis,
+      )
+    }
+    // Mark active before startOperation to avoid a small race where cleanup() would be called after acquire() returns
+    // but before startOperation() runs
+    subscribableWebSocket!!.markActive()
+    return subscribableWebSocket!!
+  }
+
+  private fun cleanupLocked(): Long {
+    if (subscribableWebSocket != null) {
+      if (subscribableWebSocket!!.shutdown) {
+        subscribableWebSocket = null
+        return idleTimeoutMillis
+      }
+
+      val lastActiveMillis = subscribableWebSocket!!.lastActiveMillis
+      if (lastActiveMillis != 0L) {
+        val elapsed = currentTimeMillis() - lastActiveMillis
+        if (elapsed > idleTimeoutMillis) {
+          subscribableWebSocket!!.shutdown(null, CLOSE_GOING_AWAY, "Idle")
+          subscribableWebSocket = null
+        } else {
+          return idleTimeoutMillis - elapsed
+        }
+      }
+
+    }
+    return idleTimeoutMillis
+  }
+
+  fun close() = lock.withLock {
+    webSocketEngine.close()
+    if (subscribableWebSocket != null) {
+      subscribableWebSocket!!.shutdown(null, CLOSE_GOING_AWAY, "Canceled")
+      subscribableWebSocket = null
+    }
+  }
+
+  fun closeCurrentConnection(reason: ApolloException?) = lock.withLock {
+    if (subscribableWebSocket != null) {
+      subscribableWebSocket!!.shutdown(reason, CLOSE_GOING_AWAY, "Client requested closing the connection")
+      subscribableWebSocket = null
+    }
+  }
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
@@ -27,6 +27,10 @@ internal class WebSocketHolder(
   private var lock = reentrantLock()
 
   init {
+    // Make sure we do not busy loop 
+    check(idleTimeoutMillis > 0) {
+      "Apollo: 'idleTimeoutMillis' must be > 0"
+    }
     triggerCleanup(timeoutMillis = idleTimeoutMillis)
   }
 

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
@@ -1,0 +1,267 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.toApolloResponse
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.DefaultApolloException
+import com.apollographql.apollo3.exception.SubscriptionOperationException
+import com.apollographql.apollo3.internal.DeferredJsonMerger
+import com.apollographql.apollo3.network.NetworkTransport
+import com.benasher44.uuid.uuid4
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ProducerScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.buffer
+import kotlinx.coroutines.flow.callbackFlow
+
+/**
+ * A [NetworkTransport] that uses WebSockets to execute GraphQL operations. Most of the time, it is used
+ * for subscriptions but some [WsProtocol] like [GraphQLWsProtocol] also allow executing queries and mutations
+ * over WebSockets.
+ *
+ * @see [WebSocketNetworkTransport.Builder]
+ */
+class WebSocketNetworkTransport private constructor(
+    private val webSocketEngine: WebSocketEngine,
+    private val serverUrl: String,
+    private val httpHeaders: List<HttpHeader>,
+    private val wsProtocol: WsProtocol,
+    private val connectionAcknowledgeTimeoutMillis: Long,
+    private val pingIntervalMillis: Long,
+    private val idleTimeoutMillis: Long,
+) : NetworkTransport {
+
+  private val holder = WebSocketHolder(
+      webSocketEngine,
+      serverUrl,
+      httpHeaders,
+      wsProtocol,
+      connectionAcknowledgeTimeoutMillis,
+      pingIntervalMillis,
+      idleTimeoutMillis
+  )
+
+  /**
+   * Executes the given [ApolloRequest] using WebSockets
+   *
+   * @return a cold [Flow] that subscribes when started and unsubscribes when cancelled.
+   * The returned [Flow] buffers responses without upper bound.
+   *
+   * Else, the [Flow] will emit a response with a non-null [ApolloResponse.exception] and terminate normally.
+   */
+  override fun <D : Operation.Data> execute(
+      request: ApolloRequest<D>,
+  ): Flow<ApolloResponse<D>> {
+
+    var renewUuid = false
+
+    val flow = callbackFlow {
+      val newRequest = if (renewUuid) {
+        request.newBuilder().requestUuid(uuid4()).build()
+      } else {
+        request
+      }
+      renewUuid = true
+
+      val operationListener = DefaultOperationListener(newRequest, this)
+
+      val webSocket = holder.acquire()
+      webSocket.startOperation(newRequest, operationListener)
+
+      awaitClose {
+        webSocket.stopOperation(newRequest)
+      }
+    }
+
+    // buffer because we're emitting from websocket callbacks and we can't suspend there
+    return flow.buffer(Channel.UNLIMITED)
+  }
+
+  override fun dispose() {
+    holder.close()
+  }
+
+  /**
+   * Close the connection to the server if it's open.
+   *
+   * This can be used to force a reconnection to the server, for instance when new auth tokens should be passed to the headers.
+   *
+   * The given [reason] will be propagated to active subscriptions.
+   */
+  fun closeConnection(reason: ApolloException) {
+    holder.closeCurrentConnection(reason)
+  }
+
+
+  class Builder {
+    private var serverUrl: String? = null
+    private var httpHeaders: List<HttpHeader>? = null
+    private var webSocketEngine: WebSocketEngine? = null
+    private var wsProtocol: WsProtocol? = null
+    private var connectionAcknowledgeTimeoutMillis: Long? = null
+    private var pingIntervalMillis: Long? = null
+    private var idleTimeoutMillis: Long? = null
+
+    /**
+     * @param serverUrl a server url that is called every time a WebSocket
+     * connects. [serverUrl] must start with:
+     *
+     * - "ws://"
+     * - "wss://"
+     * - "http://" (same as "ws://")
+     * - "https://" (same as "wss://")
+     */
+    fun serverUrl(serverUrl: String) = apply {
+      this.serverUrl = serverUrl
+    }
+
+    /**
+     * Headers to add to the HTTP handshake query.
+     */
+    fun httpHeaders(headers: List<HttpHeader>) = apply {
+      this.httpHeaders = headers
+    }
+
+    /**
+     * Headers to add to the HTTP handshake query.
+     */
+    fun addHttpHeaders(name: String, value: String) = apply {
+      this.httpHeaders = this.httpHeaders.orEmpty() + HttpHeader(name, value)
+    }
+
+    /**
+     * Set the [WebSocketEngine] to use.
+     */
+    fun webSocketEngine(webSocketEngine: WebSocketEngine) = apply {
+      this.webSocketEngine = webSocketEngine
+    }
+
+    /**
+     * The number of milliseconds before a WebSocket with no active operations disconnects.
+     *
+     * Default: `60_000`
+     */
+    fun idleTimeoutMillis(idleTimeoutMillis: Long) = apply {
+      this.idleTimeoutMillis = idleTimeoutMillis
+    }
+
+    /**
+     * The [WsProtocol] to use for this [WebSocketNetworkTransport]
+     *
+     * Default: [GraphQLWsProtocol]
+     *
+     * @see [SubscriptionWsProtocol]
+     * @see [AppSyncWsProtocol]
+     * @see [GraphQLWsProtocol]
+     */
+    fun wsProtocol(wsProtocol: WsProtocol) = apply {
+      this.wsProtocol = wsProtocol
+    }
+
+    /**
+     * The interval in milliseconds between two client pings or -1 to disable client pings.
+     * The [WsProtocol] used must also support client pings.
+     *
+     * Default: -1
+     */
+    fun pingIntervalMillis(pingIntervalMillis: Long) = apply {
+      this.pingIntervalMillis = pingIntervalMillis
+    }
+
+    /**
+     * The maximum number of milliseconds between a "connection_init" message and its acknowledgement
+     *
+     * Default: 10_000
+     */
+    fun connectionAcknowledgeTimeoutMillis(connectionAcknowledgeTimeoutMillis: Long) = apply {
+      this.connectionAcknowledgeTimeoutMillis = connectionAcknowledgeTimeoutMillis
+    }
+
+    /**
+     * Builds the [WebSocketNetworkTransport]
+     */
+    fun build(): WebSocketNetworkTransport {
+      return WebSocketNetworkTransport(
+          webSocketEngine = webSocketEngine ?: WebSocketEngine(),
+          serverUrl = serverUrl ?: error("Apollo: 'serverUrl' is required"),
+          httpHeaders = httpHeaders.orEmpty(),
+          idleTimeoutMillis = idleTimeoutMillis ?: 60_000,
+          wsProtocol = wsProtocol ?: GraphQLWsProtocol { null },
+          pingIntervalMillis = pingIntervalMillis ?: -1L,
+          connectionAcknowledgeTimeoutMillis = connectionAcknowledgeTimeoutMillis ?: 10_000L,
+      )
+    }
+  }
+}
+
+private class DefaultOperationListener<D : Operation.Data>(
+    private val request: ApolloRequest<D>,
+    private val producerScope: ProducerScope<ApolloResponse<D>>,
+) : OperationListener {
+  val deferredJsonMerger = DeferredJsonMerger()
+  val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters]!!
+
+  override fun onResponse(response: Any?) {
+    @Suppress("UNCHECKED_CAST")
+    val responseMap = response as? Map<String, Any?>
+    if (responseMap == null) {
+      producerScope.trySend(ApolloResponse.Builder(request.operation, request.requestUuid)
+          .exception(DefaultApolloException("Invalid payload")).build()
+      )
+      return
+    }
+    val (payload, mergedFragmentIds) = if (responseMap.isDeferred()) {
+      deferredJsonMerger.merge(responseMap) to deferredJsonMerger.mergedFragmentIds
+    } else {
+      responseMap to null
+    }
+    val apolloResponse: ApolloResponse<D> = payload.jsonReader().toApolloResponse(
+        operation = request.operation,
+        requestUuid = request.requestUuid,
+        customScalarAdapters = requestCustomScalarAdapters,
+        deferredFragmentIdentifiers = mergedFragmentIds
+    )
+
+    if (!deferredJsonMerger.hasNext) {
+      // Last deferred payload: reset the deferredJsonMerger for potential subsequent responses
+      deferredJsonMerger.reset()
+    }
+
+    if (!deferredJsonMerger.isEmptyPayload) {
+      producerScope.trySend(apolloResponse)
+    }
+  }
+
+  override fun onComplete() {
+    producerScope.close()
+  }
+
+  private fun errorResponse(cause: ApolloException): ApolloResponse<D> {
+    return ApolloResponse.Builder(request.operation, request.requestUuid)
+        .exception(cause)
+        .build()
+  }
+
+  override fun onError(payload: ApolloJsonElement, terminal: Boolean) {
+    producerScope.trySend(errorResponse(SubscriptionOperationException(request.operation.name(), payload)))
+    if (terminal) {
+      producerScope.close()
+    }
+  }
+
+  override fun onTransportError(cause: ApolloException) {
+    producerScope.trySend(errorResponse(cause))
+    producerScope.close()
+  }
+}
+
+private fun Map<String, Any?>.isDeferred(): Boolean {
+  return keys.contains("hasNext")
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WsProtocol.kt
@@ -1,0 +1,17 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.Operation
+
+interface WsProtocol {
+  val name: String
+
+  suspend fun connectionInit(): ClientMessage
+  suspend fun <D : Operation.Data> operationStart(request: ApolloRequest<D>): ClientMessage
+  fun <D : Operation.Data> operationStop(request: ApolloRequest<D>): ClientMessage
+  fun ping(): ClientMessage?
+  fun pong(): ClientMessage?
+
+  fun parseServerMessage(text: String): ServerMessage
+}
+

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonTest/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngineTest.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonTest/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngineTest.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.network.ws.incubating
 
+import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.mockserver.CloseFrame
 import com.apollographql.apollo3.mockserver.DataMessage
 import com.apollographql.apollo3.mockserver.MockRequestBase
@@ -28,7 +29,7 @@ import kotlin.time.Duration.Companion.seconds
 private data class Item(
     val message: WebSocketMessage? = null,
     val open: Boolean = false,
-    val throwable: Throwable? = null,
+    val exception: ApolloException? = null,
 )
 
 private class Listener(private val channel: Channel<Item>) : WebSocketListener {
@@ -44,8 +45,8 @@ private class Listener(private val channel: Channel<Item>) : WebSocketListener {
     channel.trySend(DataMessage(data))
   }
 
-  override fun onError(throwable: Throwable) {
-    channel.trySend(Item(throwable = throwable))
+  override fun onError(cause: ApolloException) {
+    channel.trySend(Item(exception = cause))
   }
 
   override fun onClosed(code: Int?, reason: String?) {
@@ -166,7 +167,7 @@ class WebSocketEngineTest {
         assertEquals(1002, code)
         assertEquals("Server Bye", reason)
       }
-    } else if (item.throwable != null) {
+    } else if (item.exception != null) {
       // Apple implementation calls onError instead on onClose
     }
 

--- a/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.jvm.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/jvmMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.jvm.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3.network.ws.incubating
 
 import com.apollographql.apollo3.api.http.HttpHeader
+import com.apollographql.apollo3.exception.ApolloNetworkException
 import okhttp3.Headers
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -53,7 +54,7 @@ internal class JvmWebSocket(
 
   override fun onFailure(webSocket: PlatformWebSocket, t: Throwable, response: Response?) {
     if (disposed.compareAndSet(false, true)) {
-      listener.onError(t)
+      listener.onError(ApolloNetworkException(t.message, t))
       platformWebSocket.cancel()
     }
   }


### PR DESCRIPTION
This PR introduces an incubating `WebSocketNetwork`. Disclaimer: this is 100% untested. It's not finished yet but it's relatively self contained so I'm making a separate PR. 

This PR introduces incubating:

* `WebSocketNetworkTransport`: a `NetworkTransport` that is a lot more simple than the non-incubating one. The `execute()` method in particular is just a `callbackFlow`
* `WebSocketHolder`: a class responsible to hold the websocket
* `SubscribableWebSocket`: the glue between `WebSocket` and `WsProtocol`. This is where most of the state machine is
* `WsProtocol` and implementations for AppSync, GraphqlWs, etc.. This is mostly unchanged from the non-incubating version.

Missing:

* retry logic (~= reopenWhen)
* suspend serverUrl and headers for AppSync or other clients that want to change the server url
* connectivity indicators (is my socket connected?)
* lots of tests
