### PR TITLE
[compiler] Make apollo-compiler aware of federation

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqldocument.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.annotations.ApolloInternal
 import com.apollographql.apollo.ast.internal.ExtensionsMerger
 import com.apollographql.apollo.ast.internal.builtinsDefinitionsStr
 import com.apollographql.apollo.ast.internal.ensureSchemaDefinition
+import com.apollographql.apollo.ast.internal.federationDefinitions_2_9
 import com.apollographql.apollo.ast.internal.kotlinLabsDefinitions_0_3
 import com.apollographql.apollo.ast.internal.kotlinLabsDefinitions_0_4
 import com.apollographql.apollo.ast.internal.linkDefinitionsStr
@@ -97,6 +98,8 @@ fun kotlinLabsDefinitions(version: String): List<GQLDefinition> {
   })
 }
 
+fun federationDefinitions(): List<GQLDefinition> = definitionsFromString(federationDefinitions_2_9)
+
 /**
  * The foreign schemas supported by Apollo Kotlin.
  * This is exported in case users want to validate documents meant for Apollo Kotlin.
@@ -108,6 +111,20 @@ fun builtinForeignSchemas(): List<ForeignSchema> {
       ForeignSchema("kotlin_labs", "v0.3", kotlinLabsDefinitions("v0.3"), listOf("optional", "nonnull")),
       ForeignSchema("kotlin_labs", "v0.4", kotlinLabsDefinitions("v0.4"), listOf("optional")),
       ForeignSchema("nullability", "v0.4", nullabilityDefinitions("v0.4"), listOf("catch")),
+      /**
+       * See https://github.com/apollographql/apollo-kotlin/issues/6221.
+       * Apollo Kotlin doesn't use the federation directives but adding them allows validating the schema.
+       */
+      ForeignSchema("federation", "v2.0", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.1", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.2", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.3", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.4", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.5", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.6", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.7", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.8", federationDefinitions(), emptyList()),
+      ForeignSchema("federation", "v2.9", federationDefinitions(), emptyList()),
   )
 }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
@@ -324,7 +324,7 @@ private fun List<GQLSchemaExtension>.getImports(
       if (gqlDirective.name == "link") {
         /**
          * Validate `@link` using a very minimal schema.
-         * This ensure we can safely cast the arguments below
+         * This ensures we can safely cast the arguments below
          */
         val minimalSchema = builtinDefinitions + linkDefinitions()
         val scope = DefaultValidationScope(

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
@@ -466,3 +466,48 @@ enum CatchTo {
     THROW
 }
 """.trimIndent()
+
+/**
+ * Taken from https://www.apollographql.com/docs/graphos/reference/federation/subgraph-spec
+ * with _Entity, _Any, _Service, Query._service and Query._entities removed.
+ */
+internal val federationDefinitions_2_9 = """
+  scalar FieldSet
+  scalar link__Import
+  scalar federation__ContextFieldValue
+  scalar federation__Scope
+  scalar federation__Policy
+
+  enum link__Purpose {
+    ""${'"'}
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    ""${'"'}
+    SECURITY
+
+    ""${'"'}
+    `EXECUTION` features provide metadata necessary for operation execution.
+    ""${'"'}
+    EXECUTION
+  }
+
+  directive @external on FIELD_DEFINITION | OBJECT
+  directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+  directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+  directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+  directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+  directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+  directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+  directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+  directive @override(from: String!) on FIELD_DEFINITION
+  directive @composeDirective(name: String!) repeatable on SCHEMA
+  directive @interfaceObject on OBJECT
+  directive @authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+  directive @requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+  directive @policy(policies: [[federation__Policy!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+  directive @context(name: String!) repeatable on INTERFACE | OBJECT | UNION
+  directive @fromContext(field: ContextFieldValue) on ARGUMENT_DEFINITION
+
+  # This definition is required only for libraries that don't support
+  # GraphQL's built-in `extend` keyword
+  directive @extends on OBJECT | INTERFACE
+""".trimIndent()

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
@@ -1,6 +1,7 @@
 package com.apollographql.apollo.graphql.ast.test
 
 import com.apollographql.apollo.ast.ForeignSchema
+import com.apollographql.apollo.ast.builtinForeignSchemas
 import com.apollographql.apollo.ast.internal.SchemaValidationOptions
 import com.apollographql.apollo.ast.parseAsGQLDocument
 import com.apollographql.apollo.ast.toGQLDocument
@@ -115,5 +116,23 @@ class SchemaTest {
 
     assertEquals(1, result.issues.size)
     assertEquals("Apollo: unknown definition '@unknownDirective'", result.issues.first().message)
+  }
+
+  @Test
+  fun federationIsSupported() {
+    // language=graphql
+    val schemaString = """
+      extend schema
+      @link(url: "https://specs.apollo.dev/federation/v2.4",
+          import: ["@key", "@extends", "@external"])
+      
+      type Query {
+        foo: Int 
+      }
+    """.trimIndent()
+
+    val result = schemaString.toGQLDocument().validateAsSchema(SchemaValidationOptions(false, builtinForeignSchemas()))
+
+    assertEquals(0, result.issues.size)
   }
 }


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-kotlin/issues/6221

I'm not 100% sold on this solution yet. If other directives appear, we can have the problem again. But maybe it's good that we have this problem? Clients should use introspection results. But sometimes introspection is disabled. And [directives are not exposed in introspection](https://github.com/graphql/graphql-spec/issues/300)...

tldr; this should at least fix the above issue while keeping our future options relatively open.