### PR TITLE
[📚 docs] Fix experimental link

### DIFF
--- a/docs/source/advanced/compiler-plugins.mdx
+++ b/docs/source/advanced/compiler-plugins.mdx
@@ -4,7 +4,7 @@ title: Apollo compiler plugins
 
 <ExperimentalFeature>
 
-**Compiler plugins are currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
+**Compiler plugins are currently [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
 
 </ExperimentalFeature>
 

--- a/docs/source/advanced/experimental-websockets.mdx
+++ b/docs/source/advanced/experimental-websockets.mdx
@@ -4,7 +4,7 @@ title: Experimental WebSockets
 
 <ExperimentalFeature>
 
-**The experimental WebSockets implementation are currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
+**The experimental WebSockets implementation are currently [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
 
 </ExperimentalFeature>
 

--- a/docs/source/advanced/js-interop.mdx
+++ b/docs/source/advanced/js-interop.mdx
@@ -22,7 +22,7 @@ dynamic JS object is callable from Kotlin directly.
 
 <ExperimentalFeature>
 
-**`JsExport` is currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
+**`JsExport` is currently [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on it, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
 
 </ExperimentalFeature>
 

--- a/docs/source/advanced/network-connectivity.mdx
+++ b/docs/source/advanced/network-connectivity.mdx
@@ -4,7 +4,7 @@ title: Monitor the network state to reduce latency
 
 <ExperimentalFeature>
 
-**Network Monitor APIs are currently [experimental](https://www.apollographql.com/docs/resources/release-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
+**Network Monitor APIs are currently [experimental](https://www.apollographql.com/docs/resources/product-launch-stages/#experimental-features) in Apollo Kotlin.** If you have feedback on them, please let us know via [GitHub issues](https://github.com/apollographql/apollo-kotlin/issues/new?assignees=&labels=Type%3A+Bug&template=bug_report.md) or in the [Kotlin Slack community](https://slack.kotl.in/).
 
 </ExperimentalFeature> 
 


### PR DESCRIPTION
There is a disconnect between Gatsby and Netlify. Will be fixed in a future version of the docs framework but for now, let's just update the link.
Fixes #5830 
