### PR TITLE
[runtime] Remove ensureUuid()

### DIFF
--- a/docs/source/advanced/experimental-websockets.mdx
+++ b/docs/source/advanced/experimental-websockets.mdx
@@ -123,23 +123,22 @@ class MyRetryOnErrorInterceptor : ApolloInterceptor {
 
   override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
     var attempt = 0
-    return request.ensureUniqueUuid()
-        .flatMapConcat { chain.proceed(it) }.onEach {
-          if (request.retryOnError == true && it.exception != null && it.exception is ApolloNetworkException) {
-            throw RetryException
-          } else {
-            attempt = 0
-          }
-        }.retryWhen { cause, _ ->
-          if (cause is RetryException) {
-            attempt++
-            delay(2.0.pow(attempt).seconds)
-            true
-          } else {
-            // Not a RetryException, probably a programming error, pass it through
-            false
-          }
-        }
+    return chain.proceed(request).onEach {
+      if (request.retryOnError == true && it.exception != null && it.exception is ApolloNetworkException) {
+        throw RetryException
+      } else {
+        attempt = 0
+      }
+    }.retryWhen { cause, _ ->
+      if (cause is RetryException) {
+        attempt++
+        delay(2.0.pow(attempt).seconds)
+        true
+      } else {
+        // Not a RetryException, probably a programming error, pass it through
+        false
+      }
+    }
   }
 }
 ```

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
@@ -1,27 +1,16 @@
 
 import app.cash.turbine.test
 import com.apollographql.apollo.ApolloClient
-import com.apollographql.apollo.annotations.ApolloExperimental
-import com.apollographql.apollo.api.ApolloRequest
-import com.apollographql.apollo.api.ApolloResponse
-import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.Subscription
-import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloHttpException
 import com.apollographql.apollo.exception.ApolloNetworkException
-import com.apollographql.apollo.interceptor.ApolloInterceptor
-import com.apollographql.apollo.interceptor.ApolloInterceptorChain
+import com.apollographql.apollo.network.websocket.WebSocketNetworkTransport
+import com.apollographql.apollo.testing.connectionAckMessage
+import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.mockserver.MockResponse
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.awaitWebSocketRequest
 import com.apollographql.mockserver.enqueueWebSocket
-import com.apollographql.apollo.network.websocket.WebSocketNetworkTransport
-import test.FooQuery
-import test.FooSubscription
-import test.FooSubscription.Companion.completeMessage
-import test.FooSubscription.Companion.nextMessage
-import com.apollographql.apollo.testing.connectionAckMessage
-import com.apollographql.apollo.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collect
@@ -29,15 +18,19 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import okio.use
+import test.FooQuery
+import test.FooSubscription
+import test.FooSubscription.Companion.completeMessage
+import test.FooSubscription.Companion.nextMessage
+import test.network.awaitSubscribe
 import test.network.enqueueMessage
 import test.network.mockServerTest
+import test.network.retryWhen
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNotEquals
 import kotlin.time.Duration.Companion.seconds
-import test.network.awaitSubscribe
-import test.network.retryWhen
 
 class RetryWebSocketsTest {
   @Test


### PR DESCRIPTION
`WebSocketNetworkTransport` already has logic to renew the uuid. It's working as long as there's a single `Flow` instance so memoize it. Makes it even simpler to implement retry interceptors. 

See https://github.com/apollographql/apollo-kotlin/pull/6069#discussion_r1687964151