### PR TITLE
Share the default OkHttpBuilder

### DIFF
--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/OkHttpExtensions.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/OkHttpExtensions.kt
@@ -62,3 +62,7 @@ internal fun List<HttpHeader>.toOkHttpHeaders(): Headers =
         headers.add(it.name, it.value)
       }
     }.build()
+
+internal val defaultOkHttpClientBuilder: OkHttpClient.Builder by lazy {
+  OkHttpClient.Builder()
+}

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.jvm.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/http/DefaultHttpEngine.jvm.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo3.api.http.HttpRequest
 import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.http.UploadsHttpBody
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.network.defaultOkHttpClientBuilder
 import com.apollographql.apollo3.network.toOkHttpHeaders
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
@@ -42,7 +43,7 @@ private class JvmHttpEngine(
   constructor(timeoutMillis: Long) : this(timeoutMillis, timeoutMillis)
 
   constructor(connectTimeoutMillis: Long, readTimeoutMillis: Long) : this(
-      OkHttpClient.Builder()
+      defaultOkHttpClientBuilder
           .connectTimeout(connectTimeoutMillis, TimeUnit.MILLISECONDS)
           .readTimeout(readTimeoutMillis, TimeUnit.MILLISECONDS)
           .build()

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/websocket/DefaultOkHttpClientBuilder.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/websocket/DefaultOkHttpClientBuilder.kt
@@ -1,8 +1,0 @@
-package com.apollographql.apollo3.network.websocket
-
-
-import okhttp3.OkHttpClient
-
-internal val defaultOkHttpClientBuilder: OkHttpClient.Builder by lazy {
-  OkHttpClient.Builder()
-}

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/websocket/WebSocketEngine.jvm.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/websocket/WebSocketEngine.jvm.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo3.network.websocket
 
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.exception.ApolloNetworkException
+import com.apollographql.apollo3.network.defaultOkHttpClientBuilder
 import com.apollographql.apollo3.network.websocket.WebSocket
 import com.apollographql.apollo3.network.websocket.WebSocketListener
 import okhttp3.Headers

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo3/network/ws/OkHttpWebSocketEngine.kt
@@ -3,10 +3,10 @@ package com.apollographql.apollo3.network.ws
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.ApolloWebSocketClosedException
+import com.apollographql.apollo3.network.defaultOkHttpClientBuilder
 import com.apollographql.apollo3.network.toOkHttpHeaders
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.Channel
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -18,7 +18,7 @@ actual class DefaultWebSocketEngine(
 ) : WebSocketEngine {
 
   actual constructor() : this(
-      webSocketFactory = OkHttpClient()
+      webSocketFactory = defaultOkHttpClientBuilder.build()
   )
 
   actual override suspend fun open(


### PR DESCRIPTION
Make sure HTTP/WebSockets share the same connection pool by default.