### PR TITLE
Fix 'pr' workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ env:
 
 # Cancel any current or previous job from the same PR
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
`github.head_ref` is undefined when running from `workflow_dispatch`, making the workflow [fail](https://github.com/apollographql/apollo-kotlin/actions/runs/9696589947/workflow), so use a [fallback value](https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value).