### PR TITLE
Codegen: avoid enum value clashing with the getter `field`

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/EnumAsEnumBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/EnumAsEnumBuilder.kt
@@ -107,7 +107,7 @@ internal class EnumAsEnumBuilder(
                     .indent()
                     .add(
                         values.map {
-                          CodeBlock.of("%N", it.targetName.escapeKotlinReservedWordInEnum())
+                          CodeBlock.of("%T.%N", ClassName(packageName, simpleName), it.targetName.escapeKotlinReservedWordInEnum())
                         }.joinToCode(",\n")
                     )
                     .unindent()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/kotlin/responseBased/case_sensitive_enum/type/Enum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/case_sensitive_enum/kotlin/responseBased/case_sensitive_enum/type/Enum.kt.expected
@@ -36,10 +36,10 @@ public enum class Enum(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Enum>
       get() = listOf(
-        north,
-        North,
-        NORTH,
-        SOUTH)
+        Enum.north,
+        Enum.North,
+        Enum.NORTH,
+        Enum.SOUTH)
 
     /**
      * Returns all [Enum] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/kotlin/responseBased/deprecation/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecation/kotlin/responseBased/deprecation/type/Episode.kt.expected
@@ -33,8 +33,8 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        JEDI,
-        CLONES)
+        Episode.JEDI,
+        Episode.CLONES)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/Gravity.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/Gravity.java.expected
@@ -14,7 +14,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 public class Gravity {
-  public static EnumType type = new EnumType("Gravity", Arrays.asList("TOP", "CENTER", "BOTTOM", "bottom", "is", "type", "String"));
+  public static EnumType type = new EnumType("Gravity", Arrays.asList("TOP", "CENTER", "BOTTOM", "bottom", "is", "type", "String", "field"));
 
   public static Gravity TOP = new Gravity("TOP");
 
@@ -29,6 +29,8 @@ public class Gravity {
   public static Gravity type_ = new Gravity("type");
 
   public static Gravity String = new Gravity("String");
+
+  public static Gravity field = new Gravity("field");
 
   public String rawValue;
 
@@ -50,6 +52,7 @@ public class Gravity {
       case "is": return Gravity.is;
       case "type": return Gravity.type_;
       case "String": return Gravity.String;
+      case "field": return Gravity.field;
       default: return new Gravity.UNKNOWN__(rawValue);
     }
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/GravityAsEnum.java.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/java/operationBased/enum_field/type/GravityAsEnum.java.expected
@@ -43,12 +43,14 @@ public enum GravityAsEnum {
    */
   String("String"),
 
+  field("field"),
+
   /**
    * Auto generated constant for unknown enum values
    */
   UNKNOWN__("UNKNOWN__");
 
-  public static EnumType type = new EnumType("GravityAsEnum", Arrays.asList("TOP", "CENTER", "BOTTOM", "bottom", "is", "while", "type", "String"));
+  public static EnumType type = new EnumType("GravityAsEnum", Arrays.asList("TOP", "CENTER", "BOTTOM", "bottom", "is", "while", "type", "String", "field"));
 
   public String rawValue;
 
@@ -71,6 +73,7 @@ public enum GravityAsEnum {
       case "while": return GravityAsEnum.while_;
       case "type": return GravityAsEnum.type_;
       case "String": return GravityAsEnum.String;
+      case "field": return GravityAsEnum.field;
       default: return GravityAsEnum.UNKNOWN__;
     }
   }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/Gravity.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/Gravity.kt.expected
@@ -6,61 +6,104 @@
 package com.example.enum_field.type
 
 import com.apollographql.apollo.api.EnumType
+import kotlin.Any
 import kotlin.Array
+import kotlin.Boolean
 import kotlin.Deprecated
+import kotlin.Int
+import kotlin.String
 import kotlin.Suppress
-import kotlin.collections.List
 
