### PR TITLE
[Introspection] Remove warning

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/introspection/introspection_reader.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/introspection/introspection_reader.kt
@@ -462,7 +462,8 @@ private class GQLDocumentBuilder(private val introspectionSchema: IntrospectionS
     }
 
     return GQLSchemaDefinition(
-        description = description.unwrapDescription("schema"),
+        // Older versions of GraphQL do not have a description, do not warn on this
+        description = description.getOrNull(),
         directives = emptyList(),
         rootOperationTypeDefinitions = rootOperationTypeDefinitions
     )


### PR DESCRIPTION
Fixes 

```
Apollo: schema is missing 'description', double check your introspection query
```

when downloading a schema from the fullstack tutorial (which uses a GraphQL versions pre-October2021 😅 )