### PR TITLE
[gradle-plugin] Manage our classloaders manually

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
@@ -1,0 +1,235 @@
+package com.apollographql.apollo.compiler
+
+import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.compiler.codegen.SchemaAndOperationsLayout
+import com.apollographql.apollo.compiler.codegen.writeTo
+import com.apollographql.apollo.compiler.internal.GradleCompilerPluginLogger
+import com.apollographql.apollo.compiler.operationoutput.OperationDescriptor
+import com.apollographql.apollo.compiler.operationoutput.OperationId
+import com.apollographql.apollo.compiler.operationoutput.OperationOutput
+import java.io.File
+import java.util.ServiceLoader
+import java.util.function.Consumer
+
+/**
+ * EntryPoints contains code that is called using reflection from the Gradle plugin.
+ * This is so that the classloader can be isolated, and we can use our preferred version of
+ * Kotlin and other dependencies without risking conflicts.
+ */
+@Suppress("UNUSED") // Used from reflection
+@ApolloInternal
+class EntryPoints {
+  fun buildCodegenSchema(
+      arguments: Map<String, Any?>,
+      logLevel: Int,
+      warnIfNotFound: Boolean = false,
+      normalizedSchemaFiles: List<Any>,
+      warning: Consumer<String>,
+      codegenSchemaOptionsFile: File,
+      codegenSchemaFile: File,
+  ) {
+    val plugin = apolloCompilerPlugin(
+        arguments,
+        logLevel,
+        warnIfNotFound
+    )
+
+    ApolloCompiler.buildCodegenSchema(
+        schemaFiles = normalizedSchemaFiles.toInputFiles(),
+        logger = warning.toLogger(),
+        codegenSchemaOptions = codegenSchemaOptionsFile.toCodegenSchemaOptions(),
+        foreignSchemas = plugin?.foreignSchemas().orEmpty()
+    ).writeTo(codegenSchemaFile)
+  }
+
+  fun buildIr(
+      arguments: Map<String, Any?>,
+      logLevel: Int,
+      graphqlFiles: List<Any>,
+      codegenSchemaFiles: List<Any>,
+      upstreamIrOperations: List<Any>,
+      irOptionsFile: File,
+      warning: Consumer<String>,
+      irOperationsFile: File,
+  ) {
+    val plugin = apolloCompilerPlugin(arguments, logLevel)
+
+    val upstream = upstreamIrOperations.toInputFiles().map { it.file.toIrOperations() }
+    ApolloCompiler.buildIrOperations(
+        executableFiles = graphqlFiles.toInputFiles(),
+        codegenSchema = codegenSchemaFiles.toInputFiles().map { it.file }.findCodegenSchemaFile().toCodegenSchema(),
+        upstreamCodegenModels = upstream.map { it.codegenModels },
+        upstreamFragmentDefinitions = upstream.flatMap { it.fragmentDefinitions },
+        documentTransform = plugin?.documentTransform(),
+        options = irOptionsFile.toIrOptions(),
+        logger = warning.toLogger(),
+    ).writeTo(irOperationsFile)
+  }
+
+  fun buildSourcesFromIr(
+      arguments: Map<String, Any?>,
+      logLevel: Int,
+      warnIfNotFound: Boolean = false,
+      codegenSchemaFiles: List<Any>,
+      upstreamMetadata: List<Any>,
+      irOperations: File,
+      downstreamUsedCoordinates: Map<String, Map<String, Set<String>>>,
+      codegenOptions: File,
+      operationManifestFile: File?,
+      outputDir: File,
+      metadataOutputFile: File?
+  ) {
+    val plugin = apolloCompilerPlugin(
+        arguments,
+        logLevel,
+        warnIfNotFound
+    )
+    val codegenSchemaFile = codegenSchemaFiles.toInputFiles().map { it.file }.findCodegenSchemaFile()
+
+    val codegenSchema = codegenSchemaFile.toCodegenSchema()
+
+    val upstreamCodegenMetadata = upstreamMetadata.toInputFiles().map { it.file.toCodegenMetadata() }
+    ApolloCompiler.buildSchemaAndOperationsSourcesFromIr(
+        codegenSchema = codegenSchema,
+        irOperations = irOperations.toIrOperations(),
+        downstreamUsedCoordinates = downstreamUsedCoordinates.toUsedCoordinates(),
+        upstreamCodegenMetadata = upstreamCodegenMetadata,
+        codegenOptions = codegenOptions.toCodegenOptions(),
+        layout = plugin?.layout(codegenSchema),
+        irOperationsTransform = plugin?.irOperationsTransform(),
+        javaOutputTransform = plugin?.javaOutputTransform(),
+        kotlinOutputTransform = plugin?.kotlinOutputTransform(),
+        operationManifestFile = operationManifestFile,
+        operationOutputGenerator = plugin?.toOperationOutputGenerator(),
+    ).writeTo(outputDir, true, metadataOutputFile)
+
+    if (upstreamCodegenMetadata.isEmpty()) {
+      plugin?.schemaListener()?.onSchema(codegenSchema.schema, outputDir)
+    }
+  }
+
+  fun buildSources(
+      arguments: Map<String, Any?>,
+      logLevel: Int,
+      warnIfNotFound: Boolean = false,
+      schemaFiles: List<Any>,
+      graphqlFiles: List<Any>,
+      codegenSchemaOptions: File,
+      codegenOptions: File,
+      irOptions: File,
+      warning: Consumer<String>,
+      operationManifestFile: File?,
+      outputDir: File
+  ) {
+    val plugin = apolloCompilerPlugin(
+        arguments,
+        logLevel,
+        warnIfNotFound
+    )
+
+    val codegenSchema = ApolloCompiler.buildCodegenSchema(
+        schemaFiles = schemaFiles.toInputFiles(),
+        codegenSchemaOptions = codegenSchemaOptions.toCodegenSchemaOptions(),
+        foreignSchemas = plugin?.foreignSchemas().orEmpty(),
+        logger = warning.toLogger()
+    )
+
+    ApolloCompiler.buildSchemaAndOperationsSources(
+        codegenSchema,
+        executableFiles = graphqlFiles.toInputFiles(),
+        codegenOptions = codegenOptions.toCodegenOptions(),
+        irOptions = irOptions.toIrOptions(),
+        logger = warning.toLogger(),
+        layoutFactory = object : LayoutFactory {
+          override fun create(codegenSchema: CodegenSchema): SchemaAndOperationsLayout? {
+            return plugin?.layout(codegenSchema)
+          }
+        },
+        operationOutputGenerator = plugin?.toOperationOutputGenerator(),
+        irOperationsTransform = plugin?.irOperationsTransform(),
+        javaOutputTransform = plugin?.javaOutputTransform(),
+        kotlinOutputTransform = plugin?.kotlinOutputTransform(),
+        documentTransform = plugin?.documentTransform(),
+        operationManifestFile = operationManifestFile,
+    ).writeTo(outputDir, true, null)
+
+    plugin?.schemaListener()?.onSchema(codegenSchema.schema, outputDir)
+  }
+}
+
+internal fun ApolloCompilerPlugin.toOperationOutputGenerator(): OperationOutputGenerator {
+  return object : OperationOutputGenerator {
+    override fun generate(operationDescriptorList: Collection<OperationDescriptor>): OperationOutput {
+      var operationIds = operationIds(operationDescriptorList.toList())
+      if (operationIds == null) {
+        operationIds = operationDescriptorList.map { OperationId(OperationIdGenerator.Sha256.apply(it.source, it.name), it.name) }
+      }
+      return operationDescriptorList.associateBy { descriptor ->
+        val operationId = operationIds.firstOrNull { it.name == descriptor.name } ?: error("No id found for operation ${descriptor.name}")
+        operationId.id
+      }
+    }
+  }
+}
+
+internal fun Consumer<String>.toLogger(): ApolloCompiler.Logger {
+  return object : ApolloCompiler.Logger {
+    override fun warning(message: String) {
+      accept(message)
+    }
+  }
+}
+
+@ApolloInternal
+fun Iterable<File>.findCodegenSchemaFile(): File {
+  return firstOrNull {
+    it.length() > 0
+  } ?: error("Cannot find CodegenSchema in $this")
+}
+
+internal fun apolloCompilerPlugin(
+    arguments: Map<String, Any?>,
+    logLevel: Int,
+    warnIfNotFound: Boolean = false,
+): ApolloCompilerPlugin? {
+  val plugins = ServiceLoader.load(ApolloCompilerPlugin::class.java, ApolloCompilerPlugin::class.java.classLoader).toList()
+
+  if (plugins.size > 1) {
+    error("Apollo: only a single compiler plugin is allowed")
+  }
+
+  val plugin = plugins.singleOrNull()
+  if (plugin != null) {
+    error("Apollo: use ApolloCompilerPluginProvider instead of ApolloCompilerPlugin directly. ApolloCompilerPluginProvider allows arguments and logging")
+  }
+
+  val pluginProviders = ServiceLoader.load(ApolloCompilerPluginProvider::class.java, ApolloCompilerPlugin::class.java.classLoader).toList()
+
+  if (pluginProviders.size > 1) {
+    error("Apollo: only a single compiler plugin provider is allowed")
+  }
+
+  if (pluginProviders.isEmpty() && warnIfNotFound) {
+    println("Apollo: a compiler plugin was added with `Service.plugin()` but could not be loaded by the ServiceLoader. Check your META-INF/services/com.apollographql.apollo.compiler.ApolloCompilerPluginProvider file.")
+  }
+
+  val provider = pluginProviders.singleOrNull()
+  if (provider != null) {
+    return provider.create(
+        ApolloCompilerPluginEnvironment(
+            arguments,
+            GradleCompilerPluginLogger(logLevel)
+        )
+    )
+  }
+
+  return plugins.singleOrNull()
+}
+
+
+internal fun List<Any>.toInputFiles(): List<InputFile> = buildList {
+  val iterator = this@toInputFiles.iterator()
+  while (iterator.hasNext()) {
+    add(InputFile(normalizedPath = iterator.next() as String, file = iterator.next() as File))
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -728,17 +728,6 @@ interface Service {
    */
   val decapitalizeFields: Property<Boolean>
 
-  /**
-   * Whether to use process isolation. By default, the Apollo tasks use classloader isolation, which may leak and increase memory usage over time.
-   * By using process isolation, the tasks are run in a separate process and the memory is reclaimed when the process stops. This comes at a price
-   * of more forking time.
-   *
-   * See https://github.com/apollographql/apollo-kotlin/issues/6266
-   * See https://github.com/gradle/gradle/issues/18313
-   */
-  @ApolloExperimental
-  val useProcessIsolation: Property<Boolean>
-
   @Deprecated("Not supported any more, use dependsOn() instead", level = DeprecationLevel.ERROR)
   @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   fun usedCoordinates(file: File)

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloBuildService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloBuildService.kt
@@ -1,0 +1,25 @@
+package com.apollographql.apollo.gradle.internal
+
+import org.gradle.api.file.FileCollection
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.net.URL
+import java.net.URLClassLoader
+
+abstract class ApolloBuildService: BuildService<BuildServiceParameters.None>, AutoCloseable {
+  private val classloaders = mutableMapOf<Array<URL>, ClassLoader>()
+
+  fun classloader(classpath: FileCollection): ClassLoader {
+    val urls = classpath.map { it.toURI().toURL() }.toTypedArray()
+    return classloaders.getOrPut(urls) {
+      URLClassLoader(
+          urls,
+          ClassLoader.getPlatformClassLoader()
+      )
+    }
+  }
+
+  override fun close() {
+    classloaders.clear()
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -80,7 +80,7 @@ private abstract class GenerateCodegenSchema : WorkAction<GenerateCodegenSchemaP
                 logLevel,
                 hasPlugin,
                 (schemaFiles.takeIf { it.isNotEmpty() }?: fallbackSchemaFiles),
-                Consumer<String> { logger().warning(it) },
+                warningMessageConsumer,
                 codegenSchemaOptionsFile.get().asFile,
                 codegenSchemaFile.get().asFile
             )

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateIrOperationsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateIrOperationsTask.kt
@@ -69,7 +69,7 @@ private abstract class GenerateIrOperations : WorkAction<GenerateIrOperationsPar
                 codegenSchemaFiles,
                 upstreamIrFiles,
                 irOptionsFile.get().asFile,
-                Consumer<String> { logger().warning(it) },
+                warningMessageConsumer,
                 irOperationsFile.get().asFile
             )
       }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -2,16 +2,18 @@ package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.compiler.ApolloCompiler
 import com.apollographql.apollo.compiler.codegen.writeTo
+import com.apollographql.apollo.compiler.findCodegenSchemaFile
 import com.apollographql.apollo.compiler.toCodegenMetadata
 import com.apollographql.apollo.compiler.toCodegenOptions
 import com.apollographql.apollo.compiler.toCodegenSchema
 import com.apollographql.apollo.compiler.toIrOperations
 import com.apollographql.apollo.compiler.toUsedCoordinates
-import com.apollographql.apollo.gradle.internal.ApolloGenerateSourcesFromIrTask.Companion.findCodegenSchemaFile
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -23,7 +25,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
-import java.io.File
 
 @CacheableTask
 abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask() {
@@ -49,7 +50,7 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
   @TaskAction
   fun taskAction() {
     if (requiresBuildscriptClasspath()) {
-      val codegenSchemaFile = codegenSchemas.findCodegenSchemaFile()
+      val codegenSchemaFile = codegenSchemas.files.findCodegenSchemaFile()
 
       ApolloCompiler.buildSchemaAndOperationsSourcesFromIr(
           codegenSchema = codegenSchemaFile.toCodegenSchema(),
@@ -79,15 +80,9 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
         it.hasPlugin = hasPlugin.get()
         it.arguments = arguments.get()
         it.logLevel = logLevel.get().ordinal
+        it.apolloBuildService.set(apolloBuildService)
+        it.classpath = classpath
       }
-    }
-  }
-
-  companion object {
-    fun Iterable<File>.findCodegenSchemaFile(): File {
-      return firstOrNull {
-        it.length() > 0
-      } ?: error("Cannot find CodegenSchema in $this")
     }
   }
 }
@@ -95,34 +90,22 @@ abstract class ApolloGenerateSourcesFromIrTask : ApolloGenerateSourcesBaseTask()
 private abstract class GenerateSourcesFromIr : WorkAction<GenerateSourcesFromIrParameters> {
   override fun execute() {
     with(parameters) {
-      val codegenSchemaFile = codegenSchemas.findCodegenSchemaFile()
-
-      val codegenSchema = codegenSchemaFile.toCodegenSchema()
-      val plugin = apolloCompilerPlugin(
-          arguments,
-          logLevel,
-          hasPlugin
-      )
-
-      val upstreamCodegenMetadata = upstreamMetadata.files.map { it.toCodegenMetadata() }
-      ApolloCompiler.buildSchemaAndOperationsSourcesFromIr(
-          codegenSchema = codegenSchema,
-          irOperations = irOperations.get().asFile.toIrOperations(),
-          downstreamUsedCoordinates = downstreamUsedCoordinates.get().toUsedCoordinates(),
-          upstreamCodegenMetadata = upstreamCodegenMetadata,
-          codegenOptions = codegenOptions.get().asFile.toCodegenOptions(),
-          layout = plugin?.layout(codegenSchema),
-          irOperationsTransform = plugin?.irOperationsTransform(),
-          javaOutputTransform = plugin?.javaOutputTransform(),
-          kotlinOutputTransform = plugin?.kotlinOutputTransform(),
-          operationManifestFile = operationManifestFile.orNull?.asFile,
-          operationOutputGenerator = plugin?.toOperationOutputGenerator(),
-      ).writeTo(outputDir.get().asFile, true, metadataOutputFile.orNull?.asFile)
-
-      if (upstreamCodegenMetadata.isEmpty()) {
-        plugin?.schemaListener()?.let { onSchemaDocument ->
-          onSchemaDocument.onSchema(codegenSchema.schema, outputDir.get().asFile)
-        }
+      runInIsolation(apolloBuildService.get(), classpath) {
+        it.javaClass.declaredMethods.single { it.name == "buildSourcesFromIr" }
+            .invoke(
+                it,
+                arguments,
+                logLevel,
+                hasPlugin,
+                codegenSchemas.toInputFiles().isolate(),
+                upstreamMetadata.toInputFiles().isolate(),
+                irOperations.get().asFile,
+                downstreamUsedCoordinates.get(),
+                codegenOptions.get().asFile,
+                operationManifestFile.orNull?.asFile,
+                outputDir.get().asFile,
+                metadataOutputFile.orNull?.asFile
+            )
       }
     }
   }
@@ -140,5 +123,7 @@ private interface GenerateSourcesFromIrParameters : WorkParameters {
   val metadataOutputFile: RegularFileProperty
   var arguments: Map<String, Any?>
   var logLevel: Int
+  val apolloBuildService: Property<ApolloBuildService>
+  var classpath: FileCollection
 }
 

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -1,16 +1,15 @@
 package com.apollographql.apollo.gradle.internal
 
 import com.apollographql.apollo.compiler.ApolloCompiler
-import com.apollographql.apollo.compiler.CodegenSchema
-import com.apollographql.apollo.compiler.LayoutFactory
-import com.apollographql.apollo.compiler.codegen.SchemaAndOperationsLayout
 import com.apollographql.apollo.compiler.codegen.writeTo
 import com.apollographql.apollo.compiler.toCodegenOptions
 import com.apollographql.apollo.compiler.toCodegenSchemaOptions
 import com.apollographql.apollo.compiler.toIrOptions
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.PathSensitive
@@ -19,6 +18,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import java.io.File
+import java.util.function.Consumer
 
 @CacheableTask
 abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
@@ -83,6 +83,8 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
         it.outputDir.set(outputDir)
         it.arguments = arguments.get()
         it.logLevel = logLevel.get().ordinal
+        it.apolloBuildService.set(apolloBuildService)
+        it.classpath = classpath
       }
     }
   }
@@ -91,42 +93,22 @@ abstract class ApolloGenerateSourcesTask : ApolloGenerateSourcesBaseTask() {
 private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
   override fun execute() {
     with(parameters) {
-      val schemaInputFiles = (schemaFiles.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles).toInputFiles()
-      val executableInputFiles = graphqlFiles.toInputFiles()
-      val plugin = apolloCompilerPlugin(
-          arguments,
-          logLevel,
-          hasPlugin
-      )
-
-      val codegenSchema = ApolloCompiler.buildCodegenSchema(
-          schemaFiles = schemaInputFiles,
-          codegenSchemaOptions = codegenSchemaOptions.get().asFile.toCodegenSchemaOptions(),
-          foreignSchemas = plugin?.foreignSchemas().orEmpty(),
-          logger = logger()
-      )
-
-      ApolloCompiler.buildSchemaAndOperationsSources(
-          codegenSchema,
-          executableFiles = executableInputFiles,
-          codegenOptions = codegenOptions.get().asFile.toCodegenOptions(),
-          irOptions = irOptions.get().asFile.toIrOptions(),
-          logger = logger(),
-          layoutFactory = object : LayoutFactory {
-            override fun create(codegenSchema: CodegenSchema): SchemaAndOperationsLayout? {
-              return plugin?.layout(codegenSchema)
-            }
-          },
-          operationOutputGenerator = plugin?.toOperationOutputGenerator(),
-          irOperationsTransform = plugin?.irOperationsTransform(),
-          javaOutputTransform = plugin?.javaOutputTransform(),
-          kotlinOutputTransform = plugin?.kotlinOutputTransform(),
-          documentTransform = plugin?.documentTransform(),
-          operationManifestFile = operationManifestFile.orNull?.asFile,
-      ).writeTo(outputDir.get().asFile, true, null)
-
-      plugin?.schemaListener()?.let { onSchemaDocument ->
-        onSchemaDocument.onSchema(codegenSchema.schema, outputDir.get().asFile)
+      runInIsolation(apolloBuildService.get(), classpath) {
+        it.javaClass.declaredMethods.single { it.name == "buildSources" }
+            .invoke(
+                it,
+                arguments,
+                logLevel,
+                hasPlugin,
+                (schemaFiles.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles),
+                graphqlFiles,
+                codegenSchemaOptions.get().asFile,
+                codegenOptions.get().asFile,
+                irOptions.get().asFile,
+                Consumer<String> { logger().warning(it) },
+                operationManifestFile.orNull?.asFile,
+                outputDir.get().asFile
+            )
       }
     }
   }
@@ -134,9 +116,9 @@ private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
 
 private interface GenerateSourcesParameters : WorkParameters {
   var hasPlugin: Boolean
-  var graphqlFiles: List<Pair<String, File>>
-  var schemaFiles: List<Pair<String, File>>
-  var fallbackSchemaFiles: List<Pair<String, File>>
+  var graphqlFiles: List<Any>
+  var schemaFiles: List<Any>
+  var fallbackSchemaFiles: List<Any>
   val codegenSchemaOptions: RegularFileProperty
   val codegenOptions: RegularFileProperty
   val irOptions: RegularFileProperty
@@ -144,4 +126,6 @@ private interface GenerateSourcesParameters : WorkParameters {
   val outputDir: DirectoryProperty
   var arguments: Map<String, Any?>
   var logLevel: Int
+  val apolloBuildService: Property<ApolloBuildService>
+  var classpath: FileCollection
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -105,7 +105,7 @@ private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
                 codegenSchemaOptions.get().asFile,
                 codegenOptions.get().asFile,
                 irOptions.get().asFile,
-                Consumer<String> { logger().warning(it) },
+                warningMessageConsumer,
                 operationManifestFile.orNull?.asFile,
                 outputDir.get().asFile
             )

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloTaskWithClasspath.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloTaskWithClasspath.kt
@@ -1,18 +1,18 @@
 package com.apollographql.apollo.gradle.internal
 
-import com.apollographql.apollo.compiler.EntryPoints
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.workers.WorkQueue
 import org.gradle.workers.WorkerExecutor
+import java.util.function.Consumer
 import javax.inject.Inject
 
 abstract class ApolloTaskWithClasspath: DefaultTask() {
@@ -54,3 +54,10 @@ internal fun runInIsolation(buildService: ApolloBuildService, classpath: FileCol
   block(clazz.declaredConstructors.single().newInstance())
 }
 
+internal val warningMessageConsumer: Consumer<String> = object : Consumer<String> {
+  private val logger = Logging.getLogger("apollo")
+
+  override fun accept(p0: String) {
+    logger.lifecycle(p0)
+  }
+}

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/defaults.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/defaults.kt
@@ -91,21 +91,6 @@ internal fun DefaultService.operationManifestFormat(): Provider<String> {
   }
 }
 
-internal fun ApolloCompilerPlugin.toOperationOutputGenerator(): OperationOutputGenerator {
-  return object : OperationOutputGenerator {
-    override fun generate(operationDescriptorList: Collection<OperationDescriptor>): OperationOutput {
-      var operationIds = operationIds(operationDescriptorList.toList())
-      if (operationIds == null) {
-        operationIds = operationDescriptorList.map { OperationId(OperationIdGenerator.Sha256.apply(it.source, it.name), it.name) }
-      }
-      return operationDescriptorList.associateBy { descriptor ->
-        val operationId = operationIds.firstOrNull { it.name == descriptor.name } ?: error("No id found for operation ${descriptor.name}")
-        operationId.id
-      }
-    }
-  }
-}
-
 internal fun generateFilterNotNull(targetLanguage: TargetLanguage, isKmp: Boolean): Boolean? {
   return if (targetLanguage == TargetLanguage.JAVA) {
     null

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/utils.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/utils.kt
@@ -18,8 +18,9 @@ internal fun FileCollection.toInputFiles(): List<InputFile> {
 }
 
 /**
- * See https://github.com/gradle/gradle/issues/28147 for why this is needed
+ * Isolates inputs so we can use them from a separate classloader.
+ *
+ * See also https://github.com/gradle/gradle/issues/28147 for why this is needed.
  */
-internal fun FileCollection.isolate(): List<Pair<String, File>> = toInputFiles().isolate()
-internal fun List<InputFile>.isolate(): List<Pair<String, File>> = map { it.normalizedPath to it.file }
-internal fun List<Pair<String, File>>.toInputFiles(): List<InputFile> = map { InputFile(it.second, it.first) }
+internal fun FileCollection.isolate(): List<Any> = toInputFiles().isolate()
+internal fun List<InputFile>.isolate(): List<Any> = flatMap { listOf(it.normalizedPath, it.file) }


### PR DESCRIPTION
Replace worker process/classloader isolation with our own manually managed classloader. The classloader is cached in a `BuildService` and released at the end of a build. 

I kept the workers for parallelism for users without configuration cache enabled. There's a lot of boilerplate, passing the arguments from the extension -> task -> worker -> entrypoint. Will try to automate some of that in a follow up PR.

running `./gradlew generateApolloSources --rerun-tasks` on a simple project:

![Screenshot 2024-12-06 at 14 08 55](https://github.com/user-attachments/assets/3f08e96a-f13d-44a4-8124-3cf42c76cecb)


See https://github.com/apollographql/apollo-kotlin/issues/6266