### PR TITLE
[CI flake] Hopefully fix WebSocketEngineTest

### DIFF
--- a/libraries/apollo-websocket-network-transport-incubating/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.apple.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketEngine.apple.kt
@@ -10,6 +10,7 @@ import kotlinx.cinterop.convert
 import okio.ByteString.Companion.toByteString
 import platform.Foundation.NSData
 import platform.Foundation.NSMutableURLRequest
+import platform.Foundation.NSOperationQueue
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLSession
 import platform.Foundation.NSURLSessionConfiguration
@@ -28,7 +29,7 @@ internal class AppleWebSocketEngine : WebSocketEngine {
   private val nsUrlSession = NSURLSession.sessionWithConfiguration(
       configuration = NSURLSessionConfiguration.defaultSessionConfiguration,
       delegate = delegate,
-      delegateQueue = null
+      delegateQueue = NSOperationQueue()
   )
 
   override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {


### PR DESCRIPTION
Looks like this happens when the host machine is under high load (e.g. compiling other modules, running compiler tests).

I'm not sure why but changing the executor moves the latency from ~1s to <100ms on my machine