### PR TITLE
Remove "incubating" from the normalized cache repo name

### DIFF
--- a/docs/source/advanced/galaxy.mdx
+++ b/docs/source/advanced/galaxy.mdx
@@ -9,16 +9,16 @@ They serve as a playground for new ideas (`apollo-kotlin-compose-support`, `apol
 
 The Apollo Kotlin galaxy projects all start with `apollo-kotlin`:
 
-| Repository                                                                                                              | Description                                                       |
-|-------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
-| [apollo-kotlin-normalized-cache-incubating](https://github.com/apollographql/apollo-kotlin-normalized-cache-incubating) | Apollo Kotlin Incubating Normalized Cache                         |
-| [apollo-kotlin-compose-support](https://github.com/apollographql/apollo-kotlin-compose-support)                         | Compose support for Apollo Kotlin                                 |
-| [apollo-kotlin-ktor-support](https://github.com/apollographql/apollo-kotlin-ktor-support)                               | HttpEngine and helpers to work with [Ktor](https://ktor.io/)      |
-| [apollo-kotlin-execution](https://github.com/apollographql/apollo-kotlin-execution)                                     | GraphQL execution algorithms                                      |
-| [apollo-kotlin-adapters](https://github.com/apollographql/apollo-kotlin-adapters)                                       | Datetime, BigDecimal and other adapters for Apollo Kotlin         |
-| [apollo-kotlin-cli](https://github.com/apollographql/apollo-kotlin-cli)                                                 | Command line tool for your GraphQL projects                       |
-| [apollo-kotlin-mockserver](https://github.com/apollographql/apollo-kotlin-mockserver)                                   | KMP ready HTTP mock server                                        |
-| [apollo-kotlin-java-support](https://github.com/apollographql/apollo-kotlin-java-support)                                      | Java language support for Apollo Kotlin                           |
-| [apollo-kotlin-ffs](https://github.com/apollographql/apollo-kotlin-ffs)                                                 | A compiler plugin that allows validation of Federation directives |
+| Repository                                                                                        | Description                                                       |
+|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| [apollo-kotlin-normalized-cache](https://github.com/apollographql/apollo-kotlin-normalized-cache) | Apollo Kotlin Normalized Cache                                    |
+| [apollo-kotlin-compose-support](https://github.com/apollographql/apollo-kotlin-compose-support)   | Compose support for Apollo Kotlin                                 |
+| [apollo-kotlin-ktor-support](https://github.com/apollographql/apollo-kotlin-ktor-support)         | HttpEngine and helpers to work with [Ktor](https://ktor.io/)      |
+| [apollo-kotlin-execution](https://github.com/apollographql/apollo-kotlin-execution)               | GraphQL execution algorithms                                      |
+| [apollo-kotlin-adapters](https://github.com/apollographql/apollo-kotlin-adapters)                 | Datetime, BigDecimal and other adapters for Apollo Kotlin         |
+| [apollo-kotlin-cli](https://github.com/apollographql/apollo-kotlin-cli)                           | Command line tool for your GraphQL projects                       |
+| [apollo-kotlin-mockserver](https://github.com/apollographql/apollo-kotlin-mockserver)             | KMP ready HTTP mock server                                        |
+| [apollo-kotlin-java-support](https://github.com/apollographql/apollo-kotlin-java-support)         | Java language support for Apollo Kotlin                           |
+| [apollo-kotlin-ffs](https://github.com/apollographql/apollo-kotlin-ffs)                           | A compiler plugin that allows validation of Federation directives |
 
 When possible, file issues in the appropriate repository. 


### PR DESCRIPTION
See also https://github.com/apollographql/apollo-kotlin-normalized-cache/pull/128