### PR TITLE
Use incubating cache v0.0.7 in benchmarks

### DIFF
--- a/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo/benchmark/CacheIncubatingTests.kt
+++ b/benchmark/microbenchmark/src/androidTest/java/com/apollographql/apollo/benchmark/CacheIncubatingTests.kt
@@ -2,30 +2,22 @@ package com.apollographql.apollo.benchmark
 
 import androidx.benchmark.junit4.BenchmarkRule
 import androidx.benchmark.junit4.measureRepeated
-import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.Query
 import com.apollographql.apollo.api.json.jsonReader
 import com.apollographql.apollo.api.parseJsonResponse
-import com.apollographql.apollo.benchmark.Utils.checkOperationBased
-import com.apollographql.apollo.benchmark.Utils.checkResponseBased
+import com.apollographql.apollo.benchmark.Utils.dbFile
+import com.apollographql.apollo.benchmark.Utils.dbName
 import com.apollographql.apollo.benchmark.Utils.operationBasedQuery
 import com.apollographql.apollo.benchmark.Utils.registerCacheSize
 import com.apollographql.apollo.benchmark.Utils.resource
 import com.apollographql.apollo.benchmark.Utils.responseBasedQuery
 import com.apollographql.apollo.benchmark.test.R
-import com.apollographql.cache.normalized.api.CacheHeaders
-import com.apollographql.cache.normalized.api.DefaultRecordMerger
-import com.apollographql.cache.normalized.api.FieldPolicyCacheResolver
+import com.apollographql.cache.normalized.ApolloStore
 import com.apollographql.cache.normalized.memory.MemoryCacheFactory
