### PR TITLE
[apollo-runtime] Allow to initialize the WebSocket.Factory lazily

### DIFF
--- a/libraries/apollo-runtime/api/android/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/android/apollo-runtime.api
@@ -354,6 +354,7 @@ public final class com/apollographql/apollo/network/ws/AppSyncWsProtocol$Factory
 
 public final class com/apollographql/apollo/network/ws/DefaultWebSocketEngine : com/apollographql/apollo/network/ws/WebSocketEngine {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public fun <init> (Lokhttp3/WebSocket$Factory;)V
 	public fun open (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/libraries/apollo-runtime/api/jvm/apollo-runtime.api
+++ b/libraries/apollo-runtime/api/jvm/apollo-runtime.api
@@ -354,6 +354,7 @@ public final class com/apollographql/apollo/network/ws/AppSyncWsProtocol$Factory
 
 public final class com/apollographql/apollo/network/ws/DefaultWebSocketEngine : com/apollographql/apollo/network/ws/WebSocketEngine {
 	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public fun <init> (Lokhttp3/WebSocket$Factory;)V
 	public fun open (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo/network/ws/OkHttpWebSocketEngine.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo/network/ws/OkHttpWebSocketEngine.kt
@@ -13,10 +13,23 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 
+/**
+ * Creates a new [DefaultWebSocketEngine] from [webSocketFactory]
+ *
+ * This constructor accepts a function so that OkHttp is initialized from a background thread
+ */
 actual class DefaultWebSocketEngine(
-    private val webSocketFactory: WebSocket.Factory,
+    webSocketFactory: () -> WebSocket.Factory,
 ) : WebSocketEngine {
+  private val webSocketFactory by lazy { webSocketFactory() }
 
+  /**
+   * Creates a new [DefaultWebSocketEngine] from [webSocketFactory]
+   *
+   * Prefer using the factory function accepting a function so that OkHttp is initialized from a background thread.
+   * See https://github.com/square/okhttp/pull/8248
+   */
+  constructor(webSocketFactory: WebSocket.Factory): this({webSocketFactory})
   actual constructor() : this(
       webSocketFactory = defaultOkHttpClientBuilder.build()
   )


### PR DESCRIPTION
Extracted from https://github.com/apollographql/apollo-kotlin/pull/6287 because this we need for sure.

See also https://github.com/apollographql/apollo-kotlin/pull/5784
