### PR TITLE
Add cache dump provider to ApolloClient context and use that from ApolloDebugServer

### DIFF
--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo/debugserver/internal/graphql/GraphQL.kt
@@ -2,11 +2,7 @@ package com.apollographql.apollo.debugserver.internal.graphql
 
 import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.ExecutionContext
-import com.apollographql.apollo.api.json.JsonNumber
 import com.apollographql.apollo.ast.GQLValue
-import com.apollographql.apollo.cache.normalized.api.CacheKey
-import com.apollographql.apollo.cache.normalized.api.Record
-import com.apollographql.apollo.cache.normalized.apolloStore
 import com.apollographql.execution.Coercing
 import com.apollographql.execution.ExecutableSchema
 import com.apollographql.execution.StringCoercing
@@ -14,11 +10,9 @@ import com.apollographql.execution.annotation.GraphQLName
 import com.apollographql.execution.annotation.GraphQLQuery
 import com.apollographql.execution.annotation.GraphQLScalar
 import com.apollographql.execution.internal.ExternalValue
-import com.apollographql.execution.internal.InternalValue
 import com.apollographql.execution.parseGraphQLRequest
 import okio.Buffer
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.reflect.KClass
 
 @GraphQLScalar(StringCoercing::class)
 internal typealias ID = String
