### PR TITLE
[IJ Plugin] Play nice with IDEs without Kotlin/Gradle

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/project/ApolloProjectManagerListener.kt
@@ -9,6 +9,8 @@ import com.apollographql.ijplugin.settings.ProjectSettingsService
 import com.apollographql.ijplugin.studio.fieldinsights.FieldInsightsService
 import com.apollographql.ijplugin.studio.sandbox.SandboxService
 import com.apollographql.ijplugin.telemetry.TelemetryService
+import com.apollographql.ijplugin.util.isGradlePluginPresent
+import com.apollographql.ijplugin.util.isKotlinPluginPresent
 import com.apollographql.ijplugin.util.isLspAvailable
 import com.apollographql.ijplugin.util.logd
 import com.intellij.openapi.components.service
@@ -23,15 +25,18 @@ internal class ApolloProjectManagerListener : ProjectManagerListener {
 
     // Initialize all services on project open.
     // But wait for 'smart mode' to do it.
+    // Most of these services can't operate without the Kotlin and Gradle plugins (e.g. in RustRover).
     DumbService.getInstance(project).runWhenSmart {
       logd("apolloVersion=" + project.apolloProjectService.apolloVersion)
-      project.service<ApolloCodegenService>()
-      project.service<GraphQLConfigService>()
-      project.service<GradleToolingModelService>()
-      project.service<ProjectSettingsService>()
-      project.service<SandboxService>()
-      project.service<FieldInsightsService>()
-      project.service<TelemetryService>()
+      if (isKotlinPluginPresent && isGradlePluginPresent) {
+        project.service<ApolloCodegenService>()
+        project.service<GraphQLConfigService>()
+        project.service<GradleToolingModelService>()
+        project.service<ProjectSettingsService>()
+        project.service<SandboxService>()
+        project.service<FieldInsightsService>()
+        project.service<TelemetryService>()
+      }
       if (isLspAvailable) {
         project.service<ApolloLspProjectService>()
         application.service<ApolloLspAppService>()

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -3,6 +3,8 @@ package com.apollographql.ijplugin.settings
 import com.apollographql.ijplugin.ApolloBundle
 import com.apollographql.ijplugin.project.apolloProjectService
 import com.apollographql.ijplugin.settings.studio.ApiKeyDialog
+import com.apollographql.ijplugin.util.isGradlePluginPresent
+import com.apollographql.ijplugin.util.isKotlinPluginPresent
 import com.intellij.openapi.observable.properties.PropertyGraph
 import com.intellij.openapi.project.Project
 import com.intellij.ui.AddEditRemovePanel
@@ -32,6 +34,7 @@ class SettingsComponent(private val project: Project) {
   private var addEditRemovePanel: AddEditRemovePanel<ApolloKotlinServiceConfiguration>? = null
 
   val panel: JPanel = panel {
+    // Some options are irrelevant without the Kotlin or Gradle plugins (e.g. in RustRover).
     group(ApolloBundle.message("settings.codegen.title")) {
       row {
         chkAutomaticCodegenTriggering = checkBox(ApolloBundle.message("settings.codegen.automaticCodegenTriggering.text"))
@@ -39,14 +42,14 @@ class SettingsComponent(private val project: Project) {
             .bindSelected(automaticCodegenTriggeringProperty)
             .component
       }
-    }
+    }.visible(isKotlinPluginPresent && isGradlePluginPresent)
     group(ApolloBundle.message("settings.graphqlPlugin.title")) {
       row {
         checkBox(ApolloBundle.message("settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.text"))
             .comment(ApolloBundle.message("settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.comment"))
             .bindSelected(contributeConfigurationToGraphqlPluginProperty)
       }
-    }
+    }.visible(isKotlinPluginPresent && isGradlePluginPresent)
     group(ApolloBundle.message("settings.studio.title")) {
       if (!project.apolloProjectService.apolloVersion.isAtLeastV4) {
         row { label(ApolloBundle.message("settings.studio.apiKeys.needV4.message")) }
@@ -98,7 +101,7 @@ class SettingsComponent(private val project: Project) {
               .comment(ApolloBundle.message("settings.studio.apiKeys.comment"))
         }
       }
-    }
+    }.visible(isKotlinPluginPresent && isGradlePluginPresent)
 
     group(ApolloBundle.message("settings.telemetry.telemetryEnabled.title")) {
       row {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/util/Environment.kt
@@ -7,3 +7,5 @@ val isAndroidPluginPresent = runCatching { Class.forName("com.android.ddmlib.And
 val isJavaPluginPresent = runCatching { Class.forName("com.intellij.psi.PsiJavaFile") }.isSuccess
 
 val isKotlinPluginPresent = runCatching { Class.forName("org.jetbrains.kotlin.psi.KtFile") }.isSuccess
+
+val isGradlePluginPresent = runCatching { Class.forName("org.jetbrains.plugins.gradle.util.GradleConstants") }.isSuccess

--- a/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-gradle.xml
+++ b/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-gradle.xml
@@ -1,0 +1,9 @@
+<idea-plugin>
+  <!-- Add here declarations that only work in presence of the Gradle plugin -->
+
+  <extensions defaultExtensionNs="com.intellij">
+    <!-- Listen to Gradle sync -->
+    <externalSystemTaskNotificationListener implementation="com.apollographql.ijplugin.gradle.GradleListener" />
+
+  </extensions>
+</idea-plugin>

--- a/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-kotlin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/com.apollographql.ijplugin-kotlin.xml
@@ -1,3 +1,336 @@
 <idea-plugin>
-  <!-- Add here declarations that only work in presence of the Java plugin -->
+  <!-- Add here declarations that only work in presence of the Kotlin plugin -->
+
+  <resource-bundle>messages.ApolloBundle</resource-bundle>
+
+  <extensions defaultExtensionNs="com.intellij">
+    <!-- Kotlin operation/fragment marker provider -->
+    <codeInsight.lineMarkerProvider
+        language="kotlin"
+        implementationClass="com.apollographql.ijplugin.navigation.KotlinDefinitionMarkerProvider"
+    />
+
+    <!-- Kotlin operation/fragment/field/enum/input 'go to declaration' handler -->
+    <gotoDeclarationHandler implementation="com.apollographql.ijplugin.navigation.KotlinGotoDeclarationHandler" />
+
+    <!-- GraphQL operation/fragment/field/enum/input 'go to declaration' handler -->
+    <gotoDeclarationHandler implementation="com.apollographql.ijplugin.navigation.GraphQLGotoDeclarationHandler" />
+
+    <!-- Kotlin operation/fragment/field/enum/input 'go to type declaration' handler -->
+    <!-- Needs order="first" so the Kotlin handler doesn't take over -->
+    <typeDeclarationProvider implementation="com.apollographql.ijplugin.navigation.KotlinTypeDeclarationProvider" order="first" />
+
+    <!-- GraphQL 'find usages' -->
+    <customUsageSearcher implementation="com.apollographql.ijplugin.navigation.GraphQLCustomUsageSearcher" />
+
+
+    <!-- "Apollo Kotlin 4 is available" inspection -->
+    <!-- Runs on Kotlin (build.gradle.kts) and Toml (*.versions.toml) files -->
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.apollo4Available.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="kotlin"
+        shortName="Apollo4AvailableKotlin"
+    />
+
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.apollo4Available.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TOML"
+        shortName="Apollo4AvailableToml"
+    />
+
+    <!-- Unused operation inspection -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloUnusedOperationInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.unusedOperation.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
+    />
+
+    <!-- Unused field inspection -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloUnusedFieldInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.unusedField.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
+    />
+
+    <!-- Missing GraphQL definition import -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloMissingGraphQLDefinitionImportInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.missingGraphQLDefinitionImport.displayName"
+        enabledByDefault="true"
+        level="ERROR"
+        editorAttributes="WRONG_REFERENCES_ATTRIBUTES"
+    />
+
+    <!-- "Missing introspection" inspection  -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="kotlin"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloEndpointNotConfiguredInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.endpointNotConfigured.displayName"
+        enabledByDefault="true"
+        level="INFO"
+    />
+
+    <!-- "OneOf Input creation" inspection  -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="kotlin"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloOneOfInputCreationInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.oneOfInputCreation.displayName"
+        enabledByDefault="true"
+        level="ERROR"
+    />
+
+    <!-- "Input class constructor issue" inspection  -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="kotlin"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloInputConstructorNamedArgsInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.inputConstructorNamedArgs.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+    />
+
+    <!-- Fields insights inspection ("expensive field") -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.studio.fieldinsights.ApolloFieldInsightsInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.studio"
+        key="inspection.fieldInsights.displayName"
+        enabledByDefault="true"
+        level="WEAK WARNING"
+    />
+
+    <!-- "Schema in .graphql file" inspection -->
+    <!--suppress PluginXmlCapitalization -->
+    <localInspection
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloSchemaInGraphqlFileInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.schemaInGraphqlFile.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+    />
+
+
+    <!-- "GraphQL config file present" inspection -->
+    <!-- Must be declared for each language the config file can be implemented in -->
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="yaml"
+        shortName="ApolloGraphQLConfigFilePresentYaml"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="JSON"
+        shortName="ApolloGraphQLConfigFilePresentJson"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TEXT"
+        shortName="ApolloGraphQLConfigFilePresentText"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TypeScript"
+        shortName="ApolloGraphQLConfigFilePresentTypeScript"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="ECMAScript 6"
+        shortName="ApolloGraphQLConfigFilePresentECMAScript6"
+    />
+
+    <!-- "GraphQL config file present" annotator -->
+    <!-- Must be declared for each language the config file can be implemented in -->
+    <annotator
+        language="yaml"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
+
+    <annotator
+        language="JSON"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
+
+    <annotator
+        language="TEXT"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
+
+    <annotator
+        language="TypeScript"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
+
+    <annotator
+        language="ECMAScript 6"
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
+
+    <problemFileHighlightFilter implementation="com.apollographql.ijplugin.inspection.GraphQLConfigFileFilter" />
+
+    <!-- "Change input class constructor to builder" intention -->
+    <intentionAction>
+      <language>kotlin</language>
+      <className>com.apollographql.ijplugin.intention.ApolloInputConstructorChangeToBuilderIntention</className>
+      <!--suppress PluginXmlCapitalization -->
+      <category>Apollo Kotlin</category>
+    </intentionAction>
+
+    <!-- Suppression of GraphQLUnresolvedReference for certain known directives -->
+    <lang.inspectionSuppressor
+        language="GraphQL"
+        implementationClass="com.apollographql.ijplugin.inspection.GraphQLUnresolvedReferenceInspectionSuppressor"
+    />
+
+    <!-- Normalized cache viewer -->
+    <toolWindow
+        id="NormalizedCacheViewer"
+        factoryClass="com.apollographql.ijplugin.normalizedcache.NormalizedCacheToolWindowFactory"
+        icon="com.apollographql.ijplugin.icons.ApolloIcons.ToolWindow.NormalizedCacheViewer"
+        anchor="bottom"
+        canCloseContents="true"
+    />
+
+    <!-- Rename GraphQL operation or fragment definition -->
+    <renamePsiElementProcessor
+        id="apollo.GraphQLDefinitionRenameProcessor"
+        implementation="com.apollographql.ijplugin.refactoring.GraphQLDefinitionRenameProcessor"
+        order="first"
+    />
+
+    <!-- Mark Apollo generated sources as generated -->
+    <generatedSourcesFilter
+        implementation="com.apollographql.ijplugin.generatedsources.ApolloGeneratedSourcesFilter"
+    />
+
+  </extensions>
+
+  <actions>
+    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 3 (also in Tools / Apollo) -->
+    <action
+        id="ApolloV2ToV3MigrationAction"
+        class="com.apollographql.ijplugin.action.ApolloV2ToV3MigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 4 (also in Tools / Apollo) -->
+    <action
+        id="ApolloV3ToV4MigrationAction"
+        class="com.apollographql.ijplugin.action.ApolloV3ToV4MigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Refactor / Apollo / Migrate to operationBased Codegen (also in Tools / Apollo) -->
+    <!--suppress PluginXmlCapitalization -->
+    <action
+        id="CompatToOperationBasedCodegenMigrationAction"
+        class="com.apollographql.ijplugin.action.CompatToOperationBasedCodegenMigrationAction"
+    >
+      <add-to-group group-id="ApolloRefactorActionGroup" />
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Tools / Apollo / Fetch Field Latencies -->
+    <action
+        id="RefreshFieldInsightsAction"
+        class="com.apollographql.ijplugin.studio.fieldinsights.RefreshFieldInsightsAction"
+    >
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Tools / Apollo / Download schema -->
+    <action
+        id="DownloadSchemaAction"
+        class="com.apollographql.ijplugin.gradle.DownloadSchemaAction"
+    >
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+    <!-- Tools / Apollo / Normalized Cache Viewer -->
+    <action
+        id="ShowNormalizedCacheToolWindowAction"
+        class="com.apollographql.ijplugin.normalizedcache.ShowNormalizedCacheToolWindowAction"
+    >
+      <add-to-group group-id="ApolloToolsActionGroup" />
+    </action>
+
+
+    <!-- 'Execute' button on a GraphQL file editor's toolbar. -->
+    <!-- Overrides the GraphQL plugin's action so we can strip Apollo client side directives before executing the query. -->
+    <action
+        id="GraphQLExecuteEditor"
+        class="com.apollographql.ijplugin.action.GraphQLExecuteEditorAction"
+        icon="com.intellij.icons.AllIcons.Actions.Execute"
+        overrides="true"
+    />
+  </actions>
+
 </idea-plugin>

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -94,6 +94,7 @@
     />
 
     <!-- "Apollo Kotlin 4 is available" inspection -->
+    <!-- Runs on Kotlin (build.gradle.kts) and Toml (*.versions.toml) files -->
     <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
     <localInspection
         implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
@@ -102,6 +103,19 @@
         key="inspection.apollo4Available.displayName"
         enabledByDefault="true"
         level="WARNING"
+        language="kotlin"
+        shortName="Apollo4AvailableKotlin"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.apollo4Available.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TOML"
+        shortName="Apollo4AvailableToml"
     />
 
     <!-- Unused operation inspection -->
@@ -180,6 +194,7 @@
     />
 
     <!-- "GraphQL config file present" inspection -->
+    <!-- Must be declared for each language the config file can be implemented in -->
     <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
     <localInspection
         implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
@@ -188,6 +203,52 @@
         key="inspection.graphQLConfigFilePresent.displayName"
         enabledByDefault="true"
         level="WARNING"
+        language="yaml"
+        shortName="ApolloGraphQLConfigFilePresentYaml"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="JSON"
+        shortName="ApolloGraphQLConfigFilePresentJson"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TEXT"
+        shortName="ApolloGraphQLConfigFilePresentText"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="TypeScript"
+        shortName="ApolloGraphQLConfigFilePresentTypeScript"
+    />
+    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
+    <localInspection
+        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
+        groupPathKey="inspection.group.graphql"
+        groupKey="inspection.group.graphql.apolloKotlin"
+        key="inspection.graphQLConfigFilePresent.displayName"
+        enabledByDefault="true"
+        level="WARNING"
+        language="ECMAScript 6"
+        shortName="ApolloGraphQLConfigFilePresentECMAScript6"
     />
 
     <!-- "@OneOf GraphQL violation" inspection -->
@@ -202,6 +263,8 @@
         level="ERROR"
     />
 
+    <!-- "GraphQL config file present" annotator -->
+    <!-- Must be declared for each language the config file can be implemented in -->
     <annotator
         language="yaml"
         implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -159,14 +159,6 @@
       <override-text place="RevealInPopup" />
     </action>
 
-    <!-- Tools / Apollo / Normalized Cache Viewer -->
-    <action
-        id="ShowNormalizedCacheToolWindowAction"
-        class="com.apollographql.ijplugin.normalizedcache.ShowNormalizedCacheToolWindowAction"
-    >
-      <add-to-group group-id="ApolloToolsActionGroup" />
-    </action>
-
     <!-- Tools / Apollo / Internal group that only appears when run from the IDE ("internal mode") -->
     <!-- See https://plugins.jetbrains.com/docs/intellij/enabling-internal.html -->
     <group

--- a/intellij-plugin/src/main/resources/META-INF/plugin.xml
+++ b/intellij-plugin/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
   <depends>com.intellij.modules.platform</depends>
   <depends optional="true" config-file="com.apollographql.ijplugin-java.xml">com.intellij.modules.java</depends>
   <depends optional="true" config-file="com.apollographql.ijplugin-kotlin.xml">org.jetbrains.kotlin</depends>
-  <depends>com.intellij.gradle</depends>
+  <depends optional="true" config-file="com.apollographql.ijplugin-gradle.xml">com.intellij.gradle</depends>
   <depends>com.intellij.lang.jsgraphql</depends>
   <depends>org.toml.lang</depends>
   <depends>com.intellij.modules.json</depends>
@@ -37,28 +37,6 @@
         nonDefaultProject="true"
     />
 
-    <!-- Kotlin operation/fragment marker provider -->
-    <codeInsight.lineMarkerProvider
-        language="kotlin"
-        implementationClass="com.apollographql.ijplugin.navigation.KotlinDefinitionMarkerProvider"
-    />
-
-    <!-- Kotlin operation/fragment/field/enum/input 'go to declaration' handler -->
-    <gotoDeclarationHandler implementation="com.apollographql.ijplugin.navigation.KotlinGotoDeclarationHandler" />
-
-    <!-- GraphQL operation/fragment/field/enum/input 'go to declaration' handler -->
-    <gotoDeclarationHandler implementation="com.apollographql.ijplugin.navigation.GraphQLGotoDeclarationHandler" />
-
-    <!-- Kotlin operation/fragment/field/enum/input 'go to type declaration' handler -->
-    <!-- Needs order="first" so the Kotlin handler doesn't take over -->
-    <typeDeclarationProvider implementation="com.apollographql.ijplugin.navigation.KotlinTypeDeclarationProvider" order="first" />
-
-    <!-- GraphQL 'find usages' -->
-    <customUsageSearcher implementation="com.apollographql.ijplugin.navigation.GraphQLCustomUsageSearcher" />
-
-    <!-- Listen to Gradle sync -->
-    <externalSystemTaskNotificationListener implementation="com.apollographql.ijplugin.gradle.GradleListener" />
-
     <!-- Icons -->
     <!-- This may be a bit controversial, but we want to override the GraphQL plugin's icons (hence order="first") -->
     <!-- because when navigating to GraphQL files from Kotlin code, a generic GraphQL logo is nicer than a specific -->
@@ -68,188 +46,6 @@
     <!-- Support for the "New UI" -->
     <!-- See https://plugins.jetbrains.com/docs/intellij/icons.html#new-ui-icons -->
     <iconMapper mappingFile="ApolloIconsMapping.json" />
-
-    <!-- Fields insights inspection ("expensive field") -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.studio.fieldinsights.ApolloFieldInsightsInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.studio"
-        key="inspection.fieldInsights.displayName"
-        enabledByDefault="true"
-        level="WEAK WARNING"
-    />
-
-    <!-- "Schema in .graphql file" inspection -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloSchemaInGraphqlFileInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.schemaInGraphqlFile.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-    />
-
-    <!-- "Apollo Kotlin 4 is available" inspection -->
-    <!-- Runs on Kotlin (build.gradle.kts) and Toml (*.versions.toml) files -->
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.apollo4Available.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="kotlin"
-        shortName="Apollo4AvailableKotlin"
-    />
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.Apollo4AvailableInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.apollo4Available.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="TOML"
-        shortName="Apollo4AvailableToml"
-    />
-
-    <!-- Unused operation inspection -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloUnusedOperationInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.unusedOperation.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-    />
-
-    <!-- Unused field inspection -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloUnusedFieldInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.unusedField.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        editorAttributes="NOT_USED_ELEMENT_ATTRIBUTES"
-    />
-
-    <!-- Missing GraphQL definition import -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloMissingGraphQLDefinitionImportInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.missingGraphQLDefinitionImport.displayName"
-        enabledByDefault="true"
-        level="ERROR"
-        editorAttributes="WRONG_REFERENCES_ATTRIBUTES"
-    />
-
-    <!-- "Missing introspection" inspection  -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="kotlin"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloEndpointNotConfiguredInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.endpointNotConfigured.displayName"
-        enabledByDefault="true"
-        level="INFO"
-    />
-
-    <!-- "OneOf Input creation" inspection  -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="kotlin"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloOneOfInputCreationInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.oneOfInputCreation.displayName"
-        enabledByDefault="true"
-        level="ERROR"
-    />
-
-    <!-- "Input class constructor issue" inspection  -->
-    <!--suppress PluginXmlCapitalization -->
-    <localInspection
-        language="kotlin"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloInputConstructorNamedArgsInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.inputConstructorNamedArgs.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-    />
-
-    <!-- "GraphQL config file present" inspection -->
-    <!-- Must be declared for each language the config file can be implemented in -->
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.graphQLConfigFilePresent.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="yaml"
-        shortName="ApolloGraphQLConfigFilePresentYaml"
-    />
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.graphQLConfigFilePresent.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="JSON"
-        shortName="ApolloGraphQLConfigFilePresentJson"
-    />
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.graphQLConfigFilePresent.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="TEXT"
-        shortName="ApolloGraphQLConfigFilePresentText"
-    />
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.graphQLConfigFilePresent.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="TypeScript"
-        shortName="ApolloGraphQLConfigFilePresentTypeScript"
-    />
-    <!--suppress PluginXmlCapitalization, PluginXmlExtensionRegistration -->
-    <localInspection
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentInspection"
-        groupPathKey="inspection.group.graphql"
-        groupKey="inspection.group.graphql.apolloKotlin"
-        key="inspection.graphQLConfigFilePresent.displayName"
-        enabledByDefault="true"
-        level="WARNING"
-        language="ECMAScript 6"
-        shortName="ApolloGraphQLConfigFilePresentECMAScript6"
-    />
 
     <!-- "@OneOf GraphQL violation" inspection -->
     <!--suppress PluginXmlCapitalization -->
@@ -263,48 +59,10 @@
         level="ERROR"
     />
 
-    <!-- "GraphQL config file present" annotator -->
-    <!-- Must be declared for each language the config file can be implemented in -->
-    <annotator
-        language="yaml"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
-
-    <annotator
-        language="JSON"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
-
-    <annotator
-        language="TEXT"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
-
-    <annotator
-        language="TypeScript"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
-
-    <annotator
-        language="ECMAScript 6"
-        implementationClass="com.apollographql.ijplugin.inspection.ApolloGraphQLConfigFilePresentAnnotator" />
-
-    <problemFileHighlightFilter implementation="com.apollographql.ijplugin.inspection.GraphQLConfigFileFilter" />
-
-    <!-- "Change input class constructor to builder" intention -->
-    <intentionAction>
-      <language>kotlin</language>
-      <className>com.apollographql.ijplugin.intention.ApolloInputConstructorChangeToBuilderIntention</className>
-      <!--suppress PluginXmlCapitalization -->
-      <category>Apollo Kotlin</category>
-    </intentionAction>
-
     <!-- Suppression of inspections on individual fields -->
     <lang.inspectionSuppressor
         language="GraphQL"
         implementationClass="com.apollographql.ijplugin.inspection.GraphQLInspectionSuppressor"
-    />
-
-    <!-- Suppression of GraphQLUnresolvedReference for certain known directives -->
-    <lang.inspectionSuppressor
-        language="GraphQL"
-        implementationClass="com.apollographql.ijplugin.inspection.GraphQLUnresolvedReferenceInspectionSuppressor"
     />
 
     <!-- Fields insights service (fetch and cache data) -->
@@ -329,15 +87,6 @@
     <!-- Error handler: open a GitHub issue -->
     <errorHandler implementation="com.apollographql.ijplugin.error.GitHubIssueErrorReportSubmitter" />
 
-    <!-- Normalized cache viewer -->
-    <toolWindow
-        id="NormalizedCacheViewer"
-        factoryClass="com.apollographql.ijplugin.normalizedcache.NormalizedCacheToolWindowFactory"
-        icon="com.apollographql.ijplugin.icons.ApolloIcons.ToolWindow.NormalizedCacheViewer"
-        anchor="bottom"
-        canCloseContents="true"
-    />
-
     <!-- Suggest plugin when Apollo Kotlin is a project dependency -->
     <!-- See https://plugins.jetbrains.com/docs/marketplace/intellij-plugin-recommendations.html#c2909003_6 -->
     <dependencySupport
@@ -358,27 +107,6 @@
         default="false"
     />
 
-    <!-- Rename GraphQL operation or fragment definition -->
-    <renamePsiElementProcessor
-        id="apollo.GraphQLDefinitionRenameProcessor"
-        implementation="com.apollographql.ijplugin.refactoring.GraphQLDefinitionRenameProcessor"
-        order="first"
-    />
-
-    <!-- Mark Apollo generated sources as generated -->
-    <generatedSourcesFilter
-        implementation="com.apollographql.ijplugin.generatedsources.ApolloGeneratedSourcesFilter"
-    />
-  </extensions>
-
-  <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">
-    <!-- Contribute configuration to the GraphQL plugin -->
-    <configContributor implementation="com.apollographql.ijplugin.graphql.ApolloGraphQLConfigContributor" />
-  </extensions>
-
-  <!-- Support K2 -->
-  <extensions defaultExtensionNs="org.jetbrains.kotlin">
-    <supportsKotlinPluginMode supportsK2="true" />
   </extensions>
 
   <applicationListeners>
@@ -389,6 +117,15 @@
     />
   </applicationListeners>
 
+  <extensions defaultExtensionNs="com.intellij.lang.jsgraphql">
+    <!-- Contribute configuration to the GraphQL plugin -->
+    <configContributor implementation="com.apollographql.ijplugin.graphql.ApolloGraphQLConfigContributor" />
+  </extensions>
+
+  <!-- Support K2 -->
+  <extensions defaultExtensionNs="org.jetbrains.kotlin">
+    <supportsKotlinPluginMode supportsK2="true" />
+  </extensions>
 
   <actions>
     <!-- Refactor / Apollo -->
@@ -412,34 +149,6 @@
       <add-to-group group-id="ToolsMenu" anchor="last" />
     </group>
 
-    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 3 (also in Tools / Apollo) -->
-    <action
-        id="ApolloV2ToV3MigrationAction"
-        class="com.apollographql.ijplugin.action.ApolloV2ToV3MigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-      <add-to-group group-id="ApolloToolsActionGroup" />
-    </action>
-
-    <!-- Refactor / Apollo / Migrate to Apollo Kotlin 4 (also in Tools / Apollo) -->
-    <action
-        id="ApolloV3ToV4MigrationAction"
-        class="com.apollographql.ijplugin.action.ApolloV3ToV4MigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-      <add-to-group group-id="ApolloToolsActionGroup" />
-    </action>
-
-    <!-- Refactor / Apollo / Migrate to operationBased Codegen (also in Tools / Apollo) -->
-    <!--suppress PluginXmlCapitalization -->
-    <action
-        id="CompatToOperationBasedCodegenMigrationAction"
-        class="com.apollographql.ijplugin.action.CompatToOperationBasedCodegenMigrationAction"
-    >
-      <add-to-group group-id="ApolloRefactorActionGroup" />
-      <add-to-group group-id="ApolloToolsActionGroup" />
-    </action>
-
     <!-- Tools / Apollo / Open in Apollo Sandbox -->
     <action
         id="OpenInSandboxAction"
@@ -448,22 +157,6 @@
       <add-to-group group-id="ApolloToolsActionGroup" />
       <add-to-group group-id="RevealGroup" />
       <override-text place="RevealInPopup" />
-    </action>
-
-    <!-- Tools / Apollo / Fetch Field Latencies -->
-    <action
-        id="RefreshFieldInsightsAction"
-        class="com.apollographql.ijplugin.studio.fieldinsights.RefreshFieldInsightsAction"
-    >
-      <add-to-group group-id="ApolloToolsActionGroup" />
-    </action>
-
-    <!-- Tools / Apollo / Download schema -->
-    <action
-        id="DownloadSchemaAction"
-        class="com.apollographql.ijplugin.gradle.DownloadSchemaAction"
-    >
-      <add-to-group group-id="ApolloToolsActionGroup" />
     </action>
 
     <!-- Tools / Apollo / Normalized Cache Viewer -->
@@ -502,15 +195,6 @@
     >
       <add-to-group group-id="ApolloInternalActionGroup" />
     </action>
-
-    <!-- 'Execute' button on a GraphQL file editor's toolbar. -->
-    <!-- Overrides the GraphQL plugin's action so we can strip Apollo client side directives before executing the query. -->
-    <action
-        id="GraphQLExecuteEditor"
-        class="com.apollographql.ijplugin.action.GraphQLExecuteEditorAction"
-        icon="com.intellij.icons.AllIcons.Actions.Execute"
-        overrides="true"
-    />
   </actions>
 
 </idea-plugin>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/Apollo4AvailableKotlin.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/Apollo4AvailableKotlin.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Suggests to migrate to Apollo Kotlin 4 on projects using an older version.
+</body>
+</html>

--- a/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresentYaml.html
+++ b/intellij-plugin/src/main/resources/inspectionDescriptions/ApolloGraphQLConfigFilePresentYaml.html
@@ -9,7 +9,8 @@ Suggests to delete GraphQL config files on projects using Apollo Kotlin 4.
     Note: the Apollo plugin uses the Gradle tooling API to retrieve the project's GraphQL configuration.
 </p>
 <p>
-    <a href="https://www.apollographql.com/docs/kotlin/v4/testing/android-studio-plugin#integration-with-the-graphql-intellij-plugin">More information</a>
+    <a href="https://www.apollographql.com/docs/kotlin/v4/testing/android-studio-plugin#integration-with-the-graphql-intellij-plugin">More
+        information</a>
 </p>
 </body>
 </html>


### PR DESCRIPTION
Some inspections were running (and trying to load Kotlin specific classes) even when in IDEs without the Kotlin plugin - e.g. RustRover. This could break the whole language support.

In general this PR makes things smoother in IDEs other than IJ/AS:
- Make inspections run only with specific file types
- Move all components specific to Apollo Kotlin to the Kotlin plugin dependency file
- Do not load services that can't work without the Kotlin and Gradle plugins
- Hide settings that are irrelevant without the Kotlin and Gradle plugins
- Mark the Gradle plugin as optional