### PR TITLE
[IJ Plugin] Don't reference AdbShellCommandsUtil.executeCommandBlocking that's been removed

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Adb.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Adb.kt
@@ -2,10 +2,11 @@ package com.apollographql.ijplugin.util
 
 import com.android.tools.idea.adb.AdbShellCommandResult
 import com.android.tools.idea.adb.AdbShellCommandsUtil
+import kotlinx.coroutines.runBlocking
 
 fun AdbShellCommandsUtil.execute(command: String): AdbShellCommandResult {
   logd("Executing adb shell command: '$command'")
-  val result = executeCommandBlocking(command)
+  val result = runBlocking { executeCommand(command) }
   logd("adb shell command result: isError=${result.isError}, isEmpty=${result.isEmpty}, output=${result.output.joinToString("\n")}")
   return result
 }


### PR DESCRIPTION
See https://github.com/JetBrains/android/commit/ee024f692d3ff5267e945bcf7c824172345386cb#diff-54b98e30e25352923b9360f5f1423a6aa1777d542b6941211875c41a31f72e36L41

