### PR TITLE
Fix using PQs with subscriptions

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -114,7 +114,7 @@ kotlinx-coroutines-rx2 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coro
 kotlinx-coroutines-rx3 = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-rx3", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
-kotlinx-nodejs = { group = "org.jetbrains.kotlinx", name = "kotlinx-nodejs", version = "0.0.7" }
+kotlinx-nodejs = "org.jetbrains.kotlin-wrappers:kotlin-node:18.16.12-pre.634"
 kotlinx-serialization-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin-plugin" }
 kotlinx-serialization-plugin-duringideasync = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin-plugin-duringideasync" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }

--- a/gradle/repositories.gradle.kts
+++ b/gradle/repositories.gradle.kts
@@ -23,14 +23,5 @@ listOf(pluginManagement.repositories, dependencyResolutionManagement.repositorie
         includeVersion("org.jetbrains.kotlin.plugin.serialization", "org.jetbrains.kotlin.plugin.serialization.gradle.plugin", "1.6.10")
       }
     }
-
-    exclusiveContent {
-      @Suppress("DEPRECATION")
-      forRepository(::jcenter)
-      filter {
-        // https://github.com/Kotlin/kotlinx-nodejs/issues/16
-        includeModule("org.jetbrains.kotlinx", "kotlinx-nodejs")
-      }
-    }
   }
 }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/Operations.kt
@@ -3,6 +3,7 @@
 package com.apollographql.apollo3.api
 
 import com.apollographql.apollo3.annotations.ApolloExperimental
+import com.apollographql.apollo3.annotations.ApolloInternal
 import com.apollographql.apollo3.api.internal.ResponseParser
 import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.JsonWriter
@@ -59,15 +60,25 @@ fun <D : Operation.Data> Operation<D>.parseJsonResponse(
     jsonReader: JsonReader,
     customScalarAdapters: CustomScalarAdapters = CustomScalarAdapters.Empty,
 ): ApolloResponse<D> {
+  return parseJsonResponseInternal(jsonReader, customScalarAdapters, true)
+}
+
+@ApolloInternal
+fun <D : Operation.Data> Operation<D>.parseJsonResponseInternal(
+  jsonReader: JsonReader,
+  customScalarAdapters: CustomScalarAdapters,
+  checkEof: Boolean
+): ApolloResponse<D> {
   val variables = variables(customScalarAdapters, withDefaultBooleanValues = true)
   return ResponseParser.parse(
-      jsonReader,
-      this,
-      customScalarAdapters.newBuilder()
-          .adapterContext(customScalarAdapters.adapterContext.newBuilder()
-              .variables(variables)
-              .build())
-          .build()
+    jsonReader,
+    this,
+    customScalarAdapters.newBuilder()
+      .adapterContext(customScalarAdapters.adapterContext.newBuilder()
+        .variables(variables)
+        .build())
+      .build(),
+    checkEof
   )
 }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo3/api/internal/ResponseParser.kt
