### PR TITLE
[IJ Plugin] Fix MemoryCache package name

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -150,7 +150,7 @@ jobs:
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 #v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
           key: plugin-verifier-${{ hashFiles('intellij-plugin/build/listProductsReleases.txt') }}

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/apollodebugserver/ApolloDebugClient.kt
@@ -120,7 +120,7 @@ val String.normalizedCacheSimpleName: String
   get() = when (this) {
     "$apollo3.cache.normalized.api.MemoryCache",
     "$apollo4.cache.normalized.api.MemoryCache",
-    "com.apollographql.cache.normalized.sql.MemoryCache",
+    "com.apollographql.cache.normalized.memory.MemoryCache",
     -> "MemoryCache"
 
     "$apollo3.cache.normalized.sql.SqlNormalizedCache",


### PR DESCRIPTION
We hide the package name of a cache from the "Pull from device" dialog when it's a well-known one - but there was a typo.