### PR TITLE
Kotlin nightlies: filter on 2.0.20, and trigger workflow

### DIFF
--- a/.github/workflows/bump-kotlin-nightlies.yml
+++ b/.github/workflows/bump-kotlin-nightlies.yml
@@ -18,3 +18,10 @@ jobs:
           git add .
           git commit -m "Bump Kotlin version"
           git push --force origin kotlin-nightlies
+      # Trigger a workflow manually because actions cannot trigger workflows to avoid endless loops
+      # https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs
+      - name: Trigger pr workflow
+        run: |
+          gh workflow run pr --ref kotlin-nightlies
+    env:
+      GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,8 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+  workflow_dispatch:
+
 env:
   DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 

--- a/scripts/bump-kotlin-nightlies.main.kts
+++ b/scripts/bump-kotlin-nightlies.main.kts
@@ -6,7 +6,7 @@ import javax.xml.parsers.DocumentBuilderFactory
 
 fun main() {
   // Update versions in libraries.toml
-  val kotlinVersion = getLatestVersion("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/org/jetbrains/kotlin/kotlin-stdlib/maven-metadata.xml")
+  val kotlinVersion = getLatestVersion("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/org/jetbrains/kotlin/kotlin-stdlib/maven-metadata.xml", prefix = "2.0.20")
   val kspVersion = getLatestVersion("https://oss.sonatype.org/content/repositories/snapshots/com/google/devtools/ksp/com.google.devtools.ksp.gradle.plugin/maven-metadata.xml")
   File("gradle/libraries.toml").let { file ->
     file.writeText(
@@ -41,17 +41,29 @@ fun String.replaceVersion(key: String, version: String): String {
   return replace(Regex("""$key = ".*""""), """$key = "$version"""")
 }
 
-fun getLatestVersion(url: String): String {
-  return URL(url)
+fun getLatestVersion(url: String, prefix: String? = null): String {
+  val document = URL(url)
       .openConnection()
       .getInputStream().use { inputStream ->
         DocumentBuilderFactory.newInstance()
             .newDocumentBuilder()
             .parse(inputStream)
       }
-      .getElementsByTagName("latest")
-      .item(0)
-      .textContent
+  return if (prefix != null) {
+    document
+        .getElementsByTagName("version")
+        .let {
+          (0 until it.length)
+              .map { i -> it.item(i).textContent }
+              .filter { it.startsWith(prefix) }
+              .first() // Assumes they are sorted by most recent first, which is true on Kotlin's repo, false on Sonatype
+        }
+  } else {
+    document
+        .getElementsByTagName("latest")
+        .item(0)
+        .textContent
+  }
 }
 
 main()


### PR DESCRIPTION
The latest Kotlin dev was 2.0.20 yesterday but today it's 1.9.24 😅 - so filter on that. There are also some 2.1.0 versions but that fails to build with missing symbols, I think it's too early.