### PR TITLE
[IJ Plugin] Tweak cache name display for Apollo 3, 4, and incubating

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo3.ApolloClient
 import com.apollographql.apollo3.debug.GetApolloClientsQuery
 import com.apollographql.apollo3.debug.GetNormalizedCacheQuery
 import com.apollographql.apollo3.network.http.LoggingInterceptor
+import com.apollographql.ijplugin.util.apollo3
 import com.apollographql.ijplugin.util.apollo4
 import com.apollographql.ijplugin.util.executeCatching
 import com.apollographql.ijplugin.util.logd
@@ -119,7 +120,15 @@ class ApolloDebugClient(
 
 val String.normalizedCacheSimpleName: String
   get() = when (this) {
-    "$apollo4.cache.normalized.api.MemoryCache" -> "MemoryCache"
-    "$apollo4.cache.normalized.sql.SqlNormalizedCache" -> "SqlNormalizedCache"
+    "$apollo3.cache.normalized.api.MemoryCache",
+    "$apollo4.cache.normalized.api.MemoryCache",
+    "com.apollographql.cache.normalized.sql.MemoryCache",
+    -> "MemoryCache"
+
+    "$apollo3.cache.normalized.sql.SqlNormalizedCache",
+    "$apollo4.cache.normalized.sql.SqlNormalizedCache",
+    "com.apollographql.cache.normalized.sql.SqlNormalizedCache",
+    -> "SqlNormalizedCache"
+
     else -> this
   }


### PR DESCRIPTION
Instead of displaying the full package name we show only the class name, for known cache types. Adjusted to work for several known packages.