### PR TITLE
[compiler] depend on kotlinpoet-jvm and not kotlinpoet

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -163,7 +163,8 @@ moshi = { group = "com.squareup.moshi", name = "moshi", version = "1.14.0" }
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 okio-nodefilesystem = { group = "com.squareup.okio", name = "okio-nodefilesystem", version.ref = "okio" }
 poet-java = { group = "com.squareup", name = "javapoet", version.ref = "javaPoet" }
-poet-kotlin = { group = "com.squareup", name = "kotlinpoet", version = "2.0.0" }
+# Depend on the -jvm artifact directly to workaround https://github.com/gradle/gradle/issues/31158
+poet-kotlin = "com.squareup:kotlinpoet-jvm:2.0.0"
 rx-java2 = { group = "io.reactivex.rxjava2", name = "rxjava", version.ref = "rx-java2" }
 rx-java3 = { group = "io.reactivex.rxjava3", name = "rxjava", version.ref = "rx-java3" }
 sqldelight-android = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }


### PR DESCRIPTION
This is a workaround for https://github.com/gradle/gradle/issues/31158. 
FWIW, I believe something spooky is happening around [here](https://github.com/gradle/gradle/blob/0490d220bbfa1a4a590cf1a5c0113d6a7d12d70d/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java#L684) but I'm not 100% sure what. 

In all cases, it shouldn't hurt.