### PR TITLE
Allow to shutdown SchemaDownloader

### DIFF
--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/SchemaDownloader.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/SchemaDownloader.kt
@@ -189,5 +189,10 @@ object SchemaDownloader {
     return data.graph.variant.latestPublication.schema.document
   }
 
+  fun shutdown() {
+    SchemaHelper.client.dispatcher.executorService.shutdown()
+    SchemaHelper.client.connectionPool.evictAll()
+  }
+  
   inline fun <reified T> Any?.cast() = this as? T
 }

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/SchemaHelper.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/SchemaHelper.kt
@@ -31,10 +31,12 @@ import javax.net.ssl.SSLSocketFactory
 import javax.net.ssl.X509TrustManager
 
 internal object SchemaHelper {
+  internal val client = OkHttpClient()
+
   internal fun newOkHttpClient(insecure: Boolean): OkHttpClient {
     val connectTimeoutSeconds = System.getProperty("okHttp.connectTimeout", "600").toLong()
     val readTimeoutSeconds = System.getProperty("okHttp.readTimeout", "600").toLong()
-    val clientBuilder = OkHttpClient.Builder()
+    val clientBuilder = client.newBuilder()
         .connectTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
         .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
 

--- a/libraries/apollo-tooling/src/test/kotlin/com/apollographql/apollo/tooling/SchemaDownloaderTests.kt
+++ b/libraries/apollo-tooling/src/test/kotlin/com/apollographql/apollo/tooling/SchemaDownloaderTests.kt
@@ -111,15 +111,4 @@ class SchemaDownloaderTests {
     assertEquals(introspectionRequestOneOf, introspectionRequest)
     assertEquals(introspectionResponse, tempFile.readText())
   }
-
-  @Test
-  fun test() {
-    SchemaDownloader.downloadIntrospection(
-        endpoint = "https://apollo-fullstack-tutorial.herokuapp.com/graphql",
-        headers = emptyMap(),
-        insecure = false
-    ).also {
-      println(it)
-    }
-  }
 }

--- a/libraries/apollo-tooling/src/test/kotlin/com/apollographql/apollo/tooling/SchemaDownloaderTests.kt
+++ b/libraries/apollo-tooling/src/test/kotlin/com/apollographql/apollo/tooling/SchemaDownloaderTests.kt
@@ -111,4 +111,15 @@ class SchemaDownloaderTests {
     assertEquals(introspectionRequestOneOf, introspectionRequest)
     assertEquals(introspectionResponse, tempFile.readText())
   }
+
+  @Test
+  fun test() {
+    SchemaDownloader.downloadIntrospection(
+        endpoint = "https://apollo-fullstack-tutorial.herokuapp.com/graphql",
+        headers = emptyMap(),
+        insecure = false
+    ).also {
+      println(it)
+    }
+  }
 }


### PR DESCRIPTION
This is important for tools like CLI that otherwise stay stuck until the threadpool terminates