### PR TITLE
Allow multiple @link schema extensions

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
@@ -65,7 +65,7 @@ class SchemaValidationOptions(
 
 internal fun validateSchema(definitions: List<GQLDefinition>, options: SchemaValidationOptions): GQLResult<Schema> {
   val issues = mutableListOf<Issue>()
-  val builtinDefinitions = builtinDefinitions()
+  val builtinDefinitions = builtinDefinitions() + linkDefinitions()
 
   // If the builtin definitions are already in the schema, keep them
   var allDefinitions = combineDefinitions(definitions, builtinDefinitions, ConflictResolution.TakeLeft)
@@ -326,7 +326,7 @@ private fun List<GQLSchemaExtension>.getImports(
          * Validate `@link` using a very minimal schema.
          * This ensure we can safely cast the arguments below
          */
-        val minimalSchema = builtinDefinitions + linkDefinitions()
+        val minimalSchema = builtinDefinitions
         val scope = DefaultValidationScope(
             minimalSchema.filterIsInstance<GQLTypeDefinition>().associateBy { it.name },
             minimalSchema.filterIsInstance<GQLDirectiveDefinition>().associateBy { it.name },

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
@@ -65,7 +65,7 @@ class SchemaValidationOptions(
 
 internal fun validateSchema(definitions: List<GQLDefinition>, options: SchemaValidationOptions): GQLResult<Schema> {
   val issues = mutableListOf<Issue>()
-  val builtinDefinitions = builtinDefinitions() + linkDefinitions()
+  val builtinDefinitions = builtinDefinitions()
 
   // If the builtin definitions are already in the schema, keep them
   var allDefinitions = combineDefinitions(definitions, builtinDefinitions, ConflictResolution.TakeLeft)
@@ -318,15 +318,20 @@ private fun List<GQLSchemaExtension>.getImports(
   val schemaExtensions = this
 
   val imports = mutableListOf<Import>()
-
+  val linkForeignSchema = ForeignSchema("link", "v1.0", linkDefinitions())
+  val linkImport = Import(linkForeignSchema, linkForeignSchema.definitions, mapOf("link" to "link"))
   schemaExtensions.forEach { schemaExtension ->
     schemaExtension.directives.forEach eachDirective@{ gqlDirective ->
       if (gqlDirective.name == "link") {
+        if (!imports.contains(linkImport)) {
+          imports.add(linkImport)
+        }
+
         /**
          * Validate `@link` using a very minimal schema.
          * This ensure we can safely cast the arguments below
          */
-        val minimalSchema = builtinDefinitions
+        val minimalSchema = builtinDefinitions + linkForeignSchema.definitions
         val scope = DefaultValidationScope(
             minimalSchema.filterIsInstance<GQLTypeDefinition>().associateBy { it.name },
             minimalSchema.filterIsInstance<GQLDirectiveDefinition>().associateBy { it.name },

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/SchemaTest.kt
@@ -80,9 +80,11 @@ class SchemaTest {
       extend schema
       @link(url: "https://specs.apollo.dev/cache/v0.1/", import: ["@cacheControl"])
       @link(url: "https://example.com/example/v0.1/", import: ["@example"])
-      
+      extend schema
+      @link(url: "https://example.com/example2/v0.1/", import: ["@example2"])
+
       type Query {
-        foo: Int @cacheControl(maxAge: 100) @example
+        foo: Int @cacheControl(maxAge: 100) @example @example2
       }
     """.trimIndent()
 
@@ -92,10 +94,10 @@ class SchemaTest {
             foreignSchemas = listOf(
                 cacheControlSchema,
                 ForeignSchema("example", "v0.1",
-                    listOf(
-                        "directive @example on FIELD_DEFINITION".parseAsGQLDocument()
-                            .getOrThrow().definitions.single()
-                    )
+                    listOf("directive @example on FIELD_DEFINITION".parseAsGQLDocument().getOrThrow().definitions.single())
+                ),
+                ForeignSchema("example2", "v0.1",
+                    listOf("directive @example2 on FIELD_DEFINITION".parseAsGQLDocument().getOrThrow().definitions.single())
                 )
             )
         )


### PR DESCRIPTION
Adding multiple `@link` extensions was failing because the definition of `@link` wasn't known, so couldn't check if it's repeatable [here](https://github.com/apollographql/apollo-kotlin/blob/7668a302eb5c62ca1d3e423ccfefa1142acee1f4/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/ExtensionsMerger.kt#L265).