### PR TITLE
Fix mapping of the builtin `Float` scalar type

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/TypesBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/java/schema/TypesBuilder.kt
@@ -35,7 +35,7 @@ internal fun IrScalar.typeFieldSpec(targetTypeName: String?): FieldSpec {
 
 private fun builtinScalarJavaName(name: String): String? = when (name) {
   "Int" -> "java.lang.Integer"
-  "Float" -> "java.lang.Float"
+  "Float" -> "java.lang.Double"
   "String" -> "java.lang.String"
   "Boolean" -> "java.lang.Boolean"
   "ID" -> "java.lang.String"

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/util/TypesBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/schema/util/TypesBuilder.kt
@@ -37,7 +37,7 @@ internal fun IrScalar.typePropertySpec(targetTypeName: String?): PropertySpec {
 
 private fun builtinScalarKotlinName(name: String): String? = when (name) {
   "Int" -> "kotlin.Int"
-  "Float" -> "kotlin.Float"
+  "Float" -> "kotlin.Double"
   "String" -> "kotlin.String"
   "Boolean" -> "kotlin.Boolean"
   "ID" -> "kotlin.String"

--- a/libraries/apollo-compiler/src/test/graphql/com/example/__schema/java/operationBased/__schema/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/__schema/java/operationBased/__schema/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/__schema/kotlin/responseBased/__schema/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/__schema/kotlin/responseBased/__schema/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/antlr_tokens/java/operationBased/antlr_tokens/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/antlr_tokens/java/operationBased/antlr_tokens/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/antlr_tokens/kotlin/responseBased/antlr_tokens/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/antlr_tokens/kotlin/responseBased/antlr_tokens/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/java/operationBased/arguments_hardcoded/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/java/operationBased/arguments_hardcoded/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/kotlin/responseBased/arguments_hardcoded/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/arguments_hardcoded/kotlin/responseBased/arguments_hardcoded/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/big_query/kotlin/responseBased/big_query/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/big_query/kotlin/responseBased/big_query/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/java/operationBased/capitalized_fields/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/java/operationBased/capitalized_fields/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/operationBased/capitalized_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/operationBased/capitalized_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/responseBased/capitalized_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/responseBased/capitalized_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/java/operationBased/case_sensitive_enum/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/java/operationBased/case_sensitive_enum/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/kotlin/responseBased/case_sensitive_enum/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/kotlin/responseBased/case_sensitive_enum/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/companion/java/operationBased/companion/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/companion/java/operationBased/companion/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/companion/kotlin/operationBased/companion/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/companion/kotlin/operationBased/companion/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/java/operationBased/custom_scalar_type/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/java/operationBased/custom_scalar_type/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/custom_scalar_type/kotlin/responseBased/custom_scalar_type/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/java/operationBased/data_builders/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/java/operationBased/data_builders/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/java/operationBased/decapitalized_fields/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/java/operationBased/decapitalized_fields/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/operationBased/decapitalized_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/operationBased/decapitalized_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/responseBased/decapitalized_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/responseBased/decapitalized_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/java/operationBased/deprecated_merged_field/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/java/operationBased/deprecated_merged_field/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/java/operationBased/deprecation/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/java/operationBased/deprecation/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/kotlin/responseBased/deprecation/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/kotlin/responseBased/deprecation/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/empty/java/operationBased/empty/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/empty/java/operationBased/empty/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/empty/kotlin/responseBased/empty/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/empty/kotlin/responseBased/empty/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/java/operationBased/enums_as_sealed/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/java/operationBased/enums_as_sealed/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enums_as_sealed/kotlin/responseBased/enums_as_sealed/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/field_with_include_directive/java/operationBased/field_with_include_directive/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/field_with_include_directive/java/operationBased/field_with_include_directive/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/field_with_include_directive/kotlin/responseBased/field_with_include_directive/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/field_with_include_directive/kotlin/responseBased/field_with_include_directive/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/java/operationBased/fieldset_with_multiple_super/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/java/operationBased/fieldset_with_multiple_super/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/operationBased/fieldset_with_multiple_super/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/operationBased/fieldset_with_multiple_super/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/responseBased/fieldset_with_multiple_super/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/responseBased/fieldset_with_multiple_super/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/java/operationBased/fragment_spread_with_include_directive/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/java/operationBased/fragment_spread_with_include_directive/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/java/operationBased/fragment_spread_with_nested_fields/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/java/operationBased/fragment_spread_with_nested_fields/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/operationBased/fragment_spread_with_nested_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/operationBased/fragment_spread_with_nested_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/responseBased/fragment_spread_with_nested_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/responseBased/fragment_spread_with_nested_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/java/operationBased/fragment_used_twice/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/java/operationBased/fragment_used_twice/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/java/operationBased/fragment_with_inline_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/java/operationBased/fragment_with_inline_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/java/operationBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/java/operationBased/fragments_same_type_condition/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/java/operationBased/fragments_same_type_condition/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/operationBased/fragments_same_type_condition/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/operationBased/fragments_same_type_condition/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/responseBased/fragments_same_type_condition/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/responseBased/fragments_same_type_condition/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/java/operationBased/fragments_with_defer_and_include_directives/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/java/operationBased/fragments_with_type_condition/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/java/operationBased/fragments_with_type_condition/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/operationBased/fragments_with_type_condition/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/operationBased/fragments_with_type_condition/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/responseBased/fragments_with_type_condition/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/responseBased/fragments_with_type_condition/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/java/operationBased/hero_details/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/java/operationBased/hero_details/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/kotlin/responseBased/hero_details/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/kotlin/responseBased/hero_details/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/java/operationBased/hero_details_semantic_naming/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/java/operationBased/hero_details_semantic_naming/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/kotlin/responseBased/hero_details_semantic_naming/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_details_semantic_naming/kotlin/responseBased/hero_details_semantic_naming/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/java/operationBased/hero_name/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/java/operationBased/hero_name/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/operationBased/hero_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/operationBased/hero_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/responseBased/hero_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/responseBased/hero_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/java/operationBased/hero_name_query_long_name/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/java/operationBased/hero_name_query_long_name/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/kotlin/responseBased/hero_name_query_long_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/kotlin/responseBased/hero_name_query_long_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/java/operationBased/hero_with_review/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/java/operationBased/hero_with_review/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/kotlin/responseBased/hero_with_review/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/kotlin/responseBased/hero_with_review/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/java/operationBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/java/operationBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/operationBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/operationBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/responseBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/responseBased/inline_fragment_for_non_optional_field/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/java/operationBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/java/operationBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/operationBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/operationBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/responseBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/responseBased/inline_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/java/operationBased/inline_fragment_intersection/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/java/operationBased/inline_fragment_intersection/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/java/operationBased/inline_fragment_merge_fields/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/java/operationBased/inline_fragment_merge_fields/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/operationBased/inline_fragment_merge_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/operationBased/inline_fragment_merge_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/responseBased/inline_fragment_merge_fields/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/responseBased/inline_fragment_merge_fields/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/java/operationBased/inline_fragment_simple/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/java/operationBased/inline_fragment_simple/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/operationBased/inline_fragment_simple/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/operationBased/inline_fragment_simple/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/responseBased/inline_fragment_simple/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/responseBased/inline_fragment_simple/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/java/operationBased/inline_fragment_type_coercion/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/java/operationBased/inline_fragment_type_coercion/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/operationBased/inline_fragment_type_coercion/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/operationBased/inline_fragment_type_coercion/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/responseBased/inline_fragment_type_coercion/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/responseBased/inline_fragment_type_coercion/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/java/operationBased/inline_fragment_with_include_directive/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/java/operationBased/inline_fragment_with_include_directive/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/kotlin/operationBased/inline_fragment_with_include_directive/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/kotlin/operationBased/inline_fragment_with_include_directive/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/java/operationBased/inline_fragments_with_friends/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/java/operationBased/inline_fragments_with_friends/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_oneof/java/operationBased/input_object_oneof/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_oneof/java/operationBased/input_object_oneof/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_oneof/kotlin/responseBased/input_object_oneof/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_oneof/kotlin/responseBased/input_object_oneof/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/java/operationBased/input_object_type/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/java/operationBased/input_object_type/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/java/operationBased/input_object_variable_and_argument/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/java/operationBased/input_object_variable_and_argument/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/kotlin/responseBased/input_object_variable_and_argument/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/kotlin/responseBased/input_object_variable_and_argument/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/java/operationBased/input_object_variable_and_argument_with_generated_methods/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/java/operationBased/input_object_variable_and_argument_with_generated_methods/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/kotlin/responseBased/input_object_variable_and_argument_with_generated_methods/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/kotlin/responseBased/input_object_variable_and_argument_with_generated_methods/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/java/operationBased/interface_always_nested/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/java/operationBased/interface_always_nested/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/operationBased/interface_always_nested/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/operationBased/interface_always_nested/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/responseBased/interface_always_nested/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/responseBased/interface_always_nested/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/java/operationBased/interface_on_interface/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/java/operationBased/interface_on_interface/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/operationBased/interface_on_interface/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/operationBased/interface_on_interface/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/responseBased/interface_on_interface/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/responseBased/interface_on_interface/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/java/operationBased/introspection_query/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/java/operationBased/introspection_query/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/kotlin/responseBased/introspection_query/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/kotlin/responseBased/introspection_query/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java8annotation/java/operationBased/java8annotation/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java8annotation/java/operationBased/java8annotation/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java8annotation/kotlin/responseBased/java8annotation/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java8annotation/kotlin/responseBased/java8annotation/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_android_annotations/java/operationBased/java_android_annotations/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_android_annotations/java/operationBased/java_android_annotations/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_android_annotations/kotlin/responseBased/java_android_annotations/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_android_annotations/kotlin/responseBased/java_android_annotations/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_apollo_optionals/java/operationBased/java_apollo_optionals/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_apollo_optionals/java/operationBased/java_apollo_optionals/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_apollo_optionals/kotlin/responseBased/java_apollo_optionals/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_apollo_optionals/kotlin/responseBased/java_apollo_optionals/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_guava_optionals/java/operationBased/java_guava_optionals/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_guava_optionals/java/operationBased/java_guava_optionals/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_guava_optionals/kotlin/responseBased/java_guava_optionals/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_guava_optionals/kotlin/responseBased/java_guava_optionals/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_hashcode/java/operationBased/java_hashcode/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_hashcode/java/operationBased/java_hashcode/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_hashcode/kotlin/responseBased/java_hashcode/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_hashcode/kotlin/responseBased/java_hashcode/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_java_optionals/java/operationBased/java_java_optionals/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_java_optionals/java/operationBased/java_java_optionals/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_java_optionals/kotlin/responseBased/java_java_optionals/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_java_optionals/kotlin/responseBased/java_java_optionals/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_jetbrains_annotations/java/operationBased/java_jetbrains_annotations/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_jetbrains_annotations/java/operationBased/java_jetbrains_annotations/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_jetbrains_annotations/kotlin/responseBased/java_jetbrains_annotations/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_jetbrains_annotations/kotlin/responseBased/java_jetbrains_annotations/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_jsr305_annotations/java/operationBased/java_jsr305_annotations/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_jsr305_annotations/java/operationBased/java_jsr305_annotations/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_jsr305_annotations/kotlin/responseBased/java_jsr305_annotations/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_jsr305_annotations/kotlin/responseBased/java_jsr305_annotations/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_primitive_types/java/operationBased/java_primitive_types/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_primitive_types/java/operationBased/java_primitive_types/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/java_primitive_types/kotlin/responseBased/java_primitive_types/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/java_primitive_types/kotlin/responseBased/java_primitive_types/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/java/operationBased/list_field_clash/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/java/operationBased/list_field_clash/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/kotlin/responseBased/list_field_clash/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/kotlin/responseBased/list_field_clash/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/merged_include/java/operationBased/merged_include/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/merged_include/java/operationBased/merged_include/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/merged_include/kotlin/responseBased/merged_include/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/merged_include/kotlin/responseBased/merged_include/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/java/operationBased/monomorphic/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/java/operationBased/monomorphic/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/operationBased/monomorphic/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/operationBased/monomorphic/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/responseBased/monomorphic/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/responseBased/monomorphic/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/java/operationBased/multiple_fragments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/java/operationBased/mutation_create_review/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/java/operationBased/mutation_create_review/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/java/operationBased/mutation_create_review_semantic_naming/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/java/operationBased/mutation_create_review_semantic_naming/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/kotlin/responseBased/mutation_create_review_semantic_naming/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/kotlin/responseBased/mutation_create_review_semantic_naming/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/java/operationBased/named_fragment_delegate/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/java/operationBased/named_fragment_delegate/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/operationBased/named_fragment_delegate/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/operationBased/named_fragment_delegate/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/responseBased/named_fragment_delegate/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/responseBased/named_fragment_delegate/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/java/operationBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/java/operationBased/named_fragment_with_variables/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/java/operationBased/named_fragment_with_variables/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/java/operationBased/named_fragment_without_implementation/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/java/operationBased/named_fragment_without_implementation/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/operationBased/named_fragment_without_implementation/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/operationBased/named_fragment_without_implementation/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/responseBased/named_fragment_without_implementation/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/responseBased/named_fragment_without_implementation/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/java/operationBased/nested_conditional_inline/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/java/operationBased/nested_conditional_inline/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/java/operationBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/java/operationBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/operationBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/operationBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/responseBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/responseBased/nested_field_with_multiple_fieldsets/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/java/operationBased/nested_named_fragments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nonnull/java/operationBased/nonnull/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nonnull/java/operationBased/nonnull/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nonnull/kotlin/responseBased/nonnull/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nonnull/kotlin/responseBased/nonnull/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/java/operationBased/not_all_combinations_are_needed/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/object/java/operationBased/object/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/object/java/operationBased/object/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/object/kotlin/responseBased/object/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/object/kotlin/responseBased/object/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operation_id_generator/java/operationBased/operation_id_generator/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operation_id_generator/java/operationBased/operation_id_generator/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operation_id_generator/kotlin/responseBased/operation_id_generator/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operation_id_generator/kotlin/responseBased/operation_id_generator/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/java/operationBased/operationbased2_ex7/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/java/operationBased/operationbased2_ex7/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/operationBased/operationbased2_ex7/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/operationBased/operationbased2_ex7/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/responseBased/operationbased2_ex7/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/responseBased/operationbased2_ex7/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/java/operationBased/operationbased2_ex8/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/java/operationBased/operationbased2_ex8/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/optional/java/operationBased/optional/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/optional/java/operationBased/optional/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/optional/kotlin/responseBased/optional/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/optional/kotlin/responseBased/optional/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/java/operationBased/path_vs_flat_accessors/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/java/operationBased/path_vs_flat_accessors/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/operationBased/path_vs_flat_accessors/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/operationBased/path_vs_flat_accessors/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/responseBased/path_vs_flat_accessors/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/responseBased/path_vs_flat_accessors/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/recursive_selection/java/operationBased/recursive_selection/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/recursive_selection/java/operationBased/recursive_selection/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/recursive_selection/kotlin/responseBased/recursive_selection/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/recursive_selection/kotlin/responseBased/recursive_selection/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/java/operationBased/reserved_keywords/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/java/operationBased/reserved_keywords/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/operationBased/reserved_keywords/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/operationBased/reserved_keywords/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/responseBased/reserved_keywords/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/responseBased/reserved_keywords/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/java/operationBased/root_query_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/java/operationBased/root_query_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/operationBased/root_query_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/operationBased/root_query_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/responseBased/root_query_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/responseBased/root_query_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/java/operationBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/java/operationBased/root_query_inline_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/java/operationBased/root_query_inline_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/java/operationBased/simple_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/java/operationBased/simple_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 internal class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/java/operationBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/java/operationBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/java/operationBased/simple_inline_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/java/operationBased/simple_inline_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/operationBased/simple_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/operationBased/simple_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/responseBased/simple_inline_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/responseBased/simple_inline_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/java/operationBased/simple_union/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/java/operationBased/simple_union/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/operationBased/simple_union/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/operationBased/simple_union/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/responseBased/simple_union/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/responseBased/simple_union/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/starships/java/operationBased/starships/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/starships/java/operationBased/starships/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/starships/kotlin/responseBased/starships/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/starships/kotlin/responseBased/starships/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/subscriptions/java/operationBased/subscriptions/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/subscriptions/java/operationBased/subscriptions/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/subscriptions/kotlin/responseBased/subscriptions/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/subscriptions/kotlin/responseBased/subscriptions/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/java/operationBased/suppressed_warnings/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/java/operationBased/suppressed_warnings/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/kotlin/responseBased/suppressed_warnings/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/kotlin/responseBased/suppressed_warnings/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/java/operationBased/target_name/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/java/operationBased/test_inline/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/java/operationBased/test_inline/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/operationBased/test_inline/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/operationBased/test_inline/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/responseBased/test_inline/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/responseBased/test_inline/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/java/operationBased/two_heroes_unique/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/java/operationBased/two_heroes_unique/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/kotlin/responseBased/two_heroes_unique/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_unique/kotlin/responseBased/two_heroes_unique/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/java/operationBased/two_heroes_with_friends/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/java/operationBased/two_heroes_with_friends/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/kotlin/responseBased/two_heroes_with_friends/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/two_heroes_with_friends/kotlin/responseBased/two_heroes_with_friends/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/java/operationBased/typename_always_first/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/java/operationBased/typename_always_first/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/operationBased/typename_always_first/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/operationBased/typename_always_first/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/responseBased/typename_always_first/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/responseBased/typename_always_first/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/java/operationBased/union_fragment/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/java/operationBased/union_fragment/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/operationBased/union_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/operationBased/union_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/responseBased/union_fragment/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/responseBased/union_fragment/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/java/operationBased/union_inline_fragments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/java/operationBased/union_inline_fragments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/java/operationBased/unique_type_name/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/java/operationBased/unique_type_name/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/java/operationBased/used_arguments/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/java/operationBased/used_arguments/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/operationBased/used_arguments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/operationBased/used_arguments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/responseBased/used_arguments/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/responseBased/used_arguments/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/java/operationBased/variable_default_value/type/GraphQLFloat.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/java/operationBased/variable_default_value/type/GraphQLFloat.java.expected
@@ -11,5 +11,5 @@ import com.apollographql.apollo3.api.CustomScalarType;
  * The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point).
  */
 public class GraphQLFloat {
-  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Float");
+  public static CustomScalarType type = new CustomScalarType("Float", "java.lang.Double");
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/kotlin/responseBased/variable_default_value/type/GraphQLFloat.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/kotlin/responseBased/variable_default_value/type/GraphQLFloat.kt.expected
@@ -13,6 +13,6 @@ import com.apollographql.apollo3.api.CustomScalarType
  */
 public class GraphQLFloat {
   public companion object {
-    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Float")
+    public val type: CustomScalarType = CustomScalarType("Float", "kotlin.Double")
   }
 }


### PR DESCRIPTION
See #5927 

This is almost never used but `Double` is better there.