### PR TITLE
Call DocumentTransform.transform after processing

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -16,7 +16,6 @@ import com.apollographql.apollo.ast.Issue
 import com.apollographql.apollo.ast.ParserOptions
 import com.apollographql.apollo.ast.QueryDocumentMinifier
 import com.apollographql.apollo.ast.Schema
-import com.apollographql.apollo.ast.UnknownDirective
 import com.apollographql.apollo.ast.UnusedFragment
 import com.apollographql.apollo.ast.UnusedVariable
 import com.apollographql.apollo.ast.builtinForeignSchemas
@@ -53,7 +52,6 @@ import com.apollographql.apollo.compiler.operationoutput.OperationId
 import com.apollographql.apollo.compiler.operationoutput.toOperationOutput
 import com.apollographql.apollo.compiler.pqm.toPersistedQueryManifest
 import java.io.File
-import kotlin.collections.plus
 
 object ApolloCompiler {
   interface Logger {
@@ -292,7 +290,7 @@ object ApolloCompiler {
     val operations = definitions.filterIsInstance<GQLOperationDefinition>().map {
       var operation = addRequiredFields(it, addTypename, schema, fragmentDefinitions)
       if (documentTransform != null) {
-        operation = documentTransform.transform(schema, it)
+        operation = documentTransform.transform(schema, operation)
       }
       if (schema.directiveDefinitions.containsKey(Schema.DISABLE_ERROR_PROPAGATION)
           && schema.schemaDefinition?.directives?.any { schema.originalDirectiveName(it.name) == Schema.CATCH_BY_DEFAULT } == true


### PR DESCRIPTION
Was playing with an Apollo compiler plugin and noticed the results of `addRequiredFields` are discarded when a `DocumentTransform` is configured.