### PR TITLE
[runtime] Change NetworkMonitor to expose a StateFlow directly

### DIFF
--- a/docs/source/advanced/network-connectivity.mdx
+++ b/docs/source/advanced/network-connectivity.mdx
@@ -27,6 +27,9 @@ val apolloClient = ApolloClient.Builder()
     .serverUrl("https://example.com/graphql")
     .retryOnErrorInterceptor(RetryOnErrorInterceptor(networkMonitor))
     .build()
+
+// once you're done with your `ApolloClient`
+networkMonitor.close()
 ```
 
 ### `failFastIfOffline`

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/interceptor/RetryOnErrorInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/interceptor/RetryOnErrorInterceptor.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo.exception.ApolloException
 import com.apollographql.apollo.exception.ApolloNetworkException
 import com.apollographql.apollo.exception.OfflineException
 import com.apollographql.apollo.network.NetworkMonitor
+import com.apollographql.apollo.network.waitForNetwork
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
@@ -60,7 +61,7 @@ private class DefaultRetryOnErrorInterceptorImpl(private val networkMonitor: Net
     val downStream = chain.proceed(request)
 
     return flow {
-          if (failFastIfOffline && networkMonitor?.isOnline() == false) {
+          if (failFastIfOffline && networkMonitor?.isOnline?.value == false) {
             emit((ApolloResponse.Builder(request.operation, request.requestUuid).exception(OfflineApolloException).build()))
           } else {
             emitAll(downStream)

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/NetworkMonitorTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/NetworkMonitorTest.kt
@@ -13,11 +13,14 @@ import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.assertNoRequest
 import com.apollographql.mockserver.enqueueString
 import com.apollographql.apollo.network.NetworkMonitor
+import com.apollographql.apollo.network.waitForNetwork
 import test.FooQuery
 import com.apollographql.apollo.testing.internal.runTest
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
@@ -91,15 +94,10 @@ class NetworkMonitorTest {
 class FakeNetworkMonitor: NetworkMonitor {
   val _isOnline = MutableStateFlow(false)
 
+  override val isOnline: StateFlow<Boolean?>
+    get() = _isOnline.asStateFlow()
+
   override fun close() {}
-
-  override suspend fun waitForNetwork() {
-    _isOnline.takeWhile { !it }.collect()
-  }
-
-  override suspend fun isOnline(): Boolean {
-    return _isOnline.mapNotNull { it }.first()
-  }
 }
 
 class NetworkMonitorInterceptor(private val networkMonitor: NetworkMonitor): ApolloInterceptor {


### PR DESCRIPTION
Closes https://github.com/apollographql/apollo-kotlin/issues/6115

The previous interface was based on what `ApolloClient` needs but it prevented using `NetworkMonitor` for other use cases. This PR allows to use `NetworkMonitor` in a more generic way. 

This is obviously 200% breaking. If anyone implements their own `NetworkMonitor`, they'll need to update but hopefully it's not too hard (and the symbol is `@ApolloExperimental` in all cases).