### PR TITLE
Unbreak benchmarks

### DIFF
--- a/scripts/run-benchmarks.main.kts
+++ b/scripts/run-benchmarks.main.kts
@@ -7,7 +7,6 @@
 @file:DependsOn("com.squareup.okhttp3:okhttp:4.10.0")
 @file:DependsOn("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0")
 
-import Run_benchmarks_main.TestResult
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageOptions


### PR DESCRIPTION
Looks like Kotlin 2 doesn't like when we import symbols from the current file.