### PR TITLE
Do not set the license URL in the POMs

### DIFF
--- a/build-logic/src/main/kotlin/Publishing.kt
+++ b/build-logic/src/main/kotlin/Publishing.kt
@@ -418,7 +418,6 @@ private fun Project.setDefaultPomFields(mavenPublication: MavenPublication) {
     licenses {
       license {
         name.set(findProperty("POM_LICENCE_NAME") as String?)
-        url.set(findProperty("POM_LICENCE_URL") as String?)
       }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,7 @@ POM_SCM_URL=https://github.com/apollographql/apollo-kotlin/
 POM_SCM_CONNECTION=scm:git:git://github.com/apollographql/apollo-kotlin.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/apollographql/apollo-kotlin.git
 
-POM_LICENCE_NAME=MIT License
-POM_LICENCE_URL=https://raw.githubusercontent.com/apollographql/apollo-kotlin/main/LICENSE
+POM_LICENCE_NAME=MIT
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=apollographql


### PR DESCRIPTION
Fix for #6240

See also https://github.com/cashapp/licensee/issues/137