### PR TITLE
Update multi-modules.mdx to add a note about it being a good idea to mark your schema module as a jvm-only module

### DIFF
--- a/docs/source/advanced/multi-modules.mdx
+++ b/docs/source/advanced/multi-modules.mdx
@@ -121,5 +121,5 @@ The `bidirectional` parameter is experimental and not compatible with <a href="h
 ## Optional optimizations
 
 In Android projects, to further improve build times you can consider making your schema module a JVM module instead of an Android library. Since Apollo Kotlin is multiplatform, and Android is capable of depending on JVM-only modules, you can benefit from reducing the amount of work needed to compile the schema module. This is true because JVM modules build faster than Android libraries even with identical source code.  
-This is often a good idea because apollo often happens to be on the critical path of compiling your app. This happens when all the feature modules that use apollo need to wait for all the type-safe code to be generated before they themselves can start building too.
+This is often a good idea because Apollo often happens to be on the critical path of compiling your app. This happens when all the feature modules that use Apollo need to wait for all the type-safe code to be generated before they themselves can start building too.
 

--- a/docs/source/advanced/multi-modules.mdx
+++ b/docs/source/advanced/multi-modules.mdx
@@ -120,6 +120,6 @@ The `bidirectional` parameter is experimental and not compatible with <a href="h
 
 ## Optional optimizations
 
-In Android projects, to further improve build times you can consider making your schema module a jvm module instead of an Android library. Since apollo-kotlin is multiplatform, and android is capable of depending on jvm-only modules, you can benefit from reducing the amount of work needed to compile the schema module. This is true because jvm modules build faster than Android libraries even with identical source code.  
+In Android projects, to further improve build times you can consider making your schema module a JVM module instead of an Android library. Since Apollo Kotlin is multiplatform, and Android is capable of depending on JVM-only modules, you can benefit from reducing the amount of work needed to compile the schema module. This is true because JVM modules build faster than Android libraries even with identical source code.  
 This is often a good idea because apollo often happens to be on the critical path of compiling your app. This happens when all the feature modules that use apollo need to wait for all the type-safe code to be generated before they themselves can start building too.
 

--- a/docs/source/advanced/multi-modules.mdx
+++ b/docs/source/advanced/multi-modules.mdx
@@ -118,3 +118,8 @@ The `bidirectional` parameter is experimental and not compatible with <a href="h
 
 </ExperimentalFeature>
 
+## Optional optimizations
+
+In Android projects, to further improve build times you can consider making your schema module a jvm module instead of an Android library. Since apollo-kotlin is multiplatform, and android is capable of depending on jvm-only modules, you can benefit from reducing the amount of work needed to compile the schema module. This is true because jvm modules build faster than Android libraries even with identical source code.  
+This is often a good idea because apollo often happens to be on the critical path of compiling your app. This happens when all the feature modules that use apollo need to wait for all the type-safe code to be generated before they themselves can start building too.
+


### PR DESCRIPTION
Add a note about it being a good idea to make your schema module a jvm-only module when building for Android

Please feel free to completely reject this change if you feel like this is not the right place for it to be in, or to completely change the wording in any way you wish, as I am not sure if I am conveying my point as well and clearly as I would like to.

Perhaps the second paragraph of this note is note necessary at all. Also, the part which talks about how apollo-kotlin is KMP compatible and android modules can depend on pure jvm moduels is also just not necessary in this part of the docs and can be considered already known information.

I just wanted to propose this as a note somewhere in the docs as I recently did this change in our project and I saw a ~2.5x times faster compilation of our schema module in clean builds, which results in much better build parallelization which I was very happy about.