### PR TITLE
adding checks for json end_document in http transport

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -158,7 +158,11 @@ fun <D : Operation.Data> JsonReader.toApolloResponse(
     deferredFragmentIdentifiers: Set<DeferredFragmentIdentifier>? = null,
 ): ApolloResponse<D> {
   return use {
-    operation.parseResponse(it, requestUuid, customScalarAdapters, deferredFragmentIdentifiers)
+    val response = operation.parseResponse(it, requestUuid, customScalarAdapters, deferredFragmentIdentifiers)
+    if (peek() != JsonReader.Token.END_DOCUMENT) {
+      throw JsonDataException("Expected END_DOCUMENT but was ${peek()}")
+    }
+    response
   }
 }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
@@ -45,10 +45,6 @@ internal object ResponseParser {
 
     jsonReader.endObject()
 
-    if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
-      println("Apollo: extra tokens after payload")
-    }
-
     return ApolloResponse.Builder(operation = operation, requestUuid = requestUuid ?: uuid4())
         .errors(errors)
         .data(data)

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
@@ -45,6 +45,10 @@ internal object ResponseParser {
 
     jsonReader.endObject()
 
+    if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
+      println("Apollo: extra tokens after payload")
+    }
+
     return ApolloResponse.Builder(operation = operation, requestUuid = requestUuid ?: uuid4())
         .errors(errors)
         .data(data)


### PR DESCRIPTION
the issue is discussed in: https://github.com/apollographql/apollo-kotlin/issues/5885

this is the recommended fix for the no http batching scenario, for the main branch