### PR TITLE
[CI flake] attempt at fixing watcher test flakes

### DIFF
--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/DefaultApolloStore.kt
@@ -28,12 +28,25 @@ internal class DefaultApolloStore(
     private val cacheResolver: CacheResolver,
 ) : ApolloStore {
   private val changedKeysEvents = MutableSharedFlow<Set<String>>(
-      // XXX: this is a potential code smell
-      // If multiple watchers start notifying each other and potentially themselves, the buffer of changedKeysEvent will grow forever.
-      // I think as long as the refetchPolicy is [FetchPolicy.CacheOnly] everything should be fine as there is no reentrant emission.
-      // If the refetechPolicy is something else, we should certainly try to detect it in the cache interceptor
-      extraBufferCapacity = 10,
-      onBufferOverflow = BufferOverflow.DROP_LATEST
+      /**
+       * The '64' magic number here is a potential code smell
+       *
+       * If a watcher is very slow to collect, cache writes continue buffering changedKeys events until the buffer is full.
+       * If that ever happens, this is probably an issue in the calling code, and we currently log that to the user. A more
+       * advanced version of this code could also expose the buffer size to the caller for better control.
+       *
+       * Also, we have had issues before where one or several watchers would loop forever, creating useless network requests.
+       * There is unfortunately very little evidence of how it could happen, but I could reproduce under the following conditions:
+       * 1. A field that returns ever-changing values (think current time for an example)
+       * 2. A refetch policy that uses the network ([NetworkOnly] or [CacheFirst] do for an example)
+       *
+       * In that case, a single watcher will trigger itself endlessly.
+       *
+       * My current understanding is that here as well, the fix is probably best done at the callsite by not using [NetworkOnly]
+       * as a refetchPolicy. If that ever becomes an issue again, please make sure to write a test about it.
+       */
+      extraBufferCapacity = 64,
+      onBufferOverflow = BufferOverflow.SUSPEND
   )
 
   override val changedKeys = changedKeysEvents.asSharedFlow()
@@ -50,7 +63,9 @@ internal class DefaultApolloStore(
       return
     }
 
-    changedKeysEvents.tryEmit(keys)
+    if (!changedKeysEvents.tryEmit(keys)) {
+      println("Apollo: changedKeys event lost, your watchers may be collecting too slowly")
+    }
   }
 
   override fun clearAll(): Boolean {

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
@@ -1,10 +1,23 @@
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloExperimental
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 
 @ApolloExperimental
-suspend fun <T> Channel<T>.receiveOrTimeout(timeoutMillis: Long = 2000) = withTimeout(timeoutMillis) {
+suspend fun <T> Channel<T>.awaitElement(timeoutMillis: Long = 30000) = withTimeout(timeoutMillis) {
   receive()
+}
+
+@ApolloExperimental
+suspend fun <T> Channel<T>.assertNoElement(timeoutMillis: Long = 300): Unit {
+  try {
+    withTimeout(timeoutMillis) {
+      receive()
+    }
+    error("An item was received and no item was ")
+  } catch (_: TimeoutCancellationException) {
+    // nothing
+  }
 }

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
@@ -16,7 +16,7 @@ suspend fun <T> Channel<T>.assertNoElement(timeoutMillis: Long = 300): Unit {
     withTimeout(timeoutMillis) {
       receive()
     }
-    error("An item was received and no item was ")
+    error("An item was unexpectedly received")
   } catch (_: TimeoutCancellationException) {
     // nothing
   }

--- a/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
+++ b/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
@@ -7,8 +7,8 @@ import com.apollographql.apollo3.cache.http.httpFetchPolicy
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueMultipart
 import com.apollographql.apollo3.mpp.currentTimeMillis
+import com.apollographql.apollo3.testing.awaitElement
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.receiveOrTimeout
 import defer.WithFragmentSpreadsQuery
 import defer.fragment.ComputerFields
 import defer.fragment.ScreenFields
@@ -112,9 +112,9 @@ class DeferJvmTest {
         channel.close()
       }
 
-      assertNull(channel.receiveOrTimeout(1000)?.product?.productInfoInventory)
+      assertNull(channel.awaitElement()?.product?.productInfoInventory)
       delay(4500)
-      assertNotNull(channel.receiveOrTimeout(1000)?.product?.productInfoInventory)
+      assertNotNull(channel.awaitElement()?.product?.productInfoInventory)
       client.close()
     }
   }

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -35,10 +35,10 @@ import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
 import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
