### PR TITLE
Fix file name discrepancies and bring attention to server null data no errors issue in Kotlin Tutorial

### DIFF
--- a/docs/source/tutorial/06-add-more-info.mdx
+++ b/docs/source/tutorial/06-add-more-info.mdx
@@ -36,7 +36,7 @@ Any GraphQL field can take arguments like `missionPatch` above, and arguments ca
 
 ## Bind the info
 
-In `LaunchListAdapter.kt`, bind the GraphQL data to the mission name, site, and mission patch using Coil's `AsyncImage`:
+In `LaunchList.kt`, bind the GraphQL data to the mission name, site, and mission patch using Coil's `AsyncImage`:
 
 ```kotlin title="app/src/main/java/com/example/rocketreserver/LaunchList.kt"
 @Composable

--- a/docs/source/tutorial/11-subscriptions.mdx
+++ b/docs/source/tutorial/11-subscriptions.mdx
@@ -119,7 +119,7 @@ Scaffold(
 
 Like for queries and mutations, the subscription will throw an error if the connection is lost or any other protocol error happens. To handle these situations, you can configure the client to retry the subscription with the `webSocketReopenWhen` function. Return `true` to retry, `false` to stop. To avoid retrying too often, you can use the `attempt` parameter to delay the retry:
 
-```kotlin title="MainActivity.kt"
+```kotlin title="Apollo.kt"
 val apolloClient = ApolloClient.Builder()
     (...)
     .webSocketReopenWhen { throwable, attempt -> // highlight-line


### PR DESCRIPTION
Hi, I mentioned these issues in [my Discord post](https://discord.com/channels/1022972389463687228/1219320092530184264)

Changes Made:

- Fixed a typo in the ["Add More Info" section](https://www.apollographql.com/docs/kotlin/tutorial/06-add-more-info/) where it incorrectly mentioned "LaunchListAdapter.kt" instead of "LaunchList.kt" for binding GraphQL data.
- Addressed a mention in the ["Subscriptions" section](https://www.apollographql.com/docs/kotlin/tutorial/11-subscriptions/#handle-errors) regarding error handling location in the client code. The mentioned location (MainActivity.kt) didn't match the actual code (Apollo.kt).

Additionally, In the ["Add a Details View" section ](https://www.apollographql.com/docs/kotlin/tutorial/08-add-a-details-view), I observed a discrepancy in the behavior of the [current server demo](https://studio.apollographql.com/sandbox/explorer) when handling invalid IDs. According to the [expected behavior](https://www.apollographql.com/docs/kotlin/tutorial/08-add-a-details-view#handle-application-errors), the server should return errors when provided with invalid IDs. However, upon testing by providing invalid IDs in the query, all responses contained only null data but no errors. Maybe the dev team to investigate this issue to ensure new learners encounter the expected behavior. 

Query:
```graphql
query LaunchDetails($id: ID!) {
  launch(id: $id) {
    id
    site
    mission {
      name
      missionPatch(size: LARGE)
    }
    rocket {
      name
      type
    }
    isBooked
  }
}
```

Query Variables:
```json
{
  "id": "invalidId"
}
```

Expected response:
```json
{
  "errors": [
    {
      "message": "Cannot read property 'flight_number' of undefined",
      "locations": [
        {
          "line": 1,
          "column": 32
        }
      ],
      "path": [
        "launch"
      ],
      "extensions": {
        "code": "INTERNAL_SERVER_ERROR"
      }
    }
  ],
  "data": {
    "launch": null
  }
}
```

Actual response:
<img width="1258" alt="Screenshot 2024-03-18 at 3 17 37 PM" src="https://github.com/apollographql/apollo-kotlin/assets/32387159/f1d26cf2-4726-48bf-8126-fa35779446c1">

Thank you!
