### PR TITLE
[codegen] Use `layout` in data builder names

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/BuilderFactoryBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/BuilderFactoryBuilder.kt
@@ -80,8 +80,8 @@ internal class BuilderFactoryBuilder(
   }
 
   private fun IrObject.toObjectBuilderMethodSpec(): MethodSpec {
-    val builderClassName = ClassName.get(packageName, "${name.capitalizeFirstLetter()}Builder")
-    return MethodSpec.methodBuilder("build${name.capitalizeFirstLetter()}")
+    val builderClassName = ClassName.get(packageName, "${layout.schemaTypeName(name)}Builder")
+    return MethodSpec.methodBuilder("build${layout.schemaTypeName(name)}")
         .addModifiers(Modifier.PUBLIC)
         .returns(builderClassName)
         .addStatement("return new $T($customScalarAdapters)", builderClassName)
@@ -89,8 +89,8 @@ internal class BuilderFactoryBuilder(
   }
 
   private fun IrSchemaType.toUnknownBuilderMethodSpec(): MethodSpec {
-    val builderClassName = ClassName.get(packageName, "Other${name.capitalizeFirstLetter()}Builder")
-    return MethodSpec.methodBuilder("buildOther${name.capitalizeFirstLetter()}")
+    val builderClassName = ClassName.get(packageName, "Other${layout.schemaTypeName(name)}Builder")
+    return MethodSpec.methodBuilder("buildOther${layout.schemaTypeName(name)}")
         .addModifiers(Modifier.PUBLIC)
         .addParameter(JavaClassNames.String, Identifier.__typename)
         .returns(builderClassName)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceBuilderBuilder.kt
@@ -29,8 +29,8 @@ internal class InterfaceBuilderBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "Other${iface.name.capitalizeFirstLetter()}Builder"
-  private val mapClassName = ClassName.get(packageName, "Other${iface.name.capitalizeFirstLetter()}Map")
+  private val simpleName = "Other${layout.schemaTypeName(iface.name)}Builder"
+  private val mapClassName = ClassName.get(packageName, "Other${layout.schemaTypeName(iface.name)}Map")
 
   override fun prepare() {
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceMapBuilder.kt
@@ -16,7 +16,7 @@ internal class InterfaceMapBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "${iface.name.capitalizeFirstLetter()}Map"
+  private val simpleName = "${layout.schemaTypeName(iface.name)}Map"
 
   override fun prepare() {
     context.resolver.registerMapType(iface.name, ClassName.get(packageName, simpleName))
@@ -35,7 +35,7 @@ internal class InterfaceMapBuilder(
         .addModifiers(Modifier.PUBLIC)
         .addSuperinterfaces(
             implements.map {
-              ClassName.get(packageName, "${it.capitalizeFirstLetter()}Map")
+              ClassName.get(packageName, "${layout.schemaTypeName(it)}Map")
             }
         )
         .build()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceUnknownMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/InterfaceUnknownMapBuilder.kt
@@ -19,7 +19,7 @@ internal class InterfaceUnknownMapBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "Other${iface.name.capitalizeFirstLetter()}Map"
+  private val simpleName = "Other${layout.schemaTypeName(iface.name)}Map"
 
   override fun prepare() {
     context.resolver.registerMapType(iface.name, ClassName.get(packageName, simpleName))
@@ -39,10 +39,10 @@ internal class InterfaceUnknownMapBuilder(
         .superclass(JavaClassNames.ObjectMap)
         .addSuperinterfaces(
             implements.map {
-              ClassName.get(packageName, "${it.capitalizeFirstLetter()}Map")
+              ClassName.get(packageName, "${layout.schemaTypeName(it)}Map")
             }
         )
-        .addSuperinterface(ClassName.get(packageName, "${iface.name.capitalizeFirstLetter()}Map"))
+        .addSuperinterface(ClassName.get(packageName, "${layout.schemaTypeName(iface.name)}Map"))
         .addMethod(
             MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/ObjectBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/ObjectBuilderBuilder.kt
@@ -28,8 +28,8 @@ internal class ObjectBuilderBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "${obj.name.capitalizeFirstLetter()}Builder"
-  private val mapClassName = ClassName.get(packageName, "${obj.name.capitalizeFirstLetter()}Map")
+  private val simpleName = "${layout.schemaTypeName(obj.name)}Builder"
+  private val mapClassName = ClassName.get(packageName, "${layout.schemaTypeName(obj.name)}Map")
 
   override fun prepare() {
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/ObjectMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/ObjectMapBuilder.kt
@@ -19,7 +19,7 @@ internal class ObjectMapBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "${obj.name.capitalizeFirstLetter()}Map"
+  private val simpleName = "${layout.schemaTypeName(obj.name)}Map"
 
   override fun prepare() {
     context.resolver.registerMapType(obj.name, ClassName.get(packageName, simpleName))
@@ -39,7 +39,7 @@ internal class ObjectMapBuilder(
         .superclass(JavaClassNames.ObjectMap)
         .addSuperinterfaces(
             superTypes.map {
-              ClassName.get(packageName, "${it.capitalizeFirstLetter()}Map")
+              ClassName.get(packageName, "${layout.schemaTypeName(it)}Map")
             }
         )
         .addMethod(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionBuilderBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionBuilderBuilder.kt
@@ -25,8 +25,8 @@ internal class UnionBuilderBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "Other${union.name.capitalizeFirstLetter()}Builder"
-  private val mapClassName = ClassName.get(packageName, "Other${union.name.capitalizeFirstLetter()}Map")
+  private val simpleName = "Other${layout.schemaTypeName(union.name)}Builder"
+  private val mapClassName = ClassName.get(packageName, "Other${layout.schemaTypeName(union.name)}Map")
 
   override fun prepare() {
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionMapBuilder.kt
@@ -16,7 +16,7 @@ internal class UnionMapBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "${union.name.capitalizeFirstLetter()}Map"
+  private val simpleName = "${layout.schemaTypeName(union.name)}Map"
 
   override fun prepare() {
     context.resolver.registerMapType(union.name, ClassName.get(packageName, simpleName))

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionUnknownMapBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/schema/UnionUnknownMapBuilder.kt
@@ -19,7 +19,7 @@ internal class UnionUnknownMapBuilder(
 ) : JavaClassBuilder {
   private val layout = context.layout
   private val packageName = layout.typeBuilderPackageName()
-  private val simpleName = "Other${union.name.capitalizeFirstLetter()}Map"
+  private val simpleName = "Other${layout.schemaTypeName(union.name)}Map"
 
   override fun prepare() {
     context.resolver.registerMapType(union.name, ClassName.get(packageName, simpleName))
@@ -37,7 +37,7 @@ internal class UnionUnknownMapBuilder(
         .classBuilder(simpleName)
         .addModifiers(Modifier.PUBLIC)
         .superclass(JavaClassNames.ObjectMap)
-        .addSuperinterface(ClassName.get(packageName, "${union.name.capitalizeFirstLetter()}Map"))
+        .addSuperinterface(ClassName.get(packageName, "${layout.schemaTypeName(union.name)}Map"))
         .addMethod(
             MethodSpec.constructorBuilder()
                 .addModifiers(Modifier.PUBLIC)

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/InterfaceBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/InterfaceBuilder.kt
@@ -26,10 +26,10 @@ internal class InterfaceBuilder(
   private val layout = context.layout
   private val packageName = layout.typePackageName()
   private val simpleName = layout.schemaTypeName(iface.name)
-  private val builderName = "${iface.name.capitalizeFirstLetter()}Builder"
-  private val otherBuilderName = "Other${iface.name.capitalizeFirstLetter()}Builder"
-  private val mapName = "${iface.name.capitalizeFirstLetter()}Map"
-  private val otherMapName = "Other${iface.name.capitalizeFirstLetter()}Map"
+  private val builderName = "${layout.schemaTypeName(iface.name)}Builder"
+  private val otherBuilderName = "Other${layout.schemaTypeName(iface.name)}Builder"
+  private val mapName = "${layout.schemaTypeName(iface.name)}Map"
+  private val otherMapName = "Other${layout.schemaTypeName(iface.name)}Map"
 
   override fun prepare() {
     context.resolver.registerSchemaType(iface.name, ClassName(packageName, simpleName))
@@ -74,7 +74,7 @@ internal class InterfaceBuilder(
           if (generateDataBuilders) {
             add(
                 topLevelBuildFunSpec(
-                    "buildOther${iface.name.capitalizeFirstLetter()}",
+                    "buildOther${layout.schemaTypeName(iface.name)}",
                     ClassName(packageName, otherBuilderName),
                     ClassName(packageName, otherMapName),
                     requiresTypename = true

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/ObjectBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/ObjectBuilder.kt
@@ -32,14 +32,14 @@ internal class ObjectBuilder(
   private val layout = context.layout
   private val packageName = layout.typePackageName()
   private val simpleName = layout.schemaTypeName(obj.name)
-  private val builderName = "${obj.name.capitalizeFirstLetter()}Builder"
-  private val mapName = "${obj.name.capitalizeFirstLetter()}Map"
+  private val builderName = "${layout.schemaTypeName(obj.name)}Builder"
+  private val mapName = "${layout.schemaTypeName(obj.name)}Map"
 
   override fun prepare() {
     context.resolver.registerSchemaType(obj.name, ClassName(packageName, simpleName))
     context.resolver.registerMapType(obj.name, ClassName(packageName, mapName))
     context.resolver.registerBuilderType(obj.name, ClassName(packageName, builderName))
-    context.resolver.registerBuilderFun(obj.name, MemberName(packageName, "build${obj.name.capitalizeFirstLetter()}"))
+    context.resolver.registerBuilderFun(obj.name, MemberName(packageName, "build${layout.schemaTypeName(obj.name)}"))
     for (fieldDefinition in obj.fieldDefinitions) {
       fieldDefinition.argumentDefinitions.forEach { argumentDefinition ->
         context.resolver.registerArgumentDefinition(argumentDefinition.id, ClassName(packageName, simpleName))
@@ -73,7 +73,7 @@ internal class ObjectBuilder(
 
   private fun IrObject.builderFunSpec(): FunSpec {
     return topLevelBuildFunSpec(
-        "build${name.capitalizeFirstLetter()}",
+        "build${layout.schemaTypeName(name)}",
         ClassName(packageName, builderName),
         ClassName(packageName, mapName),
         requiresTypename = false

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/UnionBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/schema/UnionBuilder.kt
@@ -26,10 +26,10 @@ internal class UnionBuilder(
   private val layout = context.layout
   private val packageName = layout.typePackageName()
   private val simpleName = layout.schemaTypeName(union.name)
-  private val builderName = "${union.name.capitalizeFirstLetter()}Builder"
-  private val otherBuilderName = "Other${union.name.capitalizeFirstLetter()}Builder"
-  private val mapName = "${union.name.capitalizeFirstLetter()}Map"
-  private val otherMapName = "Other${union.name.capitalizeFirstLetter()}Map"
+  private val builderName = "${layout.schemaTypeName(union.name)}Builder"
+  private val otherBuilderName = "Other${layout.schemaTypeName(union.name)}Builder"
+  private val mapName = "${layout.schemaTypeName(union.name)}Map"
+  private val otherMapName = "Other${layout.schemaTypeName(union.name)}Map"
 
   override fun prepare() {
     context.resolver.registerSchemaType(union.name, ClassName(packageName, simpleName))
@@ -69,7 +69,7 @@ internal class UnionBuilder(
           if (generateDataBuilders) {
             add(
                 topLevelBuildFunSpec(
-                    "buildOther${union.name.capitalizeFirstLetter()}",
+                    "buildOther${layout.schemaTypeName(union.name)}",
                     ClassName(packageName, otherBuilderName),
                     ClassName(packageName, otherMapName),
                     requiresTypename = true

--- a/tests/data-builders-kotlin/build.gradle.kts
+++ b/tests/data-builders-kotlin/build.gradle.kts
@@ -23,5 +23,6 @@ apollo {
     mapScalar("Long1", "com.example.MyLong", "com.example.MyLongAdapter")
     mapScalar("Long2", "com.example.MyLong")
     languageVersion.set("1.5")
+    alwaysGenerateTypesMatching.set(listOf("info", "Info"))
   }
 }

--- a/tests/data-builders-kotlin/src/main/graphql/schema.graphqls
+++ b/tests/data-builders-kotlin/src/main/graphql/schema.graphqls
@@ -83,3 +83,12 @@ union Feline2 = Cat | Lion
 scalar Long1
 scalar Long2
 scalar Long3
+
+# See https://github.com/apollographql/apollo-kotlin/issues/5537#issuecomment-2403695852
+type Info {
+  foo: String
+}
+
+type info {
+  foo: String
+}


### PR DESCRIPTION
`layout` properly escapes type names in case of name clash.

See https://github.com/apollographql/apollo-kotlin/issues/5537