### PR TITLE
Avoid a ConcurrentModificationException occurring in conjunction to the IJ Platform Gradle plugin.

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo3/gradle/internal/DefaultApolloExtension.kt
@@ -1028,7 +1028,9 @@ abstract class DefaultApolloExtension(
     private const val USAGE_APOLLO_OTHER_OPTIONS = "apollo-other-options"
 
     private fun getDeps(configurations: ConfigurationContainer): List<String> {
-      return configurations.flatMap { configuration ->
+      // See https://github.com/apollographql/apollo-kotlin/pull/5657
+      val currentConfigurations = configurations.toList()
+      return currentConfigurations.flatMap { configuration ->
         configuration.dependencies
             .filter {
               /**


### PR DESCRIPTION
See #5657.

