### PR TITLE
Fix for websocket not reopening on iOS

### DIFF
--- a/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo3/network/ws/NSURLSessionWebSocketEngine.kt
@@ -20,6 +20,7 @@ import platform.Foundation.NSURL
 import platform.Foundation.NSURLRequest
 import platform.Foundation.NSURLSession
 import platform.Foundation.NSURLSessionConfiguration
+import platform.Foundation.NSURLSessionTask
 import platform.Foundation.NSURLSessionWebSocketCloseCode
 import platform.Foundation.NSURLSessionWebSocketDelegateProtocol
 import platform.Foundation.NSURLSessionWebSocketMessage
@@ -36,6 +37,8 @@ interface WebSocketConnectionListener {
   fun onOpen(webSocket: NSURLSessionWebSocketTask)
 
   fun onClose(webSocket: NSURLSessionWebSocketTask, code: NSURLSessionWebSocketCloseCode)
+
+  fun onError(error: NSError?)
 }
 
 typealias NSWebSocketFactory = (NSURLRequest, WebSocketConnectionListener) -> NSURLSessionWebSocketTask
@@ -79,6 +82,13 @@ actual class DefaultWebSocketEngine(
       override fun onClose(webSocket: NSURLSessionWebSocketTask, code: NSURLSessionWebSocketCloseCode) {
         isOpen.cancel()
         messageChannel.close()
+      }
+
+      override fun onError(error: NSError?) {
+        if (error != null) {
+          isOpen.cancel()
+          messageChannel.close()
+        }
       }
     }
 
@@ -209,6 +219,14 @@ private class NSURLSessionWebSocketDelegate(
       reason: NSData?,
   ) {
     webSocketConnectionListener.onClose(webSocket = webSocketTask, code = didCloseWithCode)
+  }
+
+  override fun URLSession(
+      session: NSURLSession,
+      task: NSURLSessionTask,
+      didCompleteWithError: NSError?
+  ) {
+    webSocketConnectionListener.onError(error = didCompleteWithError)
   }
 }
 


### PR DESCRIPTION
Closes #5697 

This PR adds an implementation of an optional `NSURLSessionWebSocketDelegateProtocol` method in the `NSURLSessionWebSocketEngine` that's required in order to get a websocket to successfully reopen. 

Currently, the `onOpen` and `onClose` protocol methods are implemented, but if there's an error when trying to open a websocket, neither of those callbacks are called, so the flow for repeatedly attempting to reopen the websocket never continues after the first unsuccessful attempt.   

Implementing the `didCompleteWithError` protocol allows the `NSURLSessionWebSocketEngine` to be notified when there's an error opening a websocket and continue so that future attempts to reopen the websocket can be made.  