+import com.apollographql.apollo3.testing.assertNoElement
+import com.apollographql.apollo3.testing.awaitElement
 import com.apollographql.apollo3.testing.enqueue
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.receiveOrTimeout
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -561,11 +561,7 @@ class FetchPolicyTest {
      * Because the query was disjoint, the watcher will see a cache miss and not receive anything.
      * Because initially the refetchPolicy uses CacheOnly, no network request will be made
      */
-    try {
-      channel.receiveOrTimeout(50)
-      error("An exception was expected")
-    } catch (_: TimeoutCancellationException) {
-    }
+    channel.assertNoElement()
 
     mockServer.enqueueString(
         buildJsonString {
@@ -587,7 +583,7 @@ class FetchPolicyTest {
         .fetchPolicy(FetchPolicy.NetworkOnly)
         .execute()
 
-    var response = channel.receiveOrTimeout()
+    var response = channel.awaitElement()
     assertTrue(response.isFromCache)
     assertEquals("Leila", response.data?.hero?.name)
 
@@ -613,7 +609,7 @@ class FetchPolicyTest {
     /**
      * This time the watcher should do a network request
      */
-    response = channel.receiveOrTimeout()
+    response = channel.awaitElement()
     assertFalse(response.isFromCache)
     assertEquals("Chewbacca", response.data?.hero?.name)
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -21,8 +21,8 @@ import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.integration.normalizer.type.ReviewInput
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueString
+import com.apollographql.apollo3.testing.awaitElement
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.receiveOrTimeout
 import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
@@ -271,7 +271,7 @@ class OptimisticCacheTest {
     assertEquals(watcherData?.reviews?.get(2)?.commentary, "Amazing")
 
     // after mutation with rolled back optimistic updates
-    watcherData = channel.receiveOrTimeout()
+    watcherData = channel.awaitElement()
     assertEquals(watcherData?.reviews?.size, 3)
     assertEquals(watcherData?.reviews?.get(0)?.id, "empireReview1")
     assertEquals(watcherData?.reviews?.get(0)?.stars, 1)

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -17,8 +17,8 @@ import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
+import com.apollographql.apollo3.testing.awaitElement
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.receiveOrTimeout
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.catch
@@ -120,7 +120,7 @@ class WatcherErrorHandlingTest {
             channel.send(it)
           }
     }
-    assertEquals(channel.receiveOrTimeout().data?.hero?.name, "R2-D2")
+    assertEquals(channel.awaitElement().data?.hero?.name, "R2-D2")
 
     // Another newer call gets updated information with "Artoo"
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
@@ -129,7 +129,7 @@ class WatcherErrorHandlingTest {
     mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-    assertIs<ApolloHttpException>(channel.receiveOrTimeout().exception)
+    assertIs<ApolloHttpException>(channel.awaitElement().exception)
     job.cancel()
   }
 
@@ -200,7 +200,7 @@ class WatcherErrorHandlingTest {
             channel.send(it)
           }
     }
-    assertEquals(channel.receiveOrTimeout().data?.hero?.name, "R2-D2")
+    assertEquals(channel.awaitElement().data?.hero?.name, "R2-D2")
 
     // Another newer call gets updated information with "Artoo"
     // Due to .refetchPolicy(FetchPolicy.NetworkOnly), a subsequent call will be executed in watch()
@@ -209,7 +209,7 @@ class WatcherErrorHandlingTest {
     mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
-    assertIs<ApolloHttpException>(channel.receiveOrTimeout().exception)
+    assertIs<ApolloHttpException>(channel.awaitElement().exception)
 
     assertNull(throwable)
 

--- a/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsMockServerTest.kt
+++ b/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsMockServerTest.kt
@@ -9,12 +9,12 @@ import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mpp.Platform
 import com.apollographql.apollo3.mpp.platform
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
+import com.apollographql.apollo3.testing.assertNoElement
+import com.apollographql.apollo3.testing.awaitElement
 import com.apollographql.apollo3.testing.internal.ApolloTestResult
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.receiveOrTimeout
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.consumeAsFlow
@@ -30,7 +30,6 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.use
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
@@ -137,10 +136,8 @@ class MultipartSubscriptionsMockServerTest {
       }
     }
 
-    assertEquals("world", channel.receiveOrTimeout().dataOrThrow().hello)
-    assertFailsWith<TimeoutCancellationException> {
-      channel.receiveOrTimeout()
-    }
+    assertEquals("world", channel.awaitElement().dataOrThrow().hello)
+    channel.assertNoElement()
   }
 
   @Test


### PR DESCRIPTION
- log when there is a lost event and increase buffer size
- increase timeouts and add assertNoElement

See https://github.com/apollographql/apollo-kotlin/issues/3920
See https://github.com/apollographql/apollo-kotlin/issues/2226