@@ -82,9 +76,9 @@ internal class GraphQLApolloClient(
   fun displayName() = id
 
   fun normalizedCaches(): List<NormalizedCache> {
-    val apolloStore = runCatching { apolloClient.apolloStore }.getOrNull() ?: return emptyList()
-    return apolloStore.dump().map {
-      NormalizedCache(id, it.key, it.value)
+    val cacheDumpProvider = apolloClient.debugInfo<CacheDumpProvider>("cacheDumpProvider") ?: return emptyList()
+    return cacheDumpProvider().map { (displayName, cacheDump) ->
+      NormalizedCache(apolloClientId = id, displayName = displayName, cacheDump = cacheDump)
     }
   }
 
@@ -95,17 +89,18 @@ internal class GraphQLApolloClient(
 
 internal class NormalizedCache(
     apolloClientId: ID,
-    private val clazz: KClass<*>,
-    private val records: Map<String, Record>,
+    private val displayName: String,
+    private val cacheDump: CacheDump,
 ) {
-  private val id: String = "$apolloClientId:${clazz.normalizedCacheName()}"
+  private val id: String = "$apolloClientId:$displayName"
   fun id(): ID = id
 
-  fun displayName() = clazz.normalizedCacheName()
+  fun displayName() = displayName
 
-  fun recordCount() = records.count()
+  fun recordCount() = cacheDump.count()
 
-  fun records(): List<GraphQLRecord> = records.map { GraphQLRecord(it.value) }
+  fun records(): List<GraphQLRecord> =
+    cacheDump.map { (key, record) -> GraphQLRecord(key = key, sizeInBytes = record.first, fields = record.second) }
 }
 
 @GraphQLScalar(FieldsCoercing::class)
@@ -113,51 +108,49 @@ typealias Fields = Map<String, Any?>
 
 @GraphQLName("Record")
 internal class GraphQLRecord(
-    private val record: Record,
+    private val key: String,
+    private val sizeInBytes: Int,
+    private val fields: Fields,
 ) {
-  fun key(): String = record.key
+  fun key(): String = key
 
-  fun fields(): Fields = record.fields
+  fun fields(): Fields = fields
 
-  fun sizeInBytes(): Int = record.sizeInBytes
+  fun sizeInBytes(): Int = sizeInBytes
 }
 
 internal object FieldsCoercing : Coercing<Fields> {
-  // Taken from JsonRecordSerializer
-  @Suppress("UNCHECKED_CAST")
-  private fun InternalValue.toExternal(): ExternalValue {
-    return when (this) {
-      null -> this
-      is String -> this
-      is Boolean -> this
-      is Int -> this
-      is Long -> this
-      is Double -> this
-      is JsonNumber -> this
-      is CacheKey -> this.serialize()
-      is List<*> -> {
-        map { it.toExternal() }
-      }
-
-      is Map<*, *> -> {
-        mapValues { it.value.toExternal() }
-      }
-
-      else -> error("Unsupported record value type: '$this'")
-    }
-  }
-
   override fun serialize(internalValue: Map<String, Any?>): ExternalValue {
-    return internalValue.toExternal()
+    return internalValue
   }
 
   override fun deserialize(value: ExternalValue): Map<String, Any?> {
-    TODO("Not yet implemented")
+    throw NotImplementedError()
   }
 
-  override fun parseLiteral(gqlValue: GQLValue): Map<String, Any?> {
-    TODO("Not yet implemented")
+  override fun parseLiteral(value: GQLValue): Map<String, Any?> {
+    throw NotImplementedError()
   }
 }
 
-private fun KClass<*>.normalizedCacheName(): String = qualifiedName ?: toString()
+private typealias CacheDump = Map<
+    // Record key
+    String,
+
+    // Record size and fields
+    Pair<
+        // Record size in bytes
+        Int,
+
+        // Record fields
+        Map<String, Any?>,
+        >,
+    >
+
+private typealias CacheDumpProvider = () -> Map<
+    // Cache name
+    String,
+
+    // Cache dump
+    CacheDump,
+    >

--- a/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo/debugserver/internal/graphql/GraphQL.kt
+++ b/libraries/apollo-debug-server/src/commonMain/kotlin/com/apollographql/apollo/debugserver/internal/graphql/GraphQL.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.debugserver.internal.graphql
 
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.CacheDumpProviderContext
 import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.ast.GQLValue
 import com.apollographql.execution.Coercing
@@ -76,7 +77,7 @@ internal class GraphQLApolloClient(
   fun displayName() = id
 
   fun normalizedCaches(): List<NormalizedCache> {
-    val cacheDumpProvider = apolloClient.debugInfo<CacheDumpProvider>("cacheDumpProvider") ?: return emptyList()
+    val cacheDumpProvider = apolloClient.executionContext[CacheDumpProviderContext]?.cacheDumpProvider ?: return emptyList()
     return cacheDumpProvider().map { (displayName, cacheDump) ->
       NormalizedCache(apolloClientId = id, displayName = displayName, cacheDump = cacheDump)
     }

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ClientCacheExtensions.kt
@@ -4,6 +4,7 @@ package com.apollographql.apollo.cache.normalized
 
 import com.apollographql.apollo.ApolloCall
 import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.CacheDumpProviderContext
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince.Version.v4_0_0
 import com.apollographql.apollo.annotations.ApolloExperimental
@@ -133,7 +134,7 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
       .addInterceptor(FetchPolicyRouterInterceptor)
       .addInterceptor(ApolloCacheInterceptor(store))
       .writeToCacheAsynchronously(writeToCacheAsynchronously)
-      .putDebugInfo("cacheDumpProvider", store.cacheDumpProvider())
+      .addExecutionContext(CacheDumpProviderContext(store.cacheDumpProvider()))
 }
 
 @Deprecated(level = DeprecationLevel.ERROR, message = "Exceptions no longer throw", replaceWith = ReplaceWith("watch()"))

--- a/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ClientCacheExtensions.kt
+++ b/libraries/apollo-normalized-cache/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/ClientCacheExtensions.kt
@@ -133,6 +133,7 @@ fun ApolloClient.Builder.store(store: ApolloStore, writeToCacheAsynchronously: B
       .addInterceptor(FetchPolicyRouterInterceptor)
       .addInterceptor(ApolloCacheInterceptor(store))
       .writeToCacheAsynchronously(writeToCacheAsynchronously)
+      .putDebugInfo("cacheDumpProvider", store.cacheDumpProvider())
 }
 
 @Deprecated(level = DeprecationLevel.ERROR, message = "Exceptions no longer throw", replaceWith = ReplaceWith("watch()"))

--- a/libraries/apollo-normalized-cache/src/concurrentMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.concurrent.kt
+++ b/libraries/apollo-normalized-cache/src/concurrentMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.concurrent.kt
@@ -1,0 +1,7 @@
+package com.apollographql.apollo.cache.normalized
+
+import kotlin.reflect.KClass
+
+internal actual fun KClass<*>.normalizedCacheName(): String {
+  return qualifiedName ?: toString()
+}

--- a/libraries/apollo-normalized-cache/src/jsCommonMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.jsCommon.kt
+++ b/libraries/apollo-normalized-cache/src/jsCommonMain/kotlin/com/apollographql/apollo/cache/normalized/ApolloStore.jsCommon.kt
@@ -1,0 +1,8 @@
+package com.apollographql.apollo.cache.normalized
+
+import kotlin.reflect.KClass
+
+internal actual fun KClass<*>.normalizedCacheName(): String {
+  // qualifiedName is unsupported in JS
+  return simpleName ?: toString()
+}

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
@@ -86,7 +86,6 @@ private constructor(
   private val retryOnErrorInterceptor: ApolloInterceptor? = builder.retryOnErrorInterceptor
   private val failFastIfOffline = builder.failFastIfOffline
   private val listeners = builder.listeners
-  private val debugInfo = builder.debugInfo
 
   override val executionContext: ExecutionContext = builder.executionContext
   override val httpMethod: HttpMethod? = builder.httpMethod
@@ -334,12 +333,6 @@ private constructor(
         }
   }
 
-  @ApolloExperimental
-  fun <T> debugInfo(key: String): T? {
-    @Suppress("UNCHECKED_CAST")
-    return debugInfo[key] as? T
-  }
-
   /**
    * Creates a new [Builder] from this [ApolloClient].
    */
@@ -413,8 +406,6 @@ private constructor(
     @ApolloExperimental
     var failFastIfOffline: Boolean? = null
       private set
-
-    internal val debugInfo: MutableMap<String, Any> = mutableMapOf()
 
     /**
      * Whether to fail fast if the device is offline.
@@ -920,16 +911,6 @@ private constructor(
       canBeBatched(enableByDefault)
     }
 
-    @ApolloExperimental
-    fun putDebugInfo(key: String, value: Any) = apply {
-      debugInfo[key] = value
-    }
-
-    private fun debugInfo(debugInfo: Map<String, Any>) = apply {
-      this.debugInfo.clear()
-      this.debugInfo.putAll(debugInfo)
-    }
-
     /**
      * Creates an [ApolloClient] from this [Builder]
      */
@@ -967,7 +948,6 @@ private constructor(
           .retryOnErrorInterceptor(retryOnErrorInterceptor)
           .failFastIfOffline(failFastIfOffline)
           .listeners(listeners)
-          .debugInfo(debugInfo)
     }
   }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
@@ -86,6 +86,7 @@ private constructor(
   private val retryOnErrorInterceptor: ApolloInterceptor? = builder.retryOnErrorInterceptor
   private val failFastIfOffline = builder.failFastIfOffline
   private val listeners = builder.listeners
+  private val debugInfo = builder.debugInfo
 
   override val executionContext: ExecutionContext = builder.executionContext
   override val httpMethod: HttpMethod? = builder.httpMethod
@@ -333,6 +334,12 @@ private constructor(
         }
   }
 
+  @ApolloExperimental
+  fun <T> debugInfo(key: String): T? {
+    @Suppress("UNCHECKED_CAST")
+    return debugInfo[key] as? T
+  }
+
   /**
    * Creates a new [Builder] from this [ApolloClient].
    */
@@ -406,6 +413,8 @@ private constructor(
     @ApolloExperimental
     var failFastIfOffline: Boolean? = null
       private set
+
+    internal val debugInfo: MutableMap<String, Any> = mutableMapOf()
 
     /**
      * Whether to fail fast if the device is offline.
@@ -911,6 +920,16 @@ private constructor(
       canBeBatched(enableByDefault)
     }
 
+    @ApolloExperimental
+    fun putDebugInfo(key: String, value: Any) = apply {
+      debugInfo[key] = value
+    }
+
+    private fun debugInfo(debugInfo: Map<String, Any>) = apply {
+      this.debugInfo.clear()
+      this.debugInfo.putAll(debugInfo)
+    }
+
     /**
      * Creates an [ApolloClient] from this [Builder]
      */
@@ -948,6 +967,7 @@ private constructor(
           .retryOnErrorInterceptor(retryOnErrorInterceptor)
           .failFastIfOffline(failFastIfOffline)
           .listeners(listeners)
+          .debugInfo(debugInfo)
     }
   }
 

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/CacheDumpProviderContext.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/CacheDumpProviderContext.kt
@@ -1,0 +1,18 @@
+package com.apollographql.apollo
+
+import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.api.ExecutionContext
+
+/**
+ * Cache dump provider, which can be set by cache implementations.
+ */
+@ApolloInternal
+class CacheDumpProviderContext(
+    val cacheDumpProvider: () -> Map<String, Map<String, Pair<Int, Map<String, Any?>>>>,
+) : ExecutionContext.Element {
+  override val key: ExecutionContext.Key<*>
+    get() = Key
+
+  @ApolloInternal
+  companion object Key : ExecutionContext.Key<CacheDumpProviderContext>
+}


### PR DESCRIPTION
- setting a cache puts a lambda (cache dump provider) on the execution context - incubating version will do it too
- `ApolloDebugServer` gets the lambda and calls it