### PR TITLE
[IJ Plugin] Add inspection to warn about the presence of a GraphQL config file

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspection.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspection.kt
@@ -1,0 +1,84 @@
+package com.apollographql.ijplugin.inspection
+
+import com.apollographql.ijplugin.ApolloBundle
+import com.apollographql.ijplugin.project.apolloProjectService
+import com.apollographql.ijplugin.settings.projectSettingsState
+import com.apollographql.ijplugin.telemetry.TelemetryEvent
+import com.apollographql.ijplugin.telemetry.telemetryService
+import com.intellij.codeInsight.intention.preview.IntentionPreviewInfo
+import com.intellij.codeInsight.intention.preview.IntentionPreviewUtils
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Condition
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+
+private val graphQLConfigFileNames = setOf(
+    "graphql.config.json",
+    "graphql.config.js",
+    "graphql.config.cjs",
+    "graphql.config.ts",
+    "graphql.config.yaml",
+    "graphql.config.yml",
+    ".graphqlrc",
+    ".graphqlrc.json",
+    ".graphqlrc.yaml",
+    ".graphqlrc.yml",
+    ".graphqlrc.js",
+    ".graphqlrc.ts"
+)
+
+class ApolloGraphQLConfigFilePresentInspection : LocalInspectionTool() {
+  override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+    return object : PsiElementVisitor() {
+      override fun visitElement(element: PsiElement) {
+        if (!element.project.apolloProjectService.apolloVersion.isAtLeastV4 || !element.project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return
+        if (element.containingFile.name in graphQLConfigFileNames && element.containingFile == element) {
+          holder.registerProblem(element, ApolloBundle.message("inspection.graphQLConfigFilePresent.reportText"), ApolloGraphQLConfigFilePresentQuickFix(element.containingFile.name))
+        }
+      }
+    }
+  }
+}
+
+private class ApolloGraphQLConfigFilePresentQuickFix(private val fileName: String) : LocalQuickFix {
+  override fun getName(): String {
+    return ApolloBundle.message("inspection.graphQLConfigFilePresent.quickFix", fileName)
+  }
+
+  override fun getFamilyName() = name
+
+  override fun availableInBatchMode() = false
+
+  override fun generatePreview(project: Project, previewDescriptor: ProblemDescriptor): IntentionPreviewInfo = IntentionPreviewInfo.EMPTY
+
+  override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+    if (!IntentionPreviewUtils.isIntentionPreviewActive()) project.telemetryService.logEvent(TelemetryEvent.ApolloIjGraphQLConfigFilePresentQuickFix())
+    val psiFile = descriptor.psiElement.containingFile
+    psiFile.virtualFile.delete(this)
+  }
+}
+
+class ApolloGraphQLConfigFilePresentAnnotator : Annotator {
+  override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+    if (!element.project.apolloProjectService.apolloVersion.isAtLeastV4 || !element.project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return
+    if (element.containingFile.name in graphQLConfigFileNames && element.containingFile == element) {
+      holder.newAnnotation(HighlightSeverity.ERROR, ApolloBundle.message("inspection.graphQLConfigFilePresent.reportText"))
+          .range(element)
+          .create()
+    }
+  }
+}
+
+class GraphQLConfigFileFilter : Condition<VirtualFile> {
+  override fun value(virtualFile: VirtualFile): Boolean {
+    return virtualFile.name in graphQLConfigFileNames
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspection.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspection.kt
@@ -70,7 +70,7 @@ class ApolloGraphQLConfigFilePresentAnnotator : Annotator {
   override fun annotate(element: PsiElement, holder: AnnotationHolder) {
     if (!element.project.apolloProjectService.apolloVersion.isAtLeastV4 || !element.project.projectSettingsState.contributeConfigurationToGraphqlPlugin) return
     if (element.containingFile.name in graphQLConfigFileNames && element.containingFile == element) {
-      holder.newAnnotation(HighlightSeverity.ERROR, ApolloBundle.message("inspection.graphQLConfigFilePresent.reportText"))
+      holder.newAnnotation(HighlightSeverity.WARNING, ApolloBundle.message("inspection.graphQLConfigFilePresent.reportText"))
           .range(element)
           .create()
     }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/ApolloV3ToV4MigrationProcessor.kt
@@ -16,6 +16,7 @@ import com.apollographql.ijplugin.refactoring.migration.item.UpdateMethodName
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.AddLinkDirective
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.EncloseInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveFieldInService
+import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveGraphqlConfigFiles
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveMethodInService
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.RemoveWatchMethodArguments
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.item.UpdateEnumClassUpperCase
@@ -99,5 +100,8 @@ class ApolloV3ToV4MigrationProcessor(project: Project) : ApolloMigrationRefactor
 
       // Add @link to extra.graphqls
       AddLinkDirective,
+
+      // Graphql Config
+      RemoveGraphqlConfigFiles,
   )
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/RemoveGraphqlConfigFiles.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/migration/v3tov4/item/RemoveGraphqlConfigFiles.kt
@@ -1,0 +1,37 @@
+package com.apollographql.ijplugin.refactoring.migration.v3tov4.item
+
+import com.apollographql.ijplugin.refactoring.migration.item.DeletesElements
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItem
+import com.apollographql.ijplugin.refactoring.migration.item.MigrationItemUsageInfo
+import com.apollographql.ijplugin.refactoring.migration.item.toMigrationItemUsageInfo
+import com.apollographql.ijplugin.util.findPsiFilesByName
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiMigration
+import com.intellij.psi.search.GlobalSearchScope
+
+private val graphQLConfigFileNames = setOf(
+    "graphql.config.json",
+    "graphql.config.js",
+    "graphql.config.cjs",
+    "graphql.config.ts",
+    "graphql.config.yaml",
+    "graphql.config.yml",
+    ".graphqlrc",
+    ".graphqlrc.json",
+    ".graphqlrc.yaml",
+    ".graphqlrc.yml",
+    ".graphqlrc.js",
+    ".graphqlrc.ts"
+)
+
+object RemoveGraphqlConfigFiles : MigrationItem(), DeletesElements {
+  override fun findUsages(project: Project, migration: PsiMigration, searchScope: GlobalSearchScope): List<MigrationItemUsageInfo> {
+    return graphQLConfigFileNames.flatMap {
+      project.findPsiFilesByName(it, searchScope)
+    }.map { it.toMigrationItemUsageInfo() }
+  }
+
+  override fun performRefactoring(project: Project, migration: PsiMigration, usage: MigrationItemUsageInfo) {
+    usage.element.delete()
+  }
+}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetrySession.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/telemetry/TelemetrySession.kt
@@ -340,6 +340,11 @@ sealed class TelemetryEvent(
   class ApolloIjApollo4AvailableQuickFix : TelemetryEvent("akij_apollo4_available_quickfix", null)
 
   /**
+   * User applied the quickfix for the 'GraphQL config file present' inspection of the Apollo Kotlin IntelliJ plugin.
+   */
+  class ApolloIjGraphQLConfigFilePresentQuickFix : TelemetryEvent("akij_graphql_config_file_present_quickfix", null)
+
+  /**
    * User applied the quickfix for the 'Endpoint not configured' inspection of the Apollo Kotlin IntelliJ plugin.
    */
   class ApolloIjEndpointNotConfiguredQuickFix : TelemetryEvent("akij_endpoint_not_configured_quickfix", null)

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -185,7 +185,7 @@
         groupKey="inspection.group.graphql.apolloKotlin"
         key="inspection.graphQLConfigFilePresent.displayName"
         enabledByDefault="true"
-        level="ERROR"
+        level="WARNING"
     />
 
     <annotator

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -177,6 +177,39 @@
         level="WARNING"
     />
 
+    <!-- "GraphQL config file present" inspection -->
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="ERROR"
+    />
+
+    <annotator
+        language="yaml"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator"/>
+
+    <annotator
+        language="JSON"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator"/>
+
+    <annotator
+        language="TEXT"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator"/>
+
+    <annotator
+        language="TypeScript"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator"/>
+
+    <annotator
+        language="ECMAScript 6"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator"/>
+
+    <problemFileHighlightFilter implementation="com.apollographql.ijplugin.inspection.GraphQLConfigFileFilter"/>
+
     <!-- "Change input class constructor to builder" intention -->
     <intentionAction>
       <language>kotlin</language>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
@@ -1,0 +1,12 @@
+<html>
+<body>
+Suggests to delete GraphQL config files on projects using Apollo Kotlin 4.
+<p>
+    It is no longer useful to have a GraphQL config file, as the Apollo Kotlin plugin will automatically provide the location of your
+    project's operations and schema files to the GraphQL plugin.<br>
+</p>
+<p>
+    <a href="https://www.apollographql.com/docs/kotlin/v4/testing/android-studio-plugin#integration-with-the-graphql-intellij-plugin">More information</a>
+</p>
+</body>
+</html>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
@@ -2,7 +2,7 @@
 <body>
 Suggests to delete GraphQL config files on projects using Apollo Kotlin 4.
 <p>
-    It is no longer useful to have a GraphQL config file, as the Apollo plugin will automatically provide the location of your
+    It is no longer useful to have a GraphQL config file, as the Apollo plugin automatically provides the location of your
     project's operations and schema files to the GraphQL plugin, <br>
 </p>
 <p>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresent.html
@@ -2,8 +2,11 @@
 <body>
 Suggests to delete GraphQL config files on projects using Apollo Kotlin 4.
 <p>
-    It is no longer useful to have a GraphQL config file, as the Apollo Kotlin plugin will automatically provide the location of your
-    project's operations and schema files to the GraphQL plugin.<br>
+    It is no longer useful to have a GraphQL config file, as the Apollo plugin will automatically provide the location of your
+    project's operations and schema files to the GraphQL plugin, <br>
+</p>
+<p>
+    Note: the Apollo plugin uses the Gradle tooling API to retrieve the project's GraphQL configuration.
 </p>
 <p>
     <a href="https://www.apollographql.com/docs/kotlin/v4/testing/android-studio-plugin#integration-with-the-graphql-intellij-plugin">More information</a>

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -174,7 +174,7 @@ inspection.missingGraphQLDefinitionImport.reportText.scalar=scalar
 inspection.missingGraphQLDefinitionImport.quickFix=Import {0} {1}
 
 inspection.graphQLConfigFilePresent.displayName=GraphQL config file present
-inspection.graphQLConfigFilePresent.reportText=A GraphQL config file is not needed with Apollo Kotlin 4 projects
+inspection.graphQLConfigFilePresent.reportText=A GraphQL config file is not needed in Apollo Kotlin 4 projects
 inspection.graphQLConfigFilePresent.quickFix=Delete the file {0}
 
 inspection.more=More...

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -173,6 +173,10 @@ inspection.missingGraphQLDefinitionImport.reportText.input=input object
 inspection.missingGraphQLDefinitionImport.reportText.scalar=scalar
 inspection.missingGraphQLDefinitionImport.quickFix=Import {0} {1}
 
+inspection.graphQLConfigFilePresent.displayName=GraphQL config file present
+inspection.graphQLConfigFilePresent.reportText=A GraphQL config file is not needed with Apollo Kotlin 4 projects
+inspection.graphQLConfigFilePresent.quickFix=Delete the file {0}
+
 inspection.more=More...
 
 

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -174,8 +174,8 @@ inspection.missingGraphQLDefinitionImport.reportText.scalar=scalar
 inspection.missingGraphQLDefinitionImport.quickFix=Import {0} {1}
 
 inspection.graphQLConfigFilePresent.displayName=GraphQL config file present
-inspection.graphQLConfigFilePresent.reportText=A GraphQL config file is not needed in Apollo Kotlin 4 projects
-inspection.graphQLConfigFilePresent.quickFix=Delete the file {0}
+inspection.graphQLConfigFilePresent.reportText=The Apollo plugin retrieves the GraphQL configuration from Gradle and doesn't use the GraphQL config file
+inspection.graphQLConfigFilePresent.quickFix=Delete the {0} file
 
 inspection.more=More...
 

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloGraphQLConfigFilePresentInspectionTest.kt
@@ -1,0 +1,26 @@
+package com.apollographql.ijplugin.inspection
+
+import com.apollographql.ijplugin.ApolloTestCase
+import com.intellij.testFramework.TestDataPath
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@TestDataPath("\$CONTENT_ROOT/testData/inspection")
+@RunWith(JUnit4::class)
+class ApolloGraphQLConfigFilePresentInspectionTest : ApolloTestCase() {
+
+  override fun getTestDataPath() = "src/test/testData/inspection"
+
+  @Throws(Exception::class)
+  override fun setUp() {
+    super.setUp()
+    myFixture.enableInspections(ApolloGraphQLConfigFilePresentInspection())
+  }
+
+  @Test
+  fun testGraphqlConfigPresenceError() {
+    myFixture.configureByFile("graphql.config.yml")
+    checkHighlighting()
+  }
+}

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/migration/ApolloV3ToV4MigrationTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/migration/ApolloV3ToV4MigrationTest.kt
@@ -3,6 +3,7 @@ package com.apollographql.ijplugin.migration
 import com.apollographql.ijplugin.ApolloTestCase
 import com.apollographql.ijplugin.refactoring.migration.v3tov4.ApolloV3ToV4MigrationProcessor
 import com.intellij.testFramework.TestDataPath
+import junit.framework.TestCase
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -51,6 +52,13 @@ class ApolloV3ToV4MigrationTest : ApolloTestCase() {
 
   @Test
   fun testAddLinkDirective() = runMigration(extension = "graphqls", fileNameInProject = "extra.graphqls")
+
+  @Test
+  fun testRemoveGraphqlConfigFiles() {
+    myFixture.copyFileToProject("graphql.config.yml")
+    ApolloV3ToV4MigrationProcessor(project).run()
+    TestCase.assertNull(myFixture.tempDirFixture.getFile("graphql.config.yml"))
+  }
 
   private fun runMigration(extension: String = "kt", fileNameInProject: String? = null) {
     val fileBaseName = getTestName(true)

--- a/intellij-plugin/src/test/testData/inspection/graphql.config.yml
+++ b/intellij-plugin/src/test/testData/inspection/graphql.config.yml
@@ -1,4 +1,4 @@
-<error descr="A GraphQL config file is not needed with Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES"><error descr="A GraphQL config file is not needed with Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES">
+<error descr="A GraphQL config file is not needed in Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES"><error descr="A GraphQL config file is not needed in Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES">
 projects:
   main:
     schema: src/main/graphql/schema.graphqls

--- a/intellij-plugin/src/test/testData/inspection/graphql.config.yml
+++ b/intellij-plugin/src/test/testData/inspection/graphql.config.yml
@@ -1,4 +1,4 @@
-<error descr="A GraphQL config file is not needed in Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES"><error descr="A GraphQL config file is not needed in Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES">
+<warning descr="The Apollo plugin retrieves the GraphQL configuration from Gradle and doesn't use the GraphQL config file" textAttributesKey="WARNING_ATTRIBUTES"><warning descr="The Apollo plugin retrieves the GraphQL configuration from Gradle and doesn't use the GraphQL config file" textAttributesKey="WARNING_ATTRIBUTES">
 projects:
   main:
     schema: src/main/graphql/schema.graphqls
@@ -8,4 +8,4 @@ projects:
         main: "https://apollo-fullstack-tutorial.herokuapp.com/graphql"
       apollo-key: ${APOLLO_KEY}
 
-</error></error>
+</warning></warning>

--- a/intellij-plugin/src/test/testData/inspection/graphql.config.yml
+++ b/intellij-plugin/src/test/testData/inspection/graphql.config.yml
@@ -1,0 +1,11 @@
+<error descr="A GraphQL config file is not needed with Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES"><error descr="A GraphQL config file is not needed with Apollo Kotlin 4 projects" textAttributesKey="ERRORS_ATTRIBUTES">
+projects:
+  main:
+    schema: src/main/graphql/schema.graphqls
+    documents: '**/*.graphql'
+    extensions:
+      endpoints:
+        main: "https://apollo-fullstack-tutorial.herokuapp.com/graphql"
+      apollo-key: ${APOLLO_KEY}
+
+</error></error>

--- a/intellij-plugin/src/test/testData/migration/v3-to-v4/graphql.config.yml
+++ b/intellij-plugin/src/test/testData/migration/v3-to-v4/graphql.config.yml
@@ -1,0 +1,8 @@
+projects:
+  main:
+    schema: src/main/graphql/schema.graphqls
+    documents: '**/*.graphql'
+    extensions:
+      endpoints:
+        main: "https://apollo-fullstack-tutorial.herokuapp.com/graphql"
+      apollo-key: ${APOLLO_KEY}


### PR DESCRIPTION
Also remove GraphQL config files when  migrating v3 -> v4.

Fix for #5887 

<img width="194" alt="Screenshot 2024-05-20 at 19 44 13" src="https://github.com/apollographql/apollo-kotlin/assets/372852/0e5e29de-b392-47bd-a78e-a2f12be81612">
<img width="913" alt="Screenshot 2024-05-20 at 19 43 56" src="https://github.com/apollographql/apollo-kotlin/assets/372852/fe9de46e-2cc6-4514-9c8a-26f9a40d4224">
