### PR TITLE
Add suport for @disableErrorPropagation

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -203,6 +203,8 @@ class Schema internal constructor(
     const val ONE_OF = "oneOf"
     @ApolloExperimental
     const val DEFER = "defer"
+    @ApolloExperimental
+    const val DISABLE_ERROR_PROPAGATION = "experimental_disableErrorPropagation"
 
     @ApolloExperimental
     const val LINK = "link"

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqldocument.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqldocument.kt
@@ -6,6 +6,7 @@ import com.apollographql.apollo.annotations.ApolloInternal
 import com.apollographql.apollo.ast.internal.ExtensionsMerger
 import com.apollographql.apollo.ast.internal.builtinsDefinitionsStr
 import com.apollographql.apollo.ast.internal.compilerOptions_0_0
+import com.apollographql.apollo.ast.internal.disableErrorPropagationStr
 import com.apollographql.apollo.ast.internal.kotlinLabsDefinitions_0_3
 import com.apollographql.apollo.ast.internal.kotlinLabsDefinitions_0_4
 import com.apollographql.apollo.ast.internal.kotlinLabsDefinitions_0_5

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
@@ -261,7 +261,8 @@ internal fun validateSchema(definitions: List<GQLDefinition>, options: SchemaVal
       deferDefinitionsStr,
       nonNullDefinitionStr,
       kotlinLabsDefinitions_0_5,
-      nullabilityDefinitionsStr
+      nullabilityDefinitionsStr,
+      disableErrorPropagationStr
   ).flatMap {
     it.parseAsGQLDocument().getOrThrow().definitions
   }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/definitions.kt
@@ -1,5 +1,7 @@
 package com.apollographql.apollo.ast.internal
 
+import com.apollographql.apollo.annotations.ApolloInternal
+
 /**
  * This file contains several groups of GraphQL definitions we use during codegen:
  *
@@ -544,4 +546,8 @@ directive @defer(
 
 internal val nonNullDefinitionStr = """
 directive @nonnull(fields: String! = "") on OBJECT | FIELD
+""".trimIndent()
+
+internal val disableErrorPropagationStr = """
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION
 """.trimIndent()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.ast.DifferentShape
 import com.apollographql.apollo.ast.DirectiveRedefinition
 import com.apollographql.apollo.ast.ForeignSchema
 import com.apollographql.apollo.ast.GQLDefinition
+import com.apollographql.apollo.ast.GQLDirective
 import com.apollographql.apollo.ast.GQLDocument
 import com.apollographql.apollo.ast.GQLFragmentDefinition
 import com.apollographql.apollo.ast.GQLOperationDefinition
@@ -14,6 +15,7 @@ import com.apollographql.apollo.ast.IncompatibleDefinition
 import com.apollographql.apollo.ast.Issue
 import com.apollographql.apollo.ast.ParserOptions
 import com.apollographql.apollo.ast.QueryDocumentMinifier
+import com.apollographql.apollo.ast.Schema
 import com.apollographql.apollo.ast.UnknownDirective
 import com.apollographql.apollo.ast.UnusedFragment
 import com.apollographql.apollo.ast.UnusedVariable
@@ -269,10 +271,18 @@ object ApolloCompiler {
       }
     }
 
+
     val operations = definitions.filterIsInstance<GQLOperationDefinition>().map {
-      addRequiredFields(it, addTypename, schema, fragmentDefinitions).let {
-        documentTransform?.transform(schema, it) ?: it
+      var operation = addRequiredFields(it, addTypename, schema, fragmentDefinitions)
+      if (documentTransform != null) {
+        operation = documentTransform.transform(schema, it)
       }
+      if (schema.directiveDefinitions.containsKey(Schema.DISABLE_ERROR_PROPAGATION)) {
+        operation = operation.copy(
+            directives = operation.directives + GQLDirective(null, Schema.DISABLE_ERROR_PROPAGATION, emptyList())
+        )
+      }
+      operation
     }
 
     // Remember the fragments with the possibly updated fragments

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -277,7 +277,8 @@ object ApolloCompiler {
       if (documentTransform != null) {
         operation = documentTransform.transform(schema, it)
       }
-      if (schema.directiveDefinitions.containsKey(Schema.DISABLE_ERROR_PROPAGATION)) {
+      if (schema.directiveDefinitions.containsKey(Schema.DISABLE_ERROR_PROPAGATION)
+          && schema.schemaDefinition?.directives?.any { schema.originalDirectiveName(it.name) == Schema.CATCH_BY_DEFAULT } == true) {
         operation = operation.copy(
             directives = operation.directives + GQLDirective(null, Schema.DISABLE_ERROR_PROPAGATION, emptyList())
         )

--- a/tests/catch/src/main/graphql/shared/schema.graphqls
+++ b/tests/catch/src/main/graphql/shared/schema.graphqls
@@ -21,3 +21,5 @@ type User {
 type Product {
   price: String
 }
+
+directive @experimental_disableErrorPropagation on QUERY | MUTATION | SUBSCRIPTION


### PR DESCRIPTION
Closes #6412

See https://github.com/graphql/graphql-js/pull/4348
See https://github.com/graphql-java/graphql-java/pull/3772
See https://github.com/graphql/nullability-wg/discussions/85

Disable error propagation when the server supports it and the user has enabled `@catchByDefault` on their schema. 