### PR TITLE
Provide a more descriptive error message when a resolution of a specific `ResolverKey` fails

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
@@ -96,7 +96,8 @@ internal class JavaResolver(
     val result = resolve(ResolverKey(kind, id))
 
     check(result != null) {
-      "Cannot resolve $kind($id)"
+        "Cannot resolve $kind($id)" +
+          "Have you set up an 'opposite link' the downstream project to the schema module as a isADependencyOf(..)?"
     }
     return result
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
@@ -96,7 +96,7 @@ internal class JavaResolver(
     val result = resolve(ResolverKey(kind, id))
 
     check(result != null) {
-        "Cannot resolve $kind($id)" +
+        "Cannot resolve $kind($id). " +
           "Have you set up an 'opposite link' on the downstream project to the schema module as a isADependencyOf(..)?"
     }
     return result

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaResolver.kt
@@ -97,7 +97,7 @@ internal class JavaResolver(
 
     check(result != null) {
         "Cannot resolve $kind($id)" +
-          "Have you set up an 'opposite link' the downstream project to the schema module as a isADependencyOf(..)?"
+          "Have you set up an 'opposite link' on the downstream project to the schema module as a isADependencyOf(..)?"
     }
     return result
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
@@ -60,7 +60,7 @@ internal class KotlinResolver(
 
     check(result != null) {
       "Cannot resolve $kind($id). " +
-        "Have you set up an 'opposite link' the downstream project to the schema module as a isADependencyOf(..)?"
+        "Have you set up an 'opposite link' on the downstream project to the schema module as a isADependencyOf(..)?"
     }
     return result
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
@@ -59,7 +59,8 @@ internal class KotlinResolver(
     val result = resolve(ResolverKey(kind, id))
 
     check(result != null) {
-      "Cannot resolve $kind($id)"
+      "Cannot resolve $kind($id). " +
+        "Have you set up an 'opposite link' the downstream project to the schema module as a isADependencyOf(..)?"
     }
     return result
   }


### PR DESCRIPTION
This likely affects multimodule projects, but when a symbol fails to resolve in a project, we've found that it is a result of engineers forgetting to add an `isADependencyOf` backlink to the project that performs an operation on the schema. The best we can do is warn them in the logs and hope it fixes it for them. 