### PR TITLE
[IJ Plugin] Consider all Gradle projects recursively

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
@@ -12,15 +12,18 @@ interface ApolloKotlinServiceListener {
 }
 
 data class ApolloKotlinService(
-    val gradleProjectName: String,
+    val gradleProjectPath: String,
     val serviceName: String,
     val schemaPaths: List<String>,
     val operationPaths: List<String>,
     val endpointUrl: String?,
     val endpointHeaders: Map<String, String>?,
 ) {
-  data class Id(val gradleProjectName: String, val serviceName: String) {
-    override fun toString() = "$gradleProjectName/$serviceName"
+  data class Id(val gradleProjectPath: String, val serviceName: String) {
+    override fun toString(): String {
+      val formattedPath = gradleProjectPath.split(":").filterNot { it.isEmpty() }.joinToString("-")
+      return "$formattedPath/$serviceName"
+    }
 
     companion object {
       fun fromString(string: String): Id? {
@@ -31,5 +34,5 @@ data class ApolloKotlinService(
     }
   }
 
-  val id = Id(gradleProjectName, serviceName)
+  val id = Id(gradleProjectPath, serviceName)
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -174,7 +174,7 @@ class GradleToolingModelService(
       project.telemetryService.gradleModuleCount = rootGradleProject.children.size + 1
 
       // We're only interested in projects that apply the Apollo plugin - and thus have the codegen task registered
-      val allApolloGradleProjects: List<GradleProject> = (rootGradleProject.children + rootGradleProject)
+      val allApolloGradleProjects: List<GradleProject> = rootGradleProject.allChildrenRecursively()
           .filter { gradleProject -> gradleProject.tasks.any { task -> task.name == CODEGEN_GRADLE_TASK_NAME } }
       logd("allApolloGradleProjects=${allApolloGradleProjects.map { it.name }}")
       project.telemetryService.apolloKotlinModuleCount = allApolloGradleProjects.size
@@ -291,6 +291,10 @@ class GradleToolingModelService(
       return project.service<GradleToolingModelService>().apolloKotlinServices
     }
   }
+}
+
+private fun GradleProject.allChildrenRecursively(): List<GradleProject> {
+  return listOf(this) + children.flatMap { it.allChildrenRecursively() }
 }
 
 val Project.gradleToolingModelService get() = service<GradleToolingModelService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -122,7 +122,7 @@ class ApiKeysModel : AddEditRemovePanel.TableModel<ApolloKotlinServiceConfigurat
   }
 
   override fun getField(o: ApolloKotlinServiceConfiguration, columnIndex: Int) = when (columnIndex) {
-    0 -> o.apolloKotlinServiceId.gradleProjectName
+    0 -> o.apolloKotlinServiceId.gradleProjectPath
     1 -> o.apolloKotlinServiceId.serviceName
     2 -> "••••••••"
     3 -> o.graphOsGraphName

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/studio/ApiKeyDialog.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/studio/ApiKeyDialog.kt
@@ -40,7 +40,7 @@ class ApiKeyDialog(
     val isEdit = apolloKotlinServiceId != null
     title = ApolloBundle.message(if (isEdit) "settings.studio.apiKeyDialog.title.edit" else "settings.studio.apiKeyDialog.title.add")
     gradleProjectName = if (isEdit) {
-      apolloKotlinServiceId!!.gradleProjectName
+      apolloKotlinServiceId!!.gradleProjectPath
     } else {
       getGradleProjectNames().firstOrNull() ?: ""
     }
@@ -106,12 +106,12 @@ class ApiKeyDialog(
   }.withPreferredWidth(450)
 
   private fun getGradleProjectNames(): List<String> {
-    return GradleToolingModelService.getApolloKotlinServices(project).map { it.id.gradleProjectName }.distinct().sorted()
+    return GradleToolingModelService.getApolloKotlinServices(project).map { it.id.gradleProjectPath }.distinct().sorted()
   }
 
   private fun getApolloKotlinServiceNames(gradleProjectName: String): List<String> {
     return GradleToolingModelService.getApolloKotlinServices(project)
-        .filter { it.id.gradleProjectName == gradleProjectName }
+        .filter { it.id.gradleProjectPath == gradleProjectName }
         .map { it.id.serviceName }
         .sorted()
   }

--- a/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
+++ b/libraries/apollo-gradle-plugin-external/api/apollo-gradle-plugin-external.api
@@ -29,8 +29,8 @@ public abstract interface class com/apollographql/apollo3/gradle/api/ApolloExten
 public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel {
 	public static final field Companion Lcom/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$Companion;
 	public static final field VERSION_MAJOR I
-	public static final field VERSION_MINOR I
 	public abstract fun getProjectName ()Ljava/lang/String;
+	public abstract fun getProjectPath ()Ljava/lang/String;
 	public abstract fun getServiceInfos ()Ljava/util/List;
 	public abstract fun getTelemetryData ()Lcom/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$TelemetryData;
 	public abstract fun getVersionMajor ()I
@@ -39,7 +39,6 @@ public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradl
 
 public final class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$Companion {
 	public static final field VERSION_MAJOR I
-	public static final field VERSION_MINOR I
 }
 
 public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel$ServiceInfo {
@@ -48,6 +47,7 @@ public abstract interface class com/apollographql/apollo3/gradle/api/ApolloGradl
 	public abstract fun getGraphqlSrcDirs ()Ljava/util/Set;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getSchemaFiles ()Ljava/util/Set;
+	public abstract fun getUpstreamProjectPaths ()Ljava/util/Set;
 	public abstract fun getUpstreamProjects ()Ljava/util/Set;
 }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/ApolloGradleToolingModel.kt
@@ -6,7 +6,12 @@ interface ApolloGradleToolingModel {
   val versionMajor: Int
   val versionMinor: Int
 
+  @Deprecated("Use projectPath instead", ReplaceWith("projectPath"))
   val projectName: String
+
+  // Introduced in 1.3
+  val projectPath: String
+
   val serviceInfos: List<ServiceInfo>
 
   // Introduced in 1.2
@@ -16,7 +21,11 @@ interface ApolloGradleToolingModel {
     val name: String
     val schemaFiles: Set<File>
     val graphqlSrcDirs: Set<File>
+    @Deprecated("Use upstreamProjectPaths instead", ReplaceWith("upstreamProjectPaths"))
     val upstreamProjects: Set<String>
+
+    // Introduced in 1.3
+    val upstreamProjectPaths: Set<String>
 
     // Introduced in 1.1
     val endpointUrl: String?
@@ -78,6 +87,6 @@ interface ApolloGradleToolingModel {
      * Current minor version of the tooling model.
      * Increment this value when the model changes in compatible ways (additions).
      */
-    const val VERSION_MINOR = 2
+    internal const val VERSION_MINOR = 3
   }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloPlugin.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloPlugin.kt
@@ -24,6 +24,7 @@ constructor(private val toolingModelRegistry: ToolingModelBuilderRegistry) : Plu
           override fun buildAll(modelName: String, project: Project): ApolloGradleToolingModel {
             return DefaultApolloGradleToolingModel(
                 projectName = project.name,
+                projectPath = project.path,
                 serviceInfos = apolloExtension.getServiceInfos(project),
                 telemetryData = getTelemetryData(project, apolloExtension),
             )

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -56,6 +56,7 @@ abstract class DefaultApolloExtension(
         schemaFiles = service.schemaFilesSnapshot(project),
         graphqlSrcDirs = service.graphqlSourceDirectorySet.srcDirs,
         upstreamProjects = service.upstreamDependencies.filterIsInstance<ProjectDependency>().map { it.name }.toSet(),
+        upstreamProjectPaths = service.upstreamDependencies.filterIsInstance<ProjectDependency>().map { it.dependencyProject.path }.toSet(),
         endpointUrl = service.introspection?.endpointUrl?.orNull,
         endpointHeaders = service.introspection?.headers?.orNull,
     )

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloGradleToolingModel.kt
@@ -5,7 +5,9 @@ import java.io.File
 import java.io.Serializable
 
 internal data class DefaultApolloGradleToolingModel(
+    @Deprecated("Use projectPath instead", replaceWith = ReplaceWith("projectPath"))
     override val projectName: String,
+    override val projectPath: String,
     override val serviceInfos: List<ApolloGradleToolingModel.ServiceInfo>,
     override val telemetryData: ApolloGradleToolingModel.TelemetryData,
 ) : ApolloGradleToolingModel, Serializable {
@@ -17,7 +19,9 @@ internal data class DefaultServiceInfo(
     override val name: String,
     override val schemaFiles: Set<File>,
     override val graphqlSrcDirs: Set<File>,
+    @Deprecated("Use upstreamProjectPaths instead", replaceWith = ReplaceWith("upstreamProjectPaths"))
     override val upstreamProjects: Set<String>,
+    override val upstreamProjectPaths: Set<String>,
     override val endpointUrl: String?,
     override val endpointHeaders: Map<String, String>?,
 ) : ApolloGradleToolingModel.ServiceInfo, Serializable


### PR DESCRIPTION
Apollo modules were not found if they were nested more than 1 level deep (e.g. `:shared:data`).

Also, use the path instead of the name everywhere (a tad involved because of versioning).

<img width="643" alt="Screenshot 2024-03-18 at 11 47 40" src="https://github.com/apollographql/apollo-kotlin/assets/372852/cced2570-8392-40d1-a3d8-25b761a2dae7">

Here we see the Graphql project is now named `shared-data/service` vs `data/service` previously (could be a problem if several subprojects are named `data`).
