### PR TITLE
Add note about bidirectional requiring `alwaysGenerateTypesMatching.set(emptyList())`

### DIFF
--- a/docs/source/advanced/multi-modules.mdx
+++ b/docs/source/advanced/multi-modules.mdx
@@ -97,6 +97,21 @@ apollo {
 }
 ```
 
+Also disable generating types in the schema module:
+
+```kotlin
+// schema/build.gradle.kts
+apollo {
+  service("service") {
+    packageName.set("schema")
+    generateApolloMetadata.set(true)
+    
+    // Disable generating all types 
+    alwaysGenerateTypesMatching.set(emptyList())
+  }
+}
+```
+
 <ExperimentalFeature>
 
 The `bidirectional` parameter is experimental and not compatible with <a href="https://docs.gradle.org/current/userguide/build_environment.html">Gradle project isolation</a>. 


### PR DESCRIPTION
This isn't needed with `isADependencyOf()` for REASONs. We could probably fix this. Will do together with https://github.com/apollographql/apollo-kotlin/issues/6180