### PR TITLE
Prepare apollo-testing-support to new MockServer

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.internal.ResponseParser
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
+import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloNetworkException
@@ -139,6 +140,19 @@ fun <D : Operation.Data> Operation<D>.composeJsonResponse(
 ) {
   jsonWriter.use {
     it.writeObject {
+      name("data")
+      adapter().toJson(this, customScalarAdapters, data)
+    }
+  }
+}
+
+@ApolloExperimental
+fun <D : Operation.Data> Operation<D>.composeJsonResponse(
+    data: D,
+    customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
+): String {
+  return buildJsonString {
+    writeObject {
       name("data")
       adapter().toJson(this, customScalarAdapters, data)
     }

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
@@ -11,6 +11,7 @@ import com.apollographql.apollo3.interceptor.addRetryOnErrorInterceptor
 import com.apollographql.apollo3.mockserver.CloseFrame
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.TextMessage
+import com.apollographql.apollo3.mockserver.WebSocketBody
 import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
 import com.apollographql.apollo3.mockserver.enqueueWebSocket
 import com.apollographql.apollo3.mpp.Platform
@@ -351,4 +352,8 @@ class WebSocketNetworkTransportTest {
       assertEquals("oh no!", message)
     }
   }
+}
+
+internal fun WebSocketBody.enqueueMessage(message: String) {
+  enqueueMessage(TextMessage(message))
 }

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
@@ -12,6 +12,7 @@ import com.apollographql.apollo3.mockserver.CloseFrame
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.TextMessage
 import com.apollographql.apollo3.mockserver.WebSocketBody
+import com.apollographql.apollo3.mockserver.WebsocketMockRequest
 import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
 import com.apollographql.apollo3.mockserver.enqueueWebSocket
 import com.apollographql.apollo3.mpp.Platform
@@ -25,7 +26,7 @@ import com.apollographql.apollo3.testing.FooSubscription.Companion.nextMessage
 import com.apollographql.apollo3.testing.awaitSubscribe
 import com.apollographql.apollo3.testing.connectionAckMessage
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.mockServerWebSocketTest
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.merge
 import okio.use
