### PR TITLE
[gradle-plugin] expose regular configurations for multi-module projects

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
@@ -186,6 +186,9 @@ internal fun Consumer<String>.toLogger(): ApolloCompiler.Logger {
 @ApolloInternal
 fun Iterable<File>.findCodegenSchemaFile(): File {
   return firstOrNull {
+    /*
+     * TODO v5: simplify this and add a schema { } block to the Gradle configuration
+     */
     it.length() > 0
   } ?: error("Cannot find CodegenSchema in $this")
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloAttributes.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ApolloAttributes.kt
@@ -18,7 +18,6 @@ internal enum class ApolloDirection {
 }
 
 internal enum class ConfigurationKind {
-  DependencyScope,
   Consumable,
   Resolvable
 }

--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ModelNames.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/ModelNames.kt
@@ -33,29 +33,40 @@ internal object ModelNames {
   @Deprecated("Unused. Use dependsOn() instead.")
   @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v4_0_0)
   fun metadataConfiguration() = "apolloMetadata"
-  fun configuration(serviceName: String, apolloDirection: ApolloDirection, apolloUsage: ApolloUsage, configurationKind: ConfigurationKind): String {
+
+  fun scopeConfiguration(
+      serviceName: String,
+      apolloDirection: ApolloDirection,
+  ): String {
+    return camelCase(
+        "apollo",
+        serviceName,
+        apolloDirection.pretty(),
+    )
+  }
+
+  fun configuration(
+      serviceName: String,
+      apolloDirection: ApolloDirection,
+      apolloUsage: ApolloUsage,
+      configurationKind: ConfigurationKind,
+  ): String {
     return camelCase(
         "apollo",
         serviceName,
         apolloDirection.pretty(),
         apolloUsage.name,
-        configurationKind.pretty()
+        configurationKind.name
     )
   }
-  fun compilerConfiguration(service: Service) = camelCase("apollo", service.name, "Compiler")
- }
 
-private fun ConfigurationKind.pretty(): String {
-  return when(this) {
-    ConfigurationKind.DependencyScope -> ""
-    else -> name
-  }
+  fun compilerConfiguration(service: Service) = camelCase("apollo", service.name, "Compiler")
 }
 
 
 private fun ApolloDirection.pretty(): String {
-  return when(this) {
+  return when (this) {
     ApolloDirection.Upstream -> ""
-    ApolloDirection.Downstream -> name
+    ApolloDirection.Downstream -> "UsedCoordinates"
   }
 }

--- a/libraries/apollo-gradle-plugin/testProjects/configuration-cache/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/configuration-cache/leaf/build.gradle.kts
@@ -13,6 +13,11 @@ dependencies {
 apollo {
   service("service") {
     packageName.set("com.example.leaf")
-    dependsOn(project(":root"))
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/configuration-cache/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/configuration-cache/root/build.gradle.kts
@@ -7,11 +7,15 @@ apollo {
   service("service") {
     packageName.set("com.example")
     generateApolloMetadata.set(true)
-    isADependencyOf(project(":leaf"))
+    alwaysGenerateTypesMatching.set(emptyList())
 
     introspection {
       this.endpointUrl.set("ENDPOINT")
       schemaFile.set(file("schema.json"))
     }
   }
+}
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":leaf"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/leaf/build.gradle.kts
@@ -11,7 +11,12 @@ dependencies {
 apollo {
   service("service") {
     // PLACEHOLDER
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
     packageNamesFromFilePaths()
-    dependsOn(project(":root"))
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-badconfig/root/build.gradle.kts
@@ -15,8 +15,12 @@ apollo {
   service("service") {
     packageNamesFromFilePaths()
     // PLACEHOLDER
+    alwaysGenerateTypesMatching.set(emptyList())
     generateApolloMetadata.set(true)
-    isADependencyOf(project(":leaf"))
     mapScalar("Date", "java.util.Date")
   }
+}
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":leaf"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar-defined-in-leaf/leaf/build.gradle.kts
@@ -15,6 +15,13 @@ apollo {
   service("service") {
     packageName.set("com.library")
     mapScalar("Long", "java.lang.Long")
+    /**
+     * We need to call `dependsOn` here to know at graph build time that the schema is coming
+     * from a dependency and do the checks for the redundant scalar configuration.
+     *
+     * TODO v5: add a specific `schema` block so that we can know this
+     */
     dependsOn(project(":root"))
   }
 }
+

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/leaf/build.gradle.kts
@@ -19,6 +19,11 @@ application {
 apollo {
   service("service") {
     packageName.set("com.library")
-    dependsOn(project(":root"))
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-custom-scalar/root/build.gradle.kts
@@ -14,9 +14,13 @@ dependencies {
 apollo {
   service("service") {
     packageName.set("com.library")
+    alwaysGenerateTypesMatching.set(emptyList())
     generateApolloMetadata.set(true)
-    isADependencyOf(project(":leaf"))
     mapScalar("Date", "java.util.Date")
     mapScalar("ID", "com.library.MyID", "com.library.MyIDAdapter()")
   }
+}
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":leaf"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/impl/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node1/impl/build.gradle.kts
@@ -14,6 +14,13 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    dependsOn(project(":root"))
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
 }
+
+
+dependencies {
+  add("apolloService", project(":root"))
+}
+

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/impl/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/node2/impl/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    dependsOn(project(":root"))
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-duplicates/root/build.gradle.kts
@@ -16,8 +16,11 @@ apollo {
     alwaysGenerateTypesMatching.set(listOf("Cat"))
     packageNamesFromFilePaths()
     generateApolloMetadata.set(true)
-    isADependencyOf(project(":node1:impl"))
-    isADependencyOf(project(":node2:impl"))
     mapScalar("Date", "java.util.Date")
   }
+}
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":node1:impl"))
+  add("apolloServiceUsedCoordinates", project(":node2:impl"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-consumer/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-consumer/build.gradle.kts
@@ -12,11 +12,20 @@ dependencies {
 apollo {
   service("service1") {
     packageName.set("com.service1")
-    dependsOn("com.fragments:fragments:1.0.0")
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
   service("service2") {
     packageName.set("com.service2")
-    dependsOn("com.fragments:fragments:1.0.0")
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
 }
+
+
+dependencies {
+  add("apolloService1", "com.fragments:fragments:1.0.0")
+  add("apolloService2", "com.fragments:fragments:1.0.0")
+}
+
 

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/fragments/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-publishing-producer/fragments/build.gradle.kts
@@ -15,18 +15,29 @@ dependencies {
 apollo {
   service("service1") {
     packageName.set("com.service1")
-    dependsOn(project(":schema"))
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
+
     outgoingVariantsConnection {
       addToSoftwareComponent("java")
+      generateApolloMetadata.set(true)
     }
   }
   service("service2") {
     packageName.set("com.service2")
-    dependsOn(project(":schema"))
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
+
     outgoingVariantsConnection {
       addToSoftwareComponent("java")
+      generateApolloMetadata.set(true)
     }
   }
+}
+
+dependencies {
+  add("apolloService1", project(":schema"))
+  add("apolloService2", project(":schema"))
 }
 
 configure<PublishingExtension> {
@@ -42,3 +53,4 @@ configure<PublishingExtension> {
     }
   }
 }
+

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/leaf/build.gradle.kts
@@ -20,6 +20,11 @@ application {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    dependsOn(project(":node"))
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
   }
+}
+
+dependencies {
+  add("apolloService", project(":node"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/node/build.gradle.kts
@@ -12,7 +12,12 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    isADependencyOf(project(":leaf"))
-    dependsOn(project(":root"))
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
+  add("apolloServiceUsedCoordinates", project(":leaf"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules-transitive/root/build.gradle.kts
@@ -15,7 +15,12 @@ apollo {
   service("service") {
     packageNamesFromFilePaths()
     generateApolloMetadata.set(true)
-    isADependencyOf(project(":node"))
+    alwaysGenerateTypesMatching.set(emptyList())
     mapScalar("Date", "java.util.Date")
   }
 }
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":node"))
+}
+

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules/leaf/build.gradle.kts
@@ -19,6 +19,11 @@ application {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    dependsOn(project(":root"))
+    alwaysGenerateTypesMatching.set(emptyList())
+    generateApolloMetadata.set(true)
   }
+}
+
+dependencies {
+  add("apolloService", project(":root"))
 }

--- a/libraries/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
+++ b/libraries/apollo-gradle-plugin/testProjects/multi-modules/root/build.gradle.kts
@@ -14,8 +14,12 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
+    alwaysGenerateTypesMatching.set(emptyList())
     generateApolloMetadata.set(true)
     mapScalar("Date", "java.util.Date")
-    isADependencyOf(project(":leaf"))
   }
+}
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":leaf"))
 }

--- a/tests/multi-module-1/child/build.gradle.kts
+++ b/tests/multi-module-1/child/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.kotlin.dsl.add
+import org.gradle.kotlin.dsl.project
+
 plugins {
   id("org.jetbrains.kotlin.jvm")
   id("com.apollographql.apollo")
@@ -13,8 +16,13 @@ dependencies {
 
 apollo {
   service("service") {
-    dependsOn(project(":multi-module-1-root"))
     packageName.set("multimodule1.child")
     flattenModels.set(false)
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
   }
+}
+
+dependencies {
+  add("apolloService", project(":multi-module-1-root"))
 }

--- a/tests/multi-module-1/file-path/build.gradle.kts
+++ b/tests/multi-module-1/file-path/build.gradle.kts
@@ -14,6 +14,11 @@ dependencies {
 apollo {
   service("service") {
     packageNamesFromFilePaths()
-    dependsOn(project(":multi-module-1-root"))
+    generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
   }
+}
+
+dependencies {
+  add("apolloService", project(":multi-module-1-root"))
 }

--- a/tests/multi-module-1/root/build.gradle.kts
+++ b/tests/multi-module-1/root/build.gradle.kts
@@ -14,8 +14,14 @@ apollo {
   service("service") {
     packageName.set("multimodule1.root")
     generateApolloMetadata.set(true)
+    alwaysGenerateTypesMatching.set(emptyList())
     mapScalar("Long", "kotlin.Long")
-    isADependencyOf(project(":multi-module-1-child"))
-    isADependencyOf(project(":multi-module-1-file-path"))
   }
 }
+
+dependencies {
+  add("apolloServiceUsedCoordinates", project(":multi-module-1-child"))
+  add("apolloServiceUsedCoordinates", project(":multi-module-1-file-path"))
+}
+
+

--- a/tests/multi-module-2/child/build.gradle.kts
+++ b/tests/multi-module-2/child/build.gradle.kts
@@ -14,7 +14,11 @@ dependencies {
 apollo {
   service("multimodule2") {
     packageName.set("multimodule2.child")
+    generateApolloMetadata.set(true)
     flattenModels.set(false)
-    dependsOn(project(":multi-module-2-root"))
   }
+}
+
+dependencies {
+  add("apolloMultimodule2", project(":multi-module-2-root"))
 }

--- a/tests/multi-module-2/root/build.gradle.kts
+++ b/tests/multi-module-2/root/build.gradle.kts
@@ -14,10 +14,12 @@ dependencies {
 apollo {
   service("multimodule2") {
     packageName.set("multimodule2.root")
-    isADependencyOf(project(":multi-module-2-child"))
     generateApolloMetadata.set(true)
     @OptIn(ApolloExperimental::class)
     generateDataBuilders.set(true)
   }
 }
 
+dependencies {
+  add("apolloMultimodule2UsedCoordinates", project(":multi-module-2-child"))
+}

--- a/tests/multi-module-3/child/build.gradle.kts
+++ b/tests/multi-module-3/child/build.gradle.kts
@@ -15,6 +15,10 @@ apollo {
   service("multimodule3") {
     packageName.set("multimodule3.child")
     flattenModels.set(false)
-    dependsOn(project(":multi-module-3-root"))
+    generateApolloMetadata.set(true)
   }
+}
+
+dependencies {
+  add("apolloMultimodule3", project(":multi-module-3-root"))
 }

--- a/tests/multi-module-3/root/build.gradle.kts
+++ b/tests/multi-module-3/root/build.gradle.kts
@@ -15,10 +15,12 @@ apollo {
   service("multimodule3") {
     packageName.set("multimodule3.root")
     alwaysGenerateTypesMatching.set(listOf("Cat"))
-    isADependencyOf(project(":multi-module-3-child"))
     generateApolloMetadata.set(true)
     @OptIn(ApolloExperimental::class)
     generateDataBuilders.set(true)
   }
 }
 
+dependencies {
+  add("apolloMultimodule3UsedCoordinates", project(":multi-module-3-child"))
+}


### PR DESCRIPTION
This allows to configure dependency resolution using the full Gradle APIs. See https://github.com/apollographql/apollo-kotlin/pull/6343.


*  schema/build.gradle.kts

```kotlin
apollo {
  service("service") {
    packageName.set("com.example")]
    schemaFiles.from("src/main/graphql/schema.graphqls")
    generateApolloMetatata.set(true)
    alwaysGenerateTypesMatching.set(emptyList())
  }
}

dependencies {
  add("apolloServiceUsedCoordinates", project(":feature"))
}
```

*  feature/build.gradle.kts

```kotlin
apollo {
  service("service") {
    packageName.set("com.example")]
    generateApolloMetatata.set(true)
    alwaysGenerateTypesMatching.set(emptyList())
  }
}

dependencies {
  add("apolloService", project(":schema"))
}
```

One drawback is this breaks the IJ tooling model [here](https://github.com/apollographql/apollo-kotlin/blob/e111a4fb61967e6a0a4ecbff5a35a057bec1a34b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt#L65) because the dependencies are not known until the configurations are resolved.