### PR TITLE
Clear current ApolloStore related interceptors when calling `.store()` on builder

### DIFF
--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -24,6 +24,7 @@ import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.api.RecordMerger
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.reflect.KClass
@@ -235,3 +236,8 @@ fun ApolloStore(
     fieldNameGenerator = fieldNameGenerator,
     embeddedFieldsProvider = embeddedFieldsProvider,
 )
+
+/**
+ * Interface that marks all interceptors added when configuring a `store()` on ApolloClient.Builder.
+ */
+internal interface ApolloStoreInterceptor : ApolloInterceptor

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -159,6 +159,13 @@ fun ApolloClient.Builder.store(
   check(interceptors.none { it is AutoPersistedQueryInterceptor }) {
     "Apollo: the normalized cache must be configured before the auto persisted queries"
   }
+  // Removing existing interceptors added for configuring an [ApolloStore].
+  // If a builder is reused from an existing client using `newBuilder()` and we try to configure a new `store()` on it, we first need to
+  // remove the old interceptors.
+  val storeInterceptors = interceptors.filterIsInstance<ApolloStoreInterceptor>()
+  storeInterceptors.forEach {
+    removeInterceptor(it)
+  }
   return addInterceptor(WatcherInterceptor(store))
       .addInterceptor(FetchPolicyRouterInterceptor)
       .addInterceptor(ApolloCacheInterceptor(store))

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -129,7 +129,7 @@ val CacheAndNetworkInterceptor = object : ApolloInterceptor {
   }
 }
 
