### PR TITLE
[IJ Plugin] Fix high latency field inspection

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
@@ -43,6 +43,9 @@ data class ApolloKotlinService(
 
     @XCollection
     val endpointHeaders: Map<String, String>? = null,
+
+    @XCollection
+    val upstreamServiceIds: List<Id> = emptyList(),
 ) {
   data class Id(
       @Attribute
@@ -67,5 +70,4 @@ data class ApolloKotlinService(
   val id: Id
     @Transient
     get() = Id(gradleProjectPath, serviceName)
-
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/ApolloKotlinService.kt
@@ -52,20 +52,19 @@ data class ApolloKotlinService(
       val serviceName: String = "",
   ) {
     override fun toString(): String {
-      val formattedPath = gradleProjectPath.split(":").filterNot { it.isEmpty() }.joinToString("-")
-      return "$formattedPath/$serviceName"
+      return "$gradleProjectPath/$serviceName"
     }
 
     companion object {
       fun fromString(string: String): Id? {
-        val split = string.split("/")
+        val split = string.split("/", limit = 2)
         if (split.size != 2) return null
         return Id(split[0], split[1])
       }
     }
   }
 
-  val id
+  val id: Id
     @Transient
     get() = Id(gradleProjectPath, serviceName)
 

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -257,6 +257,7 @@ class GradleToolingModelService(
                 .distinct(),
             endpointUrl = serviceInfo.endpointUrlCompat(toolingModel),
             endpointHeaders = serviceInfo.endpointHeadersCompat(toolingModel),
+            upstreamServiceIds = upstreamApolloKotlinServices.map { it.id }
         )
       }
     }


### PR DESCRIPTION
A regression was introduced in #5734 which broke service id comparisons, so latencies were never fetched.

Also in this PR: consider upstream services when getting latency info, so it is no longer needed to configure API keys for modules that depend on one that is already configured.