-import com.apollographql.cache.normalized.api.TypePolicyCacheKeyGenerator
-import com.apollographql.cache.normalized.api.normalize
-import com.apollographql.cache.normalized.api.readDataFromCache
 import com.apollographql.cache.normalized.sql.SqlNormalizedCacheFactory
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
-import java.util.concurrent.Executors
 
 class CacheIncubatingTests {
   @get:Rule
@@ -33,120 +25,45 @@ class CacheIncubatingTests {
 
   @Test
   fun cacheOperationMemory() {
-    readFromCache("cacheOperationMemory", operationBasedQuery, sql = false, ::checkOperationBased)
+    readFromCache("cacheOperationMemory", operationBasedQuery, sql = false, Utils::checkOperationBased)
   }
 
   @Test
   fun cacheOperationSql() {
-    readFromCache("cacheOperationSql", operationBasedQuery, sql = true, ::checkOperationBased)
+    readFromCache("cacheOperationSql", operationBasedQuery, sql = true, Utils::checkOperationBased)
   }
 
   @Test
   fun cacheResponseMemory() {
-    readFromCache("cacheResponseMemory", responseBasedQuery, sql = false, ::checkResponseBased)
+    readFromCache("cacheResponseMemory", responseBasedQuery, sql = false, Utils::checkResponseBased)
   }
 
   @Test
   fun cacheResponseSql() {
-    readFromCache("cacheResponseSql", responseBasedQuery, sql = true, ::checkResponseBased)
+    readFromCache("cacheResponseSql", responseBasedQuery, sql = true, Utils::checkResponseBased)
   }
-
-  @Test
-  fun concurrentCacheOperationMemory() {
-    concurrentReadWriteFromCache(operationBasedQuery, sql = false)
-  }
-
-  @Test
-  fun concurrentCacheOperationSql() {
-    concurrentReadWriteFromCache(operationBasedQuery, sql = true)
-  }
-
-  @Test
-  fun concurrentCacheResponseMemory() {
-    concurrentReadWriteFromCache(responseBasedQuery, sql = false)
-  }
-
-  @Test
-  fun concurrentCacheResponseSql() {
-    concurrentReadWriteFromCache(responseBasedQuery, sql = true)
-  }
-
 
   private fun <D : Query.Data> readFromCache(testName: String, query: Query<D>, sql: Boolean, check: (D) -> Unit) {
-    val cache = if (sql) {
-      Utils.dbFile.delete()
-      SqlNormalizedCacheFactory(name = Utils.dbName).create()
-    } else {
-      MemoryCacheFactory().create()
-    }
-    val data = query.parseJsonResponse(resource(R.raw.calendar_response).jsonReader()).data!!
-
-    val records = query.normalize(
-        data,
-        CustomScalarAdapters.Empty,
-        TypePolicyCacheKeyGenerator,
+    val store = ApolloStore(
+        if (sql) {
+          dbFile.delete()
+          SqlNormalizedCacheFactory(name = dbName)
+        } else {
+          MemoryCacheFactory()
+        }
     )
 
+    val data = query.parseJsonResponse(resource(R.raw.calendar_response).jsonReader()).data!!
     runBlocking {
-      cache.merge(records.values.toList(), CacheHeaders.NONE, DefaultRecordMerger)
+      store.writeOperation(query, data)
     }
 
     if (sql) {
-      registerCacheSize("CacheIncubatingTests", testName, Utils.dbFile.length())
+      registerCacheSize("CacheIncubatingTests", testName, dbFile.length())
     }
     benchmarkRule.measureRepeated {
-      val data2 = query.readDataFromCache(
-          CustomScalarAdapters.Empty,
-          cache,
-          FieldPolicyCacheResolver,
-          CacheHeaders.NONE
-      )
+      val data2 = store.readOperation(query).data!!
       check(data2)
     }
-  }
-
-  private fun <D : Query.Data> concurrentReadWriteFromCache(query: Query<D>, sql: Boolean) {
-    val cache = if (sql) {
-      Utils.dbFile.delete()
-      SqlNormalizedCacheFactory(name = Utils.dbName).create()
-    } else {
-      MemoryCacheFactory().create()
-    }
-    val data = query.parseJsonResponse(resource(R.raw.calendar_response_simple).jsonReader()).data!!
-
-    val records = query.normalize(
-        data,
-        CustomScalarAdapters.Empty,
-        TypePolicyCacheKeyGenerator,
-    )
-
-    val threadPool = Executors.newFixedThreadPool(CONCURRENCY)
-    benchmarkRule.measureRepeated {
-      val futures = (1..CONCURRENCY).map {
-        threadPool.submit {
-          // Let each thread execute a few writes/reads
-          repeat(WORK_LOAD) {
-            cache.merge(records.values.toList(), CacheHeaders.NONE, DefaultRecordMerger)
-
-            val data2 = query.readDataFromCache(
-                CustomScalarAdapters.Empty,
-                cache,
-                FieldPolicyCacheResolver,
-                CacheHeaders.NONE
-            )
-
-            Assert.assertEquals(data, data2)
-          }
-        }
-      }
-      // Wait for all threads to finish
-      futures.forEach { it.get() }
-    }
-  }
-
-
-  companion object {
-    private const val CONCURRENCY = 15
-    private const val WORK_LOAD = 15
   }
 }

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -17,7 +17,7 @@ androidx-sqlite = "2.3.1"
 # This is used by the gradle integration tests to get the artifacts locally
 apollo = "4.1.2-SNAPSHOT"
 apollo-execution = "0.1.0"
-apollo-normalizedcache-incubating = "0.0.6"
+apollo-normalizedcache-incubating = "0.0.7"
 # Used by the apollo-tooling project which uses a published version of Apollo
 apollo-published = "4.0.1"
 atomicfu = "0.26.0"


### PR DESCRIPTION
I also had to go through ApolloStore since in 0.0.7 as `Operation.normalize` and `Operation.parseJsonResponse` have been removed.

Also removed the "concurrentReadWrite" tests, which are the same that we have in `ApolloStoreTest` (I think I just forgot to remove them when refactoring the benchmarks).