### PR TITLE
[CI] use `gradle/actions/setup-gradle` instead of `gradle-build-action`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       - run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       - run: |

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
 
       - name: Run Apollo Kotlin @defer tests
         env:

--- a/.github/workflows/defer-with-router-tests.yml
+++ b/.github/workflows/defer-with-router-tests.yml
@@ -35,7 +35,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+        uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
 
       - name: Run Apollo Kotlin @defer tests
         env:

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    uses: apollographql/docs/.github/workflows/publish.yml@main
+    uses: apollographql/docs/.github/workflows/publish.yml@main # pga-ignore
     if: github.repository == 'apollographql/apollo-kotlin'
     secrets:
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/.github/workflows/platform-api-tests.yml
+++ b/.github/workflows/platform-api-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+        uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
 
       - name: Run tests against the Apollo Platform API
         env:

--- a/.github/workflows/platform-api-tests.yml
+++ b/.github/workflows/platform-api-tests.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+        uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
 
       - name: Run tests against the Apollo Platform API
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
@@ -71,7 +71,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
@@ -47,7 +47,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
@@ -71,7 +71,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/gradle-build-action@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
         with:
           gradle-home-cache-cleanup: true
       #--no-configuration-cache for https://youtrack.jetbrains.com/issue/KT-65879

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: gradle/actions/setup-gradle@db35f2304698ac6ff98958322dfd3db0a5da9fdf #v3.4.0
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
         with:
           gradle-home-cache-cleanup: true
       #--no-configuration-cache for https://youtrack.jetbrains.com/issue/KT-65879


### PR DESCRIPTION
`gradle/gradle-build-action` is deprecated.
See https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle