### PR TITLE
[gradle-plugin] Use `registerJavaGeneratingTask`

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -871,8 +871,12 @@ interface Service {
     fun connectToAndroidSourceSet(name: String)
 
     /**
-     * Connects the generated sources to all the Android variants
-     * Throws if the Android plugin is not applied
+     * Connects the generated sources to the main Android variants.
+     * Note: despite the name, this method does not connect to the test variants as the main
+     * classpath is accessible from the tests and adding the sources twice causes issues.
+     * See https://issuetracker.google.com/u/1/issues/268218176
+     *
+     * @throws Exception if the Android plugin is not applied
      */
     fun connectToAllAndroidVariants()
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
@@ -16,7 +16,6 @@ package com.apollographql.apollo.gradle.internal
 import com.android.build.gradle.AppExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
-import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.BaseVariant
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
@@ -25,7 +24,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
 
-private fun Project.getVariants(): NamedDomainObjectContainer<BaseVariant> {
+private fun Project.getMainVariants(): NamedDomainObjectContainer<BaseVariant> {
   val container = project.container(BaseVariant::class.java)
 
   val extension: BaseExtension = project.androidExtensionOrThrow
@@ -45,15 +44,6 @@ private fun Project.getVariants(): NamedDomainObjectContainer<BaseVariant> {
     else -> error("Unsupported extension: $extension")
   }
 
-  @Suppress("USELESS_IS_CHECK", "KotlinRedundantDiagnosticSuppress")
-  if (extension is TestedExtension) {
-    extension.testVariants.configureEach { variant ->
-      container.add(variant)
-    }
-    extension.unitTestVariants.configureEach { variant ->
-      container.add(variant)
-    }
-  }
   return container
 }
 
@@ -68,7 +58,7 @@ fun connectToAndroidSourceSet(
     kotlinSourceSet.srcDir(outputDir)
   }
 
-  project.getVariants().configureEach {
+  project.getMainVariants().configureEach {
     if (it.sourceSets.any { it.name == sourceSetName }) {
       if (kotlinSourceSet == null) {
         it.registerJavaGeneratingTask(taskProvider, outputDir.get().asFile)
@@ -92,7 +82,7 @@ fun connectToAndroidVariant(variant: Any, outputDir: Provider<Directory>, taskPr
 }
 
 fun connectToAllAndroidVariants(project: Project, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
-  project.getVariants().configureEach {
+  project.getMainVariants().configureEach {
     connectToAndroidVariant(it, outputDir, taskProvider)
   }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
@@ -2,7 +2,10 @@
  * TODO: Figure out a way to make it work with the new AGP 8.0.0 variant APIs.
  * See https://issuetracker.google.com/issues/327399383
  *
- * When doing so it might interesting to refactor this code so that classes referencing possibly absent symbols are not loaded if not needed
+ * When doing so it might interesting to refactor this code so that classes referencing possibly absent symbols are not loaded if not needed.
+ *
+ * For an example, the IJ plugin calls AndroidProjectKt.androidExtension whose return type is a `BaseExtension?`. I'm not sure how come
+ * AndroidProjectKt links given BaseExtension is not always in the classpath.
  * See https://chromium.googlesource.com/chromium/src/+/HEAD/build/android/docs/class_verification_failures.md for an Android link that does
  * not apply here but gives a good description of the potential issue.
  */
@@ -15,17 +18,12 @@ import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
 import com.android.build.gradle.TestedExtension
 import com.android.build.gradle.api.BaseVariant
-import com.android.build.gradle.api.TestVariant
-import com.android.build.gradle.api.UnitTestVariant
-import com.apollographql.apollo.compiler.capitalizeFirstLetter
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskProvider
-import java.lang.reflect.Method
-import java.lang.reflect.ParameterizedType
 
 private fun Project.getVariants(): NamedDomainObjectContainer<BaseVariant> {
   val container = project.container(BaseVariant::class.java)
@@ -85,81 +83,17 @@ fun connectToAndroidSourceSet(
   }
 }
 
-/**
- * This uses https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/api/BaseVariant.java;l=539;drc=5ac687029454dec1e7bd50697dabbc24d5a9943c
- *
- * There's a newer API in 7.3 where AGP decides where the sources are put but we're not using that just yet
- * https://github.com/android/gradle-recipes/blob/agp-7.3/Kotlin/addJavaSourceFromTask/app/build.gradle.kts
- */
-private val lazyRegisterJavaGeneratingTask: Method? = BaseVariant::class.java.declaredMethods.singleOrNull {
-  if (it.name != "registerJavaGeneratingTask") {
-    return@singleOrNull false
-  }
-
-  if (it.parameters.size != 2) {
-    return@singleOrNull false
-  }
-  val parameter0Type = it.parameters[0].parameterizedType
-  if (parameter0Type !is ParameterizedType) {
-    return@singleOrNull false
-  }
-  if (parameter0Type.rawType.typeName != "org.gradle.api.tasks.TaskProvider") {
-    return@singleOrNull false
-  }
-  val parameter1Type = it.parameters[1].parameterizedType
-  if (parameter1Type !is ParameterizedType) {
-    return@singleOrNull false
-  }
-  if (parameter1Type.rawType.typeName != "java.util.Collection") {
-    return@singleOrNull false
-  }
-  if (parameter1Type.actualTypeArguments.size != 1) {
-    return@singleOrNull false
-  }
-  if (parameter1Type.actualTypeArguments.single().typeName != "java.io.File") {
-    return@singleOrNull false
-  }
-
-  true
-}
-
-fun connectToAndroidVariant(project: Project, variant: Any, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
+fun connectToAndroidVariant(variant: Any, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
   check(variant is BaseVariant) {
     "Apollo: variant must be an instance of com.android.build.gradle.api.BaseVariant (found $variant)"
   }
 
-  if (lazyRegisterJavaGeneratingTask != null) {
-    lazyRegisterJavaGeneratingTask.invoke(variant, taskProvider, listOf(outputDir.get().asFile))
-  } else {
-    /**
-     * Heuristic to get the variant-specific sourceSet from the variant name
-     * demoDebugAndroidTest -> androidTestDemoDebug
-     * demoDebugUnitTest -> testDemoDebug
-     * demoDebug -> demoDebug
-     */
-    val sourceSetName = when {
-      variant is TestVariant && variant.name.endsWith("AndroidTest") -> {
-        "androidTest${variant.name.removeSuffix("AndroidTest").capitalizeFirstLetter()}"
-      }
-
-      variant is UnitTestVariant && variant.name.endsWith("UnitTest") -> {
-        "test${variant.name.removeSuffix("UnitTest").capitalizeFirstLetter()}"
-      }
-
-      else -> variant.name
-    }
-
-    connectToAndroidSourceSet(project, sourceSetName, outputDir, taskProvider)
-  }
+  variant.registerJavaGeneratingTask(taskProvider, listOf(outputDir.get().asFile))
 }
 
 fun connectToAllAndroidVariants(project: Project, outputDir: Provider<Directory>, taskProvider: TaskProvider<out Task>) {
-  if (lazyRegisterJavaGeneratingTask != null) {
-    project.getVariants().configureEach {
-      lazyRegisterJavaGeneratingTask.invoke(it, taskProvider, listOf(outputDir.get().asFile))
-    }
-  } else {
-    connectToAndroidSourceSet(project, "main", outputDir, taskProvider)
+  project.getVariants().configureEach {
+    connectToAndroidVariant(it, outputDir, taskProvider)
   }
 }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -829,8 +829,7 @@ abstract class DefaultApolloExtension(
       }
 
       project.androidExtension != null -> {
-        // The default service is created from `afterEvaluate` and it looks like it's too late to register new sources
-        connection.connectToAndroidSourceSet("main")
+        connection.connectToAllAndroidVariants()
       }
 
       project.kotlinProjectExtension != null -> {

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultDirectoryConnection.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultDirectoryConnection.kt
@@ -25,7 +25,7 @@ internal class DefaultDirectoryConnection(
   }
 
   override fun connectToAndroidVariant(variant: Any) {
-    connectToAndroidVariant(project, variant, outputDir, task)
+    connectToAndroidVariant(variant, outputDir, task)
   }
 
   override fun connectToAndroidSourceSet(name: String) {


### PR DESCRIPTION
Go back to `registerJavaGeneratingTask` as in 3.x instead of `kotlin.srcDir()`

Some background:

1. We initially used `kotlin.srcDir()` and switched to `registerJavaGeneratingTask` in 2022 ([commit](https://github.com/apollographql/apollo-kotlin/pull/4486)) because it works better with lint (it marks the sources as generated)
1. But this had 2 drawbacks:
  a. `registerJavaGeneratingTask` wasn't working from `afterEvaluate {}`
  b. there was an issue with incremental compilation and tests ([issuetracker/268218176](https://issuetracker.google.com/u/1/issues/268218176))
1. So we reverted to `kotlin.srcDir()` ([commit](https://github.com/apollographql/apollo-kotlin/pull/4674))
1. [issuetracker/268218176](https://issuetracker.google.com/u/1/issues/268218176) has an explanation (we were adding to test variants something that was already accessible)
1. we don't need `afterEvaluate {}` anymore because there is no default service anymore 
1. besides the lint issue, `kotlin.srcDir()` doesn't seem to carry task dependencies for AGP source jar tasks ([issuetracker/366293471](https://issuetracker.google.com/u/1/issues/366293471))
1. So we're back to 1., with hopefully 2 fixes issues since 2022 (`afterEvaluate` and test variants)

Also took this opportunity to remove some reflexion that is not needed anymore now that we require Gradle 8.0.

All in all, I wish `kotlin.srcDir()` would just work as it's more consistent with how generated sources are added in non-Android cases but for the time being, I think we're good with `registerJavaGeneratingTask()` 🤞 

Fixes https://github.com/apollographql/apollo-kotlin/issues/6146