### PR TITLE
[runtime] Remove multidex dependency

### DIFF
--- a/build-logic/src/main/kotlin/Android.kt
+++ b/build-logic/src/main/kotlin/Android.kt
@@ -41,6 +41,4 @@ fun Project.configureAndroid(
       }
     }
   }
-
-  dependencies.add("implementation", getCatalogLib("androidx.multidex"))
 }

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -56,7 +56,6 @@ androidx-core = "androidx.core:core-ktx:1.12.0"
 androidx-espresso-idlingresource = { group = "androidx.test.espresso", name = "espresso-idling-resource", version = "3.5.1" }
 androidx-lint-rules = "androidx.lint:lint-gradle:1.0.0-alpha01"
 androidx-lint-gradle-plugin = { module = "com.android.lint:com.android.lint.gradle.plugin", version.ref = "android-plugin" }
-androidx-multidex = "androidx.multidex:multidex:2.0.1"
 androidx-paging-compose = "androidx.paging:paging-compose:1.0.0-alpha18"
 androidx-profileinstaller = "androidx.profileinstaller:profileinstaller:1.3.1"
 androidx-sqlite = { group = "androidx.sqlite", name = "sqlite", version.ref = "androidx-sqlite" }

--- a/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
+++ b/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
@@ -9,7 +9,7 @@ import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.NetworkMonitor
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.network.http.HttpEngine
-import com.apollographql.apollo3.testing.FooOperation
+import com.apollographql.apollo3.testing.FooQuery
 import com.apollographql.apollo3.testing.mockServerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -43,9 +43,9 @@ class NetworkMonitorTest {
         httpEngine(FaultyHttpEngine())
       }
   ) {
-    mockServer.enqueueString(FooOperation.successResponse)
+    mockServer.enqueueString(FooQuery.successResponse)
 
-    val response = apolloClient.query(FooOperation()).execute()
+    val response = apolloClient.query(FooQuery()).execute()
 
     assertEquals(42, response.data?.foo)
 


### PR DESCRIPTION
Turns out we don't even need it for integration tests because we have minSdk >= 21. Thanks @edenman for catching this!