### PR TITLE
Add `ApolloClient.retryOnError(Boolean)`

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -46,7 +46,7 @@ public final class com/apollographql/apollo3/api/ApolloOptionalAdapter : com/apo
 }
 
 public final class com/apollographql/apollo3/api/ApolloRequest : com/apollographql/apollo3/api/ExecutionOptions {
-	public synthetic fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/ExecutionContext;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/ExecutionContext;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCanBeBatched ()Ljava/lang/Boolean;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
@@ -83,6 +83,7 @@ public final class com/apollographql/apollo3/api/ApolloRequest$Builder : com/apo
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
 	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
+	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -83,7 +83,7 @@ public final class com/apollographql/apollo3/api/ApolloRequest$Builder : com/apo
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
 	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
-	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public synthetic fun retryOnError (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -21,7 +21,7 @@ private constructor(
     override val enableAutoPersistedQueries: Boolean?,
     override val canBeBatched: Boolean?,
     @ApolloExperimental
-    override val retryNetworkErrors: Boolean?,
+    override val retryOnError: Boolean?,
 ) : ExecutionOptions {
 
   fun newBuilder(): Builder<D> = newBuilder(operation)
@@ -37,7 +37,7 @@ private constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
-        .retryNetworkErrors(retryNetworkErrors)
+        .retryOnError(retryOnError)
   }
 
   class Builder<D : Operation.Data>(
@@ -60,7 +60,7 @@ private constructor(
     override var canBeBatched: Boolean? = null
       private set
     @ApolloExperimental
-    override var retryNetworkErrors: Boolean? = null
+    override var retryOnError: Boolean? = null
       private set
 
     override fun httpMethod(httpMethod: HttpMethod?): Builder<D> = apply {
@@ -92,8 +92,8 @@ private constructor(
     }
 
     @ApolloExperimental
-    override fun retryNetworkErrors(retryNetworkErrors: Boolean?): Builder<D> = apply {
-      this.retryNetworkErrors = retryNetworkErrors
+    override fun retryOnError(retryOnError: Boolean?): Builder<D> = apply {
+      this.retryOnError = retryOnError
     }
 
     fun requestUuid(requestUuid: Uuid) = apply {
@@ -119,7 +119,7 @@ private constructor(
           sendDocument = sendDocument,
           enableAutoPersistedQueries = enableAutoPersistedQueries,
           canBeBatched = canBeBatched,
-          retryNetworkErrors = retryNetworkErrors
+          retryOnError = retryOnError
       )
     }
   }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -1,7 +1,6 @@
 package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloExperimental
-import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.benasher44.uuid.Uuid
@@ -21,13 +20,13 @@ private constructor(
     override val sendDocument: Boolean?,
     override val enableAutoPersistedQueries: Boolean?,
     override val canBeBatched: Boolean?,
+    override val retryNetworkErrors: Boolean?,
 ) : ExecutionOptions {
 
   fun newBuilder(): Builder<D> = newBuilder(operation)
 
   @ApolloExperimental
-  fun <E: Operation.Data> newBuilder(operation: Operation<E>): Builder<E> {
-    @Suppress("DEPRECATION")
+  fun <E : Operation.Data> newBuilder(operation: Operation<E>): Builder<E> {
     return Builder(operation)
         .requestUuid(requestUuid)
         .executionContext(executionContext)
@@ -37,6 +36,7 @@ private constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
+        .retryNetworkErrors(retryNetworkErrors)
   }
 
   class Builder<D : Operation.Data>(
@@ -48,13 +48,22 @@ private constructor(
 
     override var httpMethod: HttpMethod? = null
       private set
+    override var httpHeaders: List<HttpHeader>? = null
+      private set
+    override var enableAutoPersistedQueries: Boolean? = null
+      private set
+    override var sendApqExtensions: Boolean? = null
+      private set
+    override var sendDocument: Boolean? = null
+      private set
+    override var canBeBatched: Boolean? = null
+      private set
+    override var retryNetworkErrors: Boolean? = null
+      private set
 
     override fun httpMethod(httpMethod: HttpMethod?): Builder<D> = apply {
       this.httpMethod = httpMethod
     }
-
-    override var httpHeaders: List<HttpHeader>? = null
-      private set
 
     override fun httpHeaders(httpHeaders: List<HttpHeader>?): Builder<D> = apply {
       this.httpHeaders = httpHeaders
@@ -64,32 +73,24 @@ private constructor(
       this.httpHeaders = (this.httpHeaders ?: emptyList()) + HttpHeader(name, value)
     }
 
-    override var sendApqExtensions: Boolean? = null
-      private set
-
     override fun sendApqExtensions(sendApqExtensions: Boolean?): Builder<D> = apply {
       this.sendApqExtensions = sendApqExtensions
     }
-
-    override var sendDocument: Boolean? = null
-      private set
 
     override fun sendDocument(sendDocument: Boolean?): Builder<D> = apply {
       this.sendDocument = sendDocument
     }
 
-    override var enableAutoPersistedQueries: Boolean? = null
-      private set
-
     override fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): Builder<D> = apply {
       this.enableAutoPersistedQueries = enableAutoPersistedQueries
     }
 
-    override var canBeBatched: Boolean? = null
-      private set
-
     override fun canBeBatched(canBeBatched: Boolean?): Builder<D> = apply {
       this.canBeBatched = canBeBatched
+    }
+
+    override fun retryNetworkErrors(retryNetworkErrors: Boolean?): Builder<D> = apply {
+      this.retryNetworkErrors = retryNetworkErrors
     }
 
     fun requestUuid(requestUuid: Uuid) = apply {
@@ -105,7 +106,6 @@ private constructor(
     }
 
     fun build(): ApolloRequest<D> {
-      @Suppress("DEPRECATION")
       return ApolloRequest(
           operation = operation,
           requestUuid = requestUuid,
@@ -116,6 +116,7 @@ private constructor(
           sendDocument = sendDocument,
           enableAutoPersistedQueries = enableAutoPersistedQueries,
           canBeBatched = canBeBatched,
+          retryNetworkErrors = retryNetworkErrors
       )
     }
   }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -20,6 +20,7 @@ private constructor(
     override val sendDocument: Boolean?,
     override val enableAutoPersistedQueries: Boolean?,
     override val canBeBatched: Boolean?,
+    @ApolloExperimental
     override val retryNetworkErrors: Boolean?,
 ) : ExecutionOptions {
 
@@ -58,6 +59,7 @@ private constructor(
       private set
     override var canBeBatched: Boolean? = null
       private set
+    @ApolloExperimental
     override var retryNetworkErrors: Boolean? = null
       private set
 
@@ -89,6 +91,7 @@ private constructor(
       this.canBeBatched = canBeBatched
     }
 
+    @ApolloExperimental
     override fun retryNetworkErrors(retryNetworkErrors: Boolean?): Builder<D> = apply {
       this.retryNetworkErrors = retryNetworkErrors
     }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
@@ -45,6 +45,11 @@ interface ExecutionOptions {
    */
   val canBeBatched: Boolean?
 
+  /**
+   * Whether to enable retrying the request on network errors
+   */
+  val retryNetworkErrors: Boolean?
+
   companion object {
     /**
      * Used by [com.apollographql.apollo3.network.http.BatchingHttpInterceptor]
@@ -82,4 +87,6 @@ interface MutableExecutionOptions<T> : ExecutionOptions {
   fun enableAutoPersistedQueries(enableAutoPersistedQueries: Boolean?): T
 
   fun canBeBatched(canBeBatched: Boolean?): T
+
+  fun retryNetworkErrors(retryNetworkErrors: Boolean?): T
 }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.api
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
 
@@ -48,6 +49,7 @@ interface ExecutionOptions {
   /**
    * Whether to enable retrying the request on network errors
    */
+  @ApolloExperimental
   val retryNetworkErrors: Boolean?
 
   companion object {
@@ -88,5 +90,6 @@ interface MutableExecutionOptions<T> : ExecutionOptions {
 
   fun canBeBatched(canBeBatched: Boolean?): T
 
+  @ApolloExperimental
   fun retryNetworkErrors(retryNetworkErrors: Boolean?): T
 }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
@@ -50,7 +50,7 @@ interface ExecutionOptions {
    * Whether to enable retrying the request on network errors
    */
   @ApolloExperimental
-  val retryNetworkErrors: Boolean?
+  val retryOnError: Boolean?
 
   companion object {
     /**
@@ -91,5 +91,5 @@ interface MutableExecutionOptions<T> : ExecutionOptions {
   fun canBeBatched(canBeBatched: Boolean?): T
 
   @ApolloExperimental
-  fun retryNetworkErrors(retryNetworkErrors: Boolean?): T
+  fun retryOnError(retryOnError: Boolean?): T
 }

--- a/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
+++ b/libraries/apollo-ksp-incubating/src/main/kotlin/com/apollographql/apollo3/ksp/ksp-validation.kt
@@ -118,7 +118,7 @@ internal class ValidationScope(
             val possibleTypes: Set<String>? = possibleTypes[className]
             if (possibleTypes == null) {
               if (typeDefinition is GQLObjectTypeDefinition) {
-                error("Expected a Kotlin object for type '${typeDefinition.name}' but none found. Did you forget a @ApolloObject? at ${ksTypeReference.location}")
+                error("Expected a Kotlin object for type '${typeDefinition.name}' but none found. Did you forget a @GraphQLObject? at ${ksTypeReference.location}")
               } else {
                 error("Expected that Kotlin '$className' is an object or interface for type '${typeDefinition.name}' but none found.")
               }

--- a/libraries/apollo-runtime-java/api/apollo-runtime-java.api
+++ b/libraries/apollo-runtime-java/api/apollo-runtime-java.api
@@ -45,6 +45,7 @@ public class com/apollographql/apollo3/runtime/java/ApolloClient$Builder : com/a
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun getHttpHeaders ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
+	public fun getRetryNetworkErrors ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public fun httpBatching (JIZ)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
@@ -59,6 +60,8 @@ public class com/apollographql/apollo3/runtime/java/ApolloClient$Builder : com/a
 	public fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public fun networkTransport (Lcom/apollographql/apollo3/runtime/java/network/NetworkTransport;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public fun okHttpClient (Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
+	public fun retryNetworkErrors (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
+	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;

--- a/libraries/apollo-runtime-java/api/apollo-runtime-java.api
+++ b/libraries/apollo-runtime-java/api/apollo-runtime-java.api
@@ -45,7 +45,7 @@ public class com/apollographql/apollo3/runtime/java/ApolloClient$Builder : com/a
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun getHttpHeaders ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
-	public fun getRetryNetworkErrors ()Ljava/lang/Boolean;
+	public fun getRetryOnError ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public fun httpBatching (JIZ)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
@@ -60,8 +60,8 @@ public class com/apollographql/apollo3/runtime/java/ApolloClient$Builder : com/a
 	public fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public fun networkTransport (Lcom/apollographql/apollo3/runtime/java/network/NetworkTransport;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public fun okHttpClient (Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
-	public fun retryNetworkErrors (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
-	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public fun retryOnError (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
+	public synthetic fun retryOnError (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/runtime/java/ApolloClient$Builder;

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
@@ -188,7 +188,7 @@ public class ApolloClient implements Closeable {
     private Boolean enableAutoPersistedQueries;
     private Boolean canBeBatched;
     private Boolean httpExposeErrorBody;
-    private Boolean retryNetworkErrors;
+    private Boolean retryOnError;
 
     public Builder() {
     }
@@ -357,9 +357,9 @@ public class ApolloClient implements Closeable {
       return this;
     }
 
-    public Builder retryNetworkErrors(Boolean retryNetworkErrors) {
+    public Builder retryOnError(Boolean retryOnError) {
       throw new IllegalStateException("Not supported yet");
-//      this.retryNetworkErrors = retryNetworkErrors;
+//      this.retryOnError = retryOnError;
 //      return this;
     }
 
@@ -533,8 +533,8 @@ public class ApolloClient implements Closeable {
       return canBeBatched;
     }
 
-    @Nullable @Override public Boolean getRetryNetworkErrors() {
-      return retryNetworkErrors;
+    @Nullable @Override public Boolean getRetryOnError() {
+      return retryOnError;
     }
 
     @Override public Builder addExecutionContext(@NotNull ExecutionContext executionContext) {

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
@@ -188,6 +188,7 @@ public class ApolloClient implements Closeable {
     private Boolean enableAutoPersistedQueries;
     private Boolean canBeBatched;
     private Boolean httpExposeErrorBody;
+    private Boolean retryNetworkErrors;
 
     public Builder() {
     }
@@ -196,16 +197,16 @@ public class ApolloClient implements Closeable {
      * The url of the GraphQL server used for HTTP. This is the same as {@link #httpServerUrl(String)}. See also
      * {@link #networkTransport(NetworkTransport)} for more customization
      */
-    public Builder serverUrl(@NotNull String serverUrl) {
-      this.httpServerUrl = checkNotNull(serverUrl, "serverUrl is null");
+    public Builder serverUrl(String serverUrl) {
+      this.httpServerUrl = serverUrl;
       return this;
     }
 
     /**
      * The url of the GraphQL server used for HTTP. See also {@link #networkTransport(NetworkTransport)} for more customization
      */
-    public Builder httpServerUrl(@NotNull String httpServerUrl) {
-      this.httpServerUrl = checkNotNull(httpServerUrl, "httpServerUrl is null");
+    public Builder httpServerUrl(String httpServerUrl) {
+      this.httpServerUrl = httpServerUrl;
       return this;
     }
 
@@ -213,8 +214,8 @@ public class ApolloClient implements Closeable {
      * The url of the GraphQL server used for WebSockets. See also {@link #subscriptionNetworkTransport(NetworkTransport)} for more
      * customization
      */
-    public Builder webSocketServerUrl(@NotNull String webSocketServerUrl) {
-      this.webSocketServerUrl = checkNotNull(webSocketServerUrl, "webSocketServerUrl is null");
+    public Builder webSocketServerUrl(String webSocketServerUrl) {
+      this.webSocketServerUrl = webSocketServerUrl;
       return this;
     }
 
@@ -224,8 +225,8 @@ public class ApolloClient implements Closeable {
      * @param okHttpClient the client to use.
      * @return The {@link Builder} object to be used for chaining method calls
      */
-    public Builder okHttpClient(@NotNull OkHttpClient okHttpClient) {
-      this.callFactory = checkNotNull(okHttpClient, "okHttpClient is null");
+    public Builder okHttpClient(OkHttpClient okHttpClient) {
+      this.callFactory = okHttpClient;
       this.webSocketFactory = okHttpClient;
       return null;
     }
@@ -234,8 +235,8 @@ public class ApolloClient implements Closeable {
      * Set the custom call factory for creating {@link Call} instances. <p> Note: Calling {@link #okHttpClient(OkHttpClient)} automatically
      * sets this value.
      */
-    public Builder callFactory(@NotNull Call.Factory factory) {
-      this.callFactory = checkNotNull(factory, "factory is null");
+    public Builder callFactory(Call.Factory factory) {
+      this.callFactory = factory;
       return this;
     }
 
@@ -243,8 +244,8 @@ public class ApolloClient implements Closeable {
      * Set the custom call factory for creating {@link WebSocket} instances. <p> Note: Calling {@link #okHttpClient(OkHttpClient)}
      * automatically sets this value.
      */
-    public Builder webSocketFactory(@NotNull WebSocket.Factory factory) {
-      this.webSocketFactory = checkNotNull(factory, "factory is null");
+    public Builder webSocketFactory(WebSocket.Factory factory) {
+      this.webSocketFactory = factory;
       return this;
     }
 
@@ -253,13 +254,13 @@ public class ApolloClient implements Closeable {
      *
      * @return The {@link Builder} object to be used for chaining method calls
      */
-    public Builder dispatcher(@NotNull Executor dispatcher) {
-      this.executor = checkNotNull(dispatcher, "dispatcher is null");
+    public Builder dispatcher(Executor dispatcher) {
+      this.executor = dispatcher;
       return this;
     }
 
-    public Builder addInterceptor(@NotNull ApolloInterceptor interceptor) {
-      this.interceptors.add(checkNotNull(interceptor, "interceptor is null"));
+    public Builder addInterceptor(ApolloInterceptor interceptor) {
+      this.interceptors.add(interceptor);
       return this;
     }
 
@@ -306,8 +307,8 @@ public class ApolloClient implements Closeable {
       return this;
     }
 
-    public Builder wsProtocolFactory(@NotNull WsProtocol.Factory wsProtocolFactory) {
-      this.wsProtocolFactory = checkNotNull(wsProtocolFactory, "wsProtocolFactory is null");
+    public Builder wsProtocolFactory(WsProtocol.Factory wsProtocolFactory) {
+      this.wsProtocolFactory = wsProtocolFactory;
       return this;
     }
 
@@ -326,8 +327,8 @@ public class ApolloClient implements Closeable {
       return this;
     }
 
-    public Builder wsReopenWhen(@NotNull WebSocketNetworkTransport.ReopenWhen reopenWhen) {
-      this.wsReopenWhen = checkNotNull(reopenWhen, "reopenWhen is null");
+    public Builder wsReopenWhen(WebSocketNetworkTransport.ReopenWhen reopenWhen) {
+      this.wsReopenWhen = reopenWhen;
       return this;
     }
 
@@ -336,8 +337,8 @@ public class ApolloClient implements Closeable {
       return this;
     }
 
-    public Builder httpEngine(@NotNull HttpEngine httpEngine) {
-      this.httpEngine = checkNotNull(httpEngine, "httpEngine is null");
+    public Builder httpEngine(HttpEngine httpEngine) {
+      this.httpEngine = httpEngine;
       return this;
     }
 
@@ -346,15 +347,22 @@ public class ApolloClient implements Closeable {
       return this;
     }
 
-    public Builder networkTransport(@NotNull NetworkTransport networkTransport) {
-      this.networkTransport = checkNotNull(networkTransport, "networkTransport is null");
+    public Builder networkTransport(NetworkTransport networkTransport) {
+      this.networkTransport = networkTransport;
       return this;
     }
 
-    public Builder subscriptionNetworkTransport(@NotNull NetworkTransport subscriptionNetworkTransport) {
-      this.subscriptionNetworkTransport = checkNotNull(subscriptionNetworkTransport, "subscriptionNetworkTransport is null");
+    public Builder subscriptionNetworkTransport(NetworkTransport subscriptionNetworkTransport) {
+      this.subscriptionNetworkTransport = subscriptionNetworkTransport;
       return this;
     }
+
+    public Builder retryNetworkErrors(Boolean retryNetworkErrors) {
+      throw new IllegalStateException("Not supported yet");
+//      this.retryNetworkErrors = retryNetworkErrors;
+//      return this;
+    }
+
 
     public ApolloClient build() {
       if (executor == null) {
@@ -523,6 +531,10 @@ public class ApolloClient implements Closeable {
 
     @Nullable @Override public Boolean getCanBeBatched() {
       return canBeBatched;
+    }
+
+    @Nullable @Override public Boolean getRetryNetworkErrors() {
+      return retryNetworkErrors;
     }
 
     @Override public Builder addExecutionContext(@NotNull ExecutionContext executionContext) {

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/internal/DefaultApolloCall.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/internal/DefaultApolloCall.java
@@ -25,6 +25,7 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
   private Boolean sendDocument;
   private Boolean enableAutoPersistedQueries;
   private Boolean canBeBatched;
+  private Boolean retryNetworkErrors;
 
   public DefaultApolloCall(ApolloClient apolloClient, Operation<D> operation) {
     this.apolloClient = apolloClient;
@@ -40,6 +41,7 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
+        .retryNetworkErrors(retryNetworkErrors)
         .build();
 
     return apolloClient.execute(apolloRequest, callback);
@@ -71,6 +73,10 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
 
   @Nullable @Override public Boolean getCanBeBatched() {
     return canBeBatched;
+  }
+
+  @Nullable @Override public Boolean getRetryNetworkErrors() {
+    return retryNetworkErrors;
   }
 
   @Override public ApolloCall<D> addExecutionContext(@NotNull ExecutionContext executionContext) {
@@ -114,5 +120,11 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
   @Override public ApolloCall<D> canBeBatched(@Nullable Boolean canBeBatched) {
     this.canBeBatched = canBeBatched;
     return this;
+  }
+
+  @Override public ApolloCall<D> retryNetworkErrors(@Nullable Boolean retryNetworkErrors) {
+    throw new IllegalStateException("Not supported yet");
+    //this.retryNetworkErrors = retryNetworkErrors;
+    //return this;
   }
 }

--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/internal/DefaultApolloCall.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/internal/DefaultApolloCall.java
@@ -25,7 +25,7 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
   private Boolean sendDocument;
   private Boolean enableAutoPersistedQueries;
   private Boolean canBeBatched;
-  private Boolean retryNetworkErrors;
+  private Boolean retryOnError;
 
   public DefaultApolloCall(ApolloClient apolloClient, Operation<D> operation) {
     this.apolloClient = apolloClient;
@@ -41,7 +41,7 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
-        .retryNetworkErrors(retryNetworkErrors)
+        .retryOnError(retryOnError)
         .build();
 
     return apolloClient.execute(apolloRequest, callback);
@@ -75,8 +75,8 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
     return canBeBatched;
   }
 
-  @Nullable @Override public Boolean getRetryNetworkErrors() {
-    return retryNetworkErrors;
+  @Nullable @Override public Boolean getRetryOnError() {
+    return retryOnError;
   }
 
   @Override public ApolloCall<D> addExecutionContext(@NotNull ExecutionContext executionContext) {
@@ -122,9 +122,9 @@ public class DefaultApolloCall<D extends Operation.Data> implements ApolloCall<D
     return this;
   }
 
-  @Override public ApolloCall<D> retryNetworkErrors(@Nullable Boolean retryNetworkErrors) {
+  @Override public ApolloCall<D> retryOnError(@Nullable Boolean retryOnError) {
     throw new IllegalStateException("Not supported yet");
-    //this.retryNetworkErrors = retryNetworkErrors;
+    //this.retryOnError = retryOnError;
     //return this;
   }
 }

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -47,6 +47,7 @@ public final class com/apollographql/apollo3/ApolloClient : com/apollographql/ap
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
 	public final fun getInterceptors ()Ljava/util/List;
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
+	public final fun getRetrySubscriptions ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public final fun getSubscriptionNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
@@ -93,6 +94,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun getHttpServerUrl ()Ljava/lang/String;
 	public final fun getInterceptors ()Ljava/util/List;
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
+	public final fun getRetrySubscriptions ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public final fun getSubscriptionNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
@@ -117,6 +119,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun networkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun retrySubscriptions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -180,6 +183,11 @@ public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInter
 }
 
 public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInterceptor$Companion {
+}
+
+public final class com/apollographql/apollo3/interceptor/RetrySubscriptionsInterceptor : com/apollographql/apollo3/interceptor/ApolloInterceptor {
+	public fun <init> ()V
+	public fun intercept (Lcom/apollographql/apollo3/api/ApolloRequest;Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract interface class com/apollographql/apollo3/network/NetworkTransport {

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -24,6 +24,7 @@ public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apol
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloCall;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
 	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
+	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
@@ -47,7 +48,6 @@ public final class com/apollographql/apollo3/ApolloClient : com/apollographql/ap
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
 	public final fun getInterceptors ()Ljava/util/List;
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
-	public final fun getRetrySubscriptions ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public final fun getSubscriptionNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
@@ -94,7 +94,6 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun getHttpServerUrl ()Ljava/lang/String;
 	public final fun getInterceptors ()Ljava/util/List;
 	public final fun getNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
-	public final fun getRetrySubscriptions ()Ljava/lang/Boolean;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public final fun getSubscriptionNetworkTransport ()Lcom/apollographql/apollo3/network/NetworkTransport;
@@ -119,7 +118,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun networkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public final fun retrySubscriptions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -185,8 +184,8 @@ public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInter
 public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInterceptor$Companion {
 }
 
-public final class com/apollographql/apollo3/interceptor/RetrySubscriptionsInterceptor : com/apollographql/apollo3/interceptor/ApolloInterceptor {
-	public fun <init> ()V
+public final class com/apollographql/apollo3/interceptor/RetryOnErrorInterceptor : com/apollographql/apollo3/interceptor/ApolloInterceptor {
+	public static final field INSTANCE Lcom/apollographql/apollo3/interceptor/RetryOnErrorInterceptor;
 	public fun intercept (Lcom/apollographql/apollo3/api/ApolloRequest;Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;)Lkotlinx/coroutines/flow/Flow;
 }
 

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -184,11 +184,6 @@ public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInter
 public final class com/apollographql/apollo3/interceptor/AutoPersistedQueryInterceptor$Companion {
 }
 
-public final class com/apollographql/apollo3/interceptor/RetryOnErrorInterceptor : com/apollographql/apollo3/interceptor/ApolloInterceptor {
-	public static final field INSTANCE Lcom/apollographql/apollo3/interceptor/RetryOnErrorInterceptor;
-	public fun intercept (Lcom/apollographql/apollo3/api/ApolloRequest;Lcom/apollographql/apollo3/interceptor/ApolloInterceptorChain;)Lkotlinx/coroutines/flow/Flow;
-}
-
 public abstract interface class com/apollographql/apollo3/network/NetworkTransport {
 	public abstract fun dispose ()V
 	public abstract fun execute (Lcom/apollographql/apollo3/api/ApolloRequest;)Lkotlinx/coroutines/flow/Flow;

--- a/libraries/apollo-runtime/api/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/apollo-runtime.api
@@ -24,7 +24,7 @@ public final class com/apollographql/apollo3/ApolloCall : com/apollographql/apol
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/ApolloCall;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
 	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
-	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public synthetic fun retryOnError (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloCall;
@@ -118,7 +118,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun networkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
-	public synthetic fun retryNetworkErrors (Ljava/lang/Boolean;)Ljava/lang/Object;
+	public synthetic fun retryOnError (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.ExecutionContext
@@ -33,6 +34,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
     private set
   override var canBeBatched: Boolean? = null
     private set
+  @ApolloExperimental
   override var retryNetworkErrors: Boolean? = null
     private set
 
@@ -89,6 +91,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
     this.canBeBatched = canBeBatched
   }
 
+  @ApolloExperimental
   override fun retryNetworkErrors(retryNetworkErrors: Boolean?): ApolloCall<D> = apply {
     this.retryNetworkErrors = retryNetworkErrors
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -33,7 +33,9 @@ class ApolloCall<D : Operation.Data> internal constructor(
     private set
   override var canBeBatched: Boolean? = null
     private set
-  
+  override var retryNetworkErrors: Boolean? = null
+    private set
+
   /**
    * The HTTP headers to be sent with the request.
    * By default, these are *added* on top of any HTTP header previously set on [ApolloClient]. Call [ignoreApolloClientHttpHeaders]`(true)`
@@ -87,6 +89,9 @@ class ApolloCall<D : Operation.Data> internal constructor(
     this.canBeBatched = canBeBatched
   }
 
+  override fun retryNetworkErrors(retryNetworkErrors: Boolean?): ApolloCall<D> = apply {
+    this.retryNetworkErrors = retryNetworkErrors
+  }
   /**
    * If set to true, the HTTP headers set on [ApolloClient] will not be used for the call, only the ones set on this [ApolloCall] will be
    * used. If set to false, both sets of headers will be concatenated and used.
@@ -107,6 +112,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
+        .retryNetworkErrors(retryNetworkErrors)
   }
 
   /**
@@ -153,6 +159,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
+        .retryNetworkErrors(retryNetworkErrors)
         .build()
   }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -35,7 +35,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
   override var canBeBatched: Boolean? = null
     private set
   @ApolloExperimental
-  override var retryNetworkErrors: Boolean? = null
+  override var retryOnError: Boolean? = null
     private set
 
   /**
@@ -92,8 +92,8 @@ class ApolloCall<D : Operation.Data> internal constructor(
   }
 
   @ApolloExperimental
-  override fun retryNetworkErrors(retryNetworkErrors: Boolean?): ApolloCall<D> = apply {
-    this.retryNetworkErrors = retryNetworkErrors
+  override fun retryOnError(retryOnError: Boolean?): ApolloCall<D> = apply {
+    this.retryOnError = retryOnError
   }
   /**
    * If set to true, the HTTP headers set on [ApolloClient] will not be used for the call, only the ones set on this [ApolloCall] will be
@@ -115,7 +115,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
-        .retryNetworkErrors(retryNetworkErrors)
+        .retryOnError(retryOnError)
   }
 
   /**
@@ -162,7 +162,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
         .sendDocument(sendDocument)
         .enableAutoPersistedQueries(enableAutoPersistedQueries)
         .canBeBatched(canBeBatched)
-        .retryNetworkErrors(retryNetworkErrors)
+        .retryOnError(retryOnError)
         .build()
   }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo3
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
@@ -58,6 +59,7 @@ private constructor(
   override val sendDocument: Boolean? = builder.sendDocument
   override val enableAutoPersistedQueries: Boolean? = builder.enableAutoPersistedQueries
   override val canBeBatched: Boolean? = builder.canBeBatched
+  @ApolloExperimental
   override val retryNetworkErrors: Boolean? = builder.retryNetworkErrors
 
   init {
@@ -254,7 +256,7 @@ private constructor(
       addAll(interceptors)
       val retryNetworkErrors = apolloRequest.retryNetworkErrors
           ?: retryNetworkErrors
-          ?: (request.operation is Subscription)
+          ?: (request.operation is Subscription && subscriptionNetworkTransport::class.qualifiedName.orEmpty().startsWith("com.apollographql.apollo3.network.ws.incubating"))
       if (retryNetworkErrors) {
         add(RetryOnErrorInterceptor)
       }
@@ -306,6 +308,7 @@ private constructor(
       private set
     override var canBeBatched: Boolean? = null
       private set
+    @ApolloExperimental
     override var retryNetworkErrors: Boolean? = null
       private set
 
@@ -334,6 +337,7 @@ private constructor(
     var webSocketReopenServerUrl: (suspend () -> String)? = null
       private set
 
+    @ApolloExperimental
     override fun retryNetworkErrors(retryNetworkErrors: Boolean?): Builder = apply {
       this.retryNetworkErrors = retryNetworkErrors
     }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -59,9 +59,9 @@ private constructor(
   override val enableAutoPersistedQueries: Boolean? = builder.enableAutoPersistedQueries
   override val canBeBatched: Boolean? = builder.canBeBatched
   @ApolloExperimental
-  override val retryNetworkErrors: Boolean? = builder.retryNetworkErrors
+  override val retryOnError: Boolean? = builder.retryOnError
   @ApolloExperimental
-  val retryNetworkErrorsInterceptor = builder.retryNetworkErrorsInterceptor
+  val retryOnErrorInterceptor = builder.retryOnErrorInterceptor
 
   init {
     networkTransport = if (builder.networkTransport != null) {
@@ -250,16 +250,16 @@ private constructor(
             // canBeBatched(apolloRequest.canBeBatched)
             addHttpHeader(ExecutionOptions.CAN_BE_BATCHED, canBeBatched.toString())
           }
-          if (apolloRequest.retryNetworkErrors != null) {
-            retryNetworkErrors(apolloRequest.retryNetworkErrors)
+          if (apolloRequest.retryOnError != null) {
+            retryOnError(apolloRequest.retryOnError)
           }
         }
         .build()
 
     val allInterceptors = buildList{
       addAll(interceptors)
-      if (retryNetworkErrorsInterceptor != null) {
-        add(retryNetworkErrorsInterceptor)
+      if (retryOnErrorInterceptor != null) {
+        add(retryOnErrorInterceptor)
       }
       add(networkInterceptor)
     }
@@ -310,7 +310,7 @@ private constructor(
     override var canBeBatched: Boolean? = null
       private set
     @ApolloExperimental
-    override var retryNetworkErrors: Boolean? = null
+    override var retryOnError: Boolean? = null
       private set
 
     var networkTransport: NetworkTransport? = null
@@ -338,17 +338,17 @@ private constructor(
     var webSocketReopenServerUrl: (suspend () -> String)? = null
       private set
     @ApolloExperimental
-    var retryNetworkErrorsInterceptor: ApolloInterceptor? = null
+    var retryOnErrorInterceptor: ApolloInterceptor? = null
       private set
 
     @ApolloExperimental
-    fun retryNetworkErrorsInterceptor(retryNetworkErrorsInterceptor: ApolloInterceptor?): Builder = apply {
-      this.retryNetworkErrorsInterceptor = retryNetworkErrorsInterceptor
+    fun retryOnErrorInterceptor(retryOnErrorInterceptor: ApolloInterceptor?): Builder = apply {
+      this.retryOnErrorInterceptor = retryOnErrorInterceptor
     }
 
     @ApolloExperimental
-    override fun retryNetworkErrors(retryNetworkErrors: Boolean?): Builder = apply {
-      this.retryNetworkErrors = retryNetworkErrors
+    override fun retryOnError(retryOnError: Boolean?): Builder = apply {
+      this.retryOnError = retryOnError
     }
 
     override fun httpMethod(httpMethod: HttpMethod?): Builder = apply {
@@ -648,8 +648,8 @@ private constructor(
           .webSocketReopenWhen(webSocketReopenWhen)
           .webSocketIdleTimeoutMillis(webSocketIdleTimeoutMillis)
           .wsProtocol(wsProtocolFactory)
-          .retryNetworkErrors(retryNetworkErrors)
-          .retryNetworkErrorsInterceptor(retryNetworkErrorsInterceptor)
+          .retryOnError(retryOnError)
+          .retryOnErrorInterceptor(retryOnErrorInterceptor)
       return builder
     }
   }

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/interceptor/RetrySubscriptionsInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/interceptor/RetrySubscriptionsInterceptor.kt
@@ -1,0 +1,58 @@
+package com.apollographql.apollo3.interceptor
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.Subscription
+import com.apollographql.apollo3.exception.ApolloException
+import com.apollographql.apollo3.exception.SubscriptionOperationException
+import com.benasher44.uuid.uuid4
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.retryWhen
+import kotlin.math.pow
+
+class RetrySubscriptionsInterceptor: ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    if (request.operation !is Subscription) {
+      return chain.proceed(request)
+    }
+
+    var first = true
+    var attempt = 0
+    return flow {
+      val actualRequest = if (first) {
+        first = false
+        request
+      } else {
+        request.newBuilder().requestUuid(uuid4()).build()
+      }
+      emitAll(chain.proceed(actualRequest))
+    }.onEach {
+      attempt = 0
+      if (it.exception != null && it.exception!!.isTerminalAndRecoverable()) {
+        throw RetryException
+      }
+    }.retryWhen { cause, _ ->
+      attempt++
+      delay(2.0.pow(attempt).toLong())
+      cause is RetryException
+    }
+  }
+}
+
+
+private fun ApolloException.isTerminalAndRecoverable(): Boolean {
+  when (this) {
+    is SubscriptionOperationException -> {
+      // This often means a validation error on the subscription. It is unrecoverable
+      return false
+    }
+    else -> return true
+  }
+}
+
+private object RetryException: Exception()

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
@@ -14,9 +14,10 @@ class MockServerTest(val mockServer: MockServer, val apolloClient: ApolloClient,
  */
 @ApolloExperimental
 fun mockServerTest(
+    skipDelays: Boolean = true,
     clientBuilder: ApolloClient.Builder.() -> Unit = {},
     block: suspend MockServerTest.() -> Unit
-) = com.apollographql.apollo3.testing.internal.runTest(true) {
+) = com.apollographql.apollo3.testing.internal.runTest(skipDelays) {
   val mockServer = MockServer()
 
   val apolloClient = ApolloClient.Builder()

--- a/tests/java-client/src/main/graphql/main/operations.graphql
+++ b/tests/java-client/src/main/graphql/main/operations.graphql
@@ -3,7 +3,7 @@ query GetRandom {
 }
 
 query TimeQuery {
-  time
+  zero
 }
 
 
@@ -11,8 +11,8 @@ subscription OperationError {
   operationError
 }
 
-subscription Count($to: Int!, $delayMillis: Int!)  {
-  count(to: $to, delayMillis: $delayMillis)
+subscription Count($to: Int!, $intervalMillis: Int!)  {
+  count(to: $to, intervalMillis: $intervalMillis)
 }
 
 mutation CloseSocketMutation {

--- a/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/QueryRoot.kt
+++ b/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/QueryRoot.kt
@@ -6,7 +6,8 @@ import com.apollographql.apollo3.annotations.GraphQLObject
 @GraphQLObject(name = "Query")
 class QueryRoot {
   fun random(): Int = 42
-  fun time(): Int = 0
+  fun zero(): Int = 0
+  fun secondsSinceEpoch(): Double = System.currentTimeMillis().div(1000).toDouble()
 }
 
 

--- a/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/QueryRoot.kt
+++ b/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/QueryRoot.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo3.annotations.GraphQLObject
 class QueryRoot {
   fun random(): Int = 42
   fun zero(): Int = 0
+  fun valueSharedWithSubscriptions(): Int = 0
   fun secondsSinceEpoch(): Double = System.currentTimeMillis().div(1000).toDouble()
 }
 

--- a/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/SubscriptionRoot.kt
+++ b/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/graphql/SubscriptionRoot.kt
@@ -60,6 +60,13 @@ class SubscriptionRoot(private val tag: String) {
       delay(intervalMillis.toLong())
     }
   }
+
+  fun valueSharedWithSubscriptions(): Flow<Int> = flow {
+    repeat(10) {
+      emit(it)
+      delay(100)
+    }
+  }
 }
 
 @GraphQLObject

--- a/tests/sample-server/src/main/resources/schema.graphqls
+++ b/tests/sample-server/src/main/resources/schema.graphqls
@@ -2,6 +2,7 @@ type Query {
   random: Int!
   zero: Int!
   secondsSinceEpoch: Float!
+  valueSharedWithSubscriptions: Int!
 }
 
 type Mutation {
@@ -27,6 +28,8 @@ type Subscription {
 
   "Returns the subscription state"
   state(intervalMillis: Int! = 1000): State
+
+  valueSharedWithSubscriptions: Int!
 }
 
 type State {

--- a/tests/sample-server/src/main/resources/schema.graphqls
+++ b/tests/sample-server/src/main/resources/schema.graphqls
@@ -1,6 +1,7 @@
 type Query {
   random: Int!
-  time: Int!
+  zero: Int!
+  secondsSinceEpoch: Float!
 }
 
 type Mutation {
@@ -10,9 +11,9 @@ type Mutation {
 
 type Subscription {
   "Count from 0 until 'to', waiting 'delayMillis' after each response"
-  count(delayMillis: Int!, to: Int!): Int!
+  count(intervalMillis: Int!, to: Int!): Int!
   "Count from 0 until 'to', waiting 'delayMillis' after each response and returns each result as a String"
-  countString(delayMillis: Int!, to: Int!): String!
+  countString(intervalMillis: Int!, to: Int!): String!
   "Trigger an error when accessed"
   operationError: String!
   "Returns a GraphQL error after 'after' items"
@@ -21,5 +22,17 @@ type Subscription {
   "Force close the websocket this subscription is executing on"
   closeWebSocket: String!
 
-  time: Int!
+  "Returns the current seconds every intervalMillis"
+  secondsSinceEpoch(intervalMillis: Int! = 1000): Float!
+
+  "Returns the subscription state"
+  state(intervalMillis: Int! = 1000): State
+}
+
+type State {
+  "The tag of this server"
+  tag: String!
+
+  "The subscription id"
+  subscriptionId: String!
 }

--- a/tests/websockets/src/commonMain/graphql/sample-server/operations.graphql
+++ b/tests/websockets/src/commonMain/graphql/sample-server/operations.graphql
@@ -1,13 +1,13 @@
-subscription Count($to: Int!, $delayMillis: Int!)  {
-  count(to: $to, delayMillis: $delayMillis)
+subscription Count($to: Int!, $intervalMillis: Int!)  {
+  count(to: $to, intervalMillis: $intervalMillis)
 }
 
-subscription CountString($to: Int!, $delayMillis: Int!)  {
-  countString(to: $to, delayMillis: $delayMillis)
+subscription CountString($to: Int!, $intervalMillis: Int!)  {
+  countString(to: $to, intervalMillis: $intervalMillis)
 }
 
-subscription TimeSubscription  {
-  time
+subscription SecondsSinceEpochSubscription($intervalMillis: Int!)  {
+  secondsSinceEpoch(intervalMillis: $intervalMillis)
 }
 
 subscription OperationError {
@@ -15,7 +15,7 @@ subscription OperationError {
 }
 
 query TimeQuery {
-  time
+  zero
 }
 
 mutation CloseSocketMutation {
@@ -28,4 +28,11 @@ subscription CloseSocketSubscription {
 
 subscription GraphqlAccessError($after: Int!) {
   graphqlAccessError(after: $after)
+}
+
+subscription Tag($intervalMillis: Int!)  {
+  state(intervalMillis: $intervalMillis) {
+    tag
+    subscriptionId
+  }
 }

--- a/tests/websockets/src/commonMain/graphql/sample-server/operations.graphql
+++ b/tests/websockets/src/commonMain/graphql/sample-server/operations.graphql
@@ -14,7 +14,15 @@ subscription OperationError {
   operationError
 }
 
-query TimeQuery {
+query ValueSharedWithSubscriptionsQuery {
+  valueSharedWithSubscriptions
+}
+
+subscription ValueSharedWithSubscriptionsSubscription {
+  valueSharedWithSubscriptions
+}
+
+query ZeroQuery {
   zero
 }
 

--- a/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.withTimeout
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
-import sample.server.CountSubscription
-import sample.server.TimeQuery
+import sample.server.ValueSharedWithSubscriptionsQuery
+import sample.server.ValueSharedWithSubscriptionsSubscription
 import kotlin.test.assertEquals
 
 class CachedSubscriptionTest {
@@ -53,11 +53,11 @@ class CachedSubscriptionTest {
     runBlocking {
       val channel = Channel<Int>()
       val job = launch {
-        apolloClient.query(TimeQuery())
+        apolloClient.query(ValueSharedWithSubscriptionsQuery())
             .watch()
             // Ignore cache miss
             .filter { it.data != null }
-            .map { it.data!!.zero }
+            .map { it.data!!.valueSharedWithSubscriptions }
             .collect {
               channel.send(it)
               println("watcher received: $it")
@@ -67,10 +67,10 @@ class CachedSubscriptionTest {
       assertEquals(0, channel.receive())
 
       println("starting subscription")
-      apolloClient.subscription(CountSubscription(to = 100, intervalMillis = 1000))
+      apolloClient.subscription(ValueSharedWithSubscriptionsSubscription())
           .toFlow()
           .take(3)
-          .map { it.data!!.count }
+          .map { it.data!!.valueSharedWithSubscriptions }
           .collect {
             println("subscription received: $it")
           }

--- a/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/CachedSubscriptionTest.kt
@@ -17,8 +17,8 @@ import kotlinx.coroutines.withTimeout
 import org.junit.AfterClass
 import org.junit.BeforeClass
 import org.junit.Test
+import sample.server.CountSubscription
 import sample.server.TimeQuery
-import sample.server.TimeSubscription
 import kotlin.test.assertEquals
 
 class CachedSubscriptionTest {
@@ -57,7 +57,7 @@ class CachedSubscriptionTest {
             .watch()
             // Ignore cache miss
             .filter { it.data != null }
-            .map { it.data!!.time }
+            .map { it.data!!.zero }
             .collect {
               channel.send(it)
               println("watcher received: $it")
@@ -67,10 +67,10 @@ class CachedSubscriptionTest {
       assertEquals(0, channel.receive())
 
       println("starting subscription")
-      apolloClient.subscription(TimeSubscription())
+      apolloClient.subscription(CountSubscription(to = 100, intervalMillis = 1000))
           .toFlow()
           .take(3)
-          .map { it.data!!.time }
+          .map { it.data!!.count }
           .collect {
             println("subscription received: $it")
           }

--- a/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/WebSocketErrorsTest.kt
@@ -18,7 +18,6 @@ import org.junit.BeforeClass
 import org.junit.Test
 import sample.server.CloseSocketMutation
 import sample.server.CountSubscription
-import sample.server.TimeSubscription
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -51,7 +50,7 @@ class WebSocketErrorsTest {
         )
         .build()
 
-    apolloClient.subscription(TimeSubscription())
+    apolloClient.subscription(CountSubscription(to = 100, intervalMillis = 100))
         .toFlow()
         .test {
           val error = awaitItem().exception
@@ -76,7 +75,7 @@ class WebSocketErrorsTest {
         )
         .build()
 
-    apolloClient.subscription(TimeSubscription())
+    apolloClient.subscription(CountSubscription(to = 100, intervalMillis = 100))
         .toFlow()
         .test {
           val error = awaitItem().exception

--- a/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.sample.server.SampleServer
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.interceptor.RetryOnErrorInterceptor
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.network.ws.incubating.SubscriptionWsProtocol
 import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
@@ -25,7 +26,7 @@ class RetryTest {
     var sampleServer = SampleServer(freePort, "tag1")
     ApolloClient.Builder()
         .serverUrl(sampleServer.graphqlUrl())
-        .retryNetworkErrors(true)
+        .retryNetworkErrorsInterceptor(RetryOnErrorInterceptor())
         .subscriptionNetworkTransport(
             WebSocketNetworkTransport.Builder()
                 .serverUrl(sampleServer.subscriptionsUrl())
@@ -61,7 +62,7 @@ class RetryTest {
     val sampleServer = SampleServer(freePort, "tag1")
     ApolloClient.Builder()
         .serverUrl(sampleServer.graphqlUrl())
-        .retryNetworkErrors(true)
+        .retryNetworkErrorsInterceptor(RetryOnErrorInterceptor())
         .subscriptionNetworkTransport(
             WebSocketNetworkTransport.Builder()
                 .serverUrl(sampleServer.subscriptionsUrl())

--- a/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
@@ -3,23 +3,29 @@ package incubating
 import app.cash.turbine.test
 import com.apollographql.apollo.sample.server.SampleServer
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.network.ws.incubating.SubscriptionWsProtocol
 import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
 import com.apollographql.apollo3.testing.internal.runTest
+import com.apollographql.apollo3.testing.mockServerTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import sample.server.TagSubscription
+import sample.server.TimeQuery
+import kotlin.test.assertIs
 
 class RetryTest {
   @Test
-  fun retryIsWorking() = runTest {
+  fun retryIsWorking() = runTest(skipDelays = false) {
     // Hopefully it's really a free port, if not this test will fail
     val freePort = 8392
     var sampleServer = SampleServer(freePort, "tag1")
     ApolloClient.Builder()
         .serverUrl(sampleServer.graphqlUrl())
-        .retrySubscriptions(true)
+        .retryNetworkErrors(true)
         .subscriptionNetworkTransport(
             WebSocketNetworkTransport.Builder()
                 .serverUrl(sampleServer.subscriptionsUrl())
@@ -44,6 +50,50 @@ class RetryTest {
 
                 cancelAndIgnoreRemainingEvents()
               }
+        }
+    sampleServer.close()
+  }
+
+  @Test
+  fun retryCanBeDisabled() = runTest(skipDelays = false) {
+    // Hopefully it's really a free port, if not this test will fail
+    val freePort = 8393
+    val sampleServer = SampleServer(freePort, "tag1")
+    ApolloClient.Builder()
+        .serverUrl(sampleServer.graphqlUrl())
+        .retryNetworkErrors(true)
+        .subscriptionNetworkTransport(
+            WebSocketNetworkTransport.Builder()
+                .serverUrl(sampleServer.subscriptionsUrl())
+                .wsProtocol(SubscriptionWsProtocol { null })
+                .build()
+        )
+        .build().use { apolloClient ->
+          apolloClient.subscription(TagSubscription(intervalMillis = Int.MAX_VALUE))
+              .retryNetworkErrors(false)
+              .toFlow()
+              .test {
+                val item1 = awaitItem()
+                assertEquals("tag1", item1.data?.state?.tag)
+
+                sampleServer.close()
+
+                val item2 = awaitItem()
+                assertIs<ApolloNetworkException>(item2.exception)
+                awaitComplete()
+              }
+        }
+  }
+
+  @Test
+  fun queriesAreNotRetriedByDefault() = mockServerTest(skipDelays = false) {
+    mockServer.enqueue(MockResponse.Builder().statusCode(500).build())
+
+    apolloClient.query(TimeQuery())
+        .toFlow()
+        .test {
+          assertIs<ApolloHttpException>(awaitItem().exception)
+          awaitComplete()
         }
   }
 }

--- a/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
@@ -1,0 +1,49 @@
+package incubating
+
+import app.cash.turbine.test
+import com.apollographql.apollo.sample.server.SampleServer
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.network.ws.incubating.SubscriptionWsProtocol
+import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
+import com.apollographql.apollo3.testing.internal.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import sample.server.TagSubscription
+
+class RetryTest {
+  @Test
+  fun retryIsWorking() = runTest {
+    // Hopefully it's really a free port, if not this test will fail
+    val freePort = 8392
+    var sampleServer = SampleServer(freePort, "tag1")
+    ApolloClient.Builder()
+        .serverUrl(sampleServer.graphqlUrl())
+        .retrySubscriptions(true)
+        .subscriptionNetworkTransport(
+            WebSocketNetworkTransport.Builder()
+                .serverUrl(sampleServer.subscriptionsUrl())
+                .wsProtocol(SubscriptionWsProtocol { null })
+                .build()
+        )
+        .build().use { apolloClient ->
+          apolloClient.subscription(TagSubscription(intervalMillis = Int.MAX_VALUE))
+              .toFlow()
+              .test {
+                val item1 = awaitItem()
+                assertEquals("tag1", item1.data?.state?.tag)
+
+                sampleServer.close()
+                sampleServer = SampleServer(freePort, "tag2")
+
+                val item2 = awaitItem()
+                assertEquals("tag2", item2.data?.state?.tag)
+
+                // The new sub MUST use a different id
+                assertNotEquals(item1.data?.state?.subscriptionId, item2.data?.state?.subscriptionId)
+
+                cancelAndIgnoreRemainingEvents()
+              }
+        }
+  }
+}

--- a/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/incubating/RetryTest.kt
@@ -15,7 +15,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import sample.server.TagSubscription
-import sample.server.TimeQuery
+import sample.server.ZeroQuery
 import kotlin.test.assertIs
 
 class RetryTest {
@@ -90,7 +90,7 @@ class RetryTest {
   fun queriesAreNotRetriedByDefault() = mockServerTest(skipDelays = false) {
     mockServer.enqueue(MockResponse.Builder().statusCode(500).build())
 
-    apolloClient.query(TimeQuery())
+    apolloClient.query(ZeroQuery())
         .toFlow()
         .test {
           assertIs<ApolloHttpException>(awaitItem().exception)

--- a/tests/websockets/src/jvmTest/kotlin/incubating/SampleServerTest.kt
+++ b/tests/websockets/src/jvmTest/kotlin/incubating/SampleServerTest.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.exception.SubscriptionOperationException
 import com.apollographql.apollo3.network.ws.incubating.SubscriptionWsProtocol
 import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
+import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.map
@@ -12,7 +13,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import sample.server.CountSubscription
 import sample.server.OperationErrorSubscription
@@ -23,7 +23,7 @@ class SampleServerTest {
   private class Scope(val apolloClient: ApolloClient, val sampleServer: SampleServer, val coroutineScope: CoroutineScope)
 
   private fun test(customizeTransport: WebSocketNetworkTransport.Builder.() -> Unit = {}, block: suspend Scope.() -> Unit) {
-    runBlocking {
+    runTest {
       SampleServer().use { sampleServer ->
         ApolloClient.Builder()
             .serverUrl(sampleServer.graphqlUrl())
@@ -35,7 +35,7 @@ class SampleServerTest {
                     .build()
             )
             .build().use { apolloClient ->
-              Scope(apolloClient, sampleServer, this@runBlocking).block()
+              Scope(apolloClient, sampleServer, this@runTest).block()
             }
       }
     }


### PR DESCRIPTION
So that took a while but I'm quite happy with this solution. It's a lot more flexible that the previous WebSocket only and in the end it's just a few lines of code meaning someone wanting to add custom logic shouldn't need copy/pasting too many things.