### PR TITLE
Remove obsolete comment

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/ApolloResponse.kt
@@ -103,9 +103,6 @@ private constructor(
 
   /**
    * A shorthand property to get a non-nullable `data` if handling partial data is **not** important
-   *
-   * Note: A future version could use [Definitely non nullable types](https://github.com/Kotlin/KEEP/pull/269)
-   * to implement something like `ApolloResponse<D>.assertNoErrors(): ApolloResponse<D & Any>`
    */
   @get:JvmName("dataAssertNoErrors")
   val dataAssertNoErrors: D


### PR DESCRIPTION
Definitely non nullable types are there but we can't use them because the `D` bound in `ApolloResponse<D: Operation.Data>` is non nullable already. Changing this is probably not worth it.