### PR TITLE
❄️ Fix retry tests flake #2

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/websocket/internal/SubscribableWebSocket.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/websocket/internal/SubscribableWebSocket.kt
@@ -160,15 +160,15 @@ internal class SubscribableWebSocket(
       }
 
       is ResponseServerMessage -> {
-        activeListeners.get(message.id)?.onResponse(message.response)
+        lock.withLock { activeListeners.get(message.id) }?.onResponse(message.response)
       }
 
       is CompleteServerMessage -> {
-        activeListeners.get(message.id)?.onComplete()
+        lock.withLock { activeListeners.get(message.id) }?.onComplete()
       }
 
       is OperationErrorServerMessage -> {
-        activeListeners.get(message.id)?.onError(message.payload)
+        lock.withLock { activeListeners.get(message.id) }?.onError(message.payload)
       }
 
       is ParseErrorServerMessage -> {


### PR DESCRIPTION
When an individual flow completes early, we were mistaking the "complete" event with a "next" event and therefore sending a response for the bad operation id.

Also took this opportunity to lock things a bit more in `SubscribableSocket`