### PR TITLE
[IJ Plugin] Do not use internal symbol

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/sandbox/SandboxService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/studio/sandbox/SandboxService.kt
@@ -4,8 +4,9 @@ import com.apollographql.ijplugin.util.logd
 import com.intellij.lang.jsgraphql.GraphQLFileType
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionToolbar
 import com.intellij.openapi.actionSystem.DefaultActionGroup
-import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.invokeLater
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.fileEditor.FileEditorManager
@@ -43,8 +44,10 @@ class SandboxService(
         object : FileEditorManagerListener {
           override fun fileOpened(source: FileEditorManager, file: VirtualFile) {
             logd("$file")
-            invokeLater {
-              addOpenInSandboxAction(file)
+            ApplicationManager.getApplication().executeOnPooledThread {
+              invokeLater {
+                addOpenInSandboxAction(file)
+              }
             }
           }
         }
@@ -62,7 +65,7 @@ class SandboxService(
 
     // XXX This is fragile as it tightly relies on how the header component's UI is built by the GraphQL Plugin
     val onePixelSplitter = existingEditorHeaderComponent.components?.firstIsInstanceOrNull<OnePixelSplitter>() ?: return
-    val actionToolbar = onePixelSplitter.secondComponent as? ActionToolbarImpl ?: return
+    val actionToolbar = onePixelSplitter.secondComponent as? ActionToolbar ?: return
     val actionGroup = actionToolbar.actionGroup as? DefaultActionGroup ?: return
 
     if (actionGroup.getChildActionsOrStubs().none { it is OpenInSandboxAction }) {


### PR DESCRIPTION
Use `ActionToolbar` instead of `ActionToolbarImpl` which became `@ApiStatus.Internal`.

Also add the action in a background thread which makes it less flaky. 