### PR TITLE
[CI flakes ❄️] Hopefully fix benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -23,7 +23,7 @@ jobs:
           gradle-home-cache-cleanup: true
       - run: |
           # Build the benchmark apks
-          ./gradlew -p benchmark assembleRelease assembleIncubatingReleaseAndroidTest assembleStableReleaseAndroidTest
+          ./gradlew -p benchmark assembleIncubatingReleaseAndroidTest assembleStableReleaseAndroidTest
       # Step can be removed if/when gcloud is added to the macos image - See https://github.com/actions/virtual-environments/issues/4639
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 #v2.1.0

--- a/scripts/run-benchmarks.main.kts
+++ b/scripts/run-benchmarks.main.kts
@@ -160,6 +160,7 @@ data class GCloud(val storage: Storage, val projectId: String)
 /**
  * Run the test remotely. To do the same thing locally, run
  *
+ * ./gradlew -p benchmark assembleRelease assembleStableReleaseAndroidTest
  * adb install benchmark/microbenchmark/build/outputs/apk/androidTest/stable/release/microbenchmark-stable-release-androidTest.apk
  * adb shell am instrument -w com.apollographql.apollo3.benchmark.stable/androidx.benchmark.junit4.AndroidBenchmarkRunner
  *
@@ -185,7 +186,9 @@ fun runTest(projectId: String, testApk: String): String {
       "--test",
       testApk,
       "--app",
-      appApk
+      appApk,
+      "--timeout",
+      "30m"
   )
 
   directoriesToPull.let {


### PR DESCRIPTION
Increase the benchmark timeout. Looks like they are doing more work and thermal throttling kicks in, which, itself delays the test by 90s every time.

If this becomes too much of an issue/too expensive, we might want to decrease the work load instead.