### PR TITLE
Fix losing response headers when using batch request

### DIFF
--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
@@ -238,6 +238,10 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         pending[index].deferred.complete(
             HttpResponse.Builder(statusCode = 200)
                 .body(Buffer().write(byteString))
+                /*
+                 * Return the global batch headers to individual responses.
+                 * This is useful for things like cache-control that rely on HTTP headers.
+                 */
                 .headers(responseHeader)
                 .build()
         )

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/BatchingHttpInterceptor.kt
@@ -7,6 +7,7 @@ import com.apollographql.apollo.api.CustomScalarAdapters
 import com.apollographql.apollo.api.ExecutionOptions
 import com.apollographql.apollo.api.Operation
 import com.apollographql.apollo.api.http.HttpBody
+import com.apollographql.apollo.api.http.HttpHeader
 import com.apollographql.apollo.api.http.HttpMethod
 import com.apollographql.apollo.api.http.HttpRequest
 import com.apollographql.apollo.api.http.HttpResponse
@@ -176,6 +177,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         .build()
 
     var exception: ApolloException? = null
+    var responseHeader = emptyList<HttpHeader>()
     val result = try {
       val response = interceptorChain!!.proceed(request)
       if (response.statusCode !in 200..299) {
@@ -193,6 +195,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         )
       }
       val responseBody = response.body ?: throw DefaultApolloException("null body when executing batched query")
+      responseHeader = response.headers
 
       val list = BufferedSourceJsonReader(responseBody).use { jsonReader ->
         // TODO: this is most likely going to transform BigNumbers into strings, not sure how much of an issue that is
@@ -235,6 +238,7 @@ class BatchingHttpInterceptor @JvmOverloads constructor(
         pending[index].deferred.complete(
             HttpResponse.Builder(statusCode = 200)
                 .body(Buffer().write(byteString))
+                .headers(responseHeader)
                 .build()
         )
       }


### PR DESCRIPTION
While using the [new Normalized Cache](https://github.com/apollographql/apollo-kotlin/issues/6533) in the [Server-controlled way](https://apollographql.github.io/apollo-kotlin-normalized-cache/cache-control.html#server-controlled), the batched requests are unable to follow the `cache-control` header from the server side and always return the cached data.

This is caused by losing response headers when splitting the batched response

Add the headers to the split response to fix this.  