### PR TITLE
Apollo API: generate the version

### DIFF
--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -37,6 +37,10 @@ public final class com/apollographql/apollo/api/Adapters {
 	public static synthetic fun -toJson$default (Lcom/apollographql/apollo/api/Adapter;Ljava/lang/Object;Lcom/apollographql/apollo/api/CustomScalarAdapters;Ljava/lang/String;ILjava/lang/Object;)Ljava/lang/String;
 }
 
+public final class com/apollographql/apollo/api/ApolloApiVersionKt {
+	public static final field apolloApiVersion Ljava/lang/String;
+}
+
 public final class com/apollographql/apollo/api/ApolloOptionalAdapter : com/apollographql/apollo/api/Adapter {
 	public fun <init> (Lcom/apollographql/apollo/api/Adapter;)V
 	public fun fromJson (Lcom/apollographql/apollo/api/json/JsonReader;Lcom/apollographql/apollo/api/CustomScalarAdapters;)Lcom/apollographql/apollo/api/Optional;

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -1356,6 +1356,9 @@ final object com.apollographql.apollo.exception/OfflineException : okio/IOExcept
     final fun toString(): kotlin/String // com.apollographql.apollo.exception/OfflineException.toString|toString(){}[0]
 }
 
+final const val com.apollographql.apollo.api/apolloApiVersion // com.apollographql.apollo.api/apolloApiVersion|{}apolloApiVersion[0]
+    final fun <get-apolloApiVersion>(): kotlin/String // com.apollographql.apollo.api/apolloApiVersion.<get-apolloApiVersion>|<get-apolloApiVersion>(){}[0]
+
 final val com.apollographql.apollo.api/AnyAdapter // com.apollographql.apollo.api/AnyAdapter|{}AnyAdapter[0]
     final fun <get-AnyAdapter>(): com.apollographql.apollo.api/Adapter<kotlin/Any> // com.apollographql.apollo.api/AnyAdapter.<get-AnyAdapter>|<get-AnyAdapter>(){}[0]
 final val com.apollographql.apollo.api/ApolloOptionalAnyAdapter // com.apollographql.apollo.api/ApolloOptionalAnyAdapter|{}ApolloOptionalAnyAdapter[0]

--- a/libraries/apollo-api/build.gradle.kts
+++ b/libraries/apollo-api/build.gradle.kts
@@ -1,3 +1,7 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import kotlin.jvm.java
+
 plugins {
   id("org.jetbrains.kotlin.multiplatform")
 }
@@ -18,3 +22,39 @@ kotlin {
   }
 }
 
+abstract class GenerateLibraryVersion : DefaultTask() {
+  @get:Input
+  abstract val version: Property<String>
+
+  @get:OutputDirectory
+  abstract val outputDir: DirectoryProperty
+
+  @TaskAction
+  fun taskAction() {
+    outputDir.asFile.get().apply {
+      deleteRecursively()
+      mkdirs()
+    }
+
+    val versionFile = File(outputDir.asFile.get(), "com/apollographql/apollo/api/ApolloApiVersion.kt")
+    versionFile.parentFile.mkdirs()
+    versionFile.writeText("""// Generated file. Do not edit!
+package com.apollographql.apollo.api
+const val apolloApiVersion = "${version.get()}"
+""")
+  }
+}
+
+val pluginVersionTaskProvider = tasks.register("generateLibraryVersion", GenerateLibraryVersion::class.java) {
+  outputDir.set(project.layout.buildDirectory.dir("generated/kotlin/"))
+  version.set(project.version.toString())
+}
+
+extensions.getByType(KotlinBaseExtension::class.java).apply {
+  val versionFileProvider = pluginVersionTaskProvider.flatMap { it.outputDir }
+  sourceSets.getByName("commonMain").kotlin.srcDir(versionFileProvider)
+}
+
+tasks.withType(KotlinCompile::class.java) {
+  dependsOn(pluginVersionTaskProvider)
+}


### PR DESCRIPTION
Adds `com.apollographql.apollo.api.apolloApiVersion` that can be used for client awareness. 

