### PR TITLE
adding checks for json end_document in http batching interceptors

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/BatchingHttpInterceptor.kt
@@ -19,6 +19,7 @@ import com.apollographql.apollo3.api.json.writeArray
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.DefaultApolloException
+import com.apollographql.apollo3.exception.JsonDataException
 import com.apollographql.apollo3.internal.CloseableSingleThreadDispatcher
 import com.apollographql.apollo3.mpp.currentTimeMillis
 import kotlinx.coroutines.CompletableDeferred
@@ -186,7 +187,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
         AnyAdapter.fromJson(jsonReader, CustomScalarAdapters.Empty).also {
           if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
-            println("Apollo: extra tokens after payload")
+            throw JsonDataException("Expected END_DOCUMENT but was ${jsonReader.peek()}")
           }
         }
       }


### PR DESCRIPTION
a cherry-pick of https://github.com/apollographql/apollo-kotlin/pull/5892 on the main branch.