-public enum class Gravity(
-  public val rawValue: kotlin.String,
-) {
-  TOP("TOP"),
-  CENTER("CENTER"),
-  BOTTOM("BOTTOM"),
-  @Deprecated(message = "use BOTTOM instead")
-  bottom("bottom"),
-  `is`("is"),
-  type_("type"),
-  String("String"),
-  /**
-   * Auto generated constant for unknown enum values
-   */
-  UNKNOWN__("UNKNOWN__"),
-  ;
+public sealed interface Gravity {
+  public val rawValue: kotlin.String
 
   public companion object {
     public val type: EnumType = EnumType("Gravity", listOf("TOP", "CENTER", "BOTTOM", "bottom",
-        "is", "type", "String"))
-
-    /**
-     * All [Gravity] known at compile time
-     */
-    @Suppress("DEPRECATION")
-    public val knownEntries: List<Gravity>
-      get() = listOf(
-        TOP,
-        CENTER,
-        BOTTOM,
-        bottom,
-        `is`,
-        type_,
-        String)
-
-    /**
-     * Returns all [Gravity] known at compile time
-     */
-    @Deprecated(
-      message = "Use knownEntries instead",
-      replaceWith = ReplaceWith("this.knownEntries"),
-    )
-    public fun knownValues(): Array<Gravity> = knownEntries.toTypedArray()
+        "is", "type", "String", "field"))
 
     /**
      * Returns the [Gravity] that represents the specified [rawValue].
      * Note: unknown values of [rawValue] will return [UNKNOWN__]. You may want to update your
      * schema instead of calling this function directly.
      */
-    public fun safeValueOf(rawValue: kotlin.String): Gravity =
-        entries.find { it.rawValue == rawValue } ?: UNKNOWN__
+    @Suppress("DEPRECATION")
+    public fun safeValueOf(rawValue: kotlin.String): Gravity = when(rawValue) {
+      "TOP" -> TOP
+      "CENTER" -> CENTER
+      "BOTTOM" -> BOTTOM
+      "bottom" -> bottom
+      "is" -> `is`
+      "type" -> type_
+      "String" -> String
+      "field" -> `field`
+      else -> UNKNOWN__Gravity(rawValue)
+    }
+
+    /**
+     * Returns all [Gravity] known at compile time
+     */
+    @Suppress("DEPRECATION")
+    public fun knownValues(): Array<Gravity> = arrayOf(
+      TOP,
+      CENTER,
+      BOTTOM,
+      bottom,
+      `is`,
+      type_,
+      String,
+      `field`)
   }
