### PR TITLE
Add support for application/graphql-response+json

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/http/DefaultHttpRequestComposer.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/http/DefaultHttpRequestComposer.kt
@@ -106,8 +106,8 @@ class DefaultHttpRequestComposer(
     // TODO The deferSpec=20220824 part is a temporary measure so early backend implementations of the @defer directive
     // can recognize early client implementations and potentially reply in a compatible way.
     // This should be removed in later versions.
-    val HEADER_ACCEPT_VALUE_DEFER = "multipart/mixed;deferSpec=20220824, application/json"
-    val HEADER_ACCEPT_VALUE_MULTIPART = "multipart/mixed;subscriptionSpec=1.0, application/json"
+    val HEADER_ACCEPT_VALUE_DEFER = "multipart/mixed;deferSpec=20220824, application/graphql-response+json, application/json"
+    val HEADER_ACCEPT_VALUE_MULTIPART = "multipart/mixed;subscriptionSpec=1.0, application/graphql-response+json, application/json"
 
     private fun <D : Operation.Data> buildGetUrl(
         serverUrl: String,

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/internal/multipart.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/internal/multipart.kt
@@ -47,3 +47,6 @@ private fun getBoundaryParameter(contentType: String?): String? {
 
 internal val HttpResponse.isMultipart: Boolean
   get() = headers.valueOf("Content-Type")?.startsWith("multipart/", ignoreCase = true) == true
+
+internal val HttpResponse.isGraphQLResponse: Boolean
+  get() = headers.valueOf("Content-Type")?.startsWith("application/graphql-response+json", ignoreCase = true) == true

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/FooOperation.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/FooOperation.kt
@@ -24,6 +24,7 @@ import com.apollographql.apollo.api.missingField
 internal class FooQuery: FooOperation("query"), Query<FooOperation.Data> {
   companion object {
     val successResponse = "{\"data\": {\"foo\": 42}}"
+    val errorResponse = "{\"errors\": [{\"message\": \"Oh no! Something went wrong :(\"}]}"
   }
 }
 

--- a/libraries/apollo-runtime/src/commonTest/kotlin/test/network/HttpNetworkTransportTest.kt
+++ b/libraries/apollo-runtime/src/commonTest/kotlin/test/network/HttpNetworkTransportTest.kt
@@ -1,0 +1,26 @@
+package test.network
+
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.testing.internal.runTest
+import com.apollographql.mockserver.MockServer
+import com.apollographql.mockserver.enqueueString
+import okio.use
+import test.FooQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HttpNetworkTransportTest {
+  @Test
+  fun graphqlResponseJsonContentTypeMayHaveNon2xxHttpCode() = runTest {
+    MockServer().use { mockServer ->
+      ApolloClient.Builder()
+          .serverUrl(mockServer.url())
+          .build()
+          .use { apolloClient ->
+            mockServer.enqueueString(string = FooQuery.errorResponse, statusCode = 500, contentType = "application/graphql-response+json")
+            val response = apolloClient.query(FooQuery()).execute()
+            assertEquals("Oh no! Something went wrong :(", response.errors?.single()?.message)
+          }
+    }
+  }
+}

--- a/tests/integration-tests/src/commonTest/kotlin/test/LoggingInterceptorTest.kt
+++ b/tests/integration-tests/src/commonTest/kotlin/test/LoggingInterceptorTest.kt
@@ -120,7 +120,7 @@ class LoggingInterceptorTest {
     client.query(HeroNameQuery()).execute()
     logger.assertLog("""
       Post http://0.0.0.0/
-      accept: multipart/mixed;deferspec=20220824, application/json
+      accept: multipart/mixed;deferspec=20220824, application/graphql-response+json, application/json
       [end of headers]
 
       HTTP: 200
@@ -140,7 +140,7 @@ class LoggingInterceptorTest {
     client.query(HeroNameQuery()).execute()
     logger.assertLog("""
       Post http://0.0.0.0/
-      accept: multipart/mixed;deferspec=20220824, application/json
+      accept: multipart/mixed;deferspec=20220824, application/graphql-response+json, application/json
       [end of headers]
       {"operationName":"HeroName","variables":{},"query":"query HeroName { hero { name } }"}
 
@@ -181,7 +181,7 @@ class LoggingInterceptorTest {
     client.query(HeroNameQuery()).execute()
     logger.assertLog("""
       Post http://0.0.0.0/
-      accept: multipart/mixed;deferspec=20220824, application/json
+      accept: multipart/mixed;deferspec=20220824, application/graphql-response+json, application/json
       [end of headers]
       {"operationName":"HeroName","variables":{},"query":"query HeroName { hero { name } }"}
 


### PR DESCRIPTION
The new content-type allows us to have more guarantees when a response is a valid GraphQL response vs potential error from an intermediate node. 

See https://graphql.github.io/graphql-over-http/draft/#sec-application-graphql-response-json
See https://github.com/apollographql/apollo-kotlin/issues/6169