### PR TITLE
[IJ Plugin] Use configured Gradle JVM when executing tasks

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
@@ -22,6 +22,7 @@ import org.gradle.tooling.model.GradleProject
 import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper
 import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings
 import org.jetbrains.plugins.gradle.util.GradleConstants
+import java.io.File
 
 class DownloadSchemaAction : AnAction() {
   override fun actionPerformed(e: AnActionEvent) {
@@ -55,7 +56,9 @@ private class DownloadSchemaTask(project: Project) : Task.Backgroundable(
     val rootGradleProject = gradleExecutionHelper.execute(rootProjectPath, executionSettings) { connection ->
       logd("Fetch Gradle project model")
       return@execute try {
-        connection.model<GradleProject>(GradleProject::class.java).get()
+        connection.model<GradleProject>(GradleProject::class.java)
+            .setJavaHome(executionSettings.javaHome?.let { File(it) })
+            .get()
       } catch (t: Throwable) {
         logw(t, "Couldn't fetch Gradle project model")
         null
@@ -83,6 +86,7 @@ private class DownloadSchemaTask(project: Project) : Task.Backgroundable(
     gradleExecutionHelper.execute(rootProjectPath, executionSettings) { connection ->
       try {
         connection.newBuild()
+            .setJavaHome(executionSettings.javaHome?.let { File(it) })
             .forTasks(*allDownloadSchemaTasks.toTypedArray())
             .addProgressListener(object : SimpleProgressListener() {
               override fun onFailure(failures: List<Failure>) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -167,6 +167,7 @@ class GradleToolingModelService(
         logd("Fetch Gradle project model")
         return@execute try {
           connection.model<GradleProject>(GradleProject::class.java)
+              .setJavaHome(executionSettings.javaHome?.let { File(it) })
               .withCancellationToken(gradleCancellation!!.token())
               .get()
         } catch (t: Throwable) {
@@ -191,6 +192,7 @@ class GradleToolingModelService(
           logd("Fetch tooling model for ${gradleProject.path}")
           return@execute try {
             connection.model<ApolloGradleToolingModel>(ApolloGradleToolingModel::class.java)
+                .setJavaHome(executionSettings.javaHome?.let { File(it) })
                 .withCancellationToken(gradleCancellation!!.token())
                 .get()
                 .takeIf {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
@@ -2,20 +2,11 @@ package com.apollographql.ijplugin.gradle
 
 import com.apollographql.ijplugin.util.logw
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import org.gradle.tooling.model.GradleProject
 
 const val CODEGEN_GRADLE_TASK_NAME = "generateApolloSources"
-
-fun Module.getGradleName(): String? {
-  val projectId = ExternalSystemApiUtil.getExternalProjectId(this) ?: return null
-  // "MyProject:main" -> ""
-  // "MyProject:MyModule:main" -> "MyModule"
-  // "MyProject:MyModule:MySubModule:main" -> "MyModule:MySubModule"
-  return projectId.split(":").drop(1).dropLast(1).joinToString(":")
-}
 
 fun Project.getGradleRootPath(): String? {
   val rootProjectPath = ModuleManager.getInstance(this).modules.firstNotNullOfOrNull {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/ProjectSettingsService.kt
@@ -47,6 +47,13 @@ class ProjectSettingsService(private val project: Project) : PersistentStateComp
       notifySettingsChanged()
     }
 
+  override var automaticCodegenAdditionalGradleJvmArguments: String
+    get() = _state.automaticCodegenAdditionalGradleJvmArguments
+    set(value) {
+      _state.automaticCodegenAdditionalGradleJvmArguments = value
+      notifySettingsChanged()
+    }
+
   override var hasEnabledGraphQLPluginApolloKotlinSupport: Boolean
     get() = _state.hasEnabledGraphQLPluginApolloKotlinSupport
     set(value) {
@@ -143,6 +150,7 @@ class ProjectSettingsService(private val project: Project) : PersistentStateComp
 
 interface ProjectSettingsState {
   var automaticCodegenTriggering: Boolean
+  var automaticCodegenAdditionalGradleJvmArguments: String
   var hasEnabledGraphQLPluginApolloKotlinSupport: Boolean
   var contributeConfigurationToGraphqlPlugin: Boolean
   var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
@@ -191,6 +199,7 @@ data class ApolloKotlinServiceConfiguration(
 
 data class ProjectSettingsStateImpl(
     override var automaticCodegenTriggering: Boolean = true,
+    override var automaticCodegenAdditionalGradleJvmArguments: String = "-Xms64m -Xmx512m",
     override var hasEnabledGraphQLPluginApolloKotlinSupport: Boolean = false,
     override var contributeConfigurationToGraphqlPlugin: Boolean = true,
     override var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration> = emptyList(),

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsComponent.kt
@@ -10,7 +10,9 @@ import com.intellij.openapi.project.Project
 import com.intellij.ui.AddEditRemovePanel
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.bindSelected
+import com.intellij.ui.dsl.builder.bindText
 import com.intellij.ui.dsl.builder.panel
+import java.awt.Font
 import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JPanel
@@ -18,10 +20,12 @@ import javax.swing.JPanel
 class SettingsComponent(private val project: Project) {
   private val propertyGraph = PropertyGraph()
   private val automaticCodegenTriggeringProperty = propertyGraph.property(false)
+  private val automaticCodegenAdditionalGradleJvmArgumentsProperty = propertyGraph.property("")
   private val contributeConfigurationToGraphqlPluginProperty = propertyGraph.property(false)
   private val telemetryEnabledProperty = propertyGraph.property(false)
 
   var automaticCodegenTriggering: Boolean by automaticCodegenTriggeringProperty
+  var automaticCodegenAdditionalGradleJvmArguments: String by automaticCodegenAdditionalGradleJvmArgumentsProperty
   var contributeConfigurationToGraphqlPlugin: Boolean by contributeConfigurationToGraphqlPluginProperty
   var apolloKotlinServiceConfigurations: List<ApolloKotlinServiceConfiguration>
     get() = addEditRemovePanel?.data?.toList() ?: emptyList()
@@ -41,6 +45,15 @@ class SettingsComponent(private val project: Project) {
             .comment(ApolloBundle.message("settings.codegen.automaticCodegenTriggering.comment"))
             .bindSelected(automaticCodegenTriggeringProperty)
             .component
+      }
+      row {
+        label(ApolloBundle.message("settings.codegen.additionalGradleJvmArguments.text"))
+        textField()
+            .align(AlignX.FILL)
+            .bindText(automaticCodegenAdditionalGradleJvmArgumentsProperty)
+            .applyToComponent {
+              font = Font(Font.MONOSPACED, font.style, font.size)
+            }
       }
     }.visible(isKotlinPluginPresent && isGradlePluginPresent)
     group(ApolloBundle.message("settings.graphqlPlugin.title")) {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/settings/SettingsConfigurable.kt
@@ -17,6 +17,7 @@ class SettingsConfigurable(private val project: Project) : Configurable {
 
   override fun isModified(): Boolean {
     return settingsComponent!!.automaticCodegenTriggering != project.projectSettingsState.automaticCodegenTriggering ||
+        settingsComponent!!.automaticCodegenAdditionalGradleJvmArguments != project.projectSettingsState.automaticCodegenAdditionalGradleJvmArguments ||
         settingsComponent!!.contributeConfigurationToGraphqlPlugin != project.projectSettingsState.contributeConfigurationToGraphqlPlugin ||
         settingsComponent!!.apolloKotlinServiceConfigurations != project.projectSettingsState.apolloKotlinServiceConfigurations ||
         settingsComponent!!.telemetryEnabled != appSettingsState.telemetryEnabled
@@ -24,6 +25,8 @@ class SettingsConfigurable(private val project: Project) : Configurable {
 
   override fun apply() {
     project.projectSettingsState.automaticCodegenTriggering = settingsComponent!!.automaticCodegenTriggering
+    project.projectSettingsState.automaticCodegenAdditionalGradleJvmArguments =
+      settingsComponent!!.automaticCodegenAdditionalGradleJvmArguments
     project.projectSettingsState.contributeConfigurationToGraphqlPlugin = settingsComponent!!.contributeConfigurationToGraphqlPlugin
     project.projectSettingsState.apolloKotlinServiceConfigurations = settingsComponent!!.apolloKotlinServiceConfigurations
     appSettingsState.telemetryEnabled = settingsComponent!!.telemetryEnabled
@@ -31,6 +34,8 @@ class SettingsConfigurable(private val project: Project) : Configurable {
 
   override fun reset() {
     settingsComponent!!.automaticCodegenTriggering = project.projectSettingsState.automaticCodegenTriggering
+    settingsComponent!!.automaticCodegenAdditionalGradleJvmArguments =
+      project.projectSettingsState.automaticCodegenAdditionalGradleJvmArguments
     settingsComponent!!.contributeConfigurationToGraphqlPlugin = project.projectSettingsState.contributeConfigurationToGraphqlPlugin
     settingsComponent!!.apolloKotlinServiceConfigurations = project.projectSettingsState.apolloKotlinServiceConfigurations
     settingsComponent!!.telemetryEnabled = appSettingsState.telemetryEnabled

--- a/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
+++ b/intellij-plugin/src/main/resources/messages/ApolloBundle.properties
@@ -86,6 +86,7 @@ settings.codegen.automaticCodegenTriggering.text=Automatic code generation
 settings.codegen.automaticCodegenTriggering.comment=Enabling this setting will run Gradle in continuous mode, similarly to \
   <code>./gradlew generateApolloSources --continuous</code>.<br>\
   This watches changes to your GraphQL files and re-generates models when they change.
+settings.codegen.additionalGradleJvmArguments.text=Additional JVM arguments:
 
 settings.graphqlPlugin.title=GraphQL Plugin
 settings.graphqlPlugin.contributeConfigurationToGraphqlPlugin.text=Contribute configuration to the GraphQL plugin


### PR DESCRIPTION
Related to #6418.

Also, now the daemon used for the continuous codegen task will use `-Xms64m -Xmx512m` by default and configurable in the settings (should help with https://github.com/apollographql/apollo-kotlin/issues/5529#issuecomment-2348980705).