### PR TITLE
Allow compiling the project with Java22

### DIFF
--- a/libraries/apollo-gradle-plugin/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/build.gradle.kts
@@ -73,6 +73,10 @@ if (relocateJar) {
 
       // Remove proguard rules from dependencies, we'll manage them ourselves
       exclude("META-INF/proguard/.*")
+
+      systemClassesToolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+      }
     }
 
     // The java-gradle-plugin adds `gradleApi()` to the `api` implementation but it contains some JDK15 bytecode at


### PR DESCRIPTION
By default, GR8 uses the current Java runtime and the R8 version we use cannot deal with 22. By passing Java 8 here, we hide 22 bytecode from R8. We still cannot bump the R8 version due to https://issuetracker.google.com/u/1/issues/365784991 but this buys us some time.