### PR TITLE
Silence a few warnings

### DIFF
--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo3/compiler/CodegenTest.kt
@@ -155,7 +155,6 @@ class CodegenTest {
             when {
               file.name == "companion" -> listOf(Parameters(file, MODELS_OPERATION_BASED, true))
               hasFragments -> {
-                @Suppress("DEPRECATION")
                 val list = listOf(
                     Parameters(file, MODELS_OPERATION_BASED, true),
                 )
@@ -254,7 +253,7 @@ class CodegenTest {
         "mutation_create_review", "simple_fragment", "data_builders" -> true
         else -> false
       }
-      val operationIdGenerator = when (folder.name) {
+      @Suppress("DEPRECATION") val operationIdGenerator = when (folder.name) {
         "operation_id_generator" -> object : OperationIdGenerator {
           override fun apply(operationDocument: String, operationName: String): String {
             return "hash"
@@ -279,6 +278,7 @@ class CodegenTest {
             ?: File("src/test/graphql/schema.sdl")
 
       val graphqlFiles = setOf(File(folder, "TestOperation.graphql"))
+      @Suppress("DEPRECATION")
       val operationOutputGenerator = OperationOutputGenerator.Default(operationIdGenerator)
 
       val targetLanguage = if (generateKotlinModels) {

--- a/libraries/apollo-engine-ktor/src/commonMain/kotlin/com/apollographql/apollo3/network/KtorExtensions.kt
+++ b/libraries/apollo-engine-ktor/src/commonMain/kotlin/com/apollographql/apollo3/network/KtorExtensions.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.network
 
 import com.apollographql.apollo3.ApolloClient

--- a/libraries/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt
+++ b/libraries/apollo-idling-resource/src/main/java/com/apollographql/apollo3/android/ApolloIdlingResource.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.android
 
 import androidx.test.espresso.IdlingResource

--- a/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/CustomHandlerTest.kt
+++ b/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/CustomHandlerTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.mockserver.test
 
 import com.apollographql.apollo3.api.http.HttpMethod

--- a/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
+++ b/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/EnqueueTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.mockserver.test
 
 import com.apollographql.apollo3.api.http.HttpMethod

--- a/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
+++ b/libraries/apollo-mockserver/src/commonTest/kotlin/com/apollographql/apollo3/mockserver/test/SocketTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.mockserver.test
 
 import com.apollographql.apollo3.api.http.HttpMethod

--- a/libraries/apollo-mockserver/src/jvmTest/kotlin/com/apollographql/apollo3/mockserver/test/MultipartTest.kt
+++ b/libraries/apollo-mockserver/src/jvmTest/kotlin/com/apollographql/apollo3/mockserver/test/MultipartTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.mockserver.test
 
 import com.apollographql.apollo3.api.http.HttpMethod

--- a/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
+++ b/libraries/apollo-runtime/src/androidInstrumentedTest/kotlin/instrumented/NetworkMonitorTest.kt
@@ -10,7 +10,7 @@ import com.apollographql.apollo3.interceptor.RetryOnErrorInterceptor
 import com.apollographql.apollo3.network.NetworkMonitor
 import com.apollographql.apollo3.network.http.DefaultHttpEngine
 import com.apollographql.apollo3.network.http.HttpEngine
-import com.apollographql.apollo3.testing.FooQuery
+import test.FooQuery
 import com.apollographql.apollo3.testing.mockServerTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/FooOperation.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/FooOperation.kt
@@ -1,4 +1,4 @@
-package com.apollographql.apollo3.testing
+package test
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo3.annotations.ApolloExperimental
@@ -21,11 +21,7 @@ import com.apollographql.apollo3.api.missingField
  *
  * Use it to test parts of the runtime without having to use included builds.
  */
-@ApolloExperimental
-@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-@Suppress("DEPRECATION")
-class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
+internal class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
   companion object {
     val successResponse = "{\"data\": {\"foo\": 42}}"
   }
@@ -36,11 +32,7 @@ class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
  *
  * Use it to test parts of the runtime without having to use included builds.
  */
-@ApolloExperimental
-@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-@Suppress("DEPRECATION")
-class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.Data> {
+internal class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.Data> {
   companion object {
     fun nextMessage(id: String, foo: Int): String {
       return buildJsonString {
@@ -96,11 +88,7 @@ class FooSubscription: FooOperation("subscription"), Subscription<FooOperation.D
  * Base class for test queries.
  * Note we can't make [FooOperation] extend both [Query] and [Subscription] because that confuses [ApolloClient] when deciding whant NetworkTransport to use.
  */
-@ApolloExperimental
-@Deprecated("This is only used for internal Apollo tests and will be removed in a future version.")
-@ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
-@Suppress("DEPRECATION")
-abstract class FooOperation(private val operationType: String): Operation<FooOperation.Data> {
+internal abstract class FooOperation(private val operationType: String): Operation<FooOperation.Data> {
   class Data(val foo: Int): Query.Data, Subscription.Data {
     override fun toString(): String {
       return "Data(foo: $foo)"

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/NetworkMonitorTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/NetworkMonitorTest.kt
@@ -13,7 +13,7 @@ import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.assertNoRequest
 import com.apollographql.mockserver.enqueueString
 import com.apollographql.apollo3.network.NetworkMonitor
-import com.apollographql.apollo3.testing.FooQuery
+import test.FooQuery
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketEngineTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketEngineTest.kt
@@ -4,9 +4,7 @@ import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.network.websocket.WebSocket
 import com.apollographql.apollo3.network.websocket.WebSocketEngine
 import com.apollographql.apollo3.network.websocket.WebSocketListener
-import com.apollographql.apollo3.testing.Platform
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.platform
 import com.apollographql.mockserver.CloseFrame
 import com.apollographql.mockserver.DataMessage
 import com.apollographql.mockserver.MockRequestBase
@@ -148,7 +146,8 @@ class WebSocketEngineTest {
     }
 
     clientWriter.close(1003, "Client Bye")
-    if (platform() != Platform.Native) {
+    @Suppress("DEPRECATION")
+    if (com.apollographql.apollo3.testing.platform() != com.apollographql.apollo3.testing.Platform.Native) {
       // Apple sometimes does not send the Close frame. See https://developer.apple.com/forums/thread/679446
       serverReader.awaitMessage().apply {
         assertIs<CloseFrame>(this)

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/WebSocketNetworkTransportTest.kt
@@ -15,14 +15,12 @@ import com.apollographql.apollo3.interceptor.ApolloInterceptor
 import com.apollographql.apollo3.interceptor.ApolloInterceptorChain
 import com.apollographql.apollo3.network.websocket.WebSocketNetworkTransport
 import com.apollographql.apollo3.network.websocket.closeConnection
-import com.apollographql.apollo3.testing.FooSubscription
-import com.apollographql.apollo3.testing.FooSubscription.Companion.completeMessage
-import com.apollographql.apollo3.testing.FooSubscription.Companion.errorMessage
-import com.apollographql.apollo3.testing.FooSubscription.Companion.nextMessage
-import com.apollographql.apollo3.testing.Platform
+import test.FooSubscription
+import test.FooSubscription.Companion.completeMessage
+import test.FooSubscription.Companion.errorMessage
+import test.FooSubscription.Companion.nextMessage
 import com.apollographql.apollo3.testing.connectionAckMessage
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.platform
 import com.apollographql.mockserver.CloseFrame
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.TextMessage
@@ -224,8 +222,9 @@ class WebSocketNetworkTransportTest {
                 webSocketBody.enqueueMessage(CloseFrame(3666, "closed"))
 
                 awaitItem().exception.apply {
-                  when (platform()){
-                    Platform.Native -> {
+                  @Suppress("DEPRECATION")
+                  when (com.apollographql.apollo3.testing.platform()){
+                    com.apollographql.apollo3.testing.Platform.Native -> {
                       assertIs<DefaultApolloException>(this)
                       assertTrue(message?.contains("Error reading websocket") == true)
                     }
@@ -284,8 +283,9 @@ class WebSocketNetworkTransportTest {
           awaitItem()
           serverWriter.enqueueMessage(CloseFrame(1001, "flowThrowsIfNoReconnect"))
           awaitItem().exception.apply {
-            when (platform()){
-              Platform.Native -> {
+            @Suppress("DEPRECATION")
+            when (com.apollographql.apollo3.testing.platform()){
+              com.apollographql.apollo3.testing.Platform.Native -> {
                 assertIs<DefaultApolloException>(this)
                 assertTrue(message?.contains("Error reading websocket") == true)
               }

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
@@ -16,10 +16,10 @@ import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.awaitWebSocketRequest
 import com.apollographql.mockserver.enqueueWebSocket
 import com.apollographql.apollo3.network.websocket.WebSocketNetworkTransport
-import com.apollographql.apollo3.testing.FooQuery
-import com.apollographql.apollo3.testing.FooSubscription
-import com.apollographql.apollo3.testing.FooSubscription.Companion.completeMessage
-import com.apollographql.apollo3.testing.FooSubscription.Companion.nextMessage
+import test.FooQuery
+import test.FooSubscription
+import test.FooSubscription.Companion.completeMessage
+import test.FooSubscription.Companion.nextMessage
 import com.apollographql.apollo3.testing.connectionAckMessage
 import com.apollographql.apollo3.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope

--- a/libraries/apollo-testing-support/api/apollo-testing-support.api
+++ b/libraries/apollo-testing-support/api/apollo-testing-support.api
@@ -4,22 +4,6 @@ public final class com/apollographql/apollo3/testing/-FileSystemCommon {
 	public static final fun pathToUtf8 (Ljava/lang/String;)Ljava/lang/String;
 }
 
-public final class com/apollographql/apollo3/testing/FooOperation$Data : com/apollographql/apollo3/api/Query$Data, com/apollographql/apollo3/api/Subscription$Data {
-	public fun <init> (I)V
-	public final fun getFoo ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/testing/FooQuery$Companion {
-	public final fun getSuccessResponse ()Ljava/lang/String;
-}
-
-public final class com/apollographql/apollo3/testing/FooSubscription$Companion {
-	public final fun completeMessage (Ljava/lang/String;)Ljava/lang/String;
-	public final fun errorMessage (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-	public final fun nextMessage (Ljava/lang/String;I)Ljava/lang/String;
-}
-
 public final class com/apollographql/apollo3/testing/MockserverKt {
 	public static final fun enqueue (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;J)V
 	public static synthetic fun enqueue$default (Lcom/apollographql/apollo3/mockserver/MockServer;Lcom/apollographql/apollo3/api/Operation;Lcom/apollographql/apollo3/api/Operation$Data;Lcom/apollographql/apollo3/api/CustomScalarAdapters;JILjava/lang/Object;)V

--- a/libraries/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/platform.apple.kt
+++ b/libraries/apollo-testing-support/src/appleMain/kotlin/com/apollographql/apollo3/testing/platform.apple.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/mockserver.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/platform.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/platform.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
+++ b/libraries/apollo-testing-support/src/commonMain/kotlin/com/apollographql/apollo3/testing/runTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.ApolloClient

--- a/libraries/apollo-testing-support/src/jsMain/kotlin/com/apollographql/apollo3/testing/platform.js.kt
+++ b/libraries/apollo-testing-support/src/jsMain/kotlin/com/apollographql/apollo3/testing/platform.js.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-testing-support/src/jvmCommonMain/kotlin/com/apollographql/apollo3/testing/platform.jvmCommon.kt
+++ b/libraries/apollo-testing-support/src/jvmCommonMain/kotlin/com/apollographql/apollo3/testing/platform.jvmCommon.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/platform.wasmJs.kt
+++ b/libraries/apollo-testing-support/src/wasmJsMain/kotlin/com/apollographql/apollo3/testing/platform.wasmJs.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package com.apollographql.apollo3.testing
 
 import com.apollographql.apollo3.annotations.ApolloDeprecatedSince

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/RegisterOperations.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/RegisterOperations.kt
@@ -25,7 +25,6 @@ import com.apollographql.apollo3.ast.parseAsGQLDocument
 import com.apollographql.apollo3.ast.toUtf8
 import com.apollographql.apollo3.ast.transform
 import com.apollographql.apollo3.compiler.APOLLO_VERSION
-import com.apollographql.apollo3.compiler.OperationIdGenerator
 import com.apollographql.apollo3.compiler.operationoutput.OperationOutput
 import com.apollographql.apollo3.tooling.platformapi.internal.RegisterOperationsMutation
 import com.apollographql.apollo3.tooling.platformapi.internal.type.RegisteredClientIdentityInput
@@ -221,7 +220,7 @@ object RegisterOperations {
   }
 
   fun String.safelistingHash(): String {
-    return OperationIdGenerator.Sha256.apply(normalize(), "")
+    return Buffer().writeUtf8(normalize()).readByteString().sha256().hex()
   }
 
   @Deprecated("Use persisted queries and publishOperations instead. See https://www.apollographql.com/docs/graphos/operations/persisted-queries/")

--- a/tests/compiler-plugins/getters-and-setters/src/main/kotlin/hooks/TestPlugin.kt
+++ b/tests/compiler-plugins/getters-and-setters/src/main/kotlin/hooks/TestPlugin.kt
@@ -2,6 +2,7 @@ package hooks
 
 import com.apollographql.apollo3.compiler.ApolloCompilerPlugin
 import com.apollographql.apollo3.compiler.Transform
+import com.apollographql.apollo3.compiler.capitalizeFirstLetter
 import com.apollographql.apollo3.compiler.codegen.java.JavaOutput
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.MethodSpec
@@ -36,12 +37,12 @@ class TestPlugin : ApolloCompilerPlugin {
                                       .filterNot { fieldSpec -> fieldSpec.hasModifier(Modifier.TRANSIENT) }
                                       .flatMap { fieldSpec ->
                                         listOf(
-                                            MethodSpec.methodBuilder("get${fieldSpec.name.removePrefix("__").capitalize()}")
+                                            MethodSpec.methodBuilder("get${fieldSpec.name.removePrefix("__").capitalizeFirstLetter()}")
                                                 .addModifiers(Modifier.PUBLIC)
                                                 .returns(fieldSpec.type)
                                                 .addStatement("return this.\$L", fieldSpec.name)
                                                 .build(),
-                                            MethodSpec.methodBuilder("set${fieldSpec.name.removePrefix("__").capitalize()}")
+                                            MethodSpec.methodBuilder("set${fieldSpec.name.removePrefix("__").capitalizeFirstLetter()}")
                                                 .addModifiers(Modifier.PUBLIC)
                                                 .addParameter(fieldSpec.type, fieldSpec.name)
                                                 .addStatement("this.\$L = \$L", fieldSpec.name, fieldSpec.name)

--- a/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferNormalizedCacheTest.kt
@@ -18,9 +18,7 @@ import com.apollographql.apollo3.exception.ApolloHttpException
 import com.apollographql.apollo3.exception.ApolloNetworkException
 import com.apollographql.apollo3.exception.CacheMissException
 import com.apollographql.apollo3.network.NetworkTransport
-import com.apollographql.apollo3.testing.Platform
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.platform
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.assertNoRequest
 import com.apollographql.mockserver.awaitRequest
@@ -464,7 +462,8 @@ class DeferNormalizedCacheTest {
 
   @Test
   fun intermediatePayloadsAreCached() = runTest(before = { setUp() }, after = { tearDown() }) {
-    if (platform() == Platform.Js) {
+    @Suppress("DEPRECATION")
+    if (com.apollographql.apollo3.testing.platform() == com.apollographql.apollo3.testing.Platform.Js) {
       // TODO For now chunked is not supported on JS - remove this check when it is
       return@runTest
     }

--- a/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
+++ b/tests/defer/src/commonTest/kotlin/test/DeferTest.kt
@@ -5,9 +5,7 @@ import com.apollographql.apollo3.api.ApolloResponse
 import com.apollographql.apollo3.api.Error
 import com.apollographql.apollo3.autoPersistedQueryInfo
 import com.apollographql.apollo3.mpp.currentTimeMillis
-import com.apollographql.apollo3.testing.Platform
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.platform
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.enqueueMultipart
 import com.apollographql.mockserver.enqueueString
@@ -255,7 +253,8 @@ class DeferTest {
 
   @Test
   fun payloadsAreReceivedIncrementally() = runTest(before = { setUp() }, after = { tearDown() }) {
-    if (platform() == Platform.Js) {
+    @Suppress("DEPRECATION")
+    if (com.apollographql.apollo3.testing.platform() == com.apollographql.apollo3.testing.Platform.Js) {
       // TODO For now chunked is not supported on JS - remove this check when it is
       return@runTest
     }

--- a/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
+++ b/tests/defer/src/jvmTest/kotlin/test/DeferJvmTest.kt
@@ -43,7 +43,7 @@ class DeferJvmTest {
         .build()
   }
 
-  private suspend fun tearDown() {
+  private fun tearDown() {
     mockServer.close()
   }
 
@@ -112,8 +112,10 @@ class DeferJvmTest {
         channel.close()
       }
 
+      @Suppress("DEPRECATION")
       assertNull(channel.awaitElement()?.product?.productInfoInventory)
       delay(4500)
+      @Suppress("DEPRECATION")
       assertNotNull(channel.awaitElement()?.product?.productInfoInventory)
       client.close()
     }

--- a/tests/idling-resource/src/test/java/IdlingResourceTest.kt
+++ b/tests/idling-resource/src/test/java/IdlingResourceTest.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION")
 
 import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.android.ApolloIdlingResource

--- a/tests/integration-tests/src/commonTest/kotlin/Utils.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/Utils.kt
@@ -12,8 +12,11 @@ import com.apollographql.apollo3.testing.pathToJsonReader
 import com.apollographql.apollo3.testing.pathToUtf8
 import kotlin.test.assertEquals
 
+@Suppress("DEPRECATION")
 fun checkTestFixture(actualText: String, name: String) = checkFile(actualText, "integration-tests/testFixtures/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("integration-tests/testFixtures/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToJsonReader(name: String) = pathToJsonReader("integration-tests/testFixtures/$name")
 
 /**

--- a/tests/integration-tests/src/commonTest/kotlin/test/NormalizedCacheThreadingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/NormalizedCacheThreadingTest.kt
@@ -17,6 +17,7 @@ import kotlin.test.assertNull
 class NormalizedCacheThreadingTest {
   @Test
   fun cacheCreationHappensInBackgroundThread() = runTest {
+    @Suppress("DEPRECATION")
     val testThreadName = currentThreadId()
     // No threading on js
     if (testThreadName == "js") return@runTest
@@ -25,6 +26,7 @@ class NormalizedCacheThreadingTest {
         .networkTransport(QueueTestNetworkTransport())
         .normalizedCache(object : NormalizedCacheFactory() {
           override fun create(): NormalizedCache {
+            @Suppress("DEPRECATION")
             cacheCreateThreadName = currentThreadId()
             return MemoryCacheFactory().create()
           }

--- a/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/OptimisticCacheTest.kt
@@ -271,6 +271,7 @@ class OptimisticCacheTest {
     assertEquals(watcherData?.reviews?.get(2)?.commentary, "Amazing")
 
     // after mutation with rolled back optimistic updates
+    @Suppress("DEPRECATION")
     watcherData = channel.awaitElement()
     assertEquals(watcherData?.reviews?.size, 3)
     assertEquals(watcherData?.reviews?.get(0)?.id, "empireReview1")

--- a/tests/integration-tests/src/commonTest/kotlin/test/ThreadTests.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/ThreadTests.kt
@@ -11,7 +11,7 @@ import com.apollographql.apollo3.cache.normalized.api.Record
 import com.apollographql.apollo3.cache.normalized.fetchPolicy
 import com.apollographql.apollo3.cache.normalized.normalizedCache
 import com.apollographql.apollo3.integration.normalizer.HeroNameQuery
-import com.apollographql.apollo3.testing.Platform
+import com.apollographql.apollo3.testing.*
 import com.apollographql.apollo3.testing.QueueTestNetworkTransport
 import com.apollographql.apollo3.testing.currentThreadId
 import com.apollographql.apollo3.testing.enqueueTestResponse
@@ -21,6 +21,7 @@ import kotlin.reflect.KClass
 import kotlin.test.Test
 
 class ThreadTests {
+  @Suppress("DEPRECATION")
   class MyNormalizedCache(val mainThreadId: String) : NormalizedCache() {
     val delegate = MemoryCache()
 
@@ -90,10 +91,12 @@ class ThreadTests {
 
   @Test
   fun cacheIsNotReadFromTheMainThread() = runTest {
+    @Suppress("DEPRECATION")
     if (platform() == Platform.Js) {
       return@runTest
     }
 
+    @Suppress("DEPRECATION")
     val apolloClient = ApolloClient.Builder()
         .normalizedCache(MyMemoryCacheFactory(currentThreadId()))
         .networkTransport(QueueTestNetworkTransport())

--- a/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/WatcherErrorHandlingTest.kt
@@ -115,6 +115,7 @@ class WatcherErrorHandlingTest {
             channel.send(it)
           }
     }
+    @Suppress("DEPRECATION")
     assertEquals(channel.awaitElement().data?.hero?.name, "R2-D2")
 
     // Another newer call gets updated information with "Artoo"
@@ -124,6 +125,7 @@ class WatcherErrorHandlingTest {
     mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
+    @Suppress("DEPRECATION")
     assertIs<ApolloHttpException>(channel.awaitElement().exception)
     job.cancel()
   }
@@ -195,6 +197,7 @@ class WatcherErrorHandlingTest {
             channel.send(it)
           }
     }
+    @Suppress("DEPRECATION")
     assertEquals(channel.awaitElement().data?.hero?.name, "R2-D2")
 
     // Another newer call gets updated information with "Artoo"
@@ -204,6 +207,7 @@ class WatcherErrorHandlingTest {
     mockServer.enqueueError(statusCode = 500)
     apolloClient.query(query).fetchPolicy(FetchPolicy.NetworkOnly).execute()
 
+    @Suppress("DEPRECATION")
     assertIs<ApolloHttpException>(channel.awaitElement().exception)
 
     assertNull(throwable)

--- a/tests/integration-tests/src/jvmTest/kotlin/test/OperationOutputTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/OperationOutputTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertEquals
 class OperationOutputTest {
   @Test
   fun operationOutputMatchesTheModels() {
-    val operationOutput = pathToUtf8("integration-tests/build/generated/manifest/apollo/httpcache-kotlin/operationOutput.json")
+    @Suppress("DEPRECATION") val operationOutput = pathToUtf8("integration-tests/build/generated/manifest/apollo/httpcache-kotlin/operationOutput.json")
     val source = Json.parseToJsonElement(operationOutput).jsonObject.entries.mapNotNull {
       val descriptor = it.value.jsonObject
       if (descriptor.getValue("name").jsonPrimitive.content == "AllFilms") {

--- a/tests/integration-tests/src/jvmTest/kotlin/test/PersistedQueryManifestTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/PersistedQueryManifestTest.kt
@@ -25,7 +25,7 @@ import kotlin.test.assertEquals
 class PersistedQueryManifestTest {
   @Test
   fun persistedQueryManifestTheModels() {
-    val manifest = pathToUtf8("integration-tests/build/generated/manifest/apollo/upload-kotlin/persistedQueryManifest.json")
+    @Suppress("DEPRECATION") val manifest = pathToUtf8("integration-tests/build/generated/manifest/apollo/upload-kotlin/persistedQueryManifest.json")
 
     val source = Json.parseToJsonElement(manifest).jsonObject.get("operations")!!.jsonArray.mapNotNull {
       val descriptor = it.jsonObject

--- a/tests/models-operation-based-with-interfaces/src/test/kotlin/Utils.kt
+++ b/tests/models-operation-based-with-interfaces/src/test/kotlin/Utils.kt
@@ -5,7 +5,9 @@ import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerato
 import com.apollographql.apollo3.testing.pathToJsonReader
 import com.apollographql.apollo3.testing.pathToUtf8
 
+@Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToJsonReader(name: String) = pathToJsonReader("models-fixtures/json/$name")
 
 /**

--- a/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
+++ b/tests/models-operation-based/src/commonTest/kotlin/Utils.kt
@@ -5,7 +5,10 @@ import com.apollographql.apollo3.cache.normalized.api.TypePolicyCacheKeyGenerato
 import com.apollographql.apollo3.testing.pathToJsonReader
 import com.apollographql.apollo3.testing.pathToUtf8
 
+
+@Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToJsonReader(name: String) = pathToJsonReader("models-fixtures/json/$name")
 
 /**

--- a/tests/models-response-based/src/commonTest/kotlin/Utils.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/Utils.kt
@@ -6,8 +6,11 @@ import com.apollographql.apollo3.testing.checkFile
 import com.apollographql.apollo3.testing.pathToJsonReader
 import com.apollographql.apollo3.testing.pathToUtf8
 
+@Suppress("DEPRECATION")
 fun checkTestFixture(actualText: String, name: String) = checkFile(actualText, "models-fixtures/json/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToUtf8(name: String) = pathToUtf8("models-fixtures/json/$name")
+@Suppress("DEPRECATION")
 fun testFixtureToJsonReader(name: String) = pathToJsonReader("models-fixtures/json/$name")
 
 /**

--- a/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
+++ b/tests/models-response-based/src/commonTest/kotlin/test/ParseResponseBodyTest.kt
@@ -9,8 +9,7 @@ import com.apollographql.apollo3.api.composeJsonResponse
 import com.apollographql.apollo3.api.json.buildJsonString
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.toApolloResponse
-import com.apollographql.apollo3.testing.Platform
-import com.apollographql.apollo3.testing.platform
+import com.apollographql.apollo3.testing.*
 import okio.Buffer
 import testFixtureToJsonReader
 import testFixtureToUtf8
@@ -57,6 +56,7 @@ class ParseResponseBodyTest {
       query.composeJsonResponse(this, data!!)
     }
 
+    @Suppress("DEPRECATION")
     if (platform() != Platform.Js) {
       // Do not check strings on JS because of https://youtrack.jetbrains.com/issue/KT-33358#focus=Comments-27-3656643.0-0
       checkTestFixture(actual, "OperationJsonWriter.json")

--- a/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsMockServerTest.kt
+++ b/tests/multipart/src/commonTest/kotlin/test/MultipartSubscriptionsMockServerTest.kt
@@ -7,11 +7,8 @@ import com.apollographql.apollo3.exception.RouterError
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
 import com.apollographql.apollo3.network.http.HttpNetworkTransport
-import com.apollographql.apollo3.testing.Platform
-import com.apollographql.apollo3.testing.assertNoElement
-import com.apollographql.apollo3.testing.awaitElement
+import com.apollographql.apollo3.testing.*
 import com.apollographql.apollo3.testing.internal.runTest
-import com.apollographql.apollo3.testing.platform
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.Channel
@@ -135,7 +132,9 @@ class MultipartSubscriptionsMockServerTest {
       }
     }
 
+    @Suppress("DEPRECATION")
     assertEquals("world", channel.awaitElement().dataOrThrow().hello)
+    @Suppress("DEPRECATION")
     channel.assertNoElement()
   }
 
@@ -291,6 +290,7 @@ private class Context(
 }
 
 private fun multipartSubsTest(block: suspend Context.() -> Unit) = runTest {
+  @Suppress("DEPRECATION")
   if (platform() != Platform.Js) {
     MockServer().use { mockServer ->
       ApolloClient.Builder()


### PR DESCRIPTION
These are mostly warnings from the internal usages of `apollo-testing-support`. Once removed, we can keep them in a non-published module.