### PR TITLE
Remove mockserver as a dependency of apollo-testing-support

### DIFF
--- a/libraries/apollo-testing-support/build.gradle.kts
+++ b/libraries/apollo-testing-support/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
       dependencies {
         api(project(":apollo-api"))
         api(project(":apollo-runtime"))
-        api(project(":apollo-mockserver"))
         api(libs.kotlinx.coroutines)
         implementation(libs.atomicfu.library.get().toString()) {
           because("We need locks in TestNetworkTransportHandler (we don't use the gradle plugin rewrite)")


### PR DESCRIPTION
`apollo-mockserver` is resolved locally but is only published as a maven tombstone and cannot be resolved in external projects.

Many thanks @jvanderwee for catching this.