### PR TITLE
[IJ Plugin] Remove untilBuild

### DIFF
--- a/intellij-plugin/build.gradle.kts
+++ b/intellij-plugin/build.gradle.kts
@@ -197,7 +197,8 @@ intellijPlatform {
     version.set(project.version.toString())
     ideaVersion {
       sinceBuild = properties("pluginSinceBuild")
-      untilBuild = properties("pluginUntilBuild")
+      // No untilBuild specified, the plugin wants to be compatible with all future versions
+      untilBuild = provider { null }
     }
     // Extract the <!-- Plugin description --> section from README.md and provide it to the plugin's manifest
     description.set(

--- a/intellij-plugin/gradle.properties
+++ b/intellij-plugin/gradle.properties
@@ -10,8 +10,8 @@ pluginRepositoryUrl=https://github.com/apollographql/apollo-kotlin
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=242
-# Upper bound: it's mandatory set it, and the plugin must be tested with this version
-pluginUntilBuild=243.*
+# No untilBuild specified, the plugin wants to be compatible with all future versions
+# pluginUntilBuild=243.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IU
 # Corresponds to AS Ladybug 2024.2.1 -> https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html


### PR DESCRIPTION
Will remove a bit of pressure to urgently publish an update whenever there's a new platform version.

Fix #6260 