### PR TITLE
Unbreak benchmarks

### DIFF
--- a/benchmark/microbenchmark/build.gradle.kts
+++ b/benchmark/microbenchmark/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
   androidTestImplementation(libs.apollo.testingsupport)
 
   // Stable cache
+  androidTestImplementation(libs.apollo.normalizedcache)
   androidTestImplementation(libs.apollo.normalizedcache.sqlite)
 
   // Incubating cache


### PR DESCRIPTION
Turns out `libs.apollo.normalizedcache.sqlite` does not pull `libs.apollo.normalizedcache` transitively