### PR TITLE
[IJ Plugin] Operation and fragment definition rename

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/GraphQLDefinitionRenameProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/GraphQLDefinitionRenameProcessor.kt
@@ -17,7 +17,11 @@ import com.intellij.refactoring.rename.RenamePsiElementProcessor
 import com.intellij.usageView.UsageInfo
 import com.intellij.util.Processor
 
-class GraphQLOperationRenameProcessor : RenamePsiElementProcessor() {
+/**
+ * Allows to rename the corresponding usage in Kotlin code when renaming a GraphQL operation or fragment definition.
+ * The file name is also renamed if it matches the current operation or fragment name (as is customary).
+ */
+class GraphQLDefinitionRenameProcessor : RenamePsiElementProcessor() {
   private var newName: String = ""
 
   override fun canProcessElement(element: PsiElement): Boolean {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/GraphQLOperationRenameProcessor.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/refactoring/GraphQLOperationRenameProcessor.kt
@@ -1,0 +1,47 @@
+package com.apollographql.ijplugin.refactoring
+
+import com.intellij.lang.jsgraphql.psi.GraphQLIdentifier
+import com.intellij.lang.jsgraphql.psi.GraphQLTypedOperationDefinition
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.refactoring.rename.RenameDialog
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+
+class GraphQLOperationRenameProcessor : RenamePsiElementProcessor() {
+  override fun canProcessElement(element: PsiElement): Boolean {
+    return element is GraphQLIdentifier && element.parent is GraphQLTypedOperationDefinition
+  }
+
+  override fun createRenameDialog(
+      project: Project,
+      element: PsiElement,
+      nameSuggestionContext: PsiElement?,
+      editor: Editor?,
+  ): RenameDialog {
+    return object : RenameDialog(project, element, nameSuggestionContext, editor) {
+      override fun getFullName(): String {
+        val definition = element.parent as GraphQLTypedOperationDefinition
+        val type = definition.operationType.text
+        return "$type '${definition.name}'"
+      }
+    }
+  }
+
+  override fun prepareRenaming(element: PsiElement, newName: String, allRenames: MutableMap<PsiElement, String>) {
+    prepareRenamingFile(element, allRenames, newName)
+  }
+
+  private fun prepareRenamingFile(
+      element: PsiElement,
+      allRenames: MutableMap<PsiElement, String>,
+      newName: String,
+  ) {
+    val file = element.containingFile ?: return
+    val virtualFile = file.virtualFile ?: return
+    val elementCurrentName = (element as GraphQLIdentifier).referenceName
+    if (virtualFile.nameWithoutExtension == elementCurrentName) {
+      allRenames[file] = newName + "." + virtualFile.extension
+    }
+  }
+}

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -238,6 +238,13 @@
         groupKey="advanced.setting.apollo"
         default="false"
     />
+
+    <!-- Rename operation -->
+    <renamePsiElementProcessor
+        id="apollo.GraphQLOperationRenameProcessor"
+        implementation="com.apollographql.ijplugin.refactoring.GraphQLOperationRenameProcessor"
+        order="first"
+    />
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -239,10 +239,10 @@
         default="false"
     />
 
-    <!-- Rename operation -->
+    <!-- Rename GraphQL operation or fragment definition -->
     <renamePsiElementProcessor
-        id="apollo.GraphQLOperationRenameProcessor"
-        implementation="com.apollographql.ijplugin.refactoring.GraphQLOperationRenameProcessor"
+        id="apollo.GraphQLDefinitionRenameProcessor"
+        implementation="com.apollographql.ijplugin.refactoring.GraphQLDefinitionRenameProcessor"
         order="first"
     />
   </extensions>


### PR DESCRIPTION
When renaming an operation or fragment, also rename its containing file (if it already had the same name). Also rename corresponding usage in Kotlin code. 

Note: renaming a fragment also impacts the generated synthetic field name - for now this isn't handled. Not sure if it's doable - will track in dedicated ticket.


https://github.com/apollographql/apollo-kotlin/assets/372852/dd5a07ef-3426-4aff-a552-ddf71c717b41



Resolves #5040

