### PR TITLE
[IJ Plugin] Add an advanced setting to include generated code references in GraphQL "Go To Declaration"

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandler.kt
@@ -14,6 +14,7 @@ import com.intellij.lang.jsgraphql.psi.GraphQLInputValueDefinition
 import com.intellij.lang.jsgraphql.psi.GraphQLTypeNameDefinition
 import com.intellij.lang.jsgraphql.psi.GraphQLTypedOperationDefinition
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.options.advanced.AdvancedSettings
 import com.intellij.psi.PsiElement
 
 /**
@@ -28,6 +29,7 @@ class GraphQLGotoDeclarationHandler : GotoDeclarationHandler {
   override fun getGotoDeclarationTargets(sourceElement: PsiElement?, offset: Int, editor: Editor?): Array<PsiElement>? {
     val gqlElement = sourceElement?.parent?.parent as? GraphQLElement ?: return null
     if (!gqlElement.project.apolloProjectService.apolloVersion.isAtLeastV3) return null
+    val enabledInAdvancedSettings = AdvancedSettings.getBoolean("apollo.graphQLGoToDeclarationGeneratedCode")
 
     val kotlinDefinitions = when (gqlElement) {
       is GraphQLTypedOperationDefinition -> {
@@ -39,14 +41,17 @@ class GraphQLGotoDeclarationHandler : GotoDeclarationHandler {
       }
 
       is GraphQLFragmentSpread -> {
+        if (!enabledInAdvancedSettings) return null
         findKotlinFragmentClassDefinitions(gqlElement)
       }
 
       is GraphQLField -> {
+        if (!enabledInAdvancedSettings) return null
         findKotlinFieldDefinitions(gqlElement)
       }
 
       is GraphQLTypeNameDefinition -> {
+        if (!enabledInAdvancedSettings) return null
         when (val parent = gqlElement.parent) {
           is GraphQLEnumTypeDefinition -> findKotlinEnumClassDefinitions(parent)
           is GraphQLInputObjectTypeDefinition -> findKotlinInputClassDefinitions(parent)
@@ -55,10 +60,12 @@ class GraphQLGotoDeclarationHandler : GotoDeclarationHandler {
       }
 
       is GraphQLEnumValue -> {
+        if (!enabledInAdvancedSettings) return null
         findKotlinEnumValueDefinitions(gqlElement)
       }
 
       is GraphQLInputValueDefinition -> {
+        if (!enabledInAdvancedSettings) return null
         findKotlinInputFieldDefinitions(gqlElement)
       }
 

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -231,6 +231,13 @@
         coordinate="com.apollographql.apollo3:apollo-api-jvm"
         displayName="Apollo Kotlin"
     />
+
+    <!-- Advanced settings -->
+    <advancedSetting
+        id="apollo.graphQLGoToDeclarationGeneratedCode"
+        groupKey="advanced.setting.apollo"
+        default="false"
+    />
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -111,7 +111,10 @@ settings.telemetry.telemetryEnabled.text=Send usage statistics
 settings.telemetry.telemetryEnabled.comment=Help improve Apollo Kotlin by sending anonymous data.<br>\
   Data includes Gradle plugin options, version of Android and Kotlin, number of modules in the project and other technical information. No personal data or sensitive information, such as source code or file names are included. For more details, consult our <a href=\"https://www.apollographql.com/docs/graphos/data-privacy/\">privacy policy</a>.
 
-GradleToolingModelService.fetchToolingModels.progress=Loading Apollo Kotlin configuration
+advanced.setting.apollo=Apollo Kotlin
+advanced.setting.apollo.graphQLGoToDeclarationGeneratedCode=Enable navigation to generated code from GraphQL
+advanced.setting.apollo.graphQLGoToDeclarationGeneratedCode.description=If enabled, "Go To Declaration" on GraphQL elements will include references to Apollo Kotlin generated code.
+
 
 CompatToOperationBasedCodegenMigrationProcessor.title=Migrate to operationBased Codegen
 CompatToOperationBasedCodegenMigrationProcessor.noUsage=No compat codegen usage found in the project

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandlerTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/navigation/GraphQLGotoDeclarationHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.apollographql.ijplugin.navigation
 
 import com.apollographql.ijplugin.ApolloTestCase
+import com.intellij.openapi.options.advanced.AdvancedSettings
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtEnumEntry
@@ -18,6 +19,7 @@ class GraphQLGotoDeclarationHandlerTest : ApolloTestCase() {
       fromElement: () -> PsiElement?,
       toFile: String,
       toElement: () -> PsiElement?,
+      navigateEvenWithAdvancedSettingChecked: Boolean = false,
       multipleTarget: Boolean = false,
   ) {
     // Open the destination file
@@ -30,8 +32,18 @@ class GraphQLGotoDeclarationHandlerTest : ApolloTestCase() {
     // Find the element to navigate from
     val gqlElement = fromElement()!!
 
-    // Simulate navigation
-    val foundKtDeclarationElements = graphQLGotoDeclarationHandler.getGotoDeclarationTargets(gqlElement, 0, editor)!!
+    // Simulate navigation, with advanced setting unchecked
+    AdvancedSettings.setBoolean("apollo.graphQLGoToDeclarationGeneratedCode", false)
+    var foundKtDeclarationElements = graphQLGotoDeclarationHandler.getGotoDeclarationTargets(gqlElement, 0, editor)
+    if (navigateEvenWithAdvancedSettingChecked) {
+      assertNotNull(foundKtDeclarationElements)
+    } else {
+      assertNull(foundKtDeclarationElements)
+      return
+    }
+    // Simulate navigation, with advanced setting checked
+    AdvancedSettings.setBoolean("apollo.graphQLGoToDeclarationGeneratedCode", true)
+    foundKtDeclarationElements = graphQLGotoDeclarationHandler.getGotoDeclarationTargets(gqlElement, 0, editor)!!
 
     if (multipleTarget) {
       // We want our target (Kotlin), but also the original targets (GraphQL)
@@ -50,6 +62,7 @@ class GraphQLGotoDeclarationHandlerTest : ApolloTestCase() {
       fromElement = { elementAt<PsiElement>("animals")!! },
       toFile = "build/generated/source/apollo/main/com/example/generated/AnimalsQuery.kt",
       toElement = { elementAt<KtClass>("class AnimalsQuery")!! },
+      navigateEvenWithAdvancedSettingChecked = true,
   )
 
   @Test
@@ -58,6 +71,7 @@ class GraphQLGotoDeclarationHandlerTest : ApolloTestCase() {
       fromElement = { elementAt<PsiElement>("computerFields")!! },
       toFile = "build/generated/source/apollo/main/com/example/generated/fragment/ComputerFields.kt",
       toElement = { elementAt<KtClass>("class ComputerFields")!! },
+      navigateEvenWithAdvancedSettingChecked = true,
       multipleTarget = true
   )
 


### PR DESCRIPTION
Fix for #5738

The setting will appear in the global Advanced section:

<img width="894" alt="Screenshot 2024-03-19 at 14 34 01" src="https://github.com/apollographql/apollo-kotlin/assets/372852/389fec4b-ab64-4e0a-97b2-b3f8206ccd39">
