### PR TITLE
Use ephemeral NSURLSessionConfiguration by default

### DIFF
--- a/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo/network/http/DefaultHttpEngine.apple.kt
+++ b/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo/network/http/DefaultHttpEngine.apple.kt
@@ -63,7 +63,7 @@ private class AppleHttpEngine(
 
   constructor(timeoutMillis: Long) : this(
       timeoutMillis = timeoutMillis,
-      nsUrlSessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
+      nsUrlSessionConfiguration = NSURLSessionConfiguration.ephemeralSessionConfiguration()
   )
 
   private val delegate = StreamingDataDelegate()


### PR DESCRIPTION
`NSURLCache` is not read from as `NSURLRequestReloadIgnoringCacheData` is set as the request policy [here](https://github.com/apollographql/apollo-kotlin/blob/main/libraries/apollo-runtime/src/appleMain/kotlin/com/apollographql/apollo/network/http/DefaultHttpEngine.apple.kt#L102). Therefore it makes sense to use `ephemeralSessionConfiguration` to prevent writing to `NSURLCache`.

Related to https://github.com/apollographql/apollo-kotlin/issues/6375.