### PR TITLE
Simplify ApolloCall

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -46,12 +46,13 @@ public final class com/apollographql/apollo3/api/ApolloOptionalAdapter : com/apo
 }
 
 public final class com/apollographql/apollo3/api/ApolloRequest : com/apollographql/apollo3/api/ExecutionOptions {
-	public synthetic fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/ExecutionContext;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/apollographql/apollo3/api/Operation;Ljava/util/UUID;Lcom/apollographql/apollo3/api/ExecutionContext;Lcom/apollographql/apollo3/api/http/HttpMethod;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getCanBeBatched ()Ljava/lang/Boolean;
 	public fun getEnableAutoPersistedQueries ()Ljava/lang/Boolean;
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun getHttpHeaders ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
+	public final fun getIgnoreApolloClientHttpHeaders ()Ljava/lang/Boolean;
 	public final fun getOperation ()Lcom/apollographql/apollo3/api/Operation;
 	public final fun getRequestUuid ()Ljava/util/UUID;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
@@ -76,12 +77,16 @@ public final class com/apollographql/apollo3/api/ApolloRequest$Builder : com/apo
 	public fun getExecutionContext ()Lcom/apollographql/apollo3/api/ExecutionContext;
 	public fun getHttpHeaders ()Ljava/util/List;
 	public fun getHttpMethod ()Lcom/apollographql/apollo3/api/http/HttpMethod;
+	public final fun getIgnoreApolloClientHttpHeaders ()Ljava/lang/Boolean;
+	public final fun getOperation ()Lcom/apollographql/apollo3/api/Operation;
+	public final fun getRequestUuid ()Ljava/util/UUID;
 	public fun getSendApqExtensions ()Ljava/lang/Boolean;
 	public fun getSendDocument ()Ljava/lang/Boolean;
 	public fun httpHeaders (Ljava/util/List;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun httpHeaders (Ljava/util/List;)Ljava/lang/Object;
 	public fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun httpMethod (Lcom/apollographql/apollo3/api/http/HttpMethod;)Ljava/lang/Object;
+	public final fun ignoreApolloClientHttpHeaders (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public final fun requestUuid (Ljava/util/UUID;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/api/ApolloRequest$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -7,7 +7,9 @@ import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 
 /**
- * A GraphQL request to execute. Execution can be customized with [executionContext]
+ * An [ApolloRequest] represents a GraphQL request to execute.
+ *
+ * [ApolloRequest] is immutable and is usually constructed from [com.apollographql.apollo3.ApolloCall]
  */
 class ApolloRequest<D : Operation.Data>
 private constructor(
@@ -20,6 +22,7 @@ private constructor(
     override val sendDocument: Boolean?,
     override val enableAutoPersistedQueries: Boolean?,
     override val canBeBatched: Boolean?,
+    val ignoreApolloClientHttpHeaders: Boolean?,
     @ApolloExperimental
     val retryOnError: Boolean?,
     @ApolloExperimental
@@ -41,15 +44,16 @@ private constructor(
         .canBeBatched(canBeBatched)
         .retryOnError(retryOnError)
         .failFastIfOffline(failFastIfOffline)
+        .ignoreApolloClientHttpHeaders(ignoreApolloClientHttpHeaders)
   }
 
   class Builder<D : Operation.Data>(
-      private var operation: Operation<D>,
+      val operation: Operation<D>,
   ) : MutableExecutionOptions<Builder<D>> {
-    private var requestUuid: Uuid = uuid4()
+    var requestUuid: Uuid? = null
+      private set
     override var executionContext: ExecutionContext = ExecutionContext.Empty
       private set
-
     override var httpMethod: HttpMethod? = null
       private set
     override var httpHeaders: List<HttpHeader>? = null
@@ -62,6 +66,8 @@ private constructor(
       private set
     override var canBeBatched: Boolean? = null
       private set
+    var ignoreApolloClientHttpHeaders: Boolean? = null
+      private set
     @ApolloExperimental
     var retryOnError: Boolean? = null
       private set
@@ -69,9 +75,21 @@ private constructor(
     var failFastIfOffline: Boolean? = null
       private set
 
-    @ApolloExperimental
-    fun failFastIfOffline(failFastIfOffline: Boolean?): Builder<D> = apply {
-      this.failFastIfOffline = failFastIfOffline
+
+    fun requestUuid(requestUuid: Uuid) = apply {
+      this.requestUuid = requestUuid
+    }
+
+    fun executionContext(executionContext: ExecutionContext) = apply {
+      this.executionContext = executionContext
+    }
+
+    override fun addExecutionContext(executionContext: ExecutionContext) = apply {
+      this.executionContext = this.executionContext + executionContext
+    }
+
+    fun ignoreApolloClientHttpHeaders(ignoreApolloClientHttpHeaders: Boolean?) = apply {
+      this.ignoreApolloClientHttpHeaders = ignoreApolloClientHttpHeaders
     }
 
     override fun httpMethod(httpMethod: HttpMethod?): Builder<D> = apply {
@@ -107,22 +125,15 @@ private constructor(
       this.retryOnError = retryOnError
     }
 
-    fun requestUuid(requestUuid: Uuid) = apply {
-      this.requestUuid = requestUuid
-    }
-
-    fun executionContext(executionContext: ExecutionContext) = apply {
-      this.executionContext = executionContext
-    }
-
-    override fun addExecutionContext(executionContext: ExecutionContext) = apply {
-      this.executionContext = this.executionContext + executionContext
+    @ApolloExperimental
+    fun failFastIfOffline(failFastIfOffline: Boolean?): Builder<D> = apply {
+      this.failFastIfOffline = failFastIfOffline
     }
 
     fun build(): ApolloRequest<D> {
       return ApolloRequest(
           operation = operation,
-          requestUuid = requestUuid,
+          requestUuid = requestUuid ?: uuid4(),
           executionContext = executionContext,
           httpMethod = httpMethod,
           httpHeaders = httpHeaders,
@@ -130,6 +141,7 @@ private constructor(
           sendDocument = sendDocument,
           enableAutoPersistedQueries = enableAutoPersistedQueries,
           canBeBatched = canBeBatched,
+          ignoreApolloClientHttpHeaders = ignoreApolloClientHttpHeaders,
           retryOnError = retryOnError,
           failFastIfOffline = failFastIfOffline,
       )

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloRequest.kt
@@ -9,7 +9,15 @@ import com.benasher44.uuid.uuid4
 /**
  * An [ApolloRequest] represents a GraphQL request to execute.
  *
- * [ApolloRequest] is immutable and is usually constructed from [com.apollographql.apollo3.ApolloCall]
+ * [ApolloRequest] is immutable and is usually constructed from [com.apollographql.apollo3.ApolloCall].
+ *
+ * You can mutate an [ApolloRequest] by calling [newBuilder]:
+ *
+ * ```
+ * val newRequest = apolloRequest.newBuilder().addHttpHeader("Authorization", "Bearer $token").build()
+ * ```
+ *
+ * @see [com.apollographql.apollo3.ApolloCall]
  */
 class ApolloRequest<D : Operation.Data>
 private constructor(

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ExecutionOptions.kt
@@ -4,11 +4,14 @@ import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.api.http.HttpMethod
 
 interface ExecutionOptions {
+  /**
+   * The [ExecutionContext] to use for the request.
+   */
   val executionContext: ExecutionContext
 
   /**
    *
-   * The HTTP method to use for the request
+   * The HTTP method to use for the request.
    *
    * Used by [com.apollographql.apollo3.api.http.DefaultHttpRequestComposer]
    */
@@ -16,7 +19,7 @@ interface ExecutionOptions {
 
   /**
    *
-   * HTTP headers to use for the request
+   * HTTP headers to use for the request.
    * Used by [com.apollographql.apollo3.api.http.DefaultHttpRequestComposer]
    */
   val httpHeaders: List<HttpHeader>?

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -49,7 +49,7 @@ internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
           if (it == Unit) {
             flowOf(ApolloResponse.Builder(request.operation, request.requestUuid).exception(WatcherSentinel).build())
           } else {
-            chain.proceed(request.newBuilder().build())
+            chain.proceed(request)
                 .onEach { response ->
                   if (response.data != null) {
                     watchedKeys = store.normalize(request.operation, response.data!!, customScalarAdapters).values.dependentKeys()

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.toList
 
 /**
- * An [ApolloCall] is a thin class that binds an [ApolloRequest] with its [ApolloClient] and offers a fluent way to build an [ApolloRequest].
+ * An [ApolloCall] is a thin class that binds an [ApolloRequest] with its [ApolloClient]. It offers a fluent way to configure the [ApolloRequest].
  *
  * Contrary to an [ApolloRequest], an [ApolloCall] doesn't have a request id and a new request id is allocated every time [execute] or [toFlow] is called.
  *

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloCall.kt
@@ -173,7 +173,7 @@ class ApolloCall<D : Operation.Data> internal constructor(
    *
    * [execute] calls [toFlow] and filters out cache or network errors to return a single success [ApolloResponse].
    *
-   * [execute] throws is more than one success [ApolloResponse] is returned, for an example, if [operation] is a subscription or a `@defer` query.
+   * [execute] throws if more than one success [ApolloResponse] is returned, for an example, if [operation] is a subscription or a `@defer` query.
    * In those cases use [toFlow] instead.
    *
    * [execute] may fail due to an I/O error, a cache miss or other reasons. In that case, check [ApolloResponse.exception]:

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -289,14 +289,15 @@ class WatcherTest {
     // - Because the network only watcher will also store in the cache a different name value, it will trigger itself again
     // Enqueue a stable response to avoid errors during tests
     apolloClient.enqueueTestResponse(episodeHeroNameQuery, episodeHeroNameChangedTwoData)
+
+    // Trigger a refetch
     val response = apolloClient.query(episodeHeroNameQuery)
         .fetchPolicy(FetchPolicy.NetworkOnly)
         .execute()
-
     assertEquals(response.data?.hero?.name, "Artoo")
 
-    // The watcher should see "ArTwo"
-    assertEquals(channel.awaitElement()?.hero?.name, "ArTwo")
+    // The watcher should refetch from the network and now see "ArTwo"
+    assertEquals("ArTwo", channel.awaitElement()?.hero?.name, )
 
     job.cancel()
   }


### PR DESCRIPTION
`ApolloCall` doesn't need to duplicate all the `ApolloRequest` properties, it can just hold a mutable `ApolloRequest.Builder` because that's what it really is today. 

This also exposes `ignoreApolloClientHttpHeaders` on `ApolloRequest` and makes the API more consistent.

Also update the KDoc. Our KDoc for those symbols is still mostly empty though because of https://github.com/Kotlin/dokka/issues/3547