### PR TITLE
Make build less verbose

### DIFF
--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketConnection.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/network/ws/WebSocketConnection.java
@@ -17,7 +17,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 public class WebSocketConnection {
-  private static final boolean DEBUG = true; // TODO
+  private static final boolean DEBUG = false;
   private static final long OPEN_TIMEOUT_MS = 10_000;
 
   private static final int CLOSE_NORMAL = 1000;

--- a/tests/engine/build.gradle.kts
+++ b/tests/engine/build.gradle.kts
@@ -29,6 +29,7 @@ kotlin {
       dependsOn(commonTest)
       dependencies {
         implementation(libs.apollo.engine.ktor)
+        implementation(libs.slf4j)
       }
     }
     val defaultTest = create("defaultTest") {


### PR DESCRIPTION
This makes it so grepping for "failed" will only return actual errors.