### PR TITLE
Expose apollo-ast as an api dependency of apollo-compiler

### DIFF
--- a/libraries/apollo-compiler/build.gradle.kts
+++ b/libraries/apollo-compiler/build.gradle.kts
@@ -10,7 +10,7 @@ apolloLibrary(
 )
 
 dependencies {
-  implementation(project(":apollo-ast"))
+  api(project(":apollo-ast"))
   api(libs.poet.kotlin) {
     // We don't use any of the KotlinPoet kotlin-reflect features
     exclude(module = "kotlin-reflect")


### PR DESCRIPTION
`ApolloCompilerPlugin` exposes `Schema` so `apollo-ast` is now part of the public API