### PR TITLE
Add CacheAndNetwork fetch policy to HttpCache

### DIFF
--- a/docs/source/caching/http-cache.mdx
+++ b/docs/source/caching/http-cache.mdx
@@ -64,6 +64,9 @@ val response = apolloClient.query(query)
 
   // Don't use the cache
   .httpFetchPolicy(HttpFetchPolicy.NetworkOnly)
+
+  // Try the cache, then also try the network
+  .httpFetchPolicy(HttpFetchPolicy.CacheAndNetwork)
   
   // Finally, execute your query
   .execute()
@@ -71,6 +74,8 @@ val response = apolloClient.query(query)
 Note: mutations and subscriptions don't go through the cache.
 
 If the query is present in cache, it will be used to return `response.data`. If not, a `HttpCacheMissException` will be thrown.
+
+`CacheAndNetwork` will always emit two values, you should use `.toFlow()` when using that policy.
 
 You can also set an expiration time either globally or for specific queries. The entries will automatically be removed from the cache after the expiration time:
 

--- a/libraries/apollo-http-cache/api/apollo-http-cache.api
+++ b/libraries/apollo-http-cache/api/apollo-http-cache.api
@@ -5,6 +5,11 @@ public abstract interface class com/apollographql/apollo/cache/http/ApolloHttpCa
 	public abstract fun write (Lcom/apollographql/apollo/api/http/HttpResponse;Ljava/lang/String;)Lcom/apollographql/apollo/api/http/HttpResponse;
 }
 
+public final class com/apollographql/apollo/cache/http/CacheAndNetworkApolloInterceptor : com/apollographql/apollo/interceptor/ApolloInterceptor {
+	public fun <init> ()V
+	public fun intercept (Lcom/apollographql/apollo/api/ApolloRequest;Lcom/apollographql/apollo/interceptor/ApolloInterceptorChain;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class com/apollographql/apollo/cache/http/CachingHttpInterceptor : com/apollographql/apollo/network/http/HttpInterceptor {
 	public static final field Companion Lcom/apollographql/apollo/cache/http/CachingHttpInterceptor$Companion;
 	public fun <init> (Ljava/io/File;JLokio/FileSystem;)V
@@ -41,6 +46,7 @@ public final class com/apollographql/apollo/cache/http/HttpCache {
 }
 
 public final class com/apollographql/apollo/cache/http/HttpFetchPolicy : java/lang/Enum {
+	public static final field CacheAndNetwork Lcom/apollographql/apollo/cache/http/HttpFetchPolicy;
 	public static final field CacheFirst Lcom/apollographql/apollo/cache/http/HttpFetchPolicy;
 	public static final field CacheOnly Lcom/apollographql/apollo/cache/http/HttpFetchPolicy;
 	public static final field NetworkFirst Lcom/apollographql/apollo/cache/http/HttpFetchPolicy;

--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/CacheAndNetworkApolloInterceptor.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/CacheAndNetworkApolloInterceptor.kt
@@ -1,0 +1,36 @@
+package com.apollographql.apollo.cache.http
+
+import com.apollographql.apollo.api.ApolloRequest
+import com.apollographql.apollo.api.ApolloResponse
+import com.apollographql.apollo.api.Operation
+import com.apollographql.apollo.api.http.valueOf
+import com.apollographql.apollo.cache.http.CachingHttpInterceptor.Companion.CACHE_FETCH_POLICY_HEADER
+import com.apollographql.apollo.cache.http.CachingHttpInterceptor.Companion.CACHE_ONLY
+import com.apollographql.apollo.cache.http.CachingHttpInterceptor.Companion.NETWORK_ONLY
+import com.apollographql.apollo.interceptor.ApolloInterceptor
+import com.apollographql.apollo.interceptor.ApolloInterceptorChain
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+
+class CacheAndNetworkApolloInterceptor : ApolloInterceptor {
+  override fun <D : Operation.Data> intercept(request: ApolloRequest<D>, chain: ApolloInterceptorChain): Flow<ApolloResponse<D>> {
+    val headers = request.httpHeaders.orEmpty()
+    val fetchPolicy = headers.valueOf(CACHE_FETCH_POLICY_HEADER)
+
+    return if (fetchPolicy == CachingHttpInterceptor.CACHE_AND_NETWORK) {
+      flow {
+        listOf(CACHE_ONLY, NETWORK_ONLY).forEach { policy ->
+          val newRequest = request.newBuilder()
+              .httpHeaders(headers.filterNot { it.name == CACHE_FETCH_POLICY_HEADER })
+              .addHttpHeader(CACHE_FETCH_POLICY_HEADER, policy)
+              .build()
+
+          emit(chain.proceed(newRequest).single())
+        }
+      }
+    } else {
+      chain.proceed(request)
+    }
+  }
+}

--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/CachingHttpInterceptor.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/CachingHttpInterceptor.kt
@@ -202,6 +202,7 @@ class CachingHttpInterceptor internal constructor(
     internal const val NETWORK_ONLY = "NETWORK_ONLY"
     internal const val CACHE_FIRST = "CACHE_FIRST"
     internal const val NETWORK_FIRST = "NETWORK_FIRST"
+    internal const val CACHE_AND_NETWORK = "CACHE_AND_NETWORK"
 
     /**
      * Request served Date/time http header

--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/HttpCacheExtensions.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/HttpCacheExtensions.kt
@@ -36,6 +36,11 @@ enum class HttpFetchPolicy {
    * Only try network
    */
   NetworkOnly,
+
+  /**
+   * Try the cache, then also the network
+   * */
+  CacheAndNetwork,
 }
 
 internal class HttpFetchPolicyContext(val httpFetchPolicy: HttpFetchPolicy) : ExecutionContext.Element {
@@ -83,6 +88,12 @@ fun ApolloClient.Builder.httpCache(
         }
       }
       .addInterceptor(HttpCacheApolloInterceptor(apolloRequestToCacheKey, cachingHttpInterceptor))
+      .apply {
+        interceptors.firstOrNull { it is CacheAndNetworkApolloInterceptor }?.let {
+          removeInterceptor(it)
+        }
+      }
+      .addInterceptor(CacheAndNetworkApolloInterceptor())
 }
 
 

--- a/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/internal/HttpCacheApolloInterceptor.kt
+++ b/libraries/apollo-http-cache/src/main/kotlin/com/apollographql/apollo/cache/http/internal/HttpCacheApolloInterceptor.kt
@@ -28,6 +28,7 @@ internal class HttpCacheApolloInterceptor(
       HttpFetchPolicy.CacheOnly -> CachingHttpInterceptor.CACHE_ONLY
       HttpFetchPolicy.NetworkFirst -> CachingHttpInterceptor.NETWORK_FIRST
       HttpFetchPolicy.NetworkOnly -> CachingHttpInterceptor.NETWORK_ONLY
+      HttpFetchPolicy.CacheAndNetwork -> CachingHttpInterceptor.CACHE_AND_NETWORK
     }
 
     return chain.proceed(


### PR DESCRIPTION
Added support for `CacheAndNetwork` fetch policy to `HttpCache`, replicating the behavior available in the normalized cache. Using this fetch policy will always emit two values, initially the cached http response (if available), and then the network response when online. 
In case of a cache miss or a network error a non-null `.exception` will be emitted for both the cases.

Closes #4235.