### PR TITLE
Add MockServer.enqueueError() and MockServer.assertNoRequest()

### DIFF
--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -75,11 +75,15 @@ public abstract interface class com/apollographql/apollo3/mockserver/MockServerH
 public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun MockServer ()Lcom/apollographql/apollo3/mockserver/MockServer;
 	public static final fun MockServer (Lcom/apollographql/apollo3/mockserver/MockServerHandler;)Lcom/apollographql/apollo3/mockserver/MockServer;
+	public static final fun assertNoRequest (Lcom/apollographql/apollo3/mockserver/MockServer;)V
 	public static final fun awaitRequest-8Mi8wO0 (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitRequest-8Mi8wO0$default (Lcom/apollographql/apollo3/mockserver/MockServer;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V
 	public static synthetic fun enqueue$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JIILjava/lang/Object;)V
-	public static final fun enqueueGraphQLString (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;)V
+	public static final fun enqueueError (Lcom/apollographql/apollo3/mockserver/MockServer;I)V
+	public static synthetic fun enqueueError$default (Lcom/apollographql/apollo3/mockserver/MockServer;IILjava/lang/Object;)V
+	public static final fun enqueueGraphQLString (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;J)V
+	public static synthetic fun enqueueGraphQLString$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JILjava/lang/Object;)V
 	public static final fun enqueueMultipart (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/util/List;)Ljava/lang/Void;
 	public static final fun enqueueString (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JILjava/lang/String;)V
 	public static synthetic fun enqueueString$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JILjava/lang/String;ILjava/lang/Object;)V

--- a/libraries/apollo-mockserver/api/apollo-mockserver.api
+++ b/libraries/apollo-mockserver/api/apollo-mockserver.api
@@ -81,7 +81,6 @@ public final class com/apollographql/apollo3/mockserver/MockServerKt {
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JI)V
 	public static synthetic fun enqueue$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JIILjava/lang/Object;)V
 	public static final fun enqueueError (Lcom/apollographql/apollo3/mockserver/MockServer;I)V
-	public static synthetic fun enqueueError$default (Lcom/apollographql/apollo3/mockserver/MockServer;IILjava/lang/Object;)V
 	public static final fun enqueueGraphQLString (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;J)V
 	public static synthetic fun enqueueGraphQLString$default (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/lang/String;JILjava/lang/Object;)V
 	public static final fun enqueueMultipart (Lcom/apollographql/apollo3/mockserver/MockServer;Ljava/util/List;)Ljava/lang/Void;

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -281,6 +281,8 @@ fun MockServer.enqueueString(string: String, delayMs: Long = 0, statusCode: Int 
 fun MockServer.enqueueError(statusCode: Int) {
   enqueue(MockResponse.Builder()
       .statusCode(statusCode)
+      .body("")
+      .addHeader("Content-Type", "text/plain")
       .build()
   )
 }

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -278,7 +278,7 @@ fun MockServer.enqueueString(string: String, delayMs: Long = 0, statusCode: Int 
   )
 }
 
