### PR TITLE
Better Gradle error message

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateCodegenSchemaTask.kt
@@ -73,17 +73,16 @@ private abstract class GenerateCodegenSchema : WorkAction<GenerateCodegenSchemaP
   override fun execute() {
     with(parameters) {
       runInIsolation(apolloBuildService.get(), classpath) {
-        it.javaClass.declaredMethods.single { it.name == "buildCodegenSchema" }
-            .invoke(
-                it,
-                arguments,
-                logLevel,
-                hasPlugin,
-                (schemaFiles.takeIf { it.isNotEmpty() }?: fallbackSchemaFiles),
-                warningMessageConsumer,
-                codegenSchemaOptionsFile.get().asFile,
-                codegenSchemaFile.get().asFile
-            )
+        it.reflectiveCall(
+            "buildCodegenSchema",
+            arguments,
+            logLevel,
+            hasPlugin,
+            (schemaFiles.takeIf { it.isNotEmpty() } ?: fallbackSchemaFiles),
+            warningMessageConsumer,
+            codegenSchemaOptionsFile.get().asFile,
+            codegenSchemaFile.get().asFile
+        )
       }
     }
   }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateIrOperationsTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateIrOperationsTask.kt
@@ -60,18 +60,17 @@ private abstract class GenerateIrOperations : WorkAction<GenerateIrOperationsPar
   override fun execute() {
     with(parameters) {
       runInIsolation(apolloBuildService.get(), classpath) {
-        it.javaClass.declaredMethods.single { it.name == "buildIr" }
-            .invoke(
-                it,
-                arguments,
-                logLevel,
-                graphqlFiles,
-                codegenSchemaFiles,
-                upstreamIrFiles,
-                irOptionsFile.get().asFile,
-                warningMessageConsumer,
-                irOperationsFile.get().asFile
-            )
+        it.reflectiveCall(
+            "buildIr",
+            arguments,
+            logLevel,
+            graphqlFiles,
+            codegenSchemaFiles,
+            upstreamIrFiles,
+            irOptionsFile.get().asFile,
+            warningMessageConsumer,
+            irOperationsFile.get().asFile
+        )
       }
     }
   }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesFromIrTask.kt
@@ -91,21 +91,20 @@ private abstract class GenerateSourcesFromIr : WorkAction<GenerateSourcesFromIrP
   override fun execute() {
     with(parameters) {
       runInIsolation(apolloBuildService.get(), classpath) {
-        it.javaClass.declaredMethods.single { it.name == "buildSourcesFromIr" }
-            .invoke(
-                it,
-                arguments,
-                logLevel,
-                hasPlugin,
-                codegenSchemas.toInputFiles().isolate(),
-                upstreamMetadata.toInputFiles().isolate(),
-                irOperations.get().asFile,
-                downstreamUsedCoordinates.get(),
-                codegenOptions.get().asFile,
-                operationManifestFile.orNull?.asFile,
-                outputDir.get().asFile,
-                metadataOutputFile.orNull?.asFile
-            )
+        it.reflectiveCall(
+            "buildSourcesFromIr",
+            arguments,
+            logLevel,
+            hasPlugin,
+            codegenSchemas.toInputFiles().isolate(),
+            upstreamMetadata.toInputFiles().isolate(),
+            irOperations.get().asFile,
+            downstreamUsedCoordinates.get(),
+            codegenOptions.get().asFile,
+            operationManifestFile.orNull?.asFile,
+            outputDir.get().asFile,
+            metadataOutputFile.orNull?.asFile
+        )
       }
     }
   }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloGenerateSourcesTask.kt
@@ -94,9 +94,7 @@ private abstract class GenerateSources : WorkAction<GenerateSourcesParameters> {
   override fun execute() {
     with(parameters) {
       runInIsolation(apolloBuildService.get(), classpath) {
-        it.javaClass.declaredMethods.single { it.name == "buildSources" }
-            .invoke(
-                it,
+        it.reflectiveCall("buildSources",
                 arguments,
                 logLevel,
                 hasPlugin,


### PR DESCRIPTION
This fixes a regression introduced by https://github.com/apollographql/apollo-kotlin/pull/6305


Before:

```
* What went wrong:
Execution failed for task ':generateServiceApolloSources'.
> A failure occurred while executing com.apollographql.apollo.gradle.internal.GenerateSources
```

After:

```
* What went wrong:
Execution failed for task ':generateServiceApolloSources'.
> A failure occurred while executing com.apollographql.apollo.gradle.internal.GenerateSources
   > e: /Users/martinbonnin/Downloads/tmp/src/main/graphql/operation.graphql: (2, 5): Can't query `foo2` on type `Query`
     ----------------------------------------------------
     [1]:query GetFoo {
     [2]:    foo2
     [3]:}
     ----------------------------------------------------
```

