### PR TITLE
Add 'OfflineException' as a cause when using failFastIfOffline

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -1292,6 +1292,13 @@ public final class com/apollographql/apollo/exception/NullOrMissingField : com/a
 	public fun <init> (Ljava/lang/String;)V
 }
 
+public final class com/apollographql/apollo/exception/OfflineException : java/io/IOException {
+	public static final field INSTANCE Lcom/apollographql/apollo/exception/OfflineException;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/apollographql/apollo/exception/RouterError : com/apollographql/apollo/exception/ApolloException {
 	public fun <init> (Ljava/util/List;)V
 	public final fun getErrors ()Ljava/util/List;

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -1000,6 +1000,11 @@ final inline fun <#A: reified kotlin/Any?> (kotlin/Any).com.apollographql.apollo
 final inline fun com.apollographql.apollo.api.json/buildJsonByteString(kotlin/String? = ..., crossinline kotlin/Function1<com.apollographql.apollo.api.json/JsonWriter, kotlin/Unit>): okio/ByteString // com.apollographql.apollo.api.json/buildJsonByteString|buildJsonByteString(kotlin.String?;kotlin.Function1<com.apollographql.apollo.api.json.JsonWriter,kotlin.Unit>){}[0]
 final inline fun com.apollographql.apollo.api.json/buildJsonMap(crossinline kotlin/Function1<com.apollographql.apollo.api.json/JsonWriter, kotlin/Unit>): kotlin/Any? // com.apollographql.apollo.api.json/buildJsonMap|buildJsonMap(kotlin.Function1<com.apollographql.apollo.api.json.JsonWriter,kotlin.Unit>){}[0]
 final inline fun com.apollographql.apollo.api.json/buildJsonString(kotlin/String? = ..., crossinline kotlin/Function1<com.apollographql.apollo.api.json/JsonWriter, kotlin/Unit>): kotlin/String // com.apollographql.apollo.api.json/buildJsonString|buildJsonString(kotlin.String?;kotlin.Function1<com.apollographql.apollo.api.json.JsonWriter,kotlin.Unit>){}[0]
+final object com.apollographql.apollo.exception/OfflineException : okio/IOException { // com.apollographql.apollo.exception/OfflineException|null[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // com.apollographql.apollo.exception/OfflineException.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // com.apollographql.apollo.exception/OfflineException.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // com.apollographql.apollo.exception/OfflineException.toString|toString(){}[0]
+}
 final val com.apollographql.apollo.api/AnyAdapter // com.apollographql.apollo.api/AnyAdapter|{}AnyAdapter[0]
     final fun <get-AnyAdapter>(): com.apollographql.apollo.api/Adapter<kotlin/Any> // com.apollographql.apollo.api/AnyAdapter.<get-AnyAdapter>|<get-AnyAdapter>(){}[0]
 final val com.apollographql.apollo.api/ApolloOptionalAnyAdapter // com.apollographql.apollo.api/ApolloOptionalAnyAdapter|{}ApolloOptionalAnyAdapter[0]

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/exception/Exceptions.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/exception/Exceptions.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.annotations.ApolloInternal
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.api.http.HttpHeader
 import okio.BufferedSource
+import okio.IOException
 
 /**
  * The base class for all exceptions
@@ -31,15 +32,19 @@ class NoDataException(cause: Throwable?) : ApolloException("No data was found", 
  * [ApolloNetworkException] is thrown when an I/O error happens reading the operation.
  *
  * @param message a message indicating what the error was.
- * @param platformCause the underlying cause. Might be null. When not null, it can be cast to:
- * - a [Throwable] on JVM platforms.
- * - a [NSError] on Darwin platforms.
- * to get more details about what went wrong.
+ * @param platformCause the underlying cause to get more details about what went wrong. When not null, it is either:
+ * - a [Throwable]
+ * - or a [NSError] on Apple platforms.
  */
 class ApolloNetworkException(
     message: String? = null,
     val platformCause: Any? = null,
 ) : ApolloException(message = message, cause = platformCause as? Throwable)
+
+/**
+ * The device has been detected as offline
+ */
+data object OfflineException: IOException("The device is offline")
 
 /**
  * The server could not process a subscription and sent an error.

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/interceptor/RetryOnErrorInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/interceptor/RetryOnErrorInterceptor.kt
@@ -6,13 +6,12 @@ import com.apollographql.apollo.api.ApolloResponse
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloNetworkException
+import com.apollographql.apollo.exception.OfflineException
 import com.apollographql.apollo.network.NetworkMonitor
-import com.benasher44.uuid.uuid4
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
@@ -62,7 +61,7 @@ private class DefaultRetryOnErrorInterceptorImpl(private val networkMonitor: Net
 
     return flow {
           if (failFastIfOffline && networkMonitor?.isOnline() == false) {
-            emit((ApolloResponse.Builder(request.operation, request.requestUuid).exception(OfflineException).build()))
+            emit((ApolloResponse.Builder(request.operation, request.requestUuid).exception(OfflineApolloException).build()))
           } else {
             emitAll(downStream)
           }
@@ -98,7 +97,7 @@ private fun ApolloException.isRecoverable(): Boolean {
 
 private object RetryException : Exception()
 
-private val OfflineException = ApolloNetworkException("The device is offline")
+private val OfflineApolloException = ApolloNetworkException("The device is offline", OfflineException)
 
 /**
  * A copy/paste of the kotlinx.coroutines version until it becomes stable


### PR DESCRIPTION
`OfflineException` is an `IOException`, not an `ApolloException` so that users can still check for `ApolloNetworkException` to filter some exceptions.

Closes #6101 