### PR TITLE
Add ApolloCompilerPluginProvider 

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -653,6 +653,9 @@ public final class com/apollographql/apollo3/compiler/codegen/kotlin/helpers/Add
 	public static final fun addInternal (Lcom/squareup/kotlinpoet/FileSpec$Builder;Ljava/util/List;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
 }
 
+public final class com/apollographql/apollo3/compiler/internal/GradleCompilerPluginLogger$Companion {
+}
+
 public final class com/apollographql/apollo3/compiler/ir/IrAccessor$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginEnvironment.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginEnvironment.kt
@@ -1,0 +1,9 @@
+package com.apollographql.apollo3.compiler
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
+@ApolloExperimental
+class ApolloCompilerPluginEnvironment(
+  val arguments: Map<String, Any?>,
+  val logger: ApolloCompilerPluginLogger,
+)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginLogger.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginLogger.kt
@@ -1,0 +1,13 @@
+package com.apollographql.apollo3.compiler
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
+@ApolloExperimental
+interface ApolloCompilerPluginLogger {
+  fun logging(message: String)
+  fun info(message: String)
+  fun warn(message: String)
+  fun error(message: String)
+
+  fun exception(e: Throwable)
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginProvider.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ApolloCompilerPluginProvider.kt
@@ -1,0 +1,17 @@
+package com.apollographql.apollo3.compiler
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
+/**
+ * [ApolloCompilerPluginProvider] is entry point for creating [ApolloCompilerPlugin].
+ *
+ * [ApolloCompilerPluginProvider] is created by [java.util.ServiceLoader], make sure to include a matching `META-INF/services` resource.
+ */
+@ApolloExperimental
+fun interface ApolloCompilerPluginProvider {
+  /**
+   * Called by Kotlin Symbol Processing to create the processor.
+   */
+  fun create(environment: ApolloCompilerPluginEnvironment): ApolloCompilerPlugin
+}
+

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/GradleCompilerPluginLogger.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/internal/GradleCompilerPluginLogger.kt
@@ -1,0 +1,41 @@
+package com.apollographql.apollo3.compiler.internal
+
+import com.apollographql.apollo3.annotations.ApolloInternal
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginLogger
+
+@ApolloInternal
+class GradleCompilerPluginLogger(val loglevel: Int) : ApolloCompilerPluginLogger {
+  private val messager = System.out
+
+  override fun logging(message: String) {
+    if (loglevel <= LOGGING_LEVEL_LOGGING)
+      messager.println("v: [apollo] $message")
+  }
+
+  override fun info(message: String) {
+    if (loglevel <= LOGGING_LEVEL_INFO)
+      messager.println("i: [apollo] $message")
+  }
+
+  override fun warn(message: String) {
+    if (loglevel <= LOGGING_LEVEL_WARN)
+      messager.println("w: [apollo] $message")
+  }
+
+  override fun error(message: String) {
+    if (loglevel <= LOGGING_LEVEL_ERROR)
+      messager.println("e: [apollo] $message")
+  }
+
+  override fun exception(e: Throwable) {
+    if (loglevel <= LOGGING_LEVEL_ERROR)
+      messager.println("e: [apollo] $e")
+  }
+
+  companion object {
+    const val LOGGING_LEVEL_LOGGING = 0
+    const val LOGGING_LEVEL_INFO = 1
+    const val LOGGING_LEVEL_WARN = 3
+    const val LOGGING_LEVEL_ERROR = 5
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/CompilerPlugin.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/CompilerPlugin.kt
@@ -1,0 +1,21 @@
+package com.apollographql.apollo3.gradle.api
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
+
+@ApolloExperimental
+interface CompilerPlugin {
+  /**
+   * Adds the given argument to the [com.apollographql.apollo3.compiler.ApolloCompilerPlugin].
+   * If two arguments are added with the same name, the second one overwrites the first one.
+   *
+   * @param name the name of the argument
+   * @param value the value of the argument. One of:
+   * - [String]
+   * - [Int]
+   * - [Double]
+   * - [Boolean]
+   * - [List]
+   * - [Map]
+   */
+  fun argument(name: String, value: Any)
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/api/Service.kt
@@ -907,4 +907,7 @@ interface Service {
   }
 
   fun plugin(dependencyNotation: Any)
+
+  @ApolloExperimental
+  fun plugin(dependencyNotation: Any, block: Action<CompilerPlugin>)
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesBaseTask.kt
@@ -9,12 +9,8 @@ import com.apollographql.apollo3.compiler.OperationOutputGenerator
 import com.apollographql.apollo3.compiler.PackageNameGenerator
 import com.apollographql.apollo3.compiler.codegen.SchemaAndOperationsLayout
 import com.apollographql.apollo3.compiler.toCodegenOptions
-import org.gradle.api.DefaultTask
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
@@ -26,7 +22,7 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
 
-abstract class ApolloGenerateSourcesBaseTask : DefaultTask() {
+abstract class ApolloGenerateSourcesBaseTask : ApolloTaskWithClasspath() {
   @get:InputFile
   @get:PathSensitive(PathSensitivity.RELATIVE)
   abstract val codegenOptionsFile: RegularFileProperty
@@ -49,12 +45,6 @@ abstract class ApolloGenerateSourcesBaseTask : DefaultTask() {
 
   @get:OutputDirectory
   abstract val outputDir: DirectoryProperty
-
-  @get:Classpath
-  abstract val classpath: ConfigurableFileCollection
-
-  @get:Input
-  abstract val hasPlugin: Property<Boolean>
 
   @Inject
   abstract fun getWorkerExecutor(): WorkerExecutor

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -79,6 +79,8 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
         it.outputDir.set(outputDir)
         it.metadataOutputFile.set(metadataOutputFile)
         it.hasPlugin = hasPlugin.get()
+        it.arguments = arguments.get()
+        it.logLevel = logLevel.get().ordinal
       }
     }
   }
@@ -98,7 +100,11 @@ private abstract class GenerateSourcesFromIr : WorkAction<GenerateSourcesFromIrP
       val codegenSchemaFile = codegenSchemas.findCodegenSchemaFile()
 
       val codegenSchema = codegenSchemaFile.toCodegenSchema()
-      val plugin = apolloCompilerPlugin(hasPlugin)
+      val plugin = apolloCompilerPlugin(
+          arguments,
+          logLevel,
+          hasPlugin
+      )
 
       ApolloCompiler.buildSchemaAndOperationsSourcesFromIr(
           codegenSchema = codegenSchema,
@@ -127,5 +133,7 @@ private interface GenerateSourcesFromIrParameters : WorkParameters {
   val operationManifestFile: RegularFileProperty
   val outputDir: DirectoryProperty
   val metadataOutputFile: RegularFileProperty
+  var arguments: Map<String, Any?>
+  var logLevel: Int
 }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -78,6 +78,8 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
         it.codegenOptions.set(codegenOptionsFile)
         it.operationManifestFile.set(operationManifestFile)
         it.outputDir.set(outputDir)
+        it.arguments = arguments.get()
+        it.logLevel = logLevel.get().ordinal
       }
     }
   }
@@ -88,7 +90,11 @@ private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
     with(parameters) {
       val schemaInputFiles = (schemaFiles.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles).toInputFiles()
       val executableInputFiles = graphqlFiles.toInputFiles()
-      val plugin = apolloCompilerPlugin(hasPlugin)
+      val plugin = apolloCompilerPlugin(
+          arguments,
+          logLevel,
+          hasPlugin
+      )
 
       ApolloCompiler.buildSchemaAndOperationsSources(
           schemaFiles = schemaInputFiles,
@@ -123,4 +129,6 @@ private interface GenerateSourcesParameters : WorkParameters {
   val irOptions: RegularFileProperty
   val operationManifestFile: RegularFileProperty
   val outputDir: DirectoryProperty
+  var arguments: Map<String, Any?>
+  var logLevel: Int
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloTaskWithClasspath.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloTaskWithClasspath.kt
@@ -1,0 +1,31 @@
+package com.apollographql.apollo3.gradle.internal
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+
+abstract class ApolloTaskWithClasspath: DefaultTask() {
+  @get:Classpath
+  abstract val classpath: ConfigurableFileCollection
+
+  @get:Input
+  abstract val hasPlugin: Property<Boolean>
+
+  @get:Input
+  abstract val arguments: MapProperty<String, Any?>
+
+  @get:Input
+  abstract val logLevel: Property<LogLevel>
+
+  class Options(
+      val classpath: FileCollection,
+      val hasPlugin: Boolean,
+      val arguments: Map<String, Any?>,
+      val logLevel: LogLevel
+  )
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultCompilerPlugin.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultCompilerPlugin.kt
@@ -1,0 +1,10 @@
+package com.apollographql.apollo3.gradle.internal
+
+import com.apollographql.apollo3.gradle.api.CompilerPlugin
+
+class DefaultCompilerPlugin: CompilerPlugin {
+  internal val arguments = mutableMapOf<String, Any>()
+  override fun argument(name: String, value: Any) {
+    arguments.put(name, value)
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ModelNames.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ModelNames.kt
@@ -40,5 +40,5 @@ object ModelNames {
   fun codegenSchemaConsumerConfiguration(service: Service) = camelCase("apollo", service.name, "CodegenSchemaConsumer")
   fun otherOptionsProducerConfiguration(service: Service) = camelCase("apollo", service.name, "OtherOptionsProducer")
   fun otherOptionsConsumerConfiguration(service: Service) = camelCase("apollo", service.name, "OtherOptionsConsumer")
-  fun pluginConfiguration(service: DefaultService) = camelCase("apollo", service.name, "PluginConsumer")
+  fun compilerConfiguration(service: DefaultService) = camelCase("apollo", service.name, "Compiler")
  }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/serviceloader.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/serviceloader.kt
@@ -1,17 +1,45 @@
 package com.apollographql.apollo3.gradle.internal
 
 import com.apollographql.apollo3.compiler.ApolloCompilerPlugin
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginEnvironment
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginProvider
+import com.apollographql.apollo3.compiler.internal.GradleCompilerPluginLogger
 import java.util.ServiceLoader
 
-internal fun apolloCompilerPlugin(warnIfNotFound: Boolean = false): ApolloCompilerPlugin? {
+internal fun apolloCompilerPlugin(
+    arguments: Map<String, Any?>,
+    logLevel: Int,
+    warnIfNotFound: Boolean = false,
+): ApolloCompilerPlugin? {
   val plugins = ServiceLoader.load(ApolloCompilerPlugin::class.java).toList()
 
   if (plugins.size > 1) {
     error("Apollo: only a single compiler plugin is allowed")
   }
 
-  if (plugins.isEmpty() && warnIfNotFound) {
-    println("Apollo: a compiler plugin was added with `Service.plugin()` but could not be loaded by the ServiceLoader. Check your META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPlugin file.")
+  val plugin = plugins.singleOrNull()
+  if (plugin != null) {
+    return plugin
+  }
+
+  val pluginProviders = ServiceLoader.load(ApolloCompilerPluginProvider::class.java).toList()
+
+  if (pluginProviders.size > 1) {
+    error("Apollo: only a single compiler plugin provider is allowed")
+  }
+
+  if (pluginProviders.isEmpty() && warnIfNotFound) {
+    println("Apollo: a compiler plugin was added with `Service.plugin()` but could not be loaded by the ServiceLoader. Check your META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPluginProvider file.")
+  }
+
+  val provider = pluginProviders.singleOrNull()
+  if (provider != null) {
+    return provider.create(
+        ApolloCompilerPluginEnvironment(
+            arguments,
+            GradleCompilerPluginLogger(logLevel)
+        )
+    )
   }
 
   return plugins.singleOrNull()

--- a/tests/compiler-plugins/app/build.gradle.kts
+++ b/tests/compiler-plugins/app/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ApolloExperimental::class)
+
+import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.compiler.MODELS_RESPONSE_BASED
 
 plugins {
@@ -24,7 +27,13 @@ apollo {
         val name = dir.name.replace("-", "")
         service(name) {
           packageName.set("hooks.$name")
-          plugin(project(":compiler-plugins-${dir.name}"))
+          plugin(project(":compiler-plugins-${dir.name}")) {
+            when(name) {
+              "prefixnames" -> {
+                argument("prefix", "GQL")
+              }
+            }
+          }
           languageVersion.set("1.5")
 
           when (name) {

--- a/tests/compiler-plugins/prefix-names/src/main/kotlin/hooks/TestPlugin.kt
+++ b/tests/compiler-plugins/prefix-names/src/main/kotlin/hooks/TestPlugin.kt
@@ -1,11 +1,19 @@
 package hooks
 
-import com.apollographql.apollo3.compiler.CodegenSchema
 import com.apollographql.apollo3.compiler.ApolloCompilerPlugin
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginEnvironment
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginLogger
+import com.apollographql.apollo3.compiler.ApolloCompilerPluginProvider
+import com.apollographql.apollo3.compiler.CodegenSchema
 import com.apollographql.apollo3.compiler.codegen.SchemaAndOperationsLayout
 
-class TestPlugin : ApolloCompilerPlugin {
-  private val prefix: String = "GQL"
+class TestPlugin(
+    val prefix: String,
+    logger: ApolloCompilerPluginLogger,
+) : ApolloCompilerPlugin {
+  init {
+    logger.info("TestPlugin.prefix=$prefix")
+  }
 
   override fun layout(codegenSchema: CodegenSchema): SchemaAndOperationsLayout {
     val delegate = SchemaAndOperationsLayout(
@@ -18,7 +26,7 @@ class TestPlugin : ApolloCompilerPlugin {
     )
 
     return object : SchemaAndOperationsLayout by delegate {
-      
+
       override fun schemaTypeName(schemaTypeName: String): String {
         return delegate.schemaTypeName(schemaTypeName).prefixed()
       }
@@ -48,4 +56,11 @@ class TestPlugin : ApolloCompilerPlugin {
       }
     }
   }
+}
+
+class TestPluginProvider : ApolloCompilerPluginProvider {
+  override fun create(environment: ApolloCompilerPluginEnvironment): ApolloCompilerPlugin {
+    return TestPlugin(environment.arguments.get("prefix") as String, environment.logger)
+  }
+
 }

--- a/tests/compiler-plugins/prefix-names/src/main/resources/META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPlugin
+++ b/tests/compiler-plugins/prefix-names/src/main/resources/META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPlugin
@@ -1,1 +1,0 @@
-hooks.TestPlugin

--- a/tests/compiler-plugins/prefix-names/src/main/resources/META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPluginProvider
+++ b/tests/compiler-plugins/prefix-names/src/main/resources/META-INF/services/com.apollographql.apollo3.compiler.ApolloCompilerPluginProvider
@@ -1,0 +1,1 @@
+hooks.TestPluginProvider


### PR DESCRIPTION
This is mostly inspired by [KSP](https://github.com/google/ksp/blob/2f857be33914493fb5ef1236ced6f5f724bc661a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorProvider.kt#L6) and allows passing logger and arguments to `ApolloCompilerPlugin`.

In order for this to work, you'll need to implement `ApolloCompilerPluginProvider` and expose that to `ServiceLoader`.

`ApolloCompilerPlugin` can still be loaded through `ServiceLoader` directly but I'll remove this possibility in a future PR