### PR TITLE
Fix backtick code formatting in ApolloCompilerPlugin docs

### DIFF
--- a/docs/source/advanced/compiler-plugins.mdx
+++ b/docs/source/advanced/compiler-plugins.mdx
@@ -62,7 +62,10 @@ Make your plugin discoverable by [ServiceLoader](https://docs.oracle.com/javase/
 mypackage.MyPlugin
 ```
 
+<Note>
+
 The name of the resource file is important. It must be `com.apollographql.apollo3.compiler.ApolloCompilerPlugin` and be in the `META-INF/services` folder. This is how `ServiceLoader` looks up plugins at runtime.
+</Note>
 
 # Adding a plugin to the Apollo compiler classpath
 

--- a/docs/source/advanced/compiler-plugins.mdx
+++ b/docs/source/advanced/compiler-plugins.mdx
@@ -62,9 +62,8 @@ Make your plugin discoverable by [ServiceLoader](https://docs.oracle.com/javase/
 mypackage.MyPlugin
 ```
 
-<Note>  
 The name of the resource file is important. It must be `com.apollographql.apollo3.compiler.ApolloCompilerPlugin` and be in the `META-INF/services` folder. This is how `ServiceLoader` looks up plugins at runtime.
-</Note>
+
 # Adding a plugin to the Apollo compiler classpath
 
 Use the `Service.plugin()` Gradle method to add the plugin to the Apollo compiler classpath:


### PR DESCRIPTION
Note sure what the `<Note>` tag does but it was breaking the backtick markdown formatting