### PR TITLE
#5777 fix ApolloClient.Builder.okHttpClient() returns `null` instead of `this`

### DIFF
--- a/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
+++ b/libraries/apollo-runtime-java/src/main/java/com/apollographql/apollo3/runtime/java/ApolloClient.java
@@ -229,7 +229,7 @@ public class ApolloClient implements Closeable {
     public Builder okHttpClient(OkHttpClient okHttpClient) {
       this.callFactory = okHttpClient;
       this.webSocketFactory = okHttpClient;
-      return null;
+      return this;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/issues/5777