### PR TITLE
[apollo-ast] Add GQLDocument.validate(SchemaValidationOptions) to allow adding external schemas.

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/api.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/api.kt
@@ -9,6 +9,7 @@ import com.apollographql.apollo.ast.internal.ExecutableValidationScope
 import com.apollographql.apollo.ast.internal.LexerException
 import com.apollographql.apollo.ast.internal.Parser
 import com.apollographql.apollo.ast.internal.ParserException
+import com.apollographql.apollo.ast.internal.SchemaValidationOptions
 import com.apollographql.apollo.ast.internal.validateSchema
 import okio.BufferedSource
 import okio.use
@@ -178,7 +179,6 @@ fun BufferedSource.parseAsGQLSelections(
     filePath: String? = null,
     options: ParserOptions = ParserOptions.Default,
 ): GQLResult<List<GQLSelection>> {
-  @Suppress("DEPRECATION")
   return parseInternal(filePath, options) { parseSelections() }
 }
 
@@ -198,12 +198,23 @@ fun BufferedSource.parseAsGQLSelections(
  */
 @ApolloExperimental
 fun GQLDocument.validateAsSchema(): GQLResult<Schema> {
-  return validateSchema(definitions)
+  return validateSchema(definitions, SchemaValidationOptions(false, emptyList()))
+}
+
+@ApolloExperimental
+fun GQLDocument.validateAsSchema(validationOptions: SchemaValidationOptions): GQLResult<Schema> {
+  return validateSchema(definitions, validationOptions)
 }
 
 @ApolloInternal
 fun GQLDocument.validateAsSchemaAndAddApolloDefinition(): GQLResult<Schema> {
-  return validateSchema(definitions, true)
+  return validateSchema(
+      definitions,
+      SchemaValidationOptions(
+          true,
+          supportedForeignSchemas()
+      )
+  )
 }
 
 /**

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gql.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gql.kt
@@ -668,6 +668,9 @@ class GQLUnionTypeDefinition(
   }
 }
 
+/**
+ * @param name the name of the directive without the '@'
+ */
 class GQLDirectiveDefinition(
     override val sourceLocation: SourceLocation? = null,
     override val description: String?,

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
@@ -7,7 +7,7 @@ package com.apollographql.apollo.ast.internal
  * - link.graphqls: the [core schemas](https://specs.apollo.dev/link/v1.0/) definitions.
  * - apollo-${version}.graphqls: the client directives supported by Apollo Kotlin. Changes are versioned at https://github.com/apollographql/specs. Changing them requires a new version and a PR.
  */
-internal val kotlinLabsDefinitions = """
+internal val kotlinLabsDefinitions_0_3 = """
   ""${'"'}
   Marks a field or variable definition as optional or required
   By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
@@ -95,6 +95,86 @@ internal val kotlinLabsDefinitions = """
       | UNION
       | SCALAR
       | INPUT_OBJECT
+""".trimIndent()
+
+internal val kotlinLabsDefinitions_0_4 = """
+""${'"'}
+Marks a field or variable definition as optional or required
+By default Apollo Kotlin generates all variables of nullable types as optional, in compliance with the GraphQL specification,
+but this can be configured with this directive, because if the variable was added in the first place, it's usually to pass a value
+Since: 3.0.0
+""${'"'}
+directive @optional(if: Boolean = true) on FIELD | VARIABLE_DEFINITION
+
+""${'"'}
+Attach extra information to a given type
+Since: 3.0.0
+""${'"'}
+directive @typePolicy(
+    ""${'"'}
+    a selection set containing fields used to compute the cache key of an object. Order is important.
+    ""${'"'}
+    keyFields: String! = "",
+    ""${'"'}
+    (experimental) a selection set containing fields that shouldn't create a new cache Record and should be
+    embedded in their parent instead. Order is unimportant.
+    ""${'"'}
+    embeddedFields: String! = "",
+    ""${'"'}
+    (experimental) a selection set containing fields that should be treated as [Relay Connection](https://relay.dev/graphql/connections.htm) fields.
+    Order is unimportant.
+    This works in conjunction with `ConnectionMetadataGenerator` and `ConnectionRecordMerger` which must be configured on the `ApolloStore`.
+    Since: 3.4.1
+    ""${'"'}
+    connectionFields: String! = ""
+) on OBJECT | INTERFACE
+
+""${'"'}
+Attach extra information to a given field
+Since: 3.3.0
+""${'"'}
+directive @fieldPolicy(
+    forField: String!,
+    ""${'"'}
+    a list of arguments used to compute the cache key of the object this field is pointing to.
+    The list is parsed as a selection set: both spaces and comas are valid separators.
+    ""${'"'}
+    keyArgs: String! = "",
+    ""${'"'}
+    (experimental) a list of arguments that vary when requesting different pages.
+    These arguments are omitted when computing the cache key of this field.
+    The list is parsed as a selection set: both spaces and comas are valid separators.
+    Since: 3.4.1
+    ""${'"'}
+    paginationArgs: String! = ""
+) repeatable on OBJECT
+
+""${'"'}
+Indicates that the given field, argument, input field or enum value requires
+giving explicit consent before being used.
+Since: 3.3.1
+""${'"'}
+directive @requiresOptIn(feature: String!) repeatable
+on FIELD_DEFINITION
+    | ARGUMENT_DEFINITION
+    | INPUT_FIELD_DEFINITION
+    | ENUM_VALUE
+
+""${'"'}
+Use the specified name in the generated code instead of the GraphQL name.
+Use this for instance when the name would clash with a reserved keyword or field in the generated code.
+This directive is experimental.
+Since: 3.3.1
+""${'"'}
+directive @targetName(name: String!)
+on OBJECT
+    | INTERFACE
+    | ENUM
+    | ENUM_VALUE
+    | UNION
+    | SCALAR
+    | INPUT_OBJECT
+
 """.trimIndent()
 
 // Built in scalar and introspection types from the Draft:

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
@@ -1,12 +1,22 @@
 package com.apollographql.apollo.graphql.ast.test
 
+import com.apollographql.apollo.ast.GQLDirectiveDefinition
+import com.apollographql.apollo.ast.GQLDirectiveLocation
+import com.apollographql.apollo.ast.GQLInputValueDefinition
+import com.apollographql.apollo.ast.internal.ForeignSchema
+import com.apollographql.apollo.ast.internal.SchemaValidationOptions
+import com.apollographql.apollo.ast.parseAsGQLDocument
 import com.apollographql.apollo.ast.toGQLDocument
 import com.apollographql.apollo.ast.toSchema
+import com.apollographql.apollo.ast.validateAsSchema
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class SchemaTest {
   @Test
   fun schemaMayContainBuiltinDirectives() {
+    // language=graphql
     val schemaString = """
       "Directs the executor to include this field or fragment only when the `if` argument is true"
       directive @include(
@@ -20,5 +30,94 @@ class SchemaTest {
     """.trimIndent()
 
     schemaString.toGQLDocument().toSchema()
+  }
+
+  /**
+   * A trimmed version of a cache foreign schema.
+   */
+  private val cacheControlSchema = ForeignSchema("cache", "v0.1", listOf("directive @cacheControl(maxAge: Int!) on FIELD_DEFINITION".parseAsGQLDocument().getOrThrow().definitions.single()))
+
+  @Test
+  fun linkDirective() {
+    // language=graphql
+    val schemaString = """
+      extend schema @link(url: "https://specs.apollo.dev/cache/v0.1/")
+      
+      type Query {
+        foo: Int @cache__cacheControl(maxAge: 100)
+      }
+    """.trimIndent()
+
+    schemaString.toGQLDocument().validateAsSchema(
+        SchemaValidationOptions(
+            addKotlinLabsDefinitions = false,
+            foreignSchemas = listOf(cacheControlSchema)
+        )
+    ).getOrThrow()
+  }
+
+  @Test
+  fun importDirective() {
+    // language=graphql
+    val schemaString = """
+      extend schema @link(url: "https://specs.apollo.dev/cache/v0.1/", import: ["@cacheControl"])
+      
+      type Query {
+        foo: Int @cacheControl(maxAge: 100)
+      }
+    """.trimIndent()
+
+    val schema = schemaString.toGQLDocument().validateAsSchema(
+        SchemaValidationOptions(
+            addKotlinLabsDefinitions = false,
+            foreignSchemas = listOf(cacheControlSchema)
+        )
+    ).getOrThrow()
+
+    assertEquals("cacheControl", schema.originalDirectiveName("cacheControl"))
+  }
+
+  @Test
+  fun unknownSchemaFails() {
+    // language=graphql
+    val schemaString = """
+      extend schema @link(url: "https://specs.apollo.dev/unknown/v0.1/")
+      
+      type Query {
+        foo: Int 
+      }
+    """.trimIndent()
+
+    val result = schemaString.toGQLDocument().validateAsSchema(
+        SchemaValidationOptions(
+            addKotlinLabsDefinitions = false,
+            foreignSchemas = listOf(cacheControlSchema)
+        )
+    )
+
+    assertEquals(1, result.issues.size)
+    assertEquals("Apollo: unknown foreign schema 'unknown/v0.1'", result.issues.first().message)
+  }
+
+  @Test
+  fun unknownImportFails() {
+    // language=graphql
+    val schemaString = """
+      extend schema @link(url: "https://specs.apollo.dev/cache/v0.1/", import: ["@unknownDirective"])
+      
+      type Query {
+        foo: Int 
+      }
+    """.trimIndent()
+
+    val result = schemaString.toGQLDocument().validateAsSchema(
+        SchemaValidationOptions(
+            addKotlinLabsDefinitions = false,
+            foreignSchemas = listOf(cacheControlSchema)
+        )
+    )
+
+    assertEquals(1, result.issues.size)
+    assertEquals("Apollo: unknown definition '@unknownDirective'", result.issues.first().message)
   }
 }

--- a/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo/ast/api.jvm.kt
+++ b/libraries/apollo-ast/src/jvmMain/kotlin/com/apollographql/apollo/ast/api.jvm.kt
@@ -20,6 +20,6 @@ fun File.toGQLDocument(options: ParserOptions = ParserOptions.Default, allowJson
   return parseAsGQLDocument(options).getOrThrow()
 }
 
-
+@Deprecated("Use toGQLDocument().validateAsSchema().getOrThrow()", ReplaceWith("toGQLDocument(allowJson = allowJson).validateAsSchema().getOrThrow()"))
 @ApolloExperimental
 fun File.toSchema(allowJson: Boolean = false): Schema = toGQLDocument(allowJson = allowJson).validateAsSchema().getOrThrow()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -535,7 +535,15 @@ internal fun List<Issue>.group(
   val ignored = mutableListOf<Issue>()
   val warnings = mutableListOf<Issue>()
   val errors = mutableListOf<Issue>()
-  val apolloDirectives = kotlinLabsDefinitions(KOTLIN_LABS_VERSION).mapNotNull { (it as? GQLDirectiveDefinition)?.name }.toSet()
+
+  /**
+   * The kotlin_labs directives as of v0.3: https://specs.apollo.dev/kotlin_labs/v0.3/
+   * v0.4 removed `@nonnull` but we may still have users on v0.3.
+   *
+   * Moving forward, do not add new names there. If the directive is already defined, it
+   * should be removed. This should even be an error.
+   */
+  val apolloDirectives = setOf("optional", "nonnull", "typePolicy", "fieldPolicy", "requiresOptIn", "targetName")
 
   forEach {
     val severity = when (it) {

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/keyfields/objectAndInterfaceTypePolicySchema.graphqls
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/keyfields/objectAndInterfaceTypePolicySchema.graphqls
@@ -1,4 +1,4 @@
-extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3/", import: ["@typePolicy", "@keyFields"])
+extend schema @link(url: "https://specs.apollo.dev/kotlin_labs/v0.3/", import: ["@typePolicy"])
 
 type Query {
   node: Node


### PR DESCRIPTION
Also add support for kotlin_labs/v0.4

```kotlin
val cacheControlSchema = ForeignSchema("cache", "v0.1", definitions)

schemaString.toGQLDocument().validateAsSchema(
    SchemaValidationOptions(
        addKotlinLabsDefinitions = false,
        foreignSchemas = listOf(cacheControlSchema)
    )
).getOrThrow()
```