-fun MockServer.enqueueError(statusCode: Int = 200) {
+fun MockServer.enqueueError(statusCode: Int) {
   enqueue(MockResponse.Builder()
       .statusCode(statusCode)
       .build()

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -102,9 +102,9 @@ interface MockServer : Closeable {
     fun listener(listener: Listener) = apply {
       this.listener = listener
     }
-    
+
     fun build(): MockServer {
-      check (tcpServer == null || port == null) {
+      check(tcpServer == null || port == null) {
         "It is an error to set both tcpServer and port"
       }
       val server = tcpServer ?: TcpServer(port ?: 0)
@@ -122,7 +122,7 @@ internal class MockServerImpl(
     private val mockServerHandler: MockServerHandler,
     private val handlePings: Boolean,
     private val server: TcpServer,
-    private val listener: MockServer.Listener?
+    private val listener: MockServer.Listener?,
 ) : MockServer {
   private val requests = Channel<MockRequestBase>(Channel.UNLIMITED)
   private val scope = CoroutineScope(SupervisorJob())
@@ -165,7 +165,7 @@ internal class MockServerImpl(
       handler: MockServerHandler,
       socket: TcpSocket,
       listener: MockServer.Listener?,
-      onRequest: (MockRequestBase) -> Unit
+      onRequest: (MockRequestBase) -> Unit,
   ) {
     val buffer = Buffer()
     val reader = object : Reader {
@@ -251,37 +251,58 @@ fun MockServer(): MockServer = MockServerImpl(
     QueueMockServerHandler(),
     true,
     TcpServer(0),
-    null)
+    null
+)
 
 @Deprecated("Use MockServer.Builder() instead", level = DeprecationLevel.ERROR)
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun MockServer(handler: MockServerHandler): MockServer =
-    MockServerImpl(
-        handler,
-        true,
-        TcpServer(0),
-        null)
+  MockServerImpl(
+      handler,
+      true,
+      TcpServer(0),
+      null
+  )
 
 @Deprecated("Use enqueueString instead", ReplaceWith("enqueueString(string = string, delayMs = delayMs, statusCode = statusCode)"), DeprecationLevel.ERROR)
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun MockServer.enqueue(string: String = "", delayMs: Long = 0, statusCode: Int = 200) = enqueueString(string, delayMs, statusCode)
 
-fun MockServer.enqueueString(string: String = "", delayMs: Long = 0, statusCode: Int = 200, contentType: String = "text/plain") {
+fun MockServer.enqueueString(string: String, delayMs: Long = 0, statusCode: Int = 200, contentType: String = "text/plain") {
   enqueue(MockResponse.Builder()
       .statusCode(statusCode)
       .body(string)
       .addHeader("Content-Type", contentType)
       .delayMillis(delayMs)
-      .build())
+      .build()
+  )
 }
 
-fun MockServer.enqueueGraphQLString(string: String) {
+fun MockServer.enqueueError(statusCode: Int = 200) {
   enqueue(MockResponse.Builder()
-      .statusCode(200)
-      .addHeader("content-type", "application/graphql-response+json")
-      .body(string)
-      .build())
+      .statusCode(statusCode)
+      .build()
+  )
 }
+
+fun MockServer.enqueueGraphQLString(
+    string: String,
+    delayMs: Long = 0,
+) = enqueueString(
+    string = string,
+    delayMs = delayMs,
+    contentType = "application/graphql-response+json"
+)
+
+fun MockServer.assertNoRequest() {
+  try {
+    takeRequest()
+    error("Apollo: response(s) were received")
+  } catch (_: Exception) {
+
+  }
+}
+
 
 @ApolloExperimental
 interface MultipartBody {
@@ -302,7 +323,7 @@ fun MultipartBody.enqueueStrings(parts: List<String>, responseDelayMillis: Long 
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 @Suppress("UNUSED_PARAMETER")
 fun MockServer.enqueueMultipart(
-    parts: List<String>
+    parts: List<String>,
 ): Nothing = TODO()
 
 @ApolloExperimental

--- a/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/commonMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -268,7 +268,7 @@ fun MockServer(handler: MockServerHandler): MockServer =
 @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun MockServer.enqueue(string: String = "", delayMs: Long = 0, statusCode: Int = 200) = enqueueString(string, delayMs, statusCode)
 
-fun MockServer.enqueueString(string: String, delayMs: Long = 0, statusCode: Int = 200, contentType: String = "text/plain") {
+fun MockServer.enqueueString(string: String = "", delayMs: Long = 0, statusCode: Int = 200, contentType: String = "text/plain") {
   enqueue(MockResponse.Builder()
       .statusCode(statusCode)
       .body(string)

--- a/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
+++ b/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
@@ -1,12 +1,12 @@
 package instrumented
 
 import com.apollographql.apollo3.mockserver.MockResponse
+import com.apollographql.apollo3.mockserver.assertNoRequest
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.FooQuery
 import com.apollographql.apollo3.testing.mockServerTest
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.fail
 
 class NetworkMonitorTest {
   /**
@@ -29,9 +29,6 @@ class NetworkMonitorTest {
 
     mockServer.takeRequest()
     mockServer.takeRequest()
-    try {
-      mockServer.takeRequest()
-      fail("An exception was expected")
-    } catch (_: Exception) {}
+    mockServer.assertNoRequest()
   }
 }

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -20,8 +20,8 @@ import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.assertNoRequest
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueMultipart
-import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.mockserver.enqueueStrings
 import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.mpp.platform
@@ -204,7 +204,7 @@ class DeferNormalizedCacheTest {
     )
     assertEquals(networkExpected, networkActual)
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     // Network will fail, so we get the cached version
     val cacheActual = apolloClient.query(WithFragmentSpreadsQuery()).execute().dataOrThrow()
 
@@ -334,7 +334,7 @@ class DeferNormalizedCacheTest {
     )
     assertResponseListEquals(networkExpected, networkActual)
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     // Because of the error the cache is missing some fields, so we get a cache miss, and fallback to the network (which also fails)
     val exception = apolloClient.query(WithFragmentSpreadsQuery()).execute().exception
     check(exception is CacheMissException)

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -18,6 +18,7 @@ import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.assertNoRequest
 import com.apollographql.apollo3.mockserver.awaitRequest
 import com.apollographql.apollo3.mockserver.enqueueMultipart
 import com.apollographql.apollo3.mockserver.enqueueString
@@ -83,7 +84,7 @@ class DeferNormalizedCacheTest {
 
     // Cache is not empty, so this doesn't go to the server
     val cacheActual = apolloClient.query(WithFragmentSpreadsQuery()).execute().dataOrThrow()
-    assertFails { mockServer.takeRequest() }
+    mockServer.assertNoRequest()
 
     // We get the last/fully formed data
     val cacheExpected = WithFragmentSpreadsQuery.Data(

--- a/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
+++ b/tests/http-cache/src/test/kotlin/HttpCacheTest.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.exception.ApolloParseException
 import com.apollographql.apollo3.exception.HttpCacheMissException
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.okHttpClient
 import com.apollographql.apollo3.testing.enqueueData
@@ -88,7 +89,7 @@ class HttpCacheTest {
   @Test
   fun NetworkOnly() = runTest(before = { before() }, after = { tearDown() }) {
     mockServer.enqueueData(data)
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
 
     runBlocking {
       val response = apolloClient.query(GetRandomQuery()).execute()
@@ -107,7 +108,7 @@ class HttpCacheTest {
   @Test
   fun NetworkFirst() = runTest(before = { before() }, after = { tearDown() }) {
     mockServer.enqueueData(data)
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
 
     runBlocking {
       var response = apolloClient.query(GetRandomQuery())
@@ -171,7 +172,7 @@ class HttpCacheTest {
     val okHttpClient = OkHttpClient.Builder().addInterceptor(interceptor).build()
 
     val mockServer = MockServer()
-    mockServer.enqueueString(statusCode = 200)
+    mockServer.enqueueString("")
     val apolloClient = ApolloClient.Builder()
         .serverUrl(mockServer.url())
         .okHttpClient(okHttpClient)

--- a/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/BodyExtensionsTest.kt
@@ -14,7 +14,7 @@ import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.integration.fullstack.LaunchDetailsQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
-import com.apollographql.apollo3.mockserver.enqueueString
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import com.apollographql.apollo3.testing.internal.runTest
 import okio.Buffer
@@ -58,7 +58,7 @@ class BodyExtensionsTest {
         )
         .build()
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     apolloClient.query(LaunchDetailsQuery("42")).execute()
 
     val request = mockServer.awaitRequest()

--- a/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ExceptionsTest.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.flow.toList
@@ -40,7 +41,7 @@ class ExceptionsTest {
 
   @Test
   fun whenHttpErrorAssertExecuteFails() = runTest(before = { setUp() }, after = { tearDown() }) {
-    mockServer.enqueueString(statusCode = 404)
+    mockServer.enqueueError(statusCode = 404)
 
     val response = apolloClient.query(HeroNameQuery()).execute()
     val exception = response.exception

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -33,6 +33,7 @@ import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.enqueue
 import com.apollographql.apollo3.testing.internal.runTest
@@ -391,7 +392,7 @@ class FetchPolicyTest {
 
     // Initial state: everything fails
     // Cache Error + Network Error => Error
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).execute().exception.let {
       assertIs<CacheMissException>(it)
       assertIs<ApolloHttpException>(it.suppressedExceptions.first())
@@ -413,7 +414,7 @@ class FetchPolicyTest {
     // Now cache is populated but make the network fail again
     // Cache Success + Network Error => 1 response with cache value + 1 response with network exception
     caught = null
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow().catch { caught = it }.toList()
 
     assertNull(caught)
@@ -462,7 +463,7 @@ class FetchPolicyTest {
     var caught: Throwable? = null
     // Initial state: everything fails
     // Cache Error + Network Error => Error
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
 
     @Suppress("DEPRECATION")
     assertFailsWith<ApolloCompositeException> {
@@ -489,7 +490,7 @@ class FetchPolicyTest {
     // Now cache is populated but make the network fail again
     // Cache Success + Network Error => 1 response + 1 network exception
     caught = null
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     @Suppress("DEPRECATION")
     responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlowV3().catch { caught = it }.toList()
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -15,6 +15,7 @@ import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.integration.normalizer.EpisodeHeroNameQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import com.apollographql.apollo3.testing.receiveOrTimeout
@@ -50,7 +51,7 @@ class WatcherErrorHandlingTest {
     val jobs = mutableListOf<Job>()
 
     jobs += launch {
-      mockServer.enqueueString(statusCode = 500)
+      mockServer.enqueueError(statusCode = 500)
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheFirst)
           .watch()
@@ -69,7 +70,7 @@ class WatcherErrorHandlingTest {
     }
 
     jobs += launch {
-      mockServer.enqueueString(statusCode = 500)
+      mockServer.enqueueError(statusCode = 500)
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkFirst)
           .watch()
@@ -79,7 +80,7 @@ class WatcherErrorHandlingTest {
     }
 
     jobs += launch {
-      mockServer.enqueueString(statusCode = 500)
+      mockServer.enqueueError(statusCode = 500)
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.NetworkOnly)
           .watch()
@@ -89,7 +90,7 @@ class WatcherErrorHandlingTest {
     }
 
     jobs += launch {
-      mockServer.enqueueString(statusCode = 500)
+      mockServer.enqueueError(statusCode = 500)
       apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
           .fetchPolicy(FetchPolicy.CacheAndNetwork)
           .watch()
@@ -125,7 +126,7 @@ class WatcherErrorHandlingTest {
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
     // we enqueue an error so a network exception is emitted
     mockServer.enqueueString(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     assertIs<ApolloHttpException>(channel.receiveOrTimeout().exception)
@@ -134,7 +135,7 @@ class WatcherErrorHandlingTest {
 
   @Test
   fun fetchEmitsExceptions() = runTest(before = { setUp() }, after = { tearDown() }) {
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     assertIs<CacheMissException>(
         apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
             .fetchPolicy(FetchPolicy.CacheFirst)
@@ -151,7 +152,7 @@ class WatcherErrorHandlingTest {
             .exception
     )
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     assertIs<ApolloHttpException>(
         apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
             .fetchPolicy(FetchPolicy.NetworkFirst)
@@ -160,7 +161,7 @@ class WatcherErrorHandlingTest {
             .exception
     )
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     assertIs<ApolloHttpException>(
         apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
             .fetchPolicy(FetchPolicy.NetworkOnly)
@@ -169,7 +170,7 @@ class WatcherErrorHandlingTest {
             .exception
     )
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     assertIs<CacheMissException>(
         apolloClient.query(EpisodeHeroNameQuery(Episode.EMPIRE))
             .fetchPolicy(FetchPolicy.CacheAndNetwork)
@@ -205,7 +206,7 @@ class WatcherErrorHandlingTest {
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
     // we enqueue an error so a network exception is emitted
     mockServer.enqueueString(testFixtureToUtf8("EpisodeHeroNameResponseNameChange.json"))
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     assertIs<ApolloHttpException>(channel.receiveOrTimeout().exception)

--- a/tests/integration-tests/src/jvmTest/kotlin/test/ExecutionContextTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/ExecutionContextTest.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.network.http.HttpEngine
@@ -41,12 +42,12 @@ class ExecutionContextTest {
           .build().use { apolloClient ->
 
             // we don't need a response
-            mockServer.enqueueString(statusCode = 404)
+            mockServer.enqueueError(statusCode = 404)
             apolloClient.query(HeroNameQuery())
                 .addExecutionContext(MyExecutionContext("value0"))
                 .execute()
 
-            mockServer.enqueueString(statusCode = 404)
+            mockServer.enqueueError(statusCode = 404)
             apolloClient.query(HeroNameQuery())
                 .addExecutionContext(MyExecutionContext("value1"))
                 .execute()

--- a/tests/integration-tests/src/jvmTest/kotlin/test/OkHttpClientTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/OkHttpClientTest.kt
@@ -4,6 +4,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.okHttpClient
 import kotlinx.coroutines.runBlocking
@@ -23,7 +24,7 @@ class OkHttpClientTest {
 
     runBlocking {
       val mockServer = MockServer()
-      mockServer.enqueueString(statusCode = 200)
+      mockServer.enqueueError(statusCode = 200)
 
       val apolloClient = ApolloClient.Builder()
           .serverUrl(mockServer.url())

--- a/tests/no-query-document/src/test/kotlin/test/NoQueryDocumentTest.kt
+++ b/tests/no-query-document/src/test/kotlin/test/NoQueryDocumentTest.kt
@@ -14,6 +14,7 @@ import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
 import com.apollographql.apollo3.testing.internal.runTest
@@ -64,7 +65,7 @@ class NoQueryDocumentTest {
         )
         .build()
 
-    mockServer.enqueueString(statusCode = 500)
+    mockServer.enqueueError(statusCode = 500)
     kotlin.runCatching {
       apolloClient.query(GetRandomQuery())
           .execute()


### PR DESCRIPTION
2 utility functions that I wish I had while writing subscription tests