### PR TITLE
Deprecate HttpNetworkTransport.httpHeaders()

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.network.http
 
+import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.api.ApolloRequest
 import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.CustomScalarAdapters
@@ -303,10 +304,14 @@ private constructor(
       this.exposeErrorBody = exposeErrorBody
     }
 
+    @Deprecated("Use ApolloClient.Builder.addHttpHeader() instead")
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
     fun addHttpHeader(name: String, value: String) = apply {
       headers.add(HttpHeader(name, value))
     }
 
+    @Deprecated("Use ApolloClient.Builder.httpHeader() instead")
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
     fun httpHeaders(headers: List<HttpHeader>) = apply {
       // In case this builder comes from newBuilder(), remove any existing interceptor
       interceptors.removeAll {


### PR DESCRIPTION
I don't think this brings much value? [Keeps precedence a bit contained](https://youtu.be/YZstpc2939s?t=1888) 