### PR TITLE
[gradle-plugin] Use lazy APIs

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloPlugin.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/ApolloPlugin.kt
@@ -16,6 +16,7 @@ constructor(private val toolingModelRegistry: ToolingModelBuilderRegistry) : Plu
   override fun apply(project: Project) {
     val defaultService = project.objects.newInstance(DefaultService::class.java, project, "service")
     val apolloExtension: DefaultApolloExtension = project.extensions.create(ApolloExtension::class.java, "apollo", DefaultApolloExtension::class.java, project, defaultService) as DefaultApolloExtension
+
     project.configureDefaultVersionsResolutionStrategy()
     toolingModelRegistry.register(
         object : ToolingModelBuilder {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -265,23 +265,24 @@ abstract class DefaultApolloExtension(
   }
 
   private fun maybeLinkSqlite() {
-    val doLink = when (linkSqlite.orNull) {
+    when (linkSqlite.orNull) {
       false -> return // explicit opt-out
-      true -> true // explicit opt-in
+      true -> {
+        // explicit opt-in
+        linkSqlite(project)
+      }
       null -> { // default: automatic detection
-        project.configurations.any {
-          it.dependencies.any {
+        project.configurations.configureEach {
+          it.dependencies.configureEach {
             // Try to detect if a native version of apollo-normalized-cache-sqlite is in the classpath
-            it.name.contains("apollo-normalized-cache-sqlite")
+            if (it.name.contains("apollo-normalized-cache-sqlite")
                 && !it.name.contains("jvm")
-                && !it.name.contains("android")
+                && !it.name.contains("android")) {
+              linkSqlite(project)
+            }
           }
         }
       }
-    }
-
-    if (doLink) {
-      linkSqlite(project)
     }
   }
 
@@ -600,7 +601,7 @@ abstract class DefaultApolloExtension(
         codegenMetadataConsumerConfiguration.dependencies.add(it)
       }
 
-      val pending = pendingDownstreamDependencies.get(name)
+      val pending = pendingDownstreamDependencies.get(service.name)
       if (pending != null) {
         pending.forEach {
           service.isADependencyOf(project.project(it))


### PR DESCRIPTION
Using `.any {}` was somewhat eagerly configuring things and that messed up KGP.

Fixes #5922