@@ -20,6 +20,7 @@ internal object ResponseParser {
       jsonReader: JsonReader,
       operation: Operation<D>,
       customScalarAdapters: CustomScalarAdapters,
+      checkEof: Boolean = true,
   ): ApolloResponse<D>  {
     @Suppress("NAME_SHADOWING")
     return jsonReader.use { jsonReader ->
@@ -40,7 +41,7 @@ internal object ResponseParser {
 
       jsonReader.endObject()
 
-      if (jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
+      if (checkEof && jsonReader.peek() != JsonReader.Token.END_DOCUMENT) {
         throw JsonDataException("Expected END_DOCUMENT but was ${jsonReader.peek()}")
       }
 

--- a/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -56,12 +56,7 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
   }
 
   override suspend fun url() = url ?: suspendCoroutine { cont ->
-    val server = requireNotNull(this.server) { "Server is not listening, please call listen() before calling address()" }
-
     server.once(Event.LISTENING) {
-      val server = requireNotNull(this.server) {
-        "close() was called during a call to address()"
-      }
       val address = server.address().unsafeCast<AddressInfo>()
       url = "http://localhost:${address.port}/"
       cont.resume(url!!)

--- a/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
+++ b/libraries/apollo-mockserver/src/jsMain/kotlin/com/apollographql/apollo3/mockserver/MockServer.kt
@@ -1,13 +1,14 @@
 package com.apollographql.apollo3.mockserver
 
-import Buffer
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.AddressInfo
-import net.Socket
-import net.createServer
+import node.buffer.Buffer
+import node.events.Event
+import node.net.AddressInfo
+import node.net.Socket
+import node.net.createServer
 import okio.Sink
 import okio.Timeout
 import okio.buffer
@@ -26,10 +27,10 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
   @OptIn(DelicateCoroutinesApi::class)
   private val server = createServer { socket ->
     val requestBody = okio.Buffer()
-    socket.on("data") { chunk ->
+    socket.on(Event.DATA) { chunk ->
       when (chunk) {
         is String -> requestBody.writeUtf8(chunk)
-        is Buffer -> requestBody.write(chunk.asByteArray())
+        is Buffer -> requestBody.write(chunk.toByteArray())
         else -> error("Unexpected chunk type: ${chunk::class}")
       }
       val request = readRequest(requestBody)!!
@@ -48,18 +49,28 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
         socket.end()
       }
     }
-  }.listen()
+  }
+
+  init {
+    server.listen()
+  }
 
   override suspend fun url() = url ?: suspendCoroutine { cont ->
-    url = "http://localhost:${server.address().unsafeCast<AddressInfo>().port}/"
-    server.on("listening") { _ ->
+    val server = requireNotNull(this.server) { "Server is not listening, please call listen() before calling address()" }
+
+    server.once(Event.LISTENING) {
+      val server = requireNotNull(this.server) {
+        "close() was called during a call to address()"
+      }
+      val address = server.address().unsafeCast<AddressInfo>()
+      url = "http://localhost:${address.port}/"
       cont.resume(url!!)
     }
   }
 
   override fun enqueue(mockResponse: MockResponse) {
     (mockServerHandler as? QueueMockServerHandler)?.enqueue(mockResponse)
-        ?: error("Apollo: cannot call MockServer.enqueue() with a custom handler")
+      ?: error("Apollo: cannot call MockServer.enqueue() with a custom handler")
   }
 
   override fun takeRequest(): MockRequest {
@@ -91,6 +102,7 @@ actual class MockServer actual constructor(override val mockServerHandler: MockS
       skip(count)
       return array
     }
+
     override fun close() {}
     override fun flush() {}
     override fun timeout() = Timeout.NONE

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo3/network/http/HttpNetworkTransport.kt
@@ -14,6 +14,7 @@ import com.apollographql.apollo3.api.json.JsonReader
 import com.apollographql.apollo3.api.json.jsonReader
 import com.apollographql.apollo3.api.json.readAny
 import com.apollographql.apollo3.api.parseJsonResponse
+import com.apollographql.apollo3.api.parseJsonResponseInternal
 import com.apollographql.apollo3.api.withDeferredFragmentIds
 import com.apollographql.apollo3.exception.ApolloException
 import com.apollographql.apollo3.exception.ApolloHttpException
@@ -153,10 +154,12 @@ private constructor(
                 reader.beginObject()
                 reader.nextName()
 
+
                 // TODO: make parseJsonResponse not close the jsonReader
-                operation.parseJsonResponse(
+                operation.parseJsonResponseInternal(
                     jsonReader = reader,
-                    customScalarAdapters = customScalarAdapters
+                    customScalarAdapters = customScalarAdapters,
+                    checkEof = false
                 )
               }
 


### PR DESCRIPTION
See #6276

* Make it possible to use PQs with subscriptions.
* Make `release-3.x` compile now that jcenter is dead.
* Fix https://github.com/apollographql/apollo-kotlin/pull/5894#pullrequestreview-2117767392 (subscriptions may do a partial read)

See test [here](https://github.com/martinbonnin/reproducers/tree/da6a1ee2454b2affda8ba174c6360e85bb5119a1/apollo-6276)