### PR TITLE
Support configuring `ApolloClient` with lazily initialized `Call.Factory`.

### DIFF
--- a/libraries/apollo-runtime/api/android/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/android/apollo-runtime.api
@@ -184,6 +184,7 @@ public abstract interface class com/apollographql/apollo3/network/NetworkTranspo
 }
 
 public final class com/apollographql/apollo3/network/OkHttpExtensionsKt {
+	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function0;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/ApolloClient$Builder;Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/network/http/HttpNetworkTransport$Builder;Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/network/http/HttpNetworkTransport$Builder;
 	public static final fun okHttpClient (Lcom/apollographql/apollo3/ApolloClient$Builder;Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -223,6 +224,7 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpIntercepto
 public final class com/apollographql/apollo3/network/http/DefaultHttpEngine {
 	public static final fun DefaultHttpEngine (J)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (JJ)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static final fun DefaultHttpEngine (Lkotlin/jvm/functions/Function0;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static synthetic fun DefaultHttpEngine$default (JILjava/lang/Object;)Lcom/apollographql/apollo3/network/http/HttpEngine;

--- a/libraries/apollo-runtime/api/jvm/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/jvm/apollo-runtime.api
@@ -181,6 +181,7 @@ public abstract interface class com/apollographql/apollo3/network/NetworkTranspo
 }
 
 public final class com/apollographql/apollo3/network/OkHttpExtensionsKt {
+	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/ApolloClient$Builder;Lkotlin/jvm/functions/Function0;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/ApolloClient$Builder;Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public static final fun okHttpCallFactory (Lcom/apollographql/apollo3/network/http/HttpNetworkTransport$Builder;Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/network/http/HttpNetworkTransport$Builder;
 	public static final fun okHttpClient (Lcom/apollographql/apollo3/ApolloClient$Builder;Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/ApolloClient$Builder;
@@ -220,6 +221,7 @@ public final class com/apollographql/apollo3/network/http/BatchingHttpIntercepto
 public final class com/apollographql/apollo3/network/http/DefaultHttpEngine {
 	public static final fun DefaultHttpEngine (J)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (JJ)Lcom/apollographql/apollo3/network/http/HttpEngine;
+	public static final fun DefaultHttpEngine (Lkotlin/jvm/functions/Function0;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (Lokhttp3/Call$Factory;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static final fun DefaultHttpEngine (Lokhttp3/OkHttpClient;)Lcom/apollographql/apollo3/network/http/HttpEngine;
 	public static synthetic fun DefaultHttpEngine$default (JILjava/lang/Object;)Lcom/apollographql/apollo3/network/http/HttpEngine;

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/OkHttpExtensions.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/OkHttpExtensions.kt
@@ -29,6 +29,13 @@ fun ApolloClient.Builder.okHttpCallFactory(callFactory: Call.Factory) = apply {
 }
 
 /**
+ * Configures the [ApolloClient] to use the lazily initialized [callFactory] for network requests.
+ */
+fun ApolloClient.Builder.okHttpCallFactory(callFactory: () -> Call.Factory) = apply {
+  httpEngine(DefaultHttpEngine(callFactory))
+}
+
+/**
  * Configures the [HttpNetworkTransport] to use the [DefaultHttpEngine] for network requests.
  */
 fun HttpNetworkTransport.Builder.okHttpClient(okHttpClient: OkHttpClient) = apply {


### PR DESCRIPTION
Resolves https://github.com/apollographql/apollo-kotlin/issues/5775

I've tested this locally:

**Eager `OkHttpClient` init:**

![image](https://github.com/apollographql/apollo-kotlin/assets/11519072/ee619d0c-5436-4fae-83ae-0ec78bef5d4a)

**Lazy `OkHttpClient` init:**

![image](https://github.com/apollographql/apollo-kotlin/assets/11519072/5298043f-c294-45b4-ae23-f6c95059ba14)

Creation of `ApolloClient` no longer crates an `OkHttpClient`.

![image](https://github.com/apollographql/apollo-kotlin/assets/11519072/e9da2332-4e54-4248-8222-e4a6329c44da)


~~The creation of `OkHttpClient` is now deferred to after the "App Startup" window (by Coil `ImageLoader`).~~

Correction: the `OkHttpClient` is still created within the "App Startup" window, but it's done in a background thread by Coil.


-----

The actual perf impact of using the lazy API obviously depends on each app.