### PR TITLE
Cache ApolloKotlinService into project settings

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
@@ -1,25 +1,56 @@
 package com.apollographql.ijplugin.gradle
 
 import com.intellij.util.messages.Topic
+import com.intellij.util.xmlb.annotations.Attribute
+import com.intellij.util.xmlb.annotations.Transient
+import com.intellij.util.xmlb.annotations.XCollection
 
 interface ApolloKotlinServiceListener {
   companion object {
     @Topic.ProjectLevel
-    val TOPIC: Topic<ApolloKotlinServiceListener> = Topic.create("ApolloKotlinServices are available", ApolloKotlinServiceListener::class.java)
+    val TOPIC: Topic<ApolloKotlinServiceListener> =
+      Topic.create("ApolloKotlinServices are available", ApolloKotlinServiceListener::class.java)
   }
 
   fun apolloKotlinServicesAvailable()
 }
 
+/**
+ * Represents an Apollo Kotlin service as configured in the Apollo Gradle plugin configuration.
+ *
+ * These are built from the [com.apollographql.apollo3.gradle.api.ApolloGradleToolingModel] and are used to configure the GraphQL plugin,
+ * and are cached into the project settings.
+ *
+ * @see com.apollographql.ijplugin.gradle.GradleToolingModelService
+ * @see com.apollographql.ijplugin.graphql.ApolloGraphQLConfigContributor
+ * @see com.apollographql.ijplugin.settings.ProjectSettingsService
+ */
 data class ApolloKotlinService(
-    val gradleProjectPath: String,
-    val serviceName: String,
-    val schemaPaths: List<String>,
-    val operationPaths: List<String>,
-    val endpointUrl: String?,
-    val endpointHeaders: Map<String, String>?,
+    @Attribute
+    val gradleProjectPath: String = "",
+
+    @Attribute
+    val serviceName: String = "",
+
+    @XCollection
+    val schemaPaths: List<String> = emptyList(),
+
+    @XCollection
+    val operationPaths: List<String> = emptyList(),
+
+    @Attribute
+    val endpointUrl: String? = null,
+
+    @XCollection
+    val endpointHeaders: Map<String, String>? = null,
 ) {
-  data class Id(val gradleProjectPath: String, val serviceName: String) {
+  data class Id(
+      @Attribute
+      val gradleProjectPath: String = "",
+
+      @Attribute
+      val serviceName: String = "",
+  ) {
     override fun toString(): String {
       val formattedPath = gradleProjectPath.split(":").filterNot { it.isEmpty() }.joinToString("-")
       return "$formattedPath/$serviceName"
@@ -34,5 +65,8 @@ data class ApolloKotlinService(
     }
   }
 
-  val id = Id(gradleProjectPath, serviceName)
+  val id
+    @Transient
+    get() = Id(gradleProjectPath, serviceName)
+
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
@@ -22,9 +22,9 @@ internal class ApolloProjectManagerListener : ProjectManagerListener {
     DumbService.getInstance(project).runWhenSmart {
       logd("apolloVersion=" + project.apolloProjectService.apolloVersion)
       project.service<ApolloCodegenService>()
+      project.service<GraphQLConfigService>()
       project.service<GradleToolingModelService>()
       project.service<ProjectSettingsService>()
-      project.service<GraphQLConfigService>()
       project.service<SandboxService>()
       project.service<FieldInsightsService>()
       project.service<TelemetryService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
@@ -71,7 +71,14 @@ class ProjectSettingsService(private val project: Project) : PersistentStateComp
       _state.telemetryInstanceId = value
     }
 
+  override var apolloKotlinServices: List<ApolloKotlinService>
+    get() = _state.apolloKotlinServices
+    set(value) {
+      _state.apolloKotlinServices = value
+    }
+
   private var lastNotifiedState: ProjectSettingsState? = null
+
   private fun notifySettingsChanged() {
     if (lastNotifiedState != _state) {
       lastNotifiedState = _state.copy()
@@ -98,8 +105,17 @@ interface ProjectSettingsState {
   var contributeConfigurationToGraphqlPlugin: Boolean
   var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
   var telemetryInstanceId: String
+
+  /**
+   * Cache of the ApolloKotlinServices constructed from the Gradle tooling models.
+   * @see com.apollographql.ijplugin.gradle.GradleToolingModelService
+   */
+  var apolloKotlinServices: List<ApolloKotlinService>
 }
 
+/**
+ * User configuration associated with an [ApolloKotlinService].
+ */
 data class ApolloKotlinServiceConfiguration(
     @Attribute
     val id: String = "",
@@ -133,6 +149,7 @@ data class ProjectSettingsStateImpl(
     override var contributeConfigurationToGraphqlPlugin: Boolean = true,
     override var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration> = emptyList(),
     override var telemetryInstanceId: String = "",
+    override var apolloKotlinServices: List<ApolloKotlinService> = emptyList(),
 ) : ProjectSettingsState
 
 


### PR DESCRIPTION
Fix for #5952

This makes the config available to the GraphQL plugin a lot faster, for example (on a project with more modules the diff will be more significant):

Before: takes about 9s

https://github.com/apollographql/apollo-kotlin/assets/372852/53ac0de6-2209-442b-a5f3-1b43f192dfc8


After: takes about 6s



https://github.com/apollographql/apollo-kotlin/assets/372852/c3f19811-041b-4a75-98c4-7bbde1e748c8

