### PR TITLE
[4.x] Ignore scalars/enums in checkCapitalizedFields (#6502)

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkCapitalizedFields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkCapitalizedFields.kt
@@ -35,6 +35,10 @@ private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection
   selections.forEach {
     when (it) {
       is GQLField -> {
+        if (it.selections.isEmpty()) {
+          // A clash can only occur if a model is generated
+          return@forEach
+        }
         val alias = it.alias
         if (alias != null) {
           if (isFirstLetterUpperCase(alias)) {

--- a/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_allowed_with_fragment_spread.expected
+++ b/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_allowed_with_fragment_spread.expected
@@ -1,5 +1,2 @@
 UpperCaseField (15:3)
 Capitalized field 'Cow' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.
-------------
-UpperCaseField (16:5)
-Capitalized field 'Moo' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.

--- a/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed.expected
+++ b/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed.expected
@@ -1,11 +1,5 @@
 UpperCaseField (2:3)
 Capitalized field 'Horse' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.
 ------------
-UpperCaseField (3:5)
-Capitalized field 'Donkey' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.
-------------
 UpperCaseField (5:7)
 Capitalized field 'Cow' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.
-------------
-UpperCaseField (6:9)
-Capitalized field 'Moo' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.


### PR DESCRIPTION
This is a backport of https://github.com/apollographql/apollo-kotlin/pull/6502