### PR TITLE
[compiler] remove unused argument to scalarAdapterInitializer()

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/AdapterCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/AdapterCommon.kt
@@ -71,7 +71,7 @@ internal fun readFromResponseCodeBlock(
         .add(
             regularProperties.mapIndexed { index, property ->
               val variableName = property.info.responseName.variableName()
-              val adapterInitializer = context.resolver.adapterInitializer(property.info.type, property.requiresBuffering, context.jsExport, customScalarAdapters)
+              val adapterInitializer = context.resolver.adapterInitializer(property.info.type, property.requiresBuffering, context.jsExport)
               CodeBlock.of(
                   "%L·->·%N·=·%L.$fromJson($reader,·${customScalarAdapters})",
                   index,
@@ -215,7 +215,7 @@ private fun IrProperty.writeToResponseCodeBlock(context: KotlinContext): CodeBlo
   val propertyName = context.layout.propertyName(info.responseName)
 
   if (!isSynthetic) {
-    val adapterInitializer = context.resolver.adapterInitializer(info.type, requiresBuffering, context.jsExport, customScalarAdapters)
+    val adapterInitializer = context.resolver.adapterInitializer(info.type, requiresBuffering, context.jsExport)
     builder.addStatement("${writer}.name(%S)", info.responseName)
     builder.addStatement(
         "%L.$toJson($writer, $customScalarAdapters, $value.%N)",

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/InputAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/helpers/InputAdapter.kt
@@ -73,7 +73,7 @@ private fun List<NamedType>.writeToResponseCodeBlock(context: KotlinContext): Co
 }
 
 private fun NamedType.writeToResponseCodeBlock(context: KotlinContext): CodeBlock {
-  val adapterInitializer = context.resolver.adapterInitializer(type, false, context.jsExport, customScalarAdapters)
+  val adapterInitializer = context.resolver.adapterInitializer(type, false, context.jsExport)
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(graphQlName)
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ExecutableCommon.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/ExecutableCommon.kt
@@ -64,7 +64,7 @@ internal fun adapterFunSpec(
       .addCode(
           CodeBlock.of(
               "return·%L",
-              context.resolver.adapterInitializer(type, property.requiresBuffering, context.jsExport, "")
+              context.resolver.adapterInitializer(type, property.requiresBuffering, context.jsExport)
           )
       )
     .build()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/VariablesAdapter.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo3/compiler/codegen/kotlin/operations/util/VariablesAdapter.kt
@@ -50,7 +50,7 @@ private fun List<IrVariable>.writeToResponseCodeBlock(context: KotlinContext): C
 }
 
 private fun IrVariable.writeToResponseCodeBlock(context: KotlinContext): CodeBlock {
-  val adapterInitializer = context.resolver.adapterInitializer(type, false, context.jsExport, customScalarAdapters)
+  val adapterInitializer = context.resolver.adapterInitializer(type, false, context.jsExport)
   val builder = CodeBlock.builder()
   val propertyName = context.layout.propertyName(name)
 


### PR DESCRIPTION
This was only needed for `apollo-execution`, keeps symmetry with Java codegen