### PR TITLE
Mark `ApolloGenerateIrOperationsTask` as Cacheable and sort `ir.json` entries

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/CodegenMetadata.kt
@@ -28,7 +28,7 @@ class CodegenMetadata(
     }
     return CodegenMetadata(
         targetLanguage = targetLanguage,
-        entries = entries + other.entries
+        entries = (entries + other.entries).sortedBy { it.key.id }
     )
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/JavaCodegen.kt
@@ -106,7 +106,7 @@ private fun buildOutput(
       javaFiles,
       CodegenMetadata(
           targetLanguage = TargetLanguage.JAVA,
-          entries = resolver.entries()
+          entries = resolver.entries().sortedBy { it.key.id }
       )
   ).maybeTransform(javaOutputTransform)
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/KotlinCodegen.kt
@@ -132,7 +132,7 @@ private fun buildOutput(
       }
   return KotlinOutput(
       fileSpecs = fileSpecs,
-      codegenMetadata = CodegenMetadata(targetLanguage = targetLanguage, entries = resolver.entries())
+      codegenMetadata = CodegenMetadata(targetLanguage = targetLanguage, entries = resolver.entries().sortedBy { it.key.id })
   ).maybeTransform(kotlinOutputTransform)
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/ir/IrOperationsBuilder.kt
@@ -245,12 +245,12 @@ internal class IrOperationsBuilder(
     }
 
     return IrOperations(
-        operations = operations,
-        fragments = fragments,
+        operations = operations.sortedBy { it.name },
+        fragments = fragments.sortedBy { it.name },
         usedCoordinates = usedCoordinates,
         flattenModels = flattenModels,
         decapitalizeFields = decapitalizeFields,
-        fragmentDefinitions = fragmentDefinitions,
+        fragmentDefinitions = fragmentDefinitions.sortedBy { it.name },
         codegenModels = codegenModels
     )
   }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -110,7 +110,7 @@ private abstract class GenerateSourcesFromIr : WorkAction<GenerateSourcesFromIrP
           codegenSchema = codegenSchema,
           irOperations = irOperations.get().asFile.toIrOperations(),
           downstreamUsedCoordinates = downstreamUsedCoordinates.get().toUsedCoordinates(),
-          upstreamCodegenMetadata = upstreamMetadata.files.map { it.toCodegenMetadata() },
+          upstreamCodegenMetadata = upstreamMetadata.files.sortedBy { it.name }.map { it.toCodegenMetadata() },
           codegenOptions = codegenOptions.get().asFile.toCodegenOptions(),
           layout = plugin?.layout(codegenSchema),
           irOperationsTransform = plugin?.irOperationsTransform(),


### PR DESCRIPTION
After enabling `generateApolloMetadata`, we started seeing gradle build cache misses. Non-stable output in `ir.json` and `metadata.json` was invalidating build cache for us. 

While it might be a good idea to find a way to make those deterministic, for now it seems like marking the `ApolloGenerateIrOperationsTask` as a `@CacheableTask` seems enough. I also tried doing the same for `ApolloGenerateOptionsTask`, but it was not quite as straightforward. 

For the future, it seems like there's [no native support](https://github.com/Kotlin/kotlinx.serialization/issues/121#issuecomment-1019916245) in kotlinx-serialization to generate deterministic output by, for example, sorting the json keys / lists before writing them to a file, but we could look into using a `JsonTransofrmingSerializer` to do something like that. 

(EDIT: I added back sorting of the keys in `ir.json`. It's not complete, though. Without the sorting, the cache key for `ApolloGenerateIrOperationsTask` can still be invalidated.)

Relates to #5917.