### PR TITLE
[gradle-plugin] expose the outgoing variants

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/ApolloExtension.kt
@@ -90,9 +90,6 @@ interface ApolloExtension {
    */
   val generateSourcesDuringGradleSync: Property<Boolean>
 
-  @ApolloExperimental
-  val useGradleVariants: Property<Boolean>
-
   /**
    * Common apollo dependencies using the same version as the Apollo Gradle Plugin currently in the classpath
    */

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -926,9 +926,7 @@ interface Service {
    * ```kotlin
    * service("service") {
    *   outgoingVariantsConnection {
-   *     outgoingVariants.forEach {
-   *       (components["java"] as AdhocSoftwareComponent).addVariantsFromConfiguration(it) {}
-   *     }
+   *     addToSoftwareComponent("java")
    *   }
    * }
    * ```

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -11,6 +11,8 @@ import com.apollographql.apollo.compiler.OperationOutputGenerator
 import com.apollographql.apollo.compiler.PackageNameGenerator
 import org.gradle.api.Action
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.component.SoftwareComponent
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
@@ -914,4 +916,32 @@ interface Service {
 
   @ApolloExperimental
   fun plugin(dependencyNotation: Any, block: Action<CompilerPlugin>)
+
+  /**
+   * Overrides the way the outgoing variants are connected.
+   * Use this to publish the metadata to an already existing software component.
+   *
+   * By default, a new software component named "apollo" is created.
+   *
+   * ```kotlin
+   * service("service") {
+   *   outgoingVariantsConnection {
+   *     outgoingVariants.forEach {
+   *       (components["java"] as AdhocSoftwareComponent).addVariantsFromConfiguration(it) {}
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  fun outgoingVariantsConnection(action: Action<in OutgoingVariantsConnection>)
+
+  /**
+   * An [OutgoingVariantsConnection] defines how outgoing variants are added to software components.
+   */
+  interface OutgoingVariantsConnection {
+    fun addToSoftwareComponent(name: String)
+    fun addToSoftwareComponent(softwareComponent: SoftwareComponent)
+
+    val outgoingVariants: List<Configuration>
+  }
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/api/Service.kt
@@ -933,11 +933,13 @@ interface Service {
    * }
    * ```
    */
+  @ApolloExperimental
   fun outgoingVariantsConnection(action: Action<in OutgoingVariantsConnection>)
 
   /**
    * An [OutgoingVariantsConnection] defines how outgoing variants are added to software components.
    */
+  @ApolloExperimental
   interface OutgoingVariantsConnection {
     fun addToSoftwareComponent(name: String)
     fun addToSoftwareComponent(softwareComponent: SoftwareComponent)

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -120,6 +120,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
   var operationOutputAction: Action<in Service.OperationOutputConnection>? = null
   var operationManifestAction: Action<in Service.OperationManifestConnection>? = null
+  var outgoingVariantsConnection: Action<in Service.OutgoingVariantsConnection>? = null
 
   @Deprecated("Use operationManifestConnection", replaceWith = ReplaceWith("operationManifestConnection"))
   @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
@@ -133,10 +134,18 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
   override fun operationManifestConnection(action: Action<in Service.OperationManifestConnection>) {
     check(!registered) {
-      "Apollo: operationOutputConnection {} cannot be configured outside of a service {} block"
+      "Apollo: operationManifestConnection {} cannot be configured outside of a service {} block"
     }
 
     this.operationManifestAction = action
+  }
+
+  override fun outgoingVariantsConnection(action: Action<in Service.OutgoingVariantsConnection>) {
+    check(!registered) {
+      "Apollo: outgoingVariantsConnection {} cannot be configured outside of a service {} block"
+    }
+
+    this.outgoingVariantsConnection = action
   }
 
   var outputDirAction: Action<in Service.DirectoryConnection>? = null

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/fragments/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/fragments/build.gradle.kts
@@ -13,15 +13,19 @@ dependencies {
 }
 
 apollo {
-  useGradleVariants.set(true)
-
   service("service1") {
     packageName.set("com.service1")
     dependsOn(project(":schema"))
+    outgoingVariantsConnection {
+      addToSoftwareComponent("java")
+    }
   }
   service("service2") {
     packageName.set("com.service2")
     dependsOn(project(":schema"))
+    outgoingVariantsConnection {
+      addToSoftwareComponent("java")
+    }
   }
 }
 

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/schema/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/schema/build.gradle.kts
@@ -13,17 +13,21 @@ dependencies {
 }
 
 apollo {
-  useGradleVariants.set(true)
-
   service("service1") {
     packageName.set("com.service1")
     generateApolloMetadata.set(true)
     alwaysGenerateTypesMatching.add(".*")
+    outgoingVariantsConnection {
+      addToSoftwareComponent("java")
+    }
   }
   service("service2") {
     packageName.set("com.service2")
     generateApolloMetadata.set(true)
     alwaysGenerateTypesMatching.add(".*")
+    outgoingVariantsConnection {
+      addToSoftwareComponent("java")
+    }
   }
 }
 


### PR DESCRIPTION
Instead of trying to guess what SoftwareComponent to add the metadata to, just expose them to the user so they can decide what to do with them:

```kotlin
  service("service") {
    generateApolloMetadata.set(true)
    outgoingVariantsConnection {
      addToSoftwareComponent("java")
    }
  }
```

Note that Android requires `afterEvaluate {}`:

```kotlin
  service("service") {
    generateApolloMetadata.set(true)
    outgoingVariantsConnection {
      afterEvaluate {
        addToSoftwareComponent("release")
      }
    }
  }
```