### PR TITLE
Make enums as sealed classes generate sealed interfaces

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/EnumAsSealedBuilder.kt
@@ -50,16 +50,15 @@ internal class EnumAsSealedBuilder(
     return CgFile(
         packageName = packageName,
         fileName = simpleName,
-        typeSpecs = listOf(enum.toSealedClassTypeSpec())
+        typeSpecs = listOf(enum.toSealedClassTypeSpec(), enum.unknownClassTypeSpec())
     )
   }
 
   private fun IrEnum.toSealedClassTypeSpec(): TypeSpec {
-    return TypeSpec.classBuilder(simpleName)
+    return TypeSpec.interfaceBuilder(simpleName)
         .maybeAddDescription(description)
         // XXX: can an enum be made deprecated (and not only its values) ?
         .addModifiers(KModifier.SEALED)
-        .primaryConstructor(primaryConstructorWithOverriddenParamSpec)
         .addProperty(rawValuePropertySpec)
         .addType(companionTypeSpec())
         .addTypes(values.map { value ->
@@ -82,19 +81,30 @@ internal class EnumAsSealedBuilder(
         .maybeAddDeprecation(deprecationReason)
         .maybeAddDescription(description)
         .maybeAddRequiresOptIn(context.resolver, optInFeature)
-        .superclass(superClass)
-        .addSuperclassConstructorParameter("rawValue·=·%S", name)
+        .addSuperinterface(superClass)
+        .addProperty(
+            PropertySpec.builder("rawValue", KotlinSymbols.String)
+                .addModifiers(KModifier.OVERRIDE)
+                .initializer("%S", name)
+                .build()
+        )
         .build()
   }
 
   private fun IrEnum.unknownValueTypeSpec(): TypeSpec {
-    return TypeSpec.classBuilder("UNKNOWN__")
-        .addKdoc("An enum value that wasn't known at compile time.\n" +
-            "Note: the `UNKNOWN__` class represents GraphQL enums that are not present in the schema and whose `rawValue` cannot be checked at build time. You may want to update your schema instead of instantiating it directly."
-        )
+    return TypeSpec.interfaceBuilder("UNKNOWN__")
+        .addKdoc("An enum value that wasn't known at compile time.")
+        .addSuperinterface(selfClassName)
+        .addProperty(unknownValueRawValuePropertySpec)
+        .build()
+  }
+
+  private fun IrEnum.unknownClassTypeSpec(): TypeSpec {
+    return TypeSpec.classBuilder("UNKNOWN__${simpleName}")
+        .addSuperinterface(unknownValueInterfaceName())
         .primaryConstructor(unknownValuePrimaryConstructorSpec)
-        .superclass(selfClassName)
-        .addSuperclassConstructorParameter("rawValue·=·rawValue")
+        .addProperty(unknownValueRawValuePropertySpecWithInitializer)
+        .addModifiers(KModifier.PRIVATE)
         .addFunction(
             FunSpec.builder("equals")
                 .addModifiers(KModifier.OVERRIDE)
@@ -139,7 +149,7 @@ internal class EnumAsSealedBuilder(
                 .map { CodeBlock.of("%S·->·%T", it.name, it.valueClassName()) }
                 .joinToCode(separator = "\n", suffix = "\n")
         )
-        .addCode("else -> @OptIn(%T::class) %T(rawValue)\n", KotlinSymbols.ApolloUnknownEnum, unknownValueClassName())
+        .addCode("else -> %T(rawValue)\n", unknownValueClassName())
         .endControlFlow()
         .build()
   }
@@ -170,24 +180,31 @@ internal class EnumAsSealedBuilder(
     return ClassName(selfClassName.packageName, selfClassName.simpleName, targetName.escapeKotlinReservedWordInSealedClass())
   }
 
-  private fun unknownValueClassName(): ClassName {
+  private fun unknownValueInterfaceName(): ClassName {
     return ClassName(selfClassName.packageName, selfClassName.simpleName, "UNKNOWN__")
+  }
+
+  private fun unknownValueClassName(): ClassName {
+    return ClassName(selfClassName.packageName, "UNKNOWN__${selfClassName.simpleName}")
   }
 
   private val unknownValuePrimaryConstructorSpec =
     FunSpec.constructorBuilder()
-        .addAnnotation(KotlinSymbols.ApolloUnknownEnum)
         .addParameter("rawValue", KotlinSymbols.String)
         .build()
 
-  private val primaryConstructorWithOverriddenParamSpec =
-    FunSpec.constructorBuilder()
-        .addParameter("rawValue", KotlinSymbols.String)
+  private val unknownValueRawValuePropertySpec =
+    PropertySpec.builder("rawValue", KotlinSymbols.String)
+        .addModifiers(KModifier.OVERRIDE)
+        .build()
+
+  private val unknownValueRawValuePropertySpecWithInitializer =
+    PropertySpec.builder("rawValue", KotlinSymbols.String)
+        .addModifiers(KModifier.OVERRIDE)
+        .initializer("rawValue")
         .build()
 
   private val rawValuePropertySpec =
     PropertySpec.builder("rawValue", KotlinSymbols.String)
-        .initializer("rawValue")
         .build()
-
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/Enum.kt.expected
@@ -15,9 +15,9 @@ import kotlin.Int
 import kotlin.String
 import kotlin.Suppress
 
-public sealed class Enum(
-  public val rawValue: String,
-) {
+public sealed interface Enum {
+  public val rawValue: String
+
   public companion object {
     public val type: EnumType = EnumType("Enum", listOf("north", "North", "NORTH", "SOUTH", "type"))
 
@@ -34,7 +34,7 @@ public sealed class Enum(
       "NORTH" -> NORTH
       "SOUTH" -> SOUTH
       "type" -> type_
-      else -> @OptIn(ApolloUnknownEnum::class) UNKNOWN__(rawValue)
+      else -> UNKNOWN__Enum(rawValue)
     }
 
     /**
@@ -50,33 +50,44 @@ public sealed class Enum(
   }
 
   @Deprecated(message = "No longer supported")
-  public object north : Enum(rawValue = "north")
+  public object north : Enum {
+    override val rawValue: String = "north"
+  }
 
   @Deprecated(message = "No longer supported")
-  public object North : Enum(rawValue = "North")
+  public object North : Enum {
+    override val rawValue: String = "North"
+  }
 
-  public object NORTH : Enum(rawValue = "NORTH")
+  public object NORTH : Enum {
+    override val rawValue: String = "NORTH"
+  }
 
-  public object SOUTH : Enum(rawValue = "SOUTH")
+  public object SOUTH : Enum {
+    override val rawValue: String = "SOUTH"
+  }
 
-  public object type_ : Enum(rawValue = "type")
+  public object type_ : Enum {
+    override val rawValue: String = "type"
+  }
 
   /**
    * An enum value that wasn't known at compile time.
-   * Note: the `UNKNOWN__` class represents GraphQL enums that are not present in the schema and
-   * whose `rawValue` cannot be checked at build time. You may want to update your schema instead of
-   * instantiating it directly.
    */
-  public class UNKNOWN__ @ApolloUnknownEnum constructor(
-    rawValue: String,
-  ) : Enum(rawValue = rawValue) {
-    override fun equals(other: Any?): Boolean {
-      if (other !is UNKNOWN__) return false
-      return this.rawValue == other.rawValue
-    }
-
-    override fun hashCode(): Int = this.rawValue.hashCode()
-
-    override fun toString(): String = "UNKNOWN__($rawValue)"
+  public interface UNKNOWN__ : Enum {
+    override val rawValue: String
   }
+}
+
+private class UNKNOWN__Enum(
+  override val rawValue: String,
+) : Enum.UNKNOWN__ {
+  override fun equals(other: Any?): Boolean {
+    if (other !is UNKNOWN__Enum) return false
+    return this.rawValue == other.rawValue
+  }
+
+  override fun hashCode(): Int = this.rawValue.hashCode()
+
+  override fun toString(): String = "UNKNOWN__($rawValue)"
 }

--- a/tests/enums/src/test/kotlin/test/EnumsTest.kt
+++ b/tests/enums/src/test/kotlin/test/EnumsTest.kt
@@ -38,7 +38,7 @@ class EnumsTest {
     assertEquals(Gravity.TOP, Gravity.safeValueOf("TOP"))
     @Suppress("DEPRECATION")
     assertEquals(Gravity.top2, Gravity.safeValueOf("top2"))
-    assertEquals(Gravity.UNKNOWN__("newGravity"), Gravity.safeValueOf("newGravity"))
+    assertIs<Gravity.UNKNOWN__>(Gravity.safeValueOf("newGravity"))
     assertEquals(Gravity.name, Gravity.safeValueOf("name"))
     assertEquals(Gravity.ordinal, Gravity.safeValueOf("ordinal"))
     assertEquals(Gravity.type__, Gravity.safeValueOf("type"))

--- a/tests/integration-tests/src/commonTest/kotlin/test/EnumTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/EnumTest.kt
@@ -1,13 +1,16 @@
 package test
 
+import com.apollographql.apollo3.annotations.ApolloUnknownEnum
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
 
 class EnumTest {
+  @OptIn(ApolloUnknownEnum::class)
   @Test
   fun safeValueOf() {
     assertEquals(Episode.EMPIRE, Episode.safeValueOf("EMPIRE"))
-    assertEquals(Episode.UNKNOWN__::class, Episode.safeValueOf("NEW_EPISODE")::class)
+    assertIs<Episode.UNKNOWN__>(Episode.safeValueOf("NEW_EPISODE"))
   }
 }


### PR DESCRIPTION
A follow-up to #5904, this makes the Kotlin version closer to the Java one: unknown enums can only be created through `safeValueOf`.