### PR TITLE
🍎 Fix a NSUrlSession warning

### DIFF
--- a/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.apple.kt
+++ b/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.apple.kt
@@ -248,6 +248,8 @@ private class StreamingDataDelegate : NSObject(), NSURLSessionDataDelegateProtoc
 
     // Cleanup
     handlers.remove(dataTask)
+
+    completionHandler(willCacheResponse)
   }
 
   fun registerHandlerForTask(task: NSURLSessionTask, handler: Handler) {


### PR DESCRIPTION
I got this when running an app in Xcode:

<img width="826" alt="Screenshot 2024-03-07 at 00 23 52" src="https://github.com/apollographql/apollo-kotlin/assets/3974977/dbee4a6c-ebaa-4451-a2dd-57b2a6db179d">
