### PR TITLE
Fix links that depend on a redirect

### DIFF
--- a/docs/source/advanced/client-awareness.mdx
+++ b/docs/source/advanced/client-awareness.mdx
@@ -2,7 +2,7 @@
 title: Client Awareness
 ---
 
-Apollo Studio users can opt-in [Client Awareness](https://www.apollographql.com/docs/studio/client-awareness/). Client Awareness allows you to view operation metrics split per client, helping you understand how each one interacts with your graph.
+GraphOS Studio users can opt-in [Client Awareness](https://www.apollographql.com/docs/graphos/metrics/client-awareness/). Client Awareness allows you to view operation metrics split per client, helping you understand how each one interacts with your graph.
 
 Client Awareness uses `apollographql-client-name` and `apollographql-client-version` custom HTTP headers to report client usage.
 

--- a/docs/source/advanced/nullability.mdx
+++ b/docs/source/advanced/nullability.mdx
@@ -3,7 +3,7 @@ title: Handling nullability and errors
 description: Make your queries even more typesafe
 ---
 
-> ⚠️ **Nullability annotations are currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md&title=[Defer%20Support]), in the [Kotlin Slack community](https://slack.kotl.in/), or in the [GraphQL nullability working group](https://github.com/graphql/nullability-wg/).
+> ⚠️ **Nullability annotations are currently [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md&title=[Defer%20Support]), in the [Kotlin Slack community](https://slack.kotl.in/), or in the [GraphQL nullability working group](https://github.com/graphql/nullability-wg/).
 
 ## Nullability in GraphQL
 

--- a/docs/source/advanced/plugin-configuration.mdx
+++ b/docs/source/advanced/plugin-configuration.mdx
@@ -181,7 +181,7 @@ apollo {
 This will create a task
 named `download<ServiceName>ApolloSchemaFromIntrospection` (`downloadServiceApolloSchemaFromIntrospection` by default).
 
-If you register your schema with [Apollo Studio](https://www.apollographql.com/docs/studio/), use the `registry` block
+If you register your schema with [GraphOS Studio](https://studio.apollographql.com/), use the `registry` block
 instead:
 
 ```kotlin

--- a/docs/source/testing/android-studio-plugin.mdx
+++ b/docs/source/testing/android-studio-plugin.mdx
@@ -95,7 +95,7 @@ A quick fix is available to encapsulate the field in a fragment with the [`@defe
 
 For the plugin to be able to fetch the metrics, you need to configure your project with its [Apollo GraphOS API key](https://www.apollographql.com/docs/graphos/api-keys/). To do this, go to the plugin's settings: <kbd>Settings</kbd> | <kbd>Languages & Frameworks</kbd> | <kbd>GraphQL</kbd> | <kbd>Apollo Kotlin</kbd>. Here you can find the <kbd>API keys</kbd> table where you can add:
 - API key: should start with `service:` or `user:`
-- Graph ID: can be found on your graph page in Apollo Studio or is filled automatically if you provide a `service:` API key
+- Graph ID: can be found on your graph page in GraphOS Studio or is filled automatically if you provide a `service:` API key
 
 ### Normalized cache viewer
 

--- a/docs/source/tutorial/00-introduction.mdx
+++ b/docs/source/tutorial/00-introduction.mdx
@@ -11,7 +11,7 @@ Welcome! This tutorial demonstrates adding the Apollo Kotlin SDK to an app to co
 * Authenticate with a backend server
 * Use subscriptions to receive real-time updates
 
-The tutorial uses an instance of [Apollo Server](https://www.apollographql.com/docs/apollo-server/) hosted on Heroku, and an [Apollo Studio Sandbox](https://studio.apollographql.com/sandbox/explorer?endpoint=https%3A%2F%2Fapollo-fullstack-tutorial.herokuapp.com%2Fgraphql) which connects to that server. If you're curious about how to build your own
+The tutorial uses an instance of [Apollo Server](https://www.apollographql.com/docs/apollo-server/) hosted on Heroku, and an [GraphOS Studio Sandbox](https://studio.apollographql.com/sandbox/explorer?endpoint=https%3A%2F%2Fapollo-fullstack-tutorial.herokuapp.com%2Fgraphql) which connects to that server. If you're curious about how to build your own
 server, see the [Apollo full-stack tutorial](https://www.apollographql.com/docs/tutorial/introduction/).
 
 All of the code for this tutorial is available [on GitHub](https://github.com/apollographql/apollo-kotlin-tutorial).

--- a/docs/source/tutorial/02-add-the-graphql-schema.mdx
+++ b/docs/source/tutorial/02-add-the-graphql-schema.mdx
@@ -2,7 +2,7 @@
 title: "2. Add the GraphQL schema"
 ---
 
-This tutorial uses a modified version of the GraphQL server you build as part of [the Apollo full-stack tutorial](https://www.apollographql.com/docs/tutorial/introduction/). You can visit [that server's Apollo Studio Sandbox Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https%3A%2F%2Fapollo-fullstack-tutorial.herokuapp.com%2Fgraphql) to explore its schema without needing to be logged in:
+This tutorial uses a modified version of the GraphQL server you build as part of [the Apollo full-stack tutorial](https://www.apollographql.com/docs/tutorial/introduction/). You can visit [that server's GraphOS Studio Sandbox Explorer](https://studio.apollographql.com/sandbox/explorer?endpoint=https%3A%2F%2Fapollo-fullstack-tutorial.herokuapp.com%2Fgraphql) to explore its schema without needing to be logged in:
 
 <img src="images/sandbox_landing.png" alt="The Sandbox query explorer" class="screenshot"/>
 
@@ -20,7 +20,7 @@ In the **Reference** tab, you can now see a list of all of the things available 
 
 ## Download your server's schema
 
-Apollo Kotlin requires a schema to generate type-safe models and code from your queries. There are multiple ways to get a schema. For example, you can go to the SDL tab and download the raw SDL schema using Apollo Studio Sandbox.
+Apollo Kotlin requires a schema to generate type-safe models and code from your queries. There are multiple ways to get a schema. For example, you can go to the SDL tab and download the raw SDL schema using GraphOS Studio Sandbox.
 
 In this tutorial, we will use the `downloadApolloSchema` Gradle task that is created by our plugin automatically. Since GraphQL supports [introspection](https://graphql.org/learn/introspection/), this will work with any GraphQL endpoint that has introspection enabled.
 


### PR DESCRIPTION
Also updates "Apollo Studio" --> "GraphOS Studio" (the updated convention).