### PR TITLE
[IJ Plugin] Rover: always pass path to supergraph.yaml if present

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
@@ -132,6 +132,7 @@ class ProjectSettingsService(private val project: Project) : PersistentStateComp
         val superGraphYamlFilePath = project.guessProjectDir()?.findChild("supergraph.yaml")?.path
         if (superGraphYamlFilePath != null) {
           lspPathToSuperGraphYaml = superGraphYamlFilePath
+          lspPassPathToSuperGraphYaml = true
         } else {
           lspPassPathToSuperGraphYaml = false
         }


### PR DESCRIPTION
Also automatically restart the LSP when we detect changes to `supergraph.yaml`.