### PR TITLE
Kotlin Nightlies: use the latest 2.1.x for now, not 2.2.x

### DIFF
--- a/scripts/bump-kotlin-nightlies.main.kts
+++ b/scripts/bump-kotlin-nightlies.main.kts
@@ -8,7 +8,7 @@ val BRANCH_NAME = "kotlin-nightlies"
 
 fun bumpVersions() {
   val kotlinVersion =
-    getLatestVersion("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/org/jetbrains/kotlin/kotlin-stdlib/maven-metadata.xml")
+    getLatestVersion("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/org/jetbrains/kotlin/kotlin-stdlib/maven-metadata.xml", prefix = "2.1")
   val kspVersion =
     getLatestVersion("https://oss.sonatype.org/content/repositories/snapshots/com/google/devtools/ksp/com.google.devtools.ksp.gradle.plugin/maven-metadata.xml")
   File("gradle/libraries.toml").let { file ->


### PR DESCRIPTION
The nightlies are using the latest available dev version which can be 2.1.x or 2.2.x, which doesn't help investigating failed builds. Let's focus on 2.1.x for now until it's released.