-internal object FetchPolicyRouterInterceptor : ApolloInterceptor {
+internal object FetchPolicyRouterInterceptor : ApolloInterceptor, ApolloStoreInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {
       // Subscriptions and Mutations do not support fetchPolicies

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo3.cache.normalized.CacheInfo
 import com.apollographql.apollo3.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
@@ -36,7 +37,7 @@ import kotlinx.coroutines.launch
 
 internal class ApolloCacheInterceptor(
     val store: ApolloStore,
-) : ApolloInterceptor {
+) : ApolloInterceptor, ApolloStoreInterceptor {
   private suspend fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: suspend () -> Unit) {
     if (request.writeToCacheAsynchronously) {
       val scope = request.executionContext[ConcurrencyInfo]!!.coroutineScope

--- a/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/libraries/apollo-normalized-cache-incubating/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo3.cache.normalized.api.dependentKeys
 import com.apollographql.apollo3.cache.normalized.watchContext
 import com.apollographql.apollo3.interceptor.ApolloInterceptor
@@ -17,7 +18,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 
-internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
+internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor, ApolloStoreInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     val watchContext = request.watchContext ?: return chain.proceed(request)
 

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ApolloStore.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.cache.normalized.api.NormalizedCacheFactory
 import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerator
 import com.apollographql.apollo3.cache.normalized.internal.DefaultApolloStore
+import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.benasher44.uuid.Uuid
 import kotlinx.coroutines.flow.SharedFlow
 import kotlin.reflect.KClass
@@ -265,3 +266,8 @@ fun ApolloStore(
     cacheKeyGenerator: CacheKeyGenerator = TypePolicyCacheKeyGenerator,
     cacheResolver: CacheResolver = FieldPolicyCacheResolver,
 ): ApolloStore = DefaultApolloStore(normalizedCacheFactory, cacheKeyGenerator, cacheResolver)
+
+/**
+ * Interface that marks all interceptors added when configuring a `store()` on ApolloClient.Builder.
+ */
+internal interface ApolloStoreInterceptor : ApolloInterceptor

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/ClientCacheExtensions.kt
@@ -122,6 +122,13 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
   check(interceptors.none { it is AutoPersistedQueryInterceptor }) {
     "Apollo: the normalized cache must be configured before the auto persisted queries"
   }
+  // Removing existing interceptors added for configuring an [ApolloStore].
+  // If a builder is reused from an existing client using `newBuilder()` and we try to configure a new `store()` on it, we first need to
+  // remove the old interceptors.
+  val storeInterceptors = interceptors.filterIsInstance<ApolloStoreInterceptor>()
+  storeInterceptors.forEach {
+    removeInterceptor(it)
+  }
   return addInterceptor(WatcherInterceptor(store))
       .addInterceptor(FetchPolicyRouterInterceptor)
       .addInterceptor(ApolloCacheInterceptor(store))

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/FetchPolicyInterceptors.kt
@@ -129,7 +129,7 @@ val CacheAndNetworkInterceptor = object : ApolloInterceptor {
   }
 }
 
-internal object FetchPolicyRouterInterceptor : ApolloInterceptor {
+internal object FetchPolicyRouterInterceptor : ApolloInterceptor, ApolloStoreInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     if (request.operation !is Query) {
       // Subscriptions and Mutations do not support fetchPolicies

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/ApolloCacheInterceptor.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.api.Subscription
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo3.cache.normalized.CacheInfo
 import com.apollographql.apollo3.cache.normalized.api.ApolloCacheHeaders
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
@@ -36,7 +37,7 @@ import kotlinx.coroutines.launch
 
 internal class ApolloCacheInterceptor(
     val store: ApolloStore,
-) : ApolloInterceptor {
+) : ApolloInterceptor, ApolloStoreInterceptor {
   private suspend fun <D : Operation.Data> maybeAsync(request: ApolloRequest<D>, block: suspend () -> Unit) {
     if (request.writeToCacheAsynchronously) {
       val scope = request.executionContext[ConcurrencyInfo]!!.coroutineScope

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo3/cache/normalized/internal/WatcherInterceptor.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.api.CustomScalarAdapters
 import com.apollographql.apollo3.api.Operation
 import com.apollographql.apollo3.api.Query
 import com.apollographql.apollo3.cache.normalized.ApolloStore
+import com.apollographql.apollo3.cache.normalized.ApolloStoreInterceptor
 import com.apollographql.apollo3.cache.normalized.api.dependentKeys
 import com.apollographql.apollo3.cache.normalized.watchContext
 import com.apollographql.apollo3.exception.DefaultApolloException
@@ -23,7 +24,7 @@ import kotlinx.coroutines.flow.onSubscription
 
 internal val WatcherSentinel = DefaultApolloException("The watcher has started")
 
-internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor {
+internal class WatcherInterceptor(val store: ApolloStore) : ApolloInterceptor, ApolloStoreInterceptor {
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     val watchContext = request.watchContext ?: return chain.proceed(request)
 

--- a/libraries/apollo-runtime/api/android/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/android/apollo-runtime.api
@@ -118,6 +118,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun networkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun removeInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;

--- a/libraries/apollo-runtime/api/jvm/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/jvm/apollo-runtime.api
@@ -118,6 +118,7 @@ public final class com/apollographql/apollo3/ApolloClient$Builder : com/apollogr
 	public final fun httpServerUrl (Ljava/lang/String;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun interceptors (Ljava/util/List;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public final fun networkTransport (Lcom/apollographql/apollo3/network/NetworkTransport;)Lcom/apollographql/apollo3/ApolloClient$Builder;
+	public final fun removeInterceptor (Lcom/apollographql/apollo3/interceptor/ApolloInterceptor;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public fun sendApqExtensions (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;
 	public synthetic fun sendApqExtensions (Ljava/lang/Boolean;)Ljava/lang/Object;
 	public fun sendDocument (Ljava/lang/Boolean;)Lcom/apollographql/apollo3/ApolloClient$Builder;

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/ApolloClient.kt
@@ -777,6 +777,15 @@ private constructor(
     }
 
     /**
+     * Removes an [ApolloInterceptor] from this [ApolloClient].
+     *
+     * **The order is important**. This method removes the first occurrence of the [ApolloInterceptor] in the list.
+     */
+    fun removeInterceptor(interceptor: ApolloInterceptor) = apply {
+      _interceptors.remove(interceptor)
+    }
+
+    /**
      * Adds several [ApolloInterceptor]s to this [ApolloClient].
      *
      * [ApolloInterceptor]s monitor, rewrite and retry an [ApolloCall]. Internally, [ApolloInterceptor] is used for features


### PR DESCRIPTION
I noticed a bug when using `.newBuilder().store()` on an existing `ApolloClient`. The intention was to set a different `ApolloStore()` using `builder.store(...)` on this client. But after `.build()` on this new client, I noticed that `.watch()` was not working when I wrote some data to the new `store.`

Turns out that we were ending up with 3 duplicated watchers, the ones that are added by `.store()` function. 

![image](https://github.com/apollographql/apollo-kotlin/assets/748533/95700d67-8bb5-4fe6-a438-138b3c33fbcf)

This PR fixes that problem by clearing the 3 store related watchers when using `.store()` on a builder. 

- Introduced a new `internal interface ApolloStoreInterceptor` to indicate these interceptors 
- In `ClientCacheExtensions`, clear them in `ApolloClient.Builder.store()` function
- This required introducing a new `removeInterceptor()` API

I am not sure if making `removeInterceptor()` a part of the builder API is desirable, but I couldn't think of a way to make this work without introducing such an API. Let me know if you have other approaches I can try for this. 