### PR TITLE
Make enum as sealed class Unknown constructor opt-in

### DIFF
--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -27,6 +27,9 @@ public final class com/apollographql/apollo3/annotations/ApolloDeprecatedSince$V
 	public static fun values ()[Lcom/apollographql/apollo3/annotations/ApolloDeprecatedSince$Version;
 }
 
+public abstract interface annotation class com/apollographql/apollo3/annotations/ApolloEnumConstructor : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/apollographql/apollo3/annotations/ApolloExperimental : java/lang/annotation/Annotation {
 }
 

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
@@ -1,0 +1,9 @@
+package com.apollographql.apollo3.annotations
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "Applied to the constructor of an enum's UNKNOWN__ value, as instantiating it is usually a mistake."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CONSTRUCTOR)
+annotation class ApolloEnumConstructor

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo3.annotations
 
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,
-    message = "Applied to the constructor of an enum's UNKNOWN__ value, as instantiating it is usually a mistake."
+    message = "The `UNKNOWN__` class represents GraphQL enums that are not present in the schema and whose `rawValue` cannot be checked at build time. You may want to update your schema instead of calling this constructor directly."
 )
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CONSTRUCTOR)

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo3/annotations/ApolloEnumConstructor.kt
@@ -1,7 +1,7 @@
 package com.apollographql.apollo3.annotations
 
 @RequiresOptIn(
-    level = RequiresOptIn.Level.ERROR,
+    level = RequiresOptIn.Level.WARNING,
     message = "Applied to the constructor of an enum's UNKNOWN__ value, as instantiating it is usually a mistake."
 )
 @Retention(AnnotationRetention.BINARY)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -105,7 +105,7 @@ internal object KotlinSymbols {
 
   val ApolloAdaptableWith = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloAdaptableWith")
   val ApolloExperimental = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloExperimental")
-  val ApolloInternal = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloInternal")
+  val ApolloEnumConstructor = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloEnumConstructor")
 
   val JsExport = ClassName("kotlin.js", "JsExport")
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinSymbols.kt
@@ -105,6 +105,7 @@ internal object KotlinSymbols {
 
   val ApolloAdaptableWith = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloAdaptableWith")
   val ApolloExperimental = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloExperimental")
+  val ApolloInternal = ClassName(ClassNames.apolloAnnotationsPackageName, "ApolloInternal")
 
   val JsExport = ClassName("kotlin.js", "JsExport")
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
@@ -89,7 +89,7 @@ internal class EnumAsSealedBuilder(
 
   private fun IrEnum.unknownValueTypeSpec(): TypeSpec {
     return TypeSpec.classBuilder("UNKNOWN__")
-        .addKdoc("An enum value that wasn't known at compile time.\nConstructor is annotated with [%T] to prevent instantiation outside of this file.", KotlinSymbols.ApolloInternal)
+        .addKdoc("An enum value that wasn't known at compile time.\nConstructor is annotated with [%T] to prevent instantiation outside of this file.", KotlinSymbols.ApolloEnumConstructor)
         .primaryConstructor(unknownValuePrimaryConstructorSpec)
         .superclass(selfClassName)
         .addSuperclassConstructorParameter("rawValue·=·rawValue")
@@ -132,7 +132,7 @@ internal class EnumAsSealedBuilder(
                 .map { CodeBlock.of("%S·->·%T", it.name, it.valueClassName()) }
                 .joinToCode(separator = "\n", suffix = "\n")
         )
-        .addCode("else -> @OptIn(%T::class) %T(rawValue)\n", KotlinSymbols.ApolloInternal, unknownValueClassName())
+        .addCode("else -> @OptIn(%T::class) %T(rawValue)\n", KotlinSymbols.ApolloEnumConstructor, unknownValueClassName())
         .endControlFlow()
         .build()
   }
@@ -169,7 +169,7 @@ internal class EnumAsSealedBuilder(
 
   private val unknownValuePrimaryConstructorSpec =
     FunSpec.constructorBuilder()
-        .addAnnotation(KotlinSymbols.ApolloInternal)
+        .addAnnotation(KotlinSymbols.ApolloEnumConstructor)
         .addParameter("rawValue", KotlinSymbols.String)
         .build()
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
@@ -89,8 +89,8 @@ internal class EnumAsSealedBuilder(
 
   private fun IrEnum.unknownValueTypeSpec(): TypeSpec {
     return TypeSpec.classBuilder("UNKNOWN__")
-        .addKdoc("%L", "An enum value that wasn't known at compile time.\n")
-        .primaryConstructor(primaryConstructorSpec)
+        .addKdoc("An enum value that wasn't known at compile time.\nConstructor is annotated with [%T] to prevent instantiation outside of this file.", KotlinSymbols.ApolloInternal)
+        .primaryConstructor(unknownValuePrimaryConstructorSpec)
         .superclass(selfClassName)
         .addSuperclassConstructorParameter("rawValue·=·rawValue")
         .addFunction(
@@ -132,7 +132,7 @@ internal class EnumAsSealedBuilder(
                 .map { CodeBlock.of("%S·->·%T", it.name, it.valueClassName()) }
                 .joinToCode(separator = "\n", suffix = "\n")
         )
-        .addCode("else -> %T(rawValue)\n", unknownValueClassName())
+        .addCode("else -> @OptIn(%T::class) %T(rawValue)\n", KotlinSymbols.ApolloInternal, unknownValueClassName())
         .endControlFlow()
         .build()
   }
@@ -167,19 +167,20 @@ internal class EnumAsSealedBuilder(
     return ClassName(selfClassName.packageName, selfClassName.simpleName, "UNKNOWN__")
   }
 
-  private val primaryConstructorSpec =
-      FunSpec.constructorBuilder()
-          .addParameter("rawValue", KotlinSymbols.String)
-          .build()
+  private val unknownValuePrimaryConstructorSpec =
+    FunSpec.constructorBuilder()
+        .addAnnotation(KotlinSymbols.ApolloInternal)
+        .addParameter("rawValue", KotlinSymbols.String)
+        .build()
 
   private val primaryConstructorWithOverriddenParamSpec =
-      FunSpec.constructorBuilder()
-          .addParameter("rawValue", KotlinSymbols.String)
-          .build()
+    FunSpec.constructorBuilder()
+        .addParameter("rawValue", KotlinSymbols.String)
+        .build()
 
   private val rawValuePropertySpec =
-      PropertySpec.builder("rawValue", KotlinSymbols.String)
-          .initializer("rawValue")
-          .build()
+    PropertySpec.builder("rawValue", KotlinSymbols.String)
+        .initializer("rawValue")
+        .build()
 
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
@@ -5,7 +5,7 @@
 //
 package com.example.enums_as_sealed.type
 
-import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.annotations.ApolloEnumConstructor
 import com.apollographql.apollo3.api.EnumType
 import kotlin.Any
 import kotlin.Array
@@ -31,7 +31,7 @@ public sealed class Enum(
       "NORTH" -> NORTH
       "SOUTH" -> SOUTH
       "type" -> type_
-      else -> @OptIn(ApolloInternal::class) UNKNOWN__(rawValue)
+      else -> @OptIn(ApolloEnumConstructor::class) UNKNOWN__(rawValue)
     }
 
     /**
@@ -60,9 +60,10 @@ public sealed class Enum(
 
   /**
    * An enum value that wasn't known at compile time.
-   * Constructor is annotated with [ApolloInternal] to prevent instantiation outside of this file.
+   * Constructor is annotated with [ApolloEnumConstructor] to prevent instantiation outside of this
+   * file.
    */
-  public class UNKNOWN__ @ApolloInternal constructor(
+  public class UNKNOWN__ @ApolloEnumConstructor constructor(
     rawValue: String,
   ) : Enum(rawValue = rawValue) {
     override fun equals(other: Any?): Boolean {

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
@@ -5,6 +5,7 @@
 //
 package com.example.enums_as_sealed.type
 
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.EnumType
 import kotlin.Any
 import kotlin.Array
@@ -30,7 +31,7 @@ public sealed class Enum(
       "NORTH" -> NORTH
       "SOUTH" -> SOUTH
       "type" -> type_
-      else -> UNKNOWN__(rawValue)
+      else -> @OptIn(ApolloInternal::class) UNKNOWN__(rawValue)
     }
 
     /**
@@ -59,8 +60,9 @@ public sealed class Enum(
 
   /**
    * An enum value that wasn't known at compile time.
+   * Constructor is annotated with [ApolloInternal] to prevent instantiation outside of this file.
    */
-  public class UNKNOWN__(
+  public class UNKNOWN__ @ApolloInternal constructor(
     rawValue: String,
   ) : Enum(rawValue = rawValue) {
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
Related to #5796

This uses `@ApolloInternal`- should we introduce a dedicated annotation instead?