### PR TITLE
2024-04-19 Roadmap update

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # 🔮 Apollo Kotlin Roadmap
 
-**Last updated: 2024-04-04**
+**Last updated: 2024-04-19**
 
 For up to date release notes, refer to the project [Changelog](https://github.com/apollographql/apollo-kotlin/blob/main/CHANGELOG.md).
 


### PR DESCRIPTION
Just bumping the timestamp - all still holds.  Kotlin 2.0 is in RC stage and we anticipate a GA release in the foreseeable future, which will unblock Apollo Kotlin 4.0