### PR TITLE
Downgrade Gradle to 8.11

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,17 +1,7 @@
-buildscript {
-  dependencies {
-    classpath("com.apollographql.apollo.build:build-logic")
-  }
-  repositories {
-    /*
-     * This duplicates the repositories in repositories.gradle.kts but I haven't found a way to make it work otherwise
-     * See https://github.com/gradle/gradle/issues/32045
-     */
-    mavenCentral()
-    google()
-    gradlePluginPortal()
-  }
+plugins {
+  id("build.logic") apply false
 }
+
 val ciBuild = tasks.register("ciBuild") {
   description = """Execute the 'build' task in subprojects and the `termination:run` task too"""
   subprojects {

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -1,3 +1,7 @@
+pluginManagement {
+  includeBuild("../build-logic")
+}
+
 plugins {
   id("com.gradle.develocity") version "3.19" // sync with libraries.toml
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.0.2"
@@ -23,7 +27,6 @@ rootProject.projectDir
     }
 
 includeBuild("../")
-includeBuild("../build-logic")
 
 dependencyResolutionManagement {
   versionCatalogs {


### PR DESCRIPTION
Keep Gradle 8.11 until https://github.com/gradle/gradle/pull/32157 is released