### PR TITLE
[IJ Plugin] Only highlight the name of unused operations, rather than the whole operation

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedOperationInspection.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedOperationInspection.kt
@@ -8,19 +8,22 @@ import com.apollographql.ijplugin.telemetry.TelemetryEvent
 import com.apollographql.ijplugin.util.isProcessCanceled
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.lang.jsgraphql.psi.GraphQLIdentifier
 import com.intellij.lang.jsgraphql.psi.GraphQLTypedOperationDefinition
 import com.intellij.lang.jsgraphql.psi.GraphQLVisitor
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.childrenOfType
 
 class ApolloUnusedOperationInspection : LocalInspectionTool() {
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
     return object : GraphQLVisitor() {
       override fun visitTypedOperationDefinition(o: GraphQLTypedOperationDefinition) {
         if (isUnusedOperation(o)) {
+          val nameElement = o.childrenOfType<GraphQLIdentifier>().firstOrNull() ?: return
           holder.registerProblem(
-              o,
+              nameElement,
               ApolloBundle.message("inspection.unusedOperation.reportText"),
-              DeleteElementQuickFix(label = "inspection.unusedOperation.quickFix", telemetryEvent = { TelemetryEvent.ApolloIjUnusedOperationQuickFix() }) { it }
+              DeleteElementQuickFix(label = "inspection.unusedOperation.quickFix", telemetryEvent = { TelemetryEvent.ApolloIjUnusedOperationQuickFix() }) { it.parent }
           )
         }
       }

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloSchemaInGraphqlFileInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloSchemaInGraphqlFileInspectionTest.kt
@@ -26,7 +26,7 @@ class ApolloSchemaInGraphqlFileInspectionTest : ApolloTestCase() {
     myFixture.configureByFile("SchemaInGraphqlFile.graphql")
     val highlightInfos = doHighlighting()
     assertTrue(highlightInfos.any { it.description == "The Apollo Kotlin compiler requires type definitions to reside in a .graphqls file" })
-    val quickFixAction = myFixture.findSingleIntention("Rename file to SchemaInGraphqlFile.graphqls");
+    val quickFixAction = myFixture.findSingleIntention("Rename file to SchemaInGraphqlFile.graphqls")
     assertNotNull(quickFixAction)
     myFixture.launchAction(quickFixAction)
     TestCase.assertEquals("SchemaInGraphqlFile.graphqls", myFixture.editor.cast<EditorEx>()!!.virtualFile.name)

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedFieldInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedFieldInspectionTest.kt
@@ -32,7 +32,7 @@ class ApolloUnusedFieldInspectionTest : ApolloTestCase() {
 
     moveCaret("id")
 
-    val quickFixAction = myFixture.findSingleIntention("Delete field");
+    val quickFixAction = myFixture.findSingleIntention("Delete field")
     assertNotNull(quickFixAction)
     myFixture.launchAction(quickFixAction)
     myFixture.checkResult("""
@@ -70,7 +70,7 @@ class ApolloUnusedFieldInspectionTest : ApolloTestCase() {
 
     moveCaret("... on Cat")
 
-    val quickFixAction = myFixture.findSingleIntention("Delete field");
+    val quickFixAction = myFixture.findSingleIntention("Delete field")
     assertNotNull(quickFixAction)
     myFixture.launchAction(quickFixAction)
     myFixture.checkResult("""

--- a/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedOperationInspectionTest.kt
+++ b/intellij-plugin/src/test/kotlin/com/apollographql/ijplugin/inspection/ApolloUnusedOperationInspectionTest.kt
@@ -19,7 +19,8 @@ class ApolloUnusedOperationInspectionTest : ApolloTestCase() {
     var highlightInfos = doHighlighting()
     assertTrue(highlightInfos.any { it.description == "Unused operation" })
 
-    val quickFixAction = myFixture.findSingleIntention("Delete operation");
+    moveCaret("Computers")
+    val quickFixAction = myFixture.findSingleIntention("Delete operation")
     assertNotNull(quickFixAction)
     myFixture.launchAction(quickFixAction)
     myFixture.checkResult("""


### PR DESCRIPTION
Fix for #6217

<img width="270" alt="Screenshot 2024-10-28 at 15 12 50" src="https://github.com/user-attachments/assets/3986ec65-6803-4388-9f8c-2c28060f9ffc">