@@ -356,4 +357,53 @@ class WebSocketNetworkTransportTest {
 
 internal fun WebSocketBody.enqueueMessage(message: String) {
   enqueueMessage(TextMessage(message))
+}
+
+class MockServerWebSocketTest(
+    val apolloClient: ApolloClient,
+    private val mockServer: MockServer,
+    val coroutineScope: CoroutineScope,
+) {
+  /**
+   * Enqueue the response straight away
+   */
+  val serverWriter: WebSocketBody = mockServer.enqueueWebSocket()
+  private var _serverReader: WebsocketMockRequest? = null
+
+  val serverReader: WebsocketMockRequest
+    get() {
+      check(_serverReader != null) {
+        "You need to call awaitConnectionInit or awaitWebSocketRequest first"
+      }
+      return _serverReader!!
+    }
+
+  suspend fun awaitWebSocketRequest() {
+    _serverReader = mockServer.awaitWebSocketRequest()
+  }
+
+  suspend fun awaitConnectionInit() {
+    awaitWebSocketRequest()
+
+    serverReader.awaitMessage()
+    serverWriter.enqueueMessage(TextMessage(connectionAckMessage()))
+  }
+}
+
+fun mockServerWebSocketTest(customizeTransport: WebSocketNetworkTransport.Builder.() -> Unit = {}, block: suspend MockServerWebSocketTest.() -> Unit) = runTest(false) {
+  MockServer().use { mockServer ->
+
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .subscriptionNetworkTransport(
+            WebSocketNetworkTransport.Builder()
+                .serverUrl(mockServer.url())
+                .apply(customizeTransport)
+                .build()
+        )
+        .build().use { apolloClient ->
+          @Suppress("DEPRECATION")
+          MockServerWebSocketTest(apolloClient, mockServer, this@runTest).block()
+        }
+  }
 }

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
@@ -17,7 +17,6 @@ import com.apollographql.apollo3.testing.FooSubscription.Companion.nextMessage
 import com.apollographql.apollo3.testing.awaitSubscribe
 import com.apollographql.apollo3.testing.connectionAckMessage
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.mockServerTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -26,6 +25,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import okio.use
 import test.network.enqueueMessage
+import test.network.mockServerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -232,7 +232,6 @@ class RetryWebSocketsTest {
       clientBuilder = {
         retryOnError { it.operation is Subscription }
       },
-      skipDelays = false
   ) {
     mockServer.enqueue(MockResponse.Builder().statusCode(500).build())
 

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import okio.use
+import test.network.enqueueMessage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs

--- a/libraries/apollo-testing-support/api/apollo-testing-support.api
+++ b/libraries/apollo-testing-support/api/apollo-testing-support.api
@@ -15,9 +15,9 @@ public final class com/apollographql/apollo3/testing/FooQuery$Companion {
 }
 
 public final class com/apollographql/apollo3/testing/FooSubscription$Companion {
-	public final fun completeMessage (Ljava/lang/String;)Lcom/apollographql/apollo3/mockserver/TextMessage;
-	public final fun errorMessage (Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo3/mockserver/TextMessage;
-	public final fun nextMessage (Ljava/lang/String;I)Lcom/apollographql/apollo3/mockserver/TextMessage;
+	public final fun completeMessage (Ljava/lang/String;)Ljava/lang/String;
+	public final fun errorMessage (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+	public final fun nextMessage (Ljava/lang/String;I)Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo3/testing/MockserverKt {

--- a/libraries/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/readFile.apple.kt
+++ b/libraries/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/readFile.apple.kt
@@ -1,5 +1,11 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual fun shouldUpdateTestFixtures(): Boolean = false
 
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual val testsPath: String = "../"

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/FilesystemCommon.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/FilesystemCommon.kt
@@ -2,9 +2,11 @@
 
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.jsonReader
 import okio.IOException
+import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.use
@@ -17,10 +19,14 @@ import kotlin.jvm.JvmName
  *
  * @param path: the path to the file, from the "tests" directory
  */
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun checkFile(actualText: String, path: String) {
+  @Suppress("DEPRECATION")
   val updateTestFixtures = shouldUpdateTestFixtures()
   val expected = path.toTestsPath()
   val expectedText = try {
+    @Suppress("DEPRECATION")
     HostFileSystem.openReadOnly(expected).source().buffer().readUtf8()
   } catch (e: IOException) {
     if (updateTestFixtures) {
@@ -34,7 +40,9 @@ fun checkFile(actualText: String, path: String) {
 
   if (actualText != expectedText) {
     if (updateTestFixtures) {
+      @Suppress("DEPRECATION")
       HostFileSystem.delete(expected)
+      @Suppress("DEPRECATION")
       HostFileSystem.openReadWrite(
           file = expected,
       ).use {
@@ -53,18 +61,27 @@ fun checkFile(actualText: String, path: String) {
   }
 }
 
-private fun String.toTestsPath() = testsPath.toPath().resolve(this.toPath())
+private fun String.toTestsPath(): Path {
+  @Suppress("DEPRECATION")
+  return testsPath.toPath().resolve(this.toPath())
+}
 
 /**
  * @param path: the path to the file, from the "tests" directory
  */
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun pathToUtf8(path: String): String {
+  @Suppress("DEPRECATION")
   return HostFileSystem.openReadOnly(path.toTestsPath()).source().buffer().readUtf8()
 }
 
 /**
  * @param path: the path to the file, from the "tests" directory
  */
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun pathToJsonReader(path: String): JsonReader {
+  @Suppress("DEPRECATION")
   return HostFileSystem.openReadOnly(path.toTestsPath()).source().buffer().jsonReader()
 }

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/FooOperation.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/FooOperation.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.Adapter
 import com.apollographql.apollo3.api.CompiledField
@@ -14,7 +15,6 @@ import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.writeArray
 import com.apollographql.apollo3.api.json.writeObject
 import com.apollographql.apollo3.api.missingField
-import com.apollographql.apollo3.mockserver.TextMessage
 
 /**
  * [FooQuery] is a query for tests that doesn't require codegen.
@@ -22,6 +22,9 @@ import com.apollographql.apollo3.mockserver.TextMessage
  * Use it to test parts of the runtime without having to use included builds.
  */
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Suppress("DEPRECATION")
 class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
   companion object {
     val successResponse = "{\"data\": {\"foo\": 42}}"
@@ -34,9 +37,12 @@ class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
  * Use it to test parts of the runtime without having to use included builds.
  */
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Suppress("DEPRECATION")
 class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.Data> {
   companion object {
-    fun nextMessage(id: String, foo: Int): TextMessage {
+    fun nextMessage(id: String, foo: Int): String {
       return buildJsonString {
         writeObject {
           name("id")
@@ -52,10 +58,10 @@ class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.D
             }
           }
         }
-      }.let { TextMessage(it) }
+      }
     }
 
-    fun completeMessage(id: String): TextMessage {
+    fun completeMessage(id: String): String {
       return buildJsonString {
         writeObject {
           name("id")
@@ -63,10 +69,10 @@ class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.D
           name("type")
           value("complete")
         }
-      }.let { TextMessage(it) }
+      }
     }
 
-    fun errorMessage(id: String, message: String): TextMessage {
+    fun errorMessage(id: String, message: String): String {
       return buildJsonString {
         writeObject {
           name("id")
@@ -81,7 +87,7 @@ class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.D
             }
           }
         }
-      }.let { TextMessage(it) }
+      }
     }
   }
 }
@@ -91,6 +97,9 @@ class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.D
  * Note we can't make [FooOperation] extend both [Query] and [Subscription] because that confuses [ApolloClient] when deciding whant NetworkTransport to use.
  */
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Suppress("DEPRECATION")
 abstract class FooOperation(private val operationType: String): Operation<FooOperation.Data> {
   class Data(val foo: Int): Query.Data, Subscription.Data {
     override fun toString(): String {

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/channels.kt
@@ -1,16 +1,21 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.withTimeout
 
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 suspend fun <T> Channel<T>.awaitElement(timeoutMillis: Long = 30000) = withTimeout(timeoutMillis) {
   receive()
 }
 
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 suspend fun <T> Channel<T>.assertNoElement(timeoutMillis: Long = 300): Unit {
   try {
     withTimeout(timeoutMillis) {

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.api.AnyAdapter
 import com.apollographql.apollo3.api.CustomScalarAdapters
@@ -12,13 +13,21 @@ import com.apollographql.apollo3.api.toJson
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.TextMessage
-import com.apollographql.apollo3.mockserver.WebSocketMessage
 import com.apollographql.apollo3.mockserver.WebsocketMockRequest
 import com.apollographql.apollo3.mockserver.enqueueString
 import okio.Buffer
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated(
+    "This is only used for internal Apollo tests and will be removed in a future version.",
+    ReplaceWith(
+        "enqueueString(operation.composeJsonResponse(data, customScalarAdapters), delayMs)",
+        "com.apollographql.apollo3.mockserver.enqueueString",
+        "com.apollographql.apollo3.api.composeJsonResponse",
+    )
+)
 fun <D : Operation.Data> MockServer.enqueue(
     operation: Operation<D>,
     data: D,
@@ -31,6 +40,10 @@ fun <D : Operation.Data> MockServer.enqueue(
   enqueueString(json, delayMs)
 }
 
+@Deprecated(
+    "This is only used for internal Apollo tests and will be removed in a future version.",
+)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun MockServer.enqueueData(
     data: Map<String, Any?>,
     customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -50,7 +63,15 @@ fun MockServer.enqueueData(
   )
 }
 
-
+@Deprecated(
+    "This is only used for internal Apollo tests and will be removed in a future version.",
+    ReplaceWith(
+        "enqueueString(data.toResponseJson(customScalarAdapters), delayMillis, statusCode)",
+        "com.apollographql.apollo3.mockserver.enqueueString",
+        "com.apollographql.apollo3.api.toResponseJson",
+    )
+)
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 fun MockServer.enqueueData(
     data: Operation.Data,
     customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
@@ -110,5 +131,5 @@ suspend fun WebsocketMockRequest.awaitComplete(timeout: Duration = 1.seconds) {
 }
 
 @ApolloExperimental
-fun connectionAckMessage(): WebSocketMessage = TextMessage("{\"type\": \"connection_ack\"}")
+fun connectionAckMessage(): String = "{\"type\": \"connection_ack\"}"
 

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/readFile.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/readFile.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import okio.FileSystem
 
@@ -7,9 +8,13 @@ import okio.FileSystem
  * The host filesystem
  */
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 expect val HostFileSystem: FileSystem
 
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 expect fun shouldUpdateTestFixtures(): Boolean
 
 /**
@@ -17,5 +22,7 @@ expect fun shouldUpdateTestFixtures(): Boolean
  * We need this for JS tests where the CWD is not properly set at the beginning of tests
  */
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 expect val testsPath: String
 

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
@@ -4,12 +4,6 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.mockserver.TextMessage
-import com.apollographql.apollo3.mockserver.WebSocketBody
-import com.apollographql.apollo3.mockserver.WebsocketMockRequest
-import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
-import com.apollographql.apollo3.mockserver.enqueueWebSocket
-import com.apollographql.apollo3.network.websocket.WebSocketNetworkTransport
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope
 import okio.use
@@ -31,74 +25,13 @@ fun mockServerTest(
     clientBuilder: ApolloClient.Builder.() -> Unit = {},
     block: suspend MockServerTest.() -> Unit
 ) = runTest(skipDelays) {
-  val mockServer = MockServer()
-
-  val apolloClient = ApolloClient.Builder()
-      .serverUrl(mockServer.url())
-      .apply(clientBuilder)
-      .build()
-
-  try {
-    apolloClient.use {
-      MockServerTest(mockServer, it, this).block()
-    }
-  } finally {
-    mockServer.close()
-  }
-}
-
-@ApolloExperimental
-@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-class MockServerWebSocketTest(
-    val apolloClient: ApolloClient,
-    private val mockServer: MockServer,
-    val coroutineScope: CoroutineScope,
-) {
-  /**
-   * Enqueue the response straight away
-   */
-  val serverWriter: WebSocketBody = mockServer.enqueueWebSocket()
-  private var _serverReader: WebsocketMockRequest? = null
-
-  val serverReader: WebsocketMockRequest
-    get() {
-      check(_serverReader != null) {
-        "You need to call awaitConnectionInit or awaitWebSocketRequest first"
-      }
-      return _serverReader!!
-    }
-
-  suspend fun awaitWebSocketRequest() {
-    _serverReader = mockServer.awaitWebSocketRequest()
-  }
-
-  suspend fun awaitConnectionInit() {
-    awaitWebSocketRequest()
-
-    serverReader.awaitMessage()
-    serverWriter.enqueueMessage(TextMessage(connectionAckMessage()))
-  }
-}
-
-@ApolloExperimental
-@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-@Suppress("DEPRECATION")
-fun mockServerWebSocketTest(customizeTransport: WebSocketNetworkTransport.Builder.() -> Unit = {}, block: suspend MockServerWebSocketTest.() -> Unit) = runTest(false) {
   MockServer().use { mockServer ->
-
     ApolloClient.Builder()
         .serverUrl(mockServer.url())
-        .subscriptionNetworkTransport(
-            WebSocketNetworkTransport.Builder()
-                .serverUrl(mockServer.url())
-                .apply(customizeTransport)
-                .build()
-        )
-        .build().use { apolloClient ->
-          @Suppress("DEPRECATION")
-          MockServerWebSocketTest(apolloClient, mockServer, this@runTest).block()
+        .apply(clientBuilder)
+        .build()
+        .use {apolloClient ->
+          MockServerTest(mockServer, apolloClient, this).block()
         }
   }
 }

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
@@ -1,8 +1,10 @@
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.TextMessage
 import com.apollographql.apollo3.mockserver.WebSocketBody
 import com.apollographql.apollo3.mockserver.WebsocketMockRequest
 import com.apollographql.apollo3.mockserver.awaitWebSocketRequest
@@ -13,12 +15,17 @@ import kotlinx.coroutines.CoroutineScope
 import okio.use
 
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 class MockServerTest(val mockServer: MockServer, val apolloClient: ApolloClient, val scope: CoroutineScope)
 
 /**
  * A convenience function that makes sure the MockServer and ApolloClient are properly closed at the end of the test
  */
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Suppress("DEPRECATION")
 fun mockServerTest(
     skipDelays: Boolean = true,
     clientBuilder: ApolloClient.Builder.() -> Unit = {},
@@ -41,6 +48,8 @@ fun mockServerTest(
 }
 
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
 class MockServerWebSocketTest(
     val apolloClient: ApolloClient,
     private val mockServer: MockServer,
@@ -68,11 +77,14 @@ class MockServerWebSocketTest(
     awaitWebSocketRequest()
 
     serverReader.awaitMessage()
-    serverWriter.enqueueMessage(connectionAckMessage())
+    serverWriter.enqueueMessage(TextMessage(connectionAckMessage()))
   }
 }
 
 @ApolloExperimental
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Suppress("DEPRECATION")
 fun mockServerWebSocketTest(customizeTransport: WebSocketNetworkTransport.Builder.() -> Unit = {}, block: suspend MockServerWebSocketTest.() -> Unit) = runTest(false) {
   MockServer().use { mockServer ->
 
@@ -85,6 +97,7 @@ fun mockServerWebSocketTest(customizeTransport: WebSocketNetworkTransport.Builde
                 .build()
         )
         .build().use { apolloClient ->
+          @Suppress("DEPRECATION")
           MockServerWebSocketTest(apolloClient, mockServer, this@runTest).block()
         }
   }

--- a/libraries/apollo-testing-support/src/concurrentMain/kotlin/com/apollographql/apollo3/testing/readFile.concurrent.kt
+++ b/libraries/apollo-testing-support/src/concurrentMain/kotlin/com/apollographql/apollo3/testing/readFile.concurrent.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import okio.FileSystem
 import okio.SYSTEM
@@ -8,5 +9,7 @@ import okio.SYSTEM
  * The host filesystem
  */
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 actual val HostFileSystem: FileSystem
   get() = FileSystem.SYSTEM

--- a/libraries/apollo-testing-support/src/jsMain/kotlin/com/apollographql/apollo3/testing/readFile.js.kt
+++ b/libraries/apollo-testing-support/src/jsMain/kotlin/com/apollographql/apollo3/testing/readFile.js.kt
@@ -1,11 +1,18 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import okio.FileSystem
 import okio.NodeJsFileSystem
 
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 actual val HostFileSystem: FileSystem = NodeJsFileSystem
 
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual fun shouldUpdateTestFixtures(): Boolean = false
 
 // Workaround for https://youtrack.jetbrains.com/issue/KT-49125
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual val testsPath: String = "../../../../../tests/"

--- a/libraries/apollo-testing-support/src/jvmMain/kotlin/com/apollographql/apollo3/testing/readFile.jvm.kt
+++ b/libraries/apollo-testing-support/src/jvmMain/kotlin/com/apollographql/apollo3/testing/readFile.jvm.kt
@@ -1,5 +1,9 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
+
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual fun shouldUpdateTestFixtures(): Boolean {
   if (System.getenv("updateTestFixtures") != null) {
     return true
@@ -11,4 +15,6 @@ actual fun shouldUpdateTestFixtures(): Boolean {
   }
 }
 
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual val testsPath: String = "../"

--- a/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/readFile.wasmJs.kt
+++ b/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/readFile.wasmJs.kt
@@ -1,16 +1,21 @@
 package com.apollographql.apollo3.testing
 
+import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
 import okio.FileSystem
 
 /**
  * The host filesystem
  */
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This function is not Apollo specific and will be removed in a future version. Copy/paste it in your codebase if you need it")
 @ApolloExperimental
 actual val HostFileSystem: FileSystem
   get() = TODO("Not yet implemented")
 
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual fun shouldUpdateTestFixtures(): Boolean {
   TODO("Not yet implemented")
 }
@@ -20,5 +25,7 @@ actual fun shouldUpdateTestFixtures(): Boolean {
  * We need this for JS tests where the CWD is not properly set at the beginning of tests
  */
 @ApolloExperimental
+@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
+@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
 actual val testsPath: String
   get() = TODO("Not yet implemented")

--- a/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/FetchPolicyTest.kt
@@ -37,7 +37,6 @@ import com.apollographql.apollo3.mockserver.enqueueError
 import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.assertNoElement
 import com.apollographql.apollo3.testing.awaitElement
-import com.apollographql.apollo3.testing.enqueue
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -76,7 +75,7 @@ class FetchPolicyTest {
   fun cacheFirst() = runTest(before = { setUp() }, after = { tearDown() }) {
     val query = HeroNameQuery()
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     // First query should hit the network and save in cache
     var response = apolloClient.query(query)
@@ -106,7 +105,7 @@ class FetchPolicyTest {
     apolloClient = apolloClient.newBuilder().build()
     val query = HeroNameQuery()
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     // First query should hit the network and save in cache
     @Suppress("DEPRECATION")
@@ -146,7 +145,7 @@ class FetchPolicyTest {
 
     val query = HeroNameQuery()
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     // First query should hit the network and save in cache
     @Suppress("DEPRECATION")
@@ -194,14 +193,14 @@ class FetchPolicyTest {
     val call = apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkFirst)
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     var response = call.execute()
 
     assertNotNull(response.data)
     assertFalse(response.isFromCache)
 
     // Now data is cached but it shouldn't be used since network will go through
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     response = call.execute()
 
     assertNotNull(response.data)
@@ -233,14 +232,14 @@ class FetchPolicyTest {
     val call = apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkFirst)
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     var response = call.execute()
 
     assertNotNull(response.data)
     assertFalse(response.isFromCache)
 
     // Now data is cached but it shouldn't be used since network will go through
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     response = call.execute()
 
     assertNotNull(response.data)
@@ -275,7 +274,7 @@ class FetchPolicyTest {
     val call = apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkFirst)
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     @Suppress("DEPRECATION")
     var responses = call.toFlowV3()
     responses.test {
@@ -286,7 +285,7 @@ class FetchPolicyTest {
     }
 
     // Now data is cached but it shouldn't be used since network will go through
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     @Suppress("DEPRECATION")
     responses = call.toFlowV3()
     responses.test {
@@ -324,7 +323,7 @@ class FetchPolicyTest {
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     var response = apolloClient.query(query).execute()
 
     assertNotNull(response.data)
@@ -346,7 +345,7 @@ class FetchPolicyTest {
     val call = apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly)
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     val response = call.execute()
 
     assertNotNull(response.data)
@@ -366,7 +365,7 @@ class FetchPolicyTest {
     val call = apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly)
 
     // First query should hit the network and save in cache
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     @Suppress("DEPRECATION")
     val response = call.executeV3()
 
@@ -400,7 +399,7 @@ class FetchPolicyTest {
 
     // Make the network return something
     // Cache Error + Network Success => 2 responses
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     var responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow().catch { caught = it }.toList()
 
     assertNull(caught)
@@ -426,7 +425,7 @@ class FetchPolicyTest {
     assertIs<ApolloHttpException>(responses[1].exception)
 
     // Cache Success + Network Success => 2 responses
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlow().toList()
 
     assertEquals(2, responses.size)
@@ -476,7 +475,7 @@ class FetchPolicyTest {
 
     // Make the network return something
     // Cache Error + Network Success => 1 response (no exception)
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     @Suppress("DEPRECATION")
     var responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork)
         .toFlowV3().catch { caught = it }.toList()
@@ -501,7 +500,7 @@ class FetchPolicyTest {
     assertEquals("R2-D2", responses[0].data?.hero?.name)
 
     // Cache Success + Network Success => 1 response
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     @Suppress("DEPRECATION")
     responses = apolloClient.query(query).fetchPolicy(FetchPolicy.CacheAndNetwork).toFlowV3().toList()
 
@@ -628,7 +627,7 @@ class FetchPolicyTest {
   fun isFromCache() = runTest(before = { setUp() }, after = { tearDown() }) {
     val query = HeroNameQuery()
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     // NetworkOnly / hit
     var response = apolloClient.query(query)
@@ -681,7 +680,7 @@ class FetchPolicyTest {
     assertTrue(responses[1].isFromCache)
 
     // CacheAndNetwork / hit / hit
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     responses = apolloClient.query(query)
         .fetchPolicy(FetchPolicy.CacheAndNetwork)
         .toFlow()

--- a/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HTTPHeadersTest.kt
@@ -8,8 +8,8 @@ import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
+import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.network.http.HttpInfo
-import com.apollographql.apollo3.testing.enqueue
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -34,7 +34,7 @@ class HTTPHeadersTest {
     val query = HeroNameQuery()
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
 
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     val response = apolloClient.query(query).execute()
 

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo3.integration.normalizer.SearchHeroQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.awaitRequest
 import com.apollographql.apollo3.mockserver.enqueueString
-import com.apollographql.apollo3.testing.enqueueData
 import com.apollographql.apollo3.testing.mockServerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -42,7 +41,7 @@ class HttpGetTest {
   @Test
   fun encodeReservedCharactersTest() = mockServerTest {
     // Response not needed, just testing generated url
-    mockServer.enqueueData(data = emptyMap())
+    mockServer.enqueueString("")
     apolloClient.query(SearchHeroQuery("!#$&'()*+,/:;=?@[]{}% "))
         .httpMethod(HttpMethod.Get)
         .execute()

--- a/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/HttpGetTest.kt
@@ -1,12 +1,16 @@
 package test
 
+import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.http.HttpMethod
 import com.apollographql.apollo3.integration.normalizer.HeroAndFriendsNamesQuery
 import com.apollographql.apollo3.integration.normalizer.SearchHeroQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
+import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
 import com.apollographql.apollo3.mockserver.enqueueString
-import com.apollographql.apollo3.testing.mockServerTest
+import com.apollographql.apollo3.testing.internal.runTest
+import kotlinx.coroutines.CoroutineScope
+import okio.use
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -49,5 +53,22 @@ class HttpGetTest {
         "/?operationName=SearchHero&variables=%7B%22text%22%3A%22%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D%7B%7D%25%20%22%7D&query=query%20SearchHero%28%24text%3A%20String%29%20%7B%20search%28text%3A%20%24text%29%20%7B%20__typename%20...%20on%20Character%20%7B%20__typename%20name%20...%20on%20Human%20%7B%20homePlanet%20%7D%20...%20on%20Droid%20%7B%20primaryFunction%20%7D%20%7D%20%7D%20%7D",
         mockServer.awaitRequest().path
     )
+  }
+}
+
+class MockServerTest(val mockServer: MockServer, val apolloClient: ApolloClient, val scope: CoroutineScope)
+
+fun mockServerTest(
+    clientBuilder: ApolloClient.Builder.() -> Unit = {},
+    block: suspend MockServerTest.() -> Unit
+) = runTest(true) {
+  MockServer().use { mockServer ->
+    ApolloClient.Builder()
+        .serverUrl(mockServer.url())
+        .apply(clientBuilder)
+        .build()
+        .use {apolloClient ->
+          MockServerTest(mockServer, apolloClient, this).block()
+        }
   }
 }

--- a/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OtherCacheTest.kt
@@ -4,6 +4,7 @@ import IdCacheKeyGenerator
 import IdCacheResolver
 import assertEquals2
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
@@ -20,7 +21,6 @@ import com.apollographql.apollo3.integration.normalizer.UpdateReviewWithoutVaria
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueString
-import com.apollographql.apollo3.testing.enqueue
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.datetime.Instant
 import testFixtureToUtf8
@@ -160,7 +160,7 @@ class OtherCacheTest {
     // Store in the cache
     val instant = Instant.fromEpochMilliseconds(0L)
     val data = InstantQuery.Data(instant)
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
     apolloClient.query(query).execute()
 
     // Get from the cache
@@ -181,7 +181,7 @@ class OtherCacheTest {
             "Great"
         )
     )
-    mockServer.enqueue(mutation, data)
+    mockServer.enqueueString(mutation.composeJsonResponse(data))
     apolloClient.mutation(mutation).execute()
 
     val storeData = store.readOperation(mutation)

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherTest.kt
@@ -4,6 +4,7 @@ import IdCacheKeyGenerator
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.CustomScalarAdapters
+import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.cache.normalized.ApolloStore
 import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.CacheHeaders
@@ -22,6 +23,7 @@ import com.apollographql.apollo3.integration.normalizer.StarshipByIdQuery
 import com.apollographql.apollo3.integration.normalizer.type.Episode
 import com.apollographql.apollo3.mockserver.MockResponse
 import com.apollographql.apollo3.mockserver.MockServer
+import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.QueueTestNetworkTransport
 import com.apollographql.apollo3.testing.assertNoElement
 import com.apollographql.apollo3.testing.awaitElement
@@ -533,7 +535,7 @@ class WatcherTest {
     val query = EpisodeHeroNameQuery(Episode.EMPIRE)
 
     // Set up the cache with a "R2-D2" name
-    mockServer.enqueue(query, episodeHeroNameData)
+    mockServer.enqueueString(query.composeJsonResponse(episodeHeroNameData))
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
     // Prepare next call to be a network error

--- a/tests/integration-tests/src/jvmTest/kotlin/test/ApqCacheTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/ApqCacheTest.kt
@@ -1,14 +1,13 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.http.HttpMethod
-import com.apollographql.apollo3.cache.normalized.FetchPolicy
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
-import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.testing.enqueue
+import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import org.junit.Test
 import kotlin.test.fail
@@ -24,8 +23,8 @@ class ApqCacheTest {
     val data = HeroNameQuery.Data(HeroNameQuery.Hero("R2-D2"))
     val query = HeroNameQuery()
 
-    mockServer.enqueue(query, data)
-    mockServer.enqueue(query, data)
+    mockServer.enqueueString(query.composeJsonResponse(data))
+    mockServer.enqueueString(query.composeJsonResponse(data))
 
     try {
      ApolloClient.Builder()

--- a/tests/ios-test/src/commonTest/kotlin/iOSTest.kt
+++ b/tests/ios-test/src/commonTest/kotlin/iOSTest.kt
@@ -2,7 +2,7 @@
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.api.GlobalBuilder
 import com.apollographql.apollo3.mockserver.MockServer
-import com.apollographql.apollo3.testing.enqueueData
+import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import ios.test.type.buildQuery
 import kotlin.test.Test
@@ -13,7 +13,8 @@ class iOSTest {
     val mockServer = MockServer()
     val apolloClient = ApolloClient.Builder().serverUrl(mockServer.url()).build()
 
-    mockServer.enqueueData(GlobalBuilder.buildQuery { random = 42 })
+    // What is passed does not matter
+    mockServer.enqueueString(GlobalBuilder.buildQuery { random = 42 }.toString())
 
     apolloClient.close()
     mockServer.close()

--- a/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
+++ b/tests/native-benchmarks/src/appleTest/kotlin/benchmarks/BenchmarksTest.kt
@@ -1,16 +1,15 @@
 package benchmarks
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.toResponseJson
 import com.apollographql.apollo3.cache.normalized.api.MemoryCacheFactory
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.enqueueString
-import com.apollographql.apollo3.testing.enqueueData
 import com.apollographql.apollo3.testing.internal.runTest
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import kotlin.test.AfterClass
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.time.Duration
 import kotlin.time.measureTime
@@ -38,11 +37,11 @@ class BenchmarksTest {
           .build()
     }
 
-    mockServer.enqueueData(
+    mockServer.enqueueString(
         GetRandomQuery.Data {
           random = 42
         }
-    )
+            .toResponseJson())
     client
         .query(GetRandomQuery())
         .execute()

--- a/tests/runtime/src/test/kotlin/test/HeadersTest.kt
+++ b/tests/runtime/src/test/kotlin/test/HeadersTest.kt
@@ -1,10 +1,11 @@
 package test
 
 import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.http.HttpHeader
 import com.apollographql.apollo3.mockserver.MockServer
 import com.apollographql.apollo3.mockserver.awaitRequest
-import com.apollographql.apollo3.testing.enqueue
+import com.apollographql.apollo3.mockserver.enqueueString
 import com.apollographql.apollo3.testing.internal.runTest
 import com.example.GetRandomQuery
 import org.junit.Test
@@ -23,7 +24,7 @@ class HeadersTest {
         .addHttpHeader("clientKey", "clientValue")
         .build()
 
-    mockServer.enqueue(operation, data)
+    mockServer.enqueueString(operation.composeJsonResponse(data))
     apolloClient.query(GetRandomQuery()).addHttpHeader("requestKey", "requestValue").execute()
 
     mockServer.awaitRequest().also {
@@ -43,7 +44,7 @@ class HeadersTest {
         .addHttpHeader("clientKey", "clientValue")
         .build()
 
-    mockServer.enqueue(operation, data)
+    mockServer.enqueueString(operation.composeJsonResponse(data))
     apolloClient.query(GetRandomQuery()).httpHeaders(listOf(HttpHeader("requestKey", "requestValue"))).execute()
 
     mockServer.awaitRequest().also {
@@ -63,7 +64,7 @@ class HeadersTest {
         .addHttpHeader("clientKey", "clientValue")
         .build()
 
-    mockServer.enqueue(operation, data)
+    mockServer.enqueueString(operation.composeJsonResponse(data))
     apolloClient.query(GetRandomQuery()).addHttpHeader("requestKey", "requestValue").ignoreApolloClientHttpHeaders(true).execute()
 
     mockServer.awaitRequest().also {
@@ -83,7 +84,7 @@ class HeadersTest {
         .addHttpHeader("clientKey", "clientValue")
         .build()
 
-    mockServer.enqueue(operation, data)
+    mockServer.enqueueString(operation.composeJsonResponse(data))
     apolloClient.query(GetRandomQuery()).httpHeaders(listOf(HttpHeader("requestKey", "requestValue"))).ignoreApolloClientHttpHeaders(true).execute()
 
     mockServer.awaitRequest().also {
@@ -103,7 +104,7 @@ class HeadersTest {
         .addHttpHeader("clientKey", "clientValue")
         .build()
 
-    mockServer.enqueue(operation, data)
+    mockServer.enqueueString(operation.composeJsonResponse(data))
     apolloClient.query(GetRandomQuery()).ignoreApolloClientHttpHeaders(true).execute()
 
     mockServer.awaitRequest().also {


### PR DESCRIPTION
Moving `MockServer` to a separate repo/packageName would make it a breaking change for `apollo-testing-support`. 

Instead, `apollo-testing-support` is going to keep using the current (soon to be deprecated) `MockServer` for now. But we don't want to pull that in other parts of the repo.

This PR tries to contain the blast radius of MockServer. It makes most of `apollo-testing-support` deprecated:

* all the  things like `HostFileSystem`, `Channel.awaitItem()`, etc... were meant to be used from our own tests and the plan is to simply remove them.
* functions that have `MockServer` could be somewhat useful but there are ways to replace relatively easily.