+
+  public object TOP : Gravity {
+    override val rawValue: kotlin.String = "TOP"
+  }
+
+  public object CENTER : Gravity {
+    override val rawValue: kotlin.String = "CENTER"
+  }
+
+  public object BOTTOM : Gravity {
+    override val rawValue: kotlin.String = "BOTTOM"
+  }
+
+  @Deprecated(message = "use BOTTOM instead")
+  public object bottom : Gravity {
+    override val rawValue: kotlin.String = "bottom"
+  }
+
+  public object `is` : Gravity {
+    override val rawValue: kotlin.String = "is"
+  }
+
+  public object type_ : Gravity {
+    override val rawValue: kotlin.String = "type"
+  }
+
+  public object String : Gravity {
+    override val rawValue: kotlin.String = "String"
+  }
+
+  public object `field` : Gravity {
+    override val rawValue: kotlin.String = "field"
+  }
+
+  /**
+   * An enum value that wasn't known at compile time.
+   */
+  public interface UNKNOWN__ : Gravity {
+    override val rawValue: kotlin.String
+  }
+}
+
+private class UNKNOWN__Gravity(
+  override val rawValue: String,
+) : Gravity.UNKNOWN__ {
+  override fun equals(other: Any?): Boolean {
+    if (other !is UNKNOWN__Gravity) return false
+    return this.rawValue == other.rawValue
+  }
+
+  override fun hashCode(): Int = this.rawValue.hashCode()
+
+  override fun toString(): String = "UNKNOWN__($rawValue)"
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/GravityAsEnum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/kotlin/responseBased/enum_field/type/GravityAsEnum.kt.expected
@@ -35,6 +35,7 @@ public enum class GravityAsEnum(
    * an enum value that clashes with the rawValue type
    */
   String("String"),
+  `field`("field"),
   /**
    * Auto generated constant for unknown enum values
    */
@@ -43,7 +44,7 @@ public enum class GravityAsEnum(
 
   public companion object {
     public val type: EnumType = EnumType("GravityAsEnum", listOf("TOP", "CENTER", "BOTTOM",
-        "bottom", "is", "while", "type", "String"))
+        "bottom", "is", "while", "type", "String", "field"))
 
     /**
      * All [GravityAsEnum] known at compile time
@@ -51,14 +52,15 @@ public enum class GravityAsEnum(
     @Suppress("DEPRECATION")
     public val knownEntries: List<GravityAsEnum>
       get() = listOf(
-        TOP,
-        CENTER,
-        BOTTOM,
-        bottom,
-        `is`,
-        `while`,
-        type_,
-        String)
+        GravityAsEnum.TOP,
+        GravityAsEnum.CENTER,
+        GravityAsEnum.BOTTOM,
+        GravityAsEnum.bottom,
+        GravityAsEnum.`is`,
+        GravityAsEnum.`while`,
+        GravityAsEnum.type_,
+        GravityAsEnum.String,
+        GravityAsEnum.`field`)
 
     /**
      * Returns all [GravityAsEnum] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/schema.graphqls
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/enum_field/schema.graphqls
@@ -18,6 +18,8 @@ enum Gravity {
 
   # an enum value that clashes with the rawValue type
   String
+
+  field
 }
 
 enum GravityAsEnum {
@@ -39,4 +41,6 @@ enum GravityAsEnum {
 
   "an enum value that clashes with the rawValue type"
   String
+
+  field
 }

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/kotlin/responseBased/hero_details/type/hero_type.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_details/kotlin/responseBased/hero_details/type/hero_type.kt.expected
@@ -33,8 +33,8 @@ public enum class Hero_type(
      */
     public val knownEntries: List<Hero_type>
       get() = listOf(
-        human,
-        droid)
+        Hero_type.human,
+        Hero_type.droid)
 
     /**
      * Returns all [Hero_type] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/kotlin/responseBased/hero_name_query_long_name/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name_query_long_name/kotlin/responseBased/hero_name_query_long_name/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/kotlin/responseBased/hero_with_review/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_with_review/kotlin/responseBased/hero_with_review/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/type/Race.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/type/Race.kt.expected
@@ -31,9 +31,9 @@ public enum class Race(
      */
     public val knownEntries: List<Race>
       get() = listOf(
-        WOOKIE,
-        GUMGAN,
-        EWOK)
+        Race.WOOKIE,
+        Race.GUMGAN,
+        Race.EWOK)
 
     /**
      * Returns all [Race] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/type/Race.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/type/Race.kt.expected
@@ -31,9 +31,9 @@ public enum class Race(
      */
     public val knownEntries: List<Race>
       get() = listOf(
-        WOOKIE,
-        GUMGAN,
-        EWOK)
+        Race.WOOKIE,
+        Race.GUMGAN,
+        Race.EWOK)
 
     /**
      * Returns all [Race] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_type/kotlin/responseBased/input_object_type/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/kotlin/responseBased/input_object_variable_and_argument/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument/kotlin/responseBased/input_object_variable_and_argument/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/kotlin/responseBased/input_object_variable_and_argument_with_generated_methods/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/input_object_variable_and_argument_with_generated_methods/kotlin/responseBased/input_object_variable_and_argument_with_generated_methods/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/kotlin/responseBased/introspection_query/type/__TypeKind.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/introspection_query/kotlin/responseBased/introspection_query/type/__TypeKind.kt.expected
@@ -37,14 +37,14 @@ public enum class __TypeKind(
      */
     public val knownEntries: List<__TypeKind>
       get() = listOf(
-        SCALAR,
-        OBJECT,
-        INTERFACE,
-        UNION,
-        ENUM,
-        INPUT_OBJECT,
-        LIST,
-        NON_NULL)
+        __TypeKind.SCALAR,
+        __TypeKind.OBJECT,
+        __TypeKind.INTERFACE,
+        __TypeKind.UNION,
+        __TypeKind.ENUM,
+        __TypeKind.INPUT_OBJECT,
+        __TypeKind.LIST,
+        __TypeKind.NON_NULL)
 
     /**
      * Returns all [__TypeKind] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/kotlin/responseBased/list_field_clash/type/AmenityCategory.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/list_field_clash/kotlin/responseBased/list_field_clash/type/AmenityCategory.kt.expected
@@ -30,8 +30,8 @@ public enum class AmenityCategory(
      */
     public val knownEntries: List<AmenityCategory>
       get() = listOf(
-        Category0,
-        Category1)
+        AmenityCategory.Category0,
+        AmenityCategory.Category1)
 
     /**
      * Returns all [AmenityCategory] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/measurements
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/measurements
@@ -2,11 +2,11 @@
 // If you updated the codegen and test fixtures, you should commit this file too.
 
 Test:                                                                                      Total LOC:
-aggregate-all                                                                                  203561
-aggregate-kotlin-responseBased                                                                  65664
+aggregate-all                                                                                  203612
+aggregate-kotlin-responseBased                                                                  65709
 aggregate-kotlin-operationBased                                                                 42225
 aggregate-kotlin-compat                                                                             0
-aggregate-java-operationBased                                                                   95672
+aggregate-java-operationBased                                                                   95678
 
 java-operationBased-fragments_with_defer_and_include_directives                                  5540
 kotlin-operationBased-fragments_with_defer_and_include_directives                                3464
@@ -175,9 +175,9 @@ kotlin-responseBased-fieldset_with_multiple_super                               
 kotlin-responseBased-reserved_keywords                                                            598
 java-operationBased-inline_fragment_for_non_optional_field                                        597
 java-operationBased-optional                                                                      588
+java-operationBased-enum_field                                                                    587
 java-operationBased-two_heroes_unique                                                             586
 java-operationBased-inline_fragment_type_coercion                                                 582
-java-operationBased-enum_field                                                                    581
 kotlin-operationBased-test_inline                                                                 579
 kotlin-operationBased-reserved_keywords                                                           571
 java-operationBased-inline_fragment_simple                                                        568
@@ -196,6 +196,7 @@ kotlin-operationBased-operationbased2_ex7                                       
 java-operationBased-arguments_hardcoded                                                           531
 kotlin-operationBased-typename_always_first                                                       526
 kotlin-operationBased-path_vs_flat_accessors                                                      525
+kotlin-responseBased-enum_field                                                                   522
 java-operationBased-antlr_tokens                                                                  521
 java-operationBased-subscriptions                                                                 520
 kotlin-responseBased-hero_name_query_long_name                                                    517
@@ -206,7 +207,6 @@ kotlin-responseBased-custom_scalar_type                                         
 kotlin-responseBased-variable_default_value                                                       491
 kotlin-operationBased-root_query_fragment                                                         487
 kotlin-responseBased-deprecation                                                                  486
-kotlin-responseBased-enum_field                                                                   477
 kotlin-responseBased-inline_fragment_for_non_optional_field                                       475
 java-operationBased-merged_include                                                                473
 kotlin-operationBased-monomorphic                                                                 473

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review/kotlin/responseBased/mutation_create_review/type/Episode.kt.expected
@@ -56,11 +56,11 @@ internal enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/kotlin/responseBased/mutation_create_review_semantic_naming/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/mutation_create_review_semantic_naming/kotlin/responseBased/mutation_create_review_semantic_naming/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/optional/kotlin/responseBased/optional/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/optional/kotlin/responseBased/optional/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/kotlin/responseBased/suppressed_warnings/type/Direction.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/suppressed_warnings/kotlin/responseBased/suppressed_warnings/type/Direction.kt.expected
@@ -38,9 +38,9 @@ public enum class Direction(
     @OptIn(ApolloRequiresOptIn::class)
     public val knownEntries: List<Direction>
       get() = listOf(
-        South,
-        North,
-        East)
+        Direction.South,
+        Direction.North,
+        Direction.East)
 
     /**
      * Returns all [Direction] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedEnum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/type/renamedEnum.kt.expected
@@ -29,7 +29,7 @@ public enum class RenamedEnum(
      */
     public val knownEntries: List<RenamedEnum>
       get() = listOf(
-        VALUE)
+        RenamedEnum.VALUE)
 
     /**
      * Returns all [RenamedEnum] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedEnum.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/type/renamedEnum.kt.expected
@@ -29,7 +29,7 @@ public enum class RenamedEnum(
      */
     public val knownEntries: List<RenamedEnum>
       get() = listOf(
-        VALUE)
+        RenamedEnum.VALUE)
 
     /**
      * Returns all [RenamedEnum] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/kotlin/responseBased/variable_default_value/type/Episode.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/variable_default_value/kotlin/responseBased/variable_default_value/type/Episode.kt.expected
@@ -56,11 +56,11 @@ public enum class Episode(
     @Suppress("DEPRECATION")
     public val knownEntries: List<Episode>
       get() = listOf(
-        NEWHOPE,
-        EMPIRE,
-        JEDI,
-        DEPRECATED,
-        new)
+        Episode.NEWHOPE,
+        Episode.EMPIRE,
+        Episode.JEDI,
+        Episode.DEPRECATED,
+        Episode.new)
 
     /**
      * Returns all [Episode] known at compile time

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -369,6 +369,7 @@ class CodegenTest {
 
       val sealedClassesForEnumsMatching = when (folder.name) {
         "enums_as_sealed" -> listOf(".*")
+        "enum_field" -> listOf("Gravity")
         else -> emptyList()
       }
 


### PR DESCRIPTION
Reproducer:

```graphql
enum Foo {
  field
}
```

Because `field` is the [backing field](https://kotlinlang.org/docs/properties.html#backing-fields) in the context of the getter, we need to scope the identifier better. 

