### PR TITLE
Add toString() method to ApolloResponse

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -108,6 +108,7 @@ public final class com/apollographql/apollo/api/ApolloResponse {
 	public final fun dataOrThrow ()Lcom/apollographql/apollo/api/Operation$Data;
 	public final fun hasErrors ()Z
 	public final fun newBuilder ()Lcom/apollographql/apollo/api/ApolloResponse$Builder;
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/apollographql/apollo/api/ApolloResponse$Builder {

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -364,6 +364,7 @@ final class <#A: com.apollographql.apollo.api/Operation.Data> com.apollographql.
     final fun dataOrThrow(): #A // com.apollographql.apollo.api/ApolloResponse.dataOrThrow|dataOrThrow(){}[0]
     final fun hasErrors(): kotlin/Boolean // com.apollographql.apollo.api/ApolloResponse.hasErrors|hasErrors(){}[0]
     final fun newBuilder(): com.apollographql.apollo.api/ApolloResponse.Builder<#A> // com.apollographql.apollo.api/ApolloResponse.newBuilder|newBuilder(){}[0]
+    final fun toString(): kotlin/String // com.apollographql.apollo.api/ApolloResponse.toString|toString(){}[0]
 
     final class <#A1: com.apollographql.apollo.api/Operation.Data> Builder { // com.apollographql.apollo.api/ApolloResponse.Builder|null[0]
         constructor <init>(com.apollographql.apollo.api/Operation<#A1>, com.benasher44.uuid/Uuid) // com.apollographql.apollo.api/ApolloResponse.Builder.<init>|<init>(com.apollographql.apollo.api.Operation<1:0>;com.benasher44.uuid.Uuid){}[0]

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloResponse.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloResponse.kt
@@ -133,8 +133,7 @@ private constructor(
         "operationName=${operation.name()}, " +
         "data=${if (data == null) "null" else "${operation.name()}.Data"}, " +
         "errors=${errors?.size ?: "null"}, " +
-        "exception=${if (exception == null) "null" else exception::class.simpleName ?: "true"}, " +
-        "isLast=$isLast" +
+        "exception=${if (exception == null) "null" else exception::class.simpleName ?: "true"}" +
         ")"
   }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloResponse.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/ApolloResponse.kt
@@ -128,6 +128,16 @@ private constructor(
         .isLast(isLast)
   }
 
+  override fun toString(): String {
+    return "ApolloResponse(" +
+        "operationName=${operation.name()}, " +
+        "data=${if (data == null) "null" else "${operation.name()}.Data"}, " +
+        "errors=${errors?.size ?: "null"}, " +
+        "exception=${if (exception == null) "null" else exception::class.simpleName ?: "true"}, " +
+        "isLast=$isLast" +
+        ")"
+  }
+
   class Builder<D : Operation.Data> internal constructor(
       private val operation: Operation<D>,
       private var requestUuid: Uuid,


### PR DESCRIPTION
First pass at adding a custom `toString()` to `ApolloResponse`.
Addresses #5872.

Open to suggestions on how this can be more useful, particularly the `data` portion of it. 