### PR TITLE
adding checks for json end_document in http batching interceptors

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -13,6 +13,7 @@ import com.apollographql.apollo3.api.http.HttpResponse
 import com.apollographql.apollo3.api.http.valueOf
 import com.apollographql.apollo3.api.json.BufferedSinkJsonWriter
 import com.apollographql.apollo3.api.json.BufferedSourceJsonReader
+import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.buildJsonByteString
 import com.apollographql.apollo3.api.json.writeArray
 import com.apollographql.apollo3.exception.ApolloException
@@ -29,6 +30,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import okio.Buffer
 import okio.BufferedSink
+import okio.use
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
@@ -179,8 +181,14 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
       }
       val responseBody = response.body ?: throw ApolloException("null body when executing batched query")
 
-      // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
-      val list = AnyAdapter.fromJson(BufferedSourceJsonReader(responseBody), CustomScalarAdapters.Empty)
+      val list = BufferedSourceJsonReader(responseBody).use { jsonReader ->
+        // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
+        AnyAdapter.fromJson(jsonReader, CustomScalarAdapters.Empty).also {
+          if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
+            println("Apollo: extra tokens after payload")
+          }
+        }
+      }
       if (list !is List<*>) throw ApolloException("batched query response is not a list when executing batched query")
 
       if (list.size != pending.size) {

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -18,6 +18,7 @@ import com.apollographql.apollo3.api.json.buildJsonByteString
 import com.apollographql.apollo3.api.json.writeArray
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
+import com.apollographql.apollo3.exception.JsonDataException
 import com.apollographql.apollo3.internal.CloseableSingleThreadDispatcher
 import com.apollographql.apollo3.mpp.currentTimeMillis
 import kotlinx.coroutines.CompletableDeferred
@@ -185,7 +186,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
         AnyAdapter.fromJson(jsonReader, CustomScalarAdapters.Empty).also {
           if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
-            println("Apollo: extra tokens after payload")
+            throw JsonDataException("Expected END_DOCUMENT but was ${jsonReader.peek()}")
           }
         }
       }


### PR DESCRIPTION
the issue is discussed in: https://github.com/apollographql/apollo-kotlin/issues/5885

this is the recommended fix for the http batching scenario.