### PR TITLE
Revert compile time possible types

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
@@ -203,7 +203,7 @@ internal object KotlinCodegen {
         builders.add(ObjectBuilder(context, irObject, generateDataBuilders))
       }
       if (generateSchema && context.resolver.resolve(ResolverKey(ResolverKeyKind.Schema, "")) == null) {
-        builders.add(SchemaBuilder(context, codegenSchema.schema, irSchema.irObjects, irSchema.irInterfaces, irSchema.irUnions, irSchema.irEnums))
+        builders.add(SchemaBuilder(context, irSchema.irObjects, irSchema.irInterfaces, irSchema.irUnions, irSchema.irEnums))
         builders.add(CustomScalarAdaptersBuilder(context, scalarMapping))
       }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
@@ -1,14 +1,12 @@
 package com.apollographql.apollo3.compiler.codegen.kotlin.schema
 
 
-import com.apollographql.apollo3.ast.Schema
 import com.apollographql.apollo3.compiler.codegen.Identifier.type
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFile
 import com.apollographql.apollo3.compiler.codegen.kotlin.CgFileBuilder
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSchemaContext
 import com.apollographql.apollo3.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo3.compiler.codegen.schemaSubPackageName
-import com.apollographql.apollo3.compiler.decapitalizeFirstLetter
 import com.apollographql.apollo3.compiler.ir.IrEnum
 import com.apollographql.apollo3.compiler.ir.IrInterface
 import com.apollographql.apollo3.compiler.ir.IrObject
@@ -20,12 +18,9 @@ import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.buildCodeBlock
-import com.squareup.kotlinpoet.joinToCode
 
 internal class SchemaBuilder(
     private val context: KotlinSchemaContext,
-    private val schema: Schema,
     private val objects: List<IrObject>,
     private val interfaces: List<IrInterface>,
     private val unions: List<IrUnion>,
@@ -70,26 +65,6 @@ internal class SchemaBuilder(
         .addKdoc("A __Schema object containing all the composite types and a possibleTypes helper function")
         .addProperty(typesPropertySpec())
         .addFunction(possibleTypesFunSpec())
-        .apply {
-          (interfaces + unions).forEach {
-            addFunction(possibleTypesFunSpec(it.name, schema.possibleTypes(schema.typeDefinition(it.name))))
-          }
-        }
-        .build()
-  }
-
-  private fun possibleTypesFunSpec(name: String, possibleTypes: Set<String>): FunSpec {
-    return FunSpec.builder("${name.decapitalizeFirstLetter()}PossibleTypes")
-        .returns(KotlinSymbols.List.parameterizedBy(KotlinSymbols.ObjectType))
-        .addCode(
-            buildCodeBlock {
-              add("return listOf(")
-              add(possibleTypes.map {
-                CodeBlock.of("%L.$type", context.resolver.resolveSchemaType(it))
-              }.joinToCode(", "))
-              add(")")
-            }
-        )
         .build()
   }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/SchemaBuilder.kt
@@ -72,17 +72,18 @@ internal class SchemaBuilder(
         .addFunction(possibleTypesFunSpec())
         .apply {
           (interfaces + unions).forEach {
-            addProperty(possibleTypesPropertySpec(it.name, schema.possibleTypes(schema.typeDefinition(it.name))))
+            addFunction(possibleTypesFunSpec(it.name, schema.possibleTypes(schema.typeDefinition(it.name))))
           }
         }
         .build()
   }
 
-  private fun possibleTypesPropertySpec(name: String, possibleTypes: Set<String>): PropertySpec {
-    return PropertySpec.builder("${name.decapitalizeFirstLetter()}PossibleTypes", KotlinSymbols.List.parameterizedBy(KotlinSymbols.ObjectType))
-        .initializer(
+  private fun possibleTypesFunSpec(name: String, possibleTypes: Set<String>): FunSpec {
+    return FunSpec.builder("${name.decapitalizeFirstLetter()}PossibleTypes")
+        .returns(KotlinSymbols.List.parameterizedBy(KotlinSymbols.ObjectType))
+        .addCode(
             buildCodeBlock {
-              add("listOf(")
+              add("return listOf(")
               add(possibleTypes.map {
                 CodeBlock.of("%L.$type", context.resolver.resolveSchemaType(it))
               }.joinToCode(", "))

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/schema/__Schema.kt.expected
@@ -20,16 +20,16 @@ public object __Schema {
             com.example.data_builders.type.Node.type, com.example.data_builders.type.Query.type)
 
 
-  public val characterPossibleTypes: List<ObjectType> =
+  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
+      com.apollographql.apollo3.api.possibleTypes(all, type)
+
+  public fun characterPossibleTypes(): List<ObjectType> =
       listOf(com.example.data_builders.type.Human.type, com.example.data_builders.type.Droid.type)
 
-  public val nodePossibleTypes: List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
+  public fun nodePossibleTypes(): List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
       com.example.data_builders.type.Dog.type, com.example.data_builders.type.Human.type,
       com.example.data_builders.type.Droid.type)
 
-  public val animalPossibleTypes: List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
-      com.example.data_builders.type.Dog.type)
-
-  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
-      com.apollographql.apollo3.api.possibleTypes(all, type)
+  public fun animalPossibleTypes(): List<ObjectType> =
+      listOf(com.example.data_builders.type.Cat.type, com.example.data_builders.type.Dog.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/schema/__Schema.kt.expected
@@ -22,14 +22,4 @@ public object __Schema {
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
       com.apollographql.apollo3.api.possibleTypes(all, type)
-
-  public fun characterPossibleTypes(): List<ObjectType> =
-      listOf(com.example.data_builders.type.Human.type, com.example.data_builders.type.Droid.type)
-
-  public fun nodePossibleTypes(): List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
-      com.example.data_builders.type.Dog.type, com.example.data_builders.type.Human.type,
-      com.example.data_builders.type.Droid.type)
-
-  public fun animalPossibleTypes(): List<ObjectType> =
-      listOf(com.example.data_builders.type.Cat.type, com.example.data_builders.type.Dog.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/schema/__Schema.kt.expected
@@ -20,16 +20,16 @@ public object __Schema {
             com.example.data_builders.type.Node.type, com.example.data_builders.type.Query.type)
 
 
-  public val characterPossibleTypes: List<ObjectType> =
+  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
+      com.apollographql.apollo3.api.possibleTypes(all, type)
+
+  public fun characterPossibleTypes(): List<ObjectType> =
       listOf(com.example.data_builders.type.Human.type, com.example.data_builders.type.Droid.type)
 
-  public val nodePossibleTypes: List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
+  public fun nodePossibleTypes(): List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
       com.example.data_builders.type.Dog.type, com.example.data_builders.type.Human.type,
       com.example.data_builders.type.Droid.type)
 
-  public val animalPossibleTypes: List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
-      com.example.data_builders.type.Dog.type)
-
-  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
-      com.apollographql.apollo3.api.possibleTypes(all, type)
+  public fun animalPossibleTypes(): List<ObjectType> =
+      listOf(com.example.data_builders.type.Cat.type, com.example.data_builders.type.Dog.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/schema/__Schema.kt.expected
@@ -22,14 +22,4 @@ public object __Schema {
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
       com.apollographql.apollo3.api.possibleTypes(all, type)
-
-  public fun characterPossibleTypes(): List<ObjectType> =
-      listOf(com.example.data_builders.type.Human.type, com.example.data_builders.type.Droid.type)
-
-  public fun nodePossibleTypes(): List<ObjectType> = listOf(com.example.data_builders.type.Cat.type,
-      com.example.data_builders.type.Dog.type, com.example.data_builders.type.Human.type,
-      com.example.data_builders.type.Droid.type)
-
-  public fun animalPossibleTypes(): List<ObjectType> =
-      listOf(com.example.data_builders.type.Cat.type, com.example.data_builders.type.Dog.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,9 +2,9 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  204924
-aggregate-kotlin-responseBased                                                                  65822
-aggregate-kotlin-operationBased                                                                 42426
+aggregate-all                                                                                  204879
+aggregate-kotlin-responseBased                                                                  65795
+aggregate-kotlin-operationBased                                                                 42408
 aggregate-kotlin-compat                                                                             0
 aggregate-java-operationBased                                                                   96676
 
@@ -13,9 +13,9 @@ kotlin-operationBased-fragments_with_defer_and_include_directives               
 java-operationBased-data_builders                                                                3031
 java-operationBased-mutation_create_review                                                       2435
 kotlin-responseBased-fragment_with_inline_fragment                                               2422
-kotlin-responseBased-data_builders                                                               2365
+kotlin-responseBased-data_builders                                                               2355
 java-operationBased-fragment_with_inline_fragment                                                2261
-kotlin-operationBased-data_builders                                                              2014
+kotlin-operationBased-data_builders                                                              2004
 java-operationBased-nested_named_fragments                                                       1910
 java-operationBased-fragment_spread_with_include_directive                                       1667
 java-operationBased-union_inline_fragments                                                       1666
@@ -27,7 +27,7 @@ java-operationBased-mutation_create_review_semantic_naming                      
 java-operationBased-root_query_fragment_with_nested_fragments                                    1607
 java-operationBased-simple_fragment                                                              1505
 java-operationBased-named_fragment_delegate                                                      1493
-kotlin-responseBased-mutation_create_review                                                      1463
+kotlin-responseBased-mutation_create_review                                                      1454
 java-operationBased-named_fragment_with_variables                                                1405
 kotlin-responseBased-named_fragment_delegate                                                     1371
 kotlin-responseBased-unique_type_name                                                            1354
@@ -42,7 +42,7 @@ kotlin-operationBased-nested_named_fragments                                    
 kotlin-responseBased-inline_fragment_intersection                                                1245
 java-operationBased-two_heroes_with_friends                                                      1241
 java-operationBased-inline_fragment_merge_fields                                                 1229
-kotlin-responseBased-simple_fragment                                                             1203
+kotlin-responseBased-simple_fragment                                                             1195
 java-operationBased-named_fragment_inside_inline_fragment                                        1186
 java-operationBased-fragments_with_type_condition                                                1183
 java-operationBased-target_name                                                                  1168
@@ -69,7 +69,7 @@ kotlin-operationBased-root_query_fragment_with_nested_fragments                 
 java-operationBased-inline_fragments_with_friends                                                1056
 java-operationBased-fragment_spread_with_nested_fields                                           1054
 kotlin-responseBased-simple_fragment_with_inline_fragments                                       1052
-kotlin-operationBased-simple_fragment                                                            1051
+kotlin-operationBased-simple_fragment                                                            1043
 java-operationBased-operationbased2_ex8                                                          1042
 kotlin-operationBased-named_fragment_delegate                                                    1013
 java-operationBased-decapitalized_fields                                                          993

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/schema/__Schema.kt.expected
@@ -26,13 +26,4 @@ internal object __Schema {
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
       com.apollographql.apollo3.api.possibleTypes(all, type)
-
-  public fun characterPossibleTypes(): List<ObjectType> =
-      listOf(com.example.mutation_create_review.type.Droid.type,
-      com.example.mutation_create_review.type.Human.type)
-
-  public fun searchResultPossibleTypes(): List<ObjectType> =
-      listOf(com.example.mutation_create_review.type.Human.type,
-      com.example.mutation_create_review.type.Droid.type,
-      com.example.mutation_create_review.type.Starship.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/schema/__Schema.kt.expected
@@ -24,15 +24,15 @@ internal object __Schema {
             com.example.mutation_create_review.type.Starship.type)
 
 
-  public val characterPossibleTypes: List<ObjectType> =
+  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
+      com.apollographql.apollo3.api.possibleTypes(all, type)
+
+  public fun characterPossibleTypes(): List<ObjectType> =
       listOf(com.example.mutation_create_review.type.Droid.type,
       com.example.mutation_create_review.type.Human.type)
 
-  public val searchResultPossibleTypes: List<ObjectType> =
+  public fun searchResultPossibleTypes(): List<ObjectType> =
       listOf(com.example.mutation_create_review.type.Human.type,
       com.example.mutation_create_review.type.Droid.type,
       com.example.mutation_create_review.type.Starship.type)
-
-  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
-      com.apollographql.apollo3.api.possibleTypes(all, type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/schema/__Schema.kt.expected
@@ -24,12 +24,4 @@ internal object __Schema {
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
       com.apollographql.apollo3.api.possibleTypes(all, type)
-
-  public fun characterPossibleTypes(): List<ObjectType> =
-      listOf(com.example.simple_fragment.type.Droid.type,
-      com.example.simple_fragment.type.Human.type)
-
-  public fun searchResultPossibleTypes(): List<ObjectType> =
-      listOf(com.example.simple_fragment.type.Human.type,
-      com.example.simple_fragment.type.Droid.type, com.example.simple_fragment.type.Starship.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/schema/__Schema.kt.expected
@@ -22,14 +22,14 @@ internal object __Schema {
             com.example.simple_fragment.type.Starship.type)
 
 
-  public val characterPossibleTypes: List<ObjectType> =
+  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
+      com.apollographql.apollo3.api.possibleTypes(all, type)
+
+  public fun characterPossibleTypes(): List<ObjectType> =
       listOf(com.example.simple_fragment.type.Droid.type,
       com.example.simple_fragment.type.Human.type)
 
-  public val searchResultPossibleTypes: List<ObjectType> =
+  public fun searchResultPossibleTypes(): List<ObjectType> =
       listOf(com.example.simple_fragment.type.Human.type,
       com.example.simple_fragment.type.Droid.type, com.example.simple_fragment.type.Starship.type)
-
-  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
-      com.apollographql.apollo3.api.possibleTypes(all, type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/schema/__Schema.kt.expected
@@ -24,12 +24,4 @@ internal object __Schema {
 
   public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
       com.apollographql.apollo3.api.possibleTypes(all, type)
-
-  public fun characterPossibleTypes(): List<ObjectType> =
-      listOf(com.example.simple_fragment.type.Droid.type,
-      com.example.simple_fragment.type.Human.type)
-
-  public fun searchResultPossibleTypes(): List<ObjectType> =
-      listOf(com.example.simple_fragment.type.Human.type,
-      com.example.simple_fragment.type.Droid.type, com.example.simple_fragment.type.Starship.type)
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/schema/__Schema.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/schema/__Schema.kt.expected
@@ -22,14 +22,14 @@ internal object __Schema {
             com.example.simple_fragment.type.Starship.type)
 
 
-  public val characterPossibleTypes: List<ObjectType> =
+  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
+      com.apollographql.apollo3.api.possibleTypes(all, type)
+
+  public fun characterPossibleTypes(): List<ObjectType> =
       listOf(com.example.simple_fragment.type.Droid.type,
       com.example.simple_fragment.type.Human.type)
 
-  public val searchResultPossibleTypes: List<ObjectType> =
+  public fun searchResultPossibleTypes(): List<ObjectType> =
       listOf(com.example.simple_fragment.type.Human.type,
       com.example.simple_fragment.type.Droid.type, com.example.simple_fragment.type.Starship.type)
-
-  public fun possibleTypes(type: CompiledNamedType): List<ObjectType> =
-      com.apollographql.apollo3.api.possibleTypes(all, type)
 }


### PR DESCRIPTION
They potentially add a lot of code and the use case still has to be validated. I'd rather wait a bit until we introduce that.

- **Revert "fun => val (#5826)"**
- **Revert "Add compile time possibleTypes (#5823)"**
