### PR TITLE
Undeprecate schemaFile

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -67,13 +67,8 @@ interface Service {
   fun srcDir(directory: Any)
 
   /**
-   * The location of the schema file.
-   *
-   * Because clients may extend the schema with client extensions in separate files, this is deprecated
-   * in favor of [schemaFiles].
+   * The location of the main schema file.
    */
-  @Deprecated("Replace with schemaFiles.from()")
-  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   val schemaFile: RegularFileProperty
 
   /**

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -104,7 +104,6 @@ abstract class DefaultApolloExtension(
           if (service.excludes.isPresent) add("excludes")
           @Suppress("DEPRECATION")
           if (service.sourceFolder.isPresent) add("excludes")
-          @Suppress("DEPRECATION")
           if (service.schemaFile.isPresent) add("schemaFile")
           if (!service.schemaFiles.isEmpty) add("schemaFiles")
           if (service.scalarAdapterMapping.isNotEmpty()) {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -248,9 +248,7 @@ internal fun DefaultService.fallbackFiles(project: Project, block: (Configurable
 internal fun DefaultService.schemaFiles(project: Project): FileCollection {
   val fileCollection = project.files()
 
-  @Suppress("DEPRECATION")
   if (schemaFile.isPresent) {
-    project.logger.lifecycle("Apollo: using 'schemaFile.set()' is deprecated as additional schema files like 'extra.graphqls' might be required. Please use 'schemaFiles.from(fileTree(\"directory\").include(\"**/*.graphqls\"))' instead.")
     fileCollection.from(schemaFile)
   } else {
     fileCollection.from(schemaFiles)


### PR DESCRIPTION
I changed my mind. There is a global expectation that there is a "main" schema file. Furthermore, deprecating this also had cascading impacts on `introspection {}` for which we don't have a good answer right now.