### PR TITLE
Add test for using the incubating WebSocketNetworkTransport with JsExport

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/http/DefaultHttpRequestComposer.kt
@@ -306,7 +306,7 @@ class DefaultHttpRequestComposer(
       val operation = apolloRequest.operation
       val sendApqExtensions = apolloRequest.sendApqExtensions ?: false
       val sendDocument = apolloRequest.sendDocument ?: true
-      val customScalarAdapters = apolloRequest.executionContext[CustomScalarAdapters] ?: error("Cannot find a ResponseAdapterCache")
+      val customScalarAdapters = apolloRequest.executionContext[CustomScalarAdapters] ?: CustomScalarAdapters.Empty
 
       val query = if (sendDocument) operation.document() else null
       return buildJsonMap {

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/json/MapJsonReader.kt
@@ -426,6 +426,7 @@ constructor(
  * - null
  * - Map<String, ApolloJsonElement> where values are any of these values recursively
  * - List<ApolloJsonElement> where values are any of these values recursively
+ * - dynamic for advanced use cases using @JsExport
  *
  * Anything else is undefined
  */

--- a/libraries/apollo-execution-incubating/src/commonMain/kotlin/com/apollographql/apollo3/execution/GraphQLRequest.kt
+++ b/libraries/apollo-execution-incubating/src/commonMain/kotlin/com/apollographql/apollo3/execution/GraphQLRequest.kt
@@ -335,6 +335,6 @@ internal fun String.parseApolloWebsocketClientMessage(): ApolloWebsocketClientMe
       return ApolloWebsocketTerminate
     }
 
-    else -> return ApolloWebsocketClientMessageParseError("Unknonw message type '$type'")
+    else -> return ApolloWebsocketClientMessageParseError("Unknown message type '$type'")
   }
 }

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/GraphQLWsProtocol.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/GraphQLWsProtocol.kt
@@ -39,11 +39,11 @@ class GraphQLWsProtocol(
     ).toClientMessage()
   }
 
-  override fun ping(): ClientMessage? {
+  override fun ping(): ClientMessage {
     return mapOf("type" to "ping").toClientMessage()
   }
 
-  override fun pong(): ClientMessage? {
+  override fun pong(): ClientMessage {
     return mapOf("type" to "pong").toClientMessage()
   }
 

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
@@ -15,7 +15,7 @@ class ConnectionErrorServerMessage(val payload: Any?) : ServerMessage
  * @param response, a GraphQL response, possibly containing errors.
  * @param complete, whether this is a terminal message for the given operation.
  */
-class ResponseServerMessage(val id: String, val response: Any?, val complete: Boolean) : ServerMessage
+class ResponseServerMessage(val id: String, val response: ApolloJsonElement, val complete: Boolean) : ServerMessage
 
 /**
  * The subscription completed normally

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/ServerMessage.kt
@@ -7,7 +7,7 @@ object ConnectionAckServerMessage : ServerMessage
 object ConnectionKeepAliveServerMessage : ServerMessage
 object PingServerMessage : ServerMessage
 object PongServerMessage : ServerMessage
-class ConnectionErrorServerMessage(val payload: Any?) : ServerMessage
+class ConnectionErrorServerMessage(val payload: ApolloJsonElement) : ServerMessage
 
 /**
  * A GraphQL response was received

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionParser.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/SubscriptionParser.kt
@@ -1,0 +1,17 @@
+package com.apollographql.apollo3.network.ws.incubating
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+
+@ApolloExperimental
+interface SubscriptionParser<D : Operation.Data> {
+  fun parse(payload: ApolloJsonElement): ApolloResponse<D>?
+}
+
+@ApolloExperimental
+interface SubscriptionParserFactory {
+  fun <D: Operation.Data> createParser(request: ApolloRequest<D>): SubscriptionParser<D>
+}

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketHolder.kt
@@ -8,6 +8,7 @@ import kotlinx.atomicfu.locks.withLock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -87,6 +88,7 @@ internal class WebSocketHolder(
   }
 
   fun close() = lock.withLock {
+    scope.cancel()
     webSocketEngine.close()
     if (subscribableWebSocket != null) {
       subscribableWebSocket!!.shutdown(null, CLOSE_GOING_AWAY, "Canceled")

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
@@ -186,11 +186,6 @@ class WebSocketNetworkTransport private constructor(
       this.connectionAcknowledgeTimeoutMillis = connectionAcknowledgeTimeoutMillis
     }
 
-    /**
-     * The maximum number of milliseconds between a "connection_init" message and its acknowledgement
-     *
-     * Default: 10_000
-     */
     @ApolloExperimental
     fun parserFactory(parserFactory: SubscriptionParserFactory?) = apply {
       this.parserFactory = parserFactory

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
@@ -99,7 +99,6 @@ class WebSocketNetworkTransport private constructor(
     holder.closeCurrentConnection(reason)
   }
 
-
   class Builder {
     private var serverUrl: String? = null
     private var httpHeaders: List<HttpHeader>? = null
@@ -206,7 +205,7 @@ private class DefaultOperationListener<D : Operation.Data>(
     private val producerScope: ProducerScope<ApolloResponse<D>>,
 ) : OperationListener {
   val deferredJsonMerger = DeferredJsonMerger()
-  val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters]!!
+  val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters] ?: CustomScalarAdapters.Empty
 
   override fun onResponse(response: Any?) {
     @Suppress("UNCHECKED_CAST")

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
@@ -207,7 +207,7 @@ private class DefaultOperationListener<D : Operation.Data>(
   val deferredJsonMerger = DeferredJsonMerger()
   val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters] ?: CustomScalarAdapters.Empty
 
-  override fun onResponse(response: Any?) {
+  override fun onResponse(response: ApolloJsonElement) {
     @Suppress("UNCHECKED_CAST")
     val responseMap = response as? Map<String, Any?>
     if (responseMap == null) {

--- a/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
+++ b/libraries/apollo-websocket-network-transport-incubating/src/commonMain/kotlin/com/apollographql/apollo3/network/ws/incubating/WebSocketNetworkTransport.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.network.ws.incubating
 
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -36,6 +37,7 @@ class WebSocketNetworkTransport private constructor(
     private val connectionAcknowledgeTimeoutMillis: Long,
     private val pingIntervalMillis: Long,
     private val idleTimeoutMillis: Long,
+    private val parserFactory: SubscriptionParserFactory
 ) : NetworkTransport {
 
   private val holder = WebSocketHolder(
@@ -70,7 +72,7 @@ class WebSocketNetworkTransport private constructor(
       }
       renewUuid = true
 
-      val operationListener = DefaultOperationListener(newRequest, this)
+      val operationListener = DefaultOperationListener(newRequest, this, parserFactory.createParser(request))
 
       val webSocket = holder.acquire()
       webSocket.startOperation(newRequest, operationListener)
@@ -107,6 +109,7 @@ class WebSocketNetworkTransport private constructor(
     private var connectionAcknowledgeTimeoutMillis: Long? = null
     private var pingIntervalMillis: Long? = null
     private var idleTimeoutMillis: Long? = null
+    private var parserFactory: SubscriptionParserFactory? = null
 
     /**
      * @param serverUrl a server url that is called every time a WebSocket
@@ -117,7 +120,7 @@ class WebSocketNetworkTransport private constructor(
      * - "http://" (same as "ws://")
      * - "https://" (same as "wss://")
      */
-    fun serverUrl(serverUrl: String) = apply {
+    fun serverUrl(serverUrl: String?) = apply {
       this.serverUrl = serverUrl
     }
 
@@ -138,7 +141,7 @@ class WebSocketNetworkTransport private constructor(
     /**
      * Set the [WebSocketEngine] to use.
      */
-    fun webSocketEngine(webSocketEngine: WebSocketEngine) = apply {
+    fun webSocketEngine(webSocketEngine: WebSocketEngine?) = apply {
       this.webSocketEngine = webSocketEngine
     }
 
@@ -147,7 +150,7 @@ class WebSocketNetworkTransport private constructor(
      *
      * Default: `60_000`
      */
-    fun idleTimeoutMillis(idleTimeoutMillis: Long) = apply {
+    fun idleTimeoutMillis(idleTimeoutMillis: Long?) = apply {
       this.idleTimeoutMillis = idleTimeoutMillis
     }
 
@@ -160,7 +163,7 @@ class WebSocketNetworkTransport private constructor(
      * @see [AppSyncWsProtocol]
      * @see [GraphQLWsProtocol]
      */
-    fun wsProtocol(wsProtocol: WsProtocol) = apply {
+    fun wsProtocol(wsProtocol: WsProtocol?) = apply {
       this.wsProtocol = wsProtocol
     }
 
@@ -170,7 +173,7 @@ class WebSocketNetworkTransport private constructor(
      *
      * Default: -1
      */
-    fun pingIntervalMillis(pingIntervalMillis: Long) = apply {
+    fun pingIntervalMillis(pingIntervalMillis: Long?) = apply {
       this.pingIntervalMillis = pingIntervalMillis
     }
 
@@ -179,9 +182,20 @@ class WebSocketNetworkTransport private constructor(
      *
      * Default: 10_000
      */
-    fun connectionAcknowledgeTimeoutMillis(connectionAcknowledgeTimeoutMillis: Long) = apply {
+    fun connectionAcknowledgeTimeoutMillis(connectionAcknowledgeTimeoutMillis: Long?) = apply {
       this.connectionAcknowledgeTimeoutMillis = connectionAcknowledgeTimeoutMillis
     }
+
+    /**
+     * The maximum number of milliseconds between a "connection_init" message and its acknowledgement
+     *
+     * Default: 10_000
+     */
+    @ApolloExperimental
+    fun parserFactory(parserFactory: SubscriptionParserFactory?) = apply {
+      this.parserFactory = parserFactory
+    }
+
 
     /**
      * Builds the [WebSocketNetworkTransport]
@@ -195,27 +209,31 @@ class WebSocketNetworkTransport private constructor(
           wsProtocol = wsProtocol ?: GraphQLWsProtocol { null },
           pingIntervalMillis = pingIntervalMillis ?: -1L,
           connectionAcknowledgeTimeoutMillis = connectionAcknowledgeTimeoutMillis ?: 10_000L,
+          parserFactory = parserFactory ?: DefaultSubscriptionParserFactory
       )
     }
   }
 }
 
-private class DefaultOperationListener<D : Operation.Data>(
-    private val request: ApolloRequest<D>,
-    private val producerScope: ProducerScope<ApolloResponse<D>>,
-) : OperationListener {
-  val deferredJsonMerger = DeferredJsonMerger()
-  val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters] ?: CustomScalarAdapters.Empty
+private object DefaultSubscriptionParserFactory: SubscriptionParserFactory {
+  override fun <D : Operation.Data> createParser(request: ApolloRequest<D>): SubscriptionParser<D> {
+    return DefaultSubscriptionParser(request)
+  }
+}
 
-  override fun onResponse(response: ApolloJsonElement) {
+private class DefaultSubscriptionParser<D : Operation.Data>(private val request: ApolloRequest<D>) : SubscriptionParser<D> {
+  private var deferredJsonMerger: DeferredJsonMerger = DeferredJsonMerger()
+  private val requestCustomScalarAdapters = request.executionContext[CustomScalarAdapters] ?: CustomScalarAdapters.Empty
+
+  @Suppress("NAME_SHADOWING")
+  override fun parse(payload: ApolloJsonElement): ApolloResponse<D>? {
     @Suppress("UNCHECKED_CAST")
-    val responseMap = response as? Map<String, Any?>
+    val responseMap = payload as? Map<String, Any?>
     if (responseMap == null) {
-      producerScope.trySend(ApolloResponse.Builder(request.operation, request.requestUuid)
+      return ApolloResponse.Builder(request.operation, request.requestUuid)
           .exception(DefaultApolloException("Invalid payload")).build()
-      )
-      return
     }
+
     val (payload, mergedFragmentIds) = if (responseMap.isDeferred()) {
       deferredJsonMerger.merge(responseMap) to deferredJsonMerger.mergedFragmentIds
     } else {
@@ -233,8 +251,22 @@ private class DefaultOperationListener<D : Operation.Data>(
       deferredJsonMerger.reset()
     }
 
-    if (!deferredJsonMerger.isEmptyPayload) {
-      producerScope.trySend(apolloResponse)
+    if (deferredJsonMerger.isEmptyPayload) {
+      return null
+    } else {
+      return apolloResponse
+    }
+  }
+}
+
+private class DefaultOperationListener<D : Operation.Data>(
+    private val request: ApolloRequest<D>,
+    private val producerScope: ProducerScope<ApolloResponse<D>>,
+    private val parser: SubscriptionParser<D>
+) : OperationListener {
+  override fun onResponse(response: ApolloJsonElement) {
+    parser.parse(response)?.let {
+      producerScope.trySend(it)
     }
   }
 

--- a/tests/jsexport/build.gradle.kts
+++ b/tests/jsexport/build.gradle.kts
@@ -17,6 +17,15 @@ kotlin {
     findByName("commonMain")?.apply {
       dependencies {
         implementation(libs.apollo.runtime)
+        implementation(libs.apollo.websocket.network.transport.incubating)
+      }
+    }
+
+    getByName("commonTest") {
+      dependencies {
+        implementation(libs.apollo.testingsupport)
+        implementation(libs.apollo.mockserver)
+        implementation(libs.turbine)
       }
     }
 

--- a/tests/jsexport/src/commonMain/graphql/operations.graphql
+++ b/tests/jsexport/src/commonMain/graphql/operations.graphql
@@ -17,3 +17,11 @@ query GetAnimal {
     }
   }
 }
+
+
+subscription Event {
+  event {
+    time
+    currentTimeMillis
+  }
+}

--- a/tests/jsexport/src/commonMain/graphql/schema.graphqls
+++ b/tests/jsexport/src/commonMain/graphql/schema.graphqls
@@ -5,6 +5,15 @@ type Query {
   bookOrLion: BookOrLion
 }
 
+type Subscription {
+  event: Event
+}
+
+type Event {
+  time: String
+  currentTimeMillis: Int
+}
+
 interface Animal {
   species: String!
 }

--- a/tests/jsexport/src/commonTest/kotlin/JsExportTest.kt
+++ b/tests/jsexport/src/commonTest/kotlin/JsExportTest.kt
@@ -1,5 +1,21 @@
+import app.cash.turbine.test
+import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.apolloUnsafeCast
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+import com.apollographql.apollo3.api.json.buildJsonString
+import com.apollographql.apollo3.api.json.jsonReader
+import com.apollographql.apollo3.api.json.readAny
+import com.apollographql.apollo3.api.json.writeAny
+import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.TextMessage
+import com.apollographql.apollo3.mockserver.WebSocketMessage
+import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
+import com.apollographql.apollo3.mockserver.enqueueWebSocket
+import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
+import com.apollographql.apollo3.testing.internal.runTest
+import jsexport.EventSubscription
 import jsexport.GetAnimalQuery
+import okio.Buffer
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,14 +46,81 @@ class JsExportTest {
   fun test() {
     val data = data(response)
 
-    assertEquals("Maine Coon", data.animal.species, )
-    assertEquals("Cat", data.animal.__typename, )
-    assertEquals("Noushka", data.animal.apolloUnsafeCast<GetAnimalQuery.Data.CatAnimal>().name, )
+    assertEquals("Maine Coon", data.animal.species)
+    assertEquals("Cat", data.animal.__typename)
+    assertEquals("Noushka", data.animal.apolloUnsafeCast<GetAnimalQuery.Data.CatAnimal>().name)
 
-    assertEquals("SOUTH", data.direction, )
+    assertEquals("SOUTH", data.direction)
 
-    assertEquals(1, data.point?.x, )
-    assertEquals(2, data.point?.y, )
+    assertEquals(1, data.point?.x)
+    assertEquals(2, data.point?.y)
     assertEquals("The Lion, the Witch and the Wardrobe", data.bookOrLion?.apolloUnsafeCast<GetAnimalQuery.Data.BookBookOrLion>()?.title)
+  }
+
+  @Test
+  fun testMockServer() = runTest {
+    val mockServer = MockServer()
+
+    val serverWriter = mockServer.enqueueWebSocket()
+
+    val webSocketNetworkTransport = WebSocketNetworkTransport.Builder()
+        .serverUrl(mockServer.url())
+        .build()
+
+    val request = ApolloRequest.Builder(EventSubscription())
+        .build()
+
+    webSocketNetworkTransport.execute(request).test {
+      val serverReader = mockServer.awaitWebSocketRequest()
+      serverReader.awaitMessage() 
+      serverWriter.enqueueMessage(mapOf("type" to "connection_ack").toTextMessage())
+
+      @Suppress("UNCHECKED_CAST")
+      val subscribe = serverReader.awaitMessage().toApolloJsonElement() as Map<String, *>
+      val id = subscribe["id"].toString()
+
+      serverWriter.enqueueMessage(
+          mapOf(
+              "type" to "next",
+              "id" to id,
+              "payload" to mapOf(
+                  "data" to mapOf(
+                      "event" to mapOf(
+                          "time" to "Jan 1st 1970",
+                          "currentTimeMillis" to 42
+                      )
+                  )
+              )
+          ).toTextMessage())
+      serverWriter.enqueueMessage(mapOf("type" to "complete", "id" to id).toTextMessage())
+
+      awaitItem().data!!.apply {
+        assertEquals("Jan 1st 1970", event?.time)
+        assertEquals(42, event?.currentTimeMillis)
+      }
+
+      awaitComplete()
+    }
+
+
+    val data = data(response)
+
+    assertEquals("Maine Coon", data.animal.species)
+    assertEquals("Cat", data.animal.__typename)
+    assertEquals("Noushka", data.animal.apolloUnsafeCast<GetAnimalQuery.Data.CatAnimal>().name)
+
+    assertEquals("SOUTH", data.direction)
+
+    assertEquals(1, data.point?.x)
+    assertEquals(2, data.point?.y)
+    assertEquals("The Lion, the Witch and the Wardrobe", data.bookOrLion?.apolloUnsafeCast<GetAnimalQuery.Data.BookBookOrLion>()?.title)
+  }
+
+  private fun ApolloJsonElement.toTextMessage(): TextMessage {
+    return TextMessage(buildJsonString { writeAny(this@toTextMessage) })
+  }
+
+  private fun WebSocketMessage.toApolloJsonElement(): ApolloJsonElement {
+    return Buffer().writeUtf8((this as TextMessage).text).jsonReader().readAny()
   }
 }

--- a/tests/jsexport/src/commonTest/kotlin/JsExportTest.kt
+++ b/tests/jsexport/src/commonTest/kotlin/JsExportTest.kt
@@ -1,3 +1,4 @@
+
 import app.cash.turbine.test
 import com.apollographql.apollo3.api.ApolloRequest
 import com.apollographql.apollo3.api.apolloUnsafeCast
@@ -11,11 +12,14 @@ import com.apollographql.apollo3.mockserver.TextMessage
 import com.apollographql.apollo3.mockserver.WebSocketMessage
 import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
 import com.apollographql.apollo3.mockserver.enqueueWebSocket
+import com.apollographql.apollo3.network.ws.incubating.SubscriptionParserFactory
 import com.apollographql.apollo3.network.ws.incubating.WebSocketNetworkTransport
+import com.apollographql.apollo3.network.ws.incubating.WsProtocol
 import com.apollographql.apollo3.testing.internal.runTest
 import jsexport.EventSubscription
 import jsexport.GetAnimalQuery
 import okio.Buffer
+import okio.use
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -41,6 +45,9 @@ val response = """
 
 expect fun data(response: String): GetAnimalQuery.Data
 
+expect val parserFactory: SubscriptionParserFactory?
+expect val wsProtocol: WsProtocol?
+
 class JsExportTest {
   @Test
   fun test() {
@@ -59,61 +66,53 @@ class JsExportTest {
 
   @Test
   fun testMockServer() = runTest {
-    val mockServer = MockServer()
+    MockServer().use { mockServer ->
+      val serverWriter = mockServer.enqueueWebSocket()
 
-    val serverWriter = mockServer.enqueueWebSocket()
+      val webSocketNetworkTransport = WebSocketNetworkTransport.Builder()
+          .serverUrl(mockServer.url())
+          .parserFactory(parserFactory)
+          .wsProtocol(wsProtocol)
+          .build()
 
-    val webSocketNetworkTransport = WebSocketNetworkTransport.Builder()
-        .serverUrl(mockServer.url())
-        .build()
+      val request = ApolloRequest.Builder(EventSubscription())
+          .build()
 
-    val request = ApolloRequest.Builder(EventSubscription())
-        .build()
+      webSocketNetworkTransport.execute(request).test {
+        val serverReader = mockServer.awaitWebSocketRequest()
+        serverReader.awaitMessage()
+        serverWriter.enqueueMessage(mapOf("type" to "connection_ack").toTextMessage())
 
-    webSocketNetworkTransport.execute(request).test {
-      val serverReader = mockServer.awaitWebSocketRequest()
-      serverReader.awaitMessage() 
-      serverWriter.enqueueMessage(mapOf("type" to "connection_ack").toTextMessage())
+        @Suppress("UNCHECKED_CAST")
+        val subscribe = serverReader.awaitMessage().toApolloJsonElement() as Map<String, *>
+        val id = subscribe["id"].toString()
 
-      @Suppress("UNCHECKED_CAST")
-      val subscribe = serverReader.awaitMessage().toApolloJsonElement() as Map<String, *>
-      val id = subscribe["id"].toString()
+        serverWriter.enqueueMessage(
+            mapOf(
+                "type" to "next",
+                "id" to id,
+                "payload" to mapOf(
+                    "data" to mapOf(
+                        "event" to mapOf(
+                            "time" to "Jan 1st 1970",
+                            "currentTimeMillis" to 42
+                        )
+                    )
+                )
+            ).toTextMessage()
+        )
+        serverWriter.enqueueMessage(mapOf("type" to "complete", "id" to id).toTextMessage())
 
-      serverWriter.enqueueMessage(
-          mapOf(
-              "type" to "next",
-              "id" to id,
-              "payload" to mapOf(
-                  "data" to mapOf(
-                      "event" to mapOf(
-                          "time" to "Jan 1st 1970",
-                          "currentTimeMillis" to 42
-                      )
-                  )
-              )
-          ).toTextMessage())
-      serverWriter.enqueueMessage(mapOf("type" to "complete", "id" to id).toTextMessage())
+        awaitItem().data!!.apply {
+          assertEquals("Jan 1st 1970", event?.time)
+          assertEquals(42, event?.currentTimeMillis)
+        }
 
-      awaitItem().data!!.apply {
-        assertEquals("Jan 1st 1970", event?.time)
-        assertEquals(42, event?.currentTimeMillis)
+        awaitComplete()
       }
 
-      awaitComplete()
+      webSocketNetworkTransport.dispose()
     }
-
-
-    val data = data(response)
-
-    assertEquals("Maine Coon", data.animal.species)
-    assertEquals("Cat", data.animal.__typename)
-    assertEquals("Noushka", data.animal.apolloUnsafeCast<GetAnimalQuery.Data.CatAnimal>().name)
-
-    assertEquals("SOUTH", data.direction)
-
-    assertEquals(1, data.point?.x)
-    assertEquals(2, data.point?.y)
-    assertEquals("The Lion, the Witch and the Wardrobe", data.bookOrLion?.apolloUnsafeCast<GetAnimalQuery.Data.BookBookOrLion>()?.title)
   }
 
   private fun ApolloJsonElement.toTextMessage(): TextMessage {

--- a/tests/jsexport/src/jsTest/kotlin/JsExportTest.js.kt
+++ b/tests/jsexport/src/jsTest/kotlin/JsExportTest.js.kt
@@ -1,0 +1,93 @@
+
+import com.apollographql.apollo3.api.ApolloRequest
+import com.apollographql.apollo3.api.ApolloResponse
+import com.apollographql.apollo3.api.Error
+import com.apollographql.apollo3.api.Operation
+import com.apollographql.apollo3.api.json.ApolloJsonElement
+import com.apollographql.apollo3.network.ws.incubating.ClientMessage
+import com.apollographql.apollo3.network.ws.incubating.CompleteServerMessage
+import com.apollographql.apollo3.network.ws.incubating.ConnectionAckServerMessage
+import com.apollographql.apollo3.network.ws.incubating.GraphQLWsProtocol
+import com.apollographql.apollo3.network.ws.incubating.ParseErrorServerMessage
+import com.apollographql.apollo3.network.ws.incubating.PingServerMessage
+import com.apollographql.apollo3.network.ws.incubating.PongServerMessage
+import com.apollographql.apollo3.network.ws.incubating.ResponseServerMessage
+import com.apollographql.apollo3.network.ws.incubating.ServerMessage
+import com.apollographql.apollo3.network.ws.incubating.SubscriptionParser
+import com.apollographql.apollo3.network.ws.incubating.SubscriptionParserFactory
+import com.apollographql.apollo3.network.ws.incubating.WsProtocol
+
+actual val parserFactory: SubscriptionParserFactory?
+  get() = JsSubscriptionParserFactory
+
+class ApolloDynamic(val value: dynamic)
+
+object JsSubscriptionParserFactory : SubscriptionParserFactory {
+  override fun <D : Operation.Data> createParser(request: ApolloRequest<D>): SubscriptionParser<D> {
+    return object : SubscriptionParser<D> {
+      override fun parse(payload: ApolloJsonElement): ApolloResponse<D> {
+        payload as ApolloDynamic
+        return ApolloResponse.Builder(request.operation, request.requestUuid)
+            .data(payload.value.data.unsafeCast<D>())
+            .errors(payload.value.errors.unsafeCast<List<Error>?>())
+            .build()
+      }
+    }
+  }
+}
+
+actual val wsProtocol: WsProtocol?
+  get() = JsWsProtocol
+
+object JsWsProtocol : WsProtocol {
+  private val delegate = GraphQLWsProtocol({ null })
+  override val name: String
+    get() = delegate.name
+
+  override suspend fun connectionInit(): ClientMessage {
+    return delegate.connectionInit()
+  }
+
+  override suspend fun <D : Operation.Data> operationStart(request: ApolloRequest<D>): ClientMessage {
+    return delegate.operationStart(request)
+  }
+
+  override fun <D : Operation.Data> operationStop(request: ApolloRequest<D>): ClientMessage {
+    return delegate.operationStop(request)
+  }
+
+  override fun ping(): ClientMessage {
+    return delegate.ping()
+  }
+
+  override fun pong(): ClientMessage {
+    return delegate.pong()
+  }
+
+  override fun parseServerMessage(text: String): ServerMessage {
+    val map:dynamic = JSON.parse(text)
+
+    val type = map.type
+    if (type == null) {
+      return ParseErrorServerMessage("No 'type' found in server message: '$text'")
+    }
+
+    return when (type) {
+      "connection_ack" -> ConnectionAckServerMessage
+      "ping" -> PingServerMessage
+      "pong" -> PongServerMessage
+      "next", "complete", "error" -> {
+        val id = map.id
+        when {
+          id == null -> ParseErrorServerMessage("No 'id' found in message: '$text'")
+          type == "next" -> ResponseServerMessage(id, ApolloDynamic(map.payload), false)
+          type == "complete" -> CompleteServerMessage(id)
+          type == "error" -> ResponseServerMessage(id, ApolloDynamic(map.payload), true)
+          else -> error("") // make the compiler happy
+        }
+      }
+
+      else -> ParseErrorServerMessage("Unknown type: '$type' found in server message: '$text'")
+    }
+  }
+}

--- a/tests/jsexport/src/nonJsTest/kotlin/JsExportTest.nonJs.kt
+++ b/tests/jsexport/src/nonJsTest/kotlin/JsExportTest.nonJs.kt
@@ -1,0 +1,7 @@
+import com.apollographql.apollo3.network.ws.incubating.SubscriptionParserFactory
+import com.apollographql.apollo3.network.ws.incubating.WsProtocol
+
+actual val parserFactory: SubscriptionParserFactory?
+  get() = null
+actual val wsProtocol: WsProtocol?
+  get() = null


### PR DESCRIPTION
Closes #5701

This PR introduces `SubscriptionParser` (could probably reused outside of subscriptions) to allow callers to implement their own parsing, in this case using `JSON.parse()`