### PR TITLE
Cleanup ApolloClient.Builder

### DIFF
--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -34,7 +34,7 @@ public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apol
 
 public final class com/apollographql/apollo3/ApolloClient : com/apollographql/apollo3/api/ExecutionOptions, java/io/Closeable {
 	public static final field Companion Lcom/apollographql/apollo3/ApolloClient$Companion;
-	public synthetic fun <init> (Lcom/apollographql/apollo3/network/NetworkTransport;Lcom/apollographql/apollo3/api/CustomScalarAdapters;Lcom/apollographql/apollo3/network/NetworkTransport;Ljava/util/List;Lcom/apollographql/apollo3/api/ExecutionContext;Lkotlinx/coroutines/CoroutineDispatcher;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun builder ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun close ()V
 	public final fun dispose ()V
@@ -81,22 +81,37 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public synthetic fun enableAutoPersistedQueries (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public final fun executionContext (Lcom/apollographql/apollo3/api/ExecutionContext;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun getCanBeBatched ()Ljava/lang/Boolean;
+	public final fun getCustomScalarAdapters ()Lcom/apollographql/apollo3/api/CustomScalarAdapters;
+	public final fun getDispatcher ()Lkotlinx/coroutines/CoroutineDispatcher;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
+	public final fun getHttpEngine ()Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public final fun getHttpExposeErrorBody ()Ljava/lang/Boolean;
 	public fun getHttpHeaders ()Ljava/util/List;
+	public final fun getHttpInterceptors ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
+	public final fun getHttpServerUrl ()Ljava/lang/String;
 	public final fun getInterceptors ()Ljava/util/List;
+	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
+	public final fun getSubscriptionNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
+	public final fun getWebSocketEngine ()Lcom/apollographql/apollo3/network/ws/WebSocketEngine;
+	public final fun getWebSocketIdleTimeoutMillis ()Ljava/lang/Long;
+	public final fun getWebSocketReopenServerUrl ()Lkotlin/jvm/functions/Function1;
+	public final fun getWebSocketReopenWhen ()Lkotlin/jvm/functions/Function3;
+	public final fun getWebSocketServerUrl ()Ljava/lang/String;
+	public final fun getWsProtocolFactory ()Lcom/apollographql/apollo3/network/ws/WsProtocol$Factory;
 	public final fun httpBatching ()Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpBatching (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpBatching (JI)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpBatching (JIZ)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static synthetic fun httpBatching$default (Lcom/apollographql/apollo3/ApolloClient$Builder;JIZILjava/lang/Object;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun httpEngine (Lcom/apollographql/apollo3/network/http/HttpEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun httpExposeErrorBody (Z)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun httpExposeErrorBody (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun httpHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun httpHeaders (Ljava/util/List;)Ljava/lang/Object;
+	public final fun httpInterceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -109,7 +124,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun serverUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun subscriptionNetworkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketEngine (Lcom/apollographql/apollo3/network/ws/WebSocketEngine;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun webSocketIdleTimeoutMillis (J)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun webSocketIdleTimeoutMillis (Ljava/lang/Long;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketReopenWhen (Lkotlin/jvm/functions/Function3;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun webSocketServerUrl (Lkotlin/jvm/functions/Function1;)Lcom/apollographql/apollo3/ApolloClient$Builder;


### PR DESCRIPTION
Prep work for adding more retry related things in `ApolloClient.Builder`.

This PR:
* moves the `networkTransport`/`subscriptionNetworkTransport` creation and checks to `ApolloClient`.
* makes all `Builder` functions accept a nullable value to reset the parameter (and consistency as well).
* gives `ApolloClient` its own copy of `Builder` (never mutated)

The previous code was problematic in cases like this:

```kotlin
val builder = ApolloClient.Builder().serverUrl("https://example.com")

val apolloClient = builder.build()
builder.serverUrl("https://somethingelse.com")

// customize cache here
val cachingApolloClient = apolloClient1.newBuilder().normalizedCache(...).build()
// Oh no, cachingApolloClient use somethingelse.com instead of example.com

```

See also https://github.com/apollographql/apollo-kotlin/issues/3759