### PR TITLE
[IJ Plugin] Make Java and Kotlin dependencies optional

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/lsp/LspUtil.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/lsp/LspUtil.kt
@@ -1,5 +1,0 @@
-package com.apollographql.ijplugin.lsp
-
-fun isLspAvailable(): Boolean {
-  return runCatching { Class.forName("com.intellij.platform.lsp.api.LspServerManager") }.isSuccess
-}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/NormalizedCacheToolWindowFactory.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/NormalizedCacheToolWindowFactory.kt
@@ -14,6 +14,7 @@ import com.apollographql.ijplugin.telemetry.TelemetryEvent.ApolloIjNormalizedCac
 import com.apollographql.ijplugin.telemetry.TelemetryEvent.ApolloIjNormalizedCacheOpenDeviceFile
 import com.apollographql.ijplugin.telemetry.TelemetryEvent.ApolloIjNormalizedCacheOpenLocalFile
 import com.apollographql.ijplugin.telemetry.telemetryService
+import com.apollographql.ijplugin.util.isAndroidPluginPresent
 import com.apollographql.ijplugin.util.logw
 import com.apollographql.ijplugin.util.showNotification
 import com.intellij.icons.AllIcons

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDevice.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/normalizedcache/PullFromDevice.kt
@@ -14,13 +14,6 @@ import java.io.File
 import java.nio.file.Paths
 import java.util.concurrent.TimeUnit
 
-val isAndroidPluginPresent = try {
-  Class.forName("com.android.ddmlib.AndroidDebugBridge")
-  true
-} catch (e: ClassNotFoundException) {
-  false
-}
-
 fun getConnectedDevices(): List<IDevice> {
   return AndroidDebugBridge.createBridge(1, TimeUnit.SECONDS).devices.sortedBy { it.name }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
@@ -5,11 +5,11 @@ import com.apollographql.ijplugin.gradle.GradleToolingModelService
 import com.apollographql.ijplugin.graphql.GraphQLConfigService
 import com.apollographql.ijplugin.lsp.ApolloLspAppService
 import com.apollographql.ijplugin.lsp.ApolloLspProjectService
-import com.apollographql.ijplugin.lsp.isLspAvailable
 import com.apollographql.ijplugin.settings.ProjectSettingsService
 import com.apollographql.ijplugin.studio.fieldinsights.FieldInsightsService
 import com.apollographql.ijplugin.studio.sandbox.SandboxService
 import com.apollographql.ijplugin.telemetry.TelemetryService
+import com.apollographql.ijplugin.util.isLspAvailable
 import com.apollographql.ijplugin.util.logd
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbService
@@ -32,7 +32,7 @@ internal class ApolloProjectManagerListener : ProjectManagerListener {
       project.service<SandboxService>()
       project.service<FieldInsightsService>()
       project.service<TelemetryService>()
-      if (isLspAvailable()) {
+      if (isLspAvailable) {
         project.service<ApolloLspProjectService>()
         application.service<ApolloLspAppService>()
       }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/AppSettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/AppSettingsService.kt
@@ -1,5 +1,8 @@
 package com.apollographql.ijplugin.settings
 
+import com.apollographql.ijplugin.util.isJavaPluginPresent
+import com.apollographql.ijplugin.util.isKotlinPluginPresent
+import com.apollographql.ijplugin.util.isLspAvailable
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.State
@@ -54,6 +57,14 @@ class AppSettingsService : PersistentStateComponent<AppSettingsStateImpl>, AppSe
     if (lastNotifiedState != _state) {
       lastNotifiedState = _state.copy()
       application.messageBus.syncPublisher(AppSettingsListener.TOPIC).settingsChanged(_state)
+    }
+  }
+
+  override fun initializeComponent() {
+    // Running in an IDE without the Java or Kotlin plugin (e.g. RustRover): the user is most likely not an Apollo Kotlin developer.
+    // In that case, the LSP mode (if available) is the best default.
+    if (isLspAvailable && (!isJavaPluginPresent || !isKotlinPluginPresent)) {
+      lspModeEnabled = true
     }
   }
 }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
@@ -1,0 +1,9 @@
+package com.apollographql.ijplugin.util
+
+val isLspAvailable = runCatching { Class.forName("com.intellij.platform.lsp.api.LspServerManager") }.isSuccess
+
+val isAndroidPluginPresent = runCatching { Class.forName("com.android.ddmlib.AndroidDebugBridge") }.isSuccess
+
+val isJavaPluginPresent = runCatching { Class.forName("com.intellij.psi.PsiJavaFile") }.isSuccess
+
+val isKotlinPluginPresent = runCatching { Class.forName("org.jetbrains.kotlin.psi.KtFile") }.isSuccess

--- a/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-java.xml
+++ b/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-java.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+  <!-- Add here declarations that only work in presence of the Java plugin -->
+</idea-plugin>

--- a/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-kotlin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-kotlin.xml
@@ -1,0 +1,3 @@
+<idea-plugin>
+  <!-- Add here declarations that only work in presence of the Java plugin -->
+</idea-plugin>

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -8,8 +8,8 @@
   <!-- In most cases, this should be the same list as what is listed under gradle.properties/platformPlugins -->
   <!-- See https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html#declaring-plugin-dependencies -->
   <depends>com.intellij.modules.platform</depends>
-  <depends>com.intellij.modules.java</depends>
-  <depends>org.jetbrains.kotlin</depends>
+  <depends optional="true" config-file="com.apollographql.ijplugin-java.xml">com.intellij.modules.java</depends>
+  <depends optional="true" config-file="com.apollographql.ijplugin-kotlin.xml">org.jetbrains.kotlin</depends>
   <depends>com.intellij.gradle</depends>
   <depends>com.intellij.lang.jsgraphql</depends>
   <depends>org.toml.lang</depends>


### PR DESCRIPTION
This makes the plugin available to more IDEs (e.g. RustRover), for users that are interested in the LSP mode more than the Apollo Kotlin mode.