### PR TITLE
Keep compiler plugin in sync with v4

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -15,9 +15,9 @@ public final class com/apollographql/apollo/compiler/ApolloCompiler {
 	public static final field INSTANCE Lcom/apollographql/apollo/compiler/ApolloCompiler;
 	public final fun buildCodegenSchema (Ljava/util/List;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;Lcom/apollographql/apollo/compiler/CodegenSchemaOptions;Ljava/util/List;Lcom/apollographql/apollo/compiler/SchemaTransform;)Lcom/apollographql/apollo/compiler/CodegenSchema;
 	public final fun buildDataBuilders (Lcom/apollographql/apollo/compiler/CodegenSchema;Lcom/apollographql/apollo/compiler/UsedCoordinates;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/codegen/SchemaLayout;Ljava/util/List;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
-	public final fun buildIrOperations (Lcom/apollographql/apollo/compiler/CodegenSchema;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/OperationsTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
-	public final fun buildSchemaAndOperationsSources (Lcom/apollographql/apollo/compiler/CodegenSchema;Ljava/util/List;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/LayoutFactory;Lcom/apollographql/apollo/compiler/OperationIdsGenerator;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/OperationsTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
-	public final fun buildSchemaAndOperationsSources (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/LayoutFactory;Lcom/apollographql/apollo/compiler/OperationIdsGenerator;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/OperationsTransform;Lcom/apollographql/apollo/compiler/SchemaTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
+	public final fun buildIrOperations (Lcom/apollographql/apollo/compiler/CodegenSchema;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;)Lcom/apollographql/apollo/compiler/ir/IrOperations;
+	public final fun buildSchemaAndOperationsSources (Lcom/apollographql/apollo/compiler/CodegenSchema;Ljava/util/List;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/LayoutFactory;Lcom/apollographql/apollo/compiler/OperationIdsGenerator;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
+	public final fun buildSchemaAndOperationsSources (Ljava/util/List;Ljava/util/List;Lcom/apollographql/apollo/compiler/CodegenSchemaOptions;Lcom/apollographql/apollo/compiler/IrOptions;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/LayoutFactory;Lcom/apollographql/apollo/compiler/OperationIdsGenerator;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;Lcom/apollographql/apollo/compiler/SchemaTransform;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;Ljava/io/File;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
 	public final fun buildSchemaAndOperationsSourcesFromIr (Lcom/apollographql/apollo/compiler/CodegenSchema;Lcom/apollographql/apollo/compiler/ir/IrOperations;Lcom/apollographql/apollo/compiler/UsedCoordinates;Ljava/util/List;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/codegen/SchemaAndOperationsLayout;Lcom/apollographql/apollo/compiler/OperationIdsGenerator;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;Ljava/io/File;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
 	public final fun buildSchemaSources (Lcom/apollographql/apollo/compiler/CodegenSchema;Lcom/apollographql/apollo/compiler/UsedCoordinates;Lcom/apollographql/apollo/compiler/CodegenOptions;Lcom/apollographql/apollo/compiler/codegen/SchemaLayout;Lcom/apollographql/apollo/compiler/Transform;Lcom/apollographql/apollo/compiler/Transform;)Lcom/apollographql/apollo/compiler/codegen/SourceOutput;
 }
@@ -31,15 +31,14 @@ public final class com/apollographql/apollo/compiler/ApolloCompilerKt {
 }
 
 public abstract interface class com/apollographql/apollo/compiler/ApolloCompilerPlugin {
-	public abstract fun beforeCompilationStep (Lcom/apollographql/apollo/compiler/ApolloCompilerPluginEnvironment;Lcom/apollographql/apollo/compiler/ApolloCompilerRegistry;)V
+	public fun beforeCompilationStep (Lcom/apollographql/apollo/compiler/ApolloCompilerPluginEnvironment;Lcom/apollographql/apollo/compiler/ApolloCompilerRegistry;)V
 	public fun operationIds (Ljava/util/List;)Ljava/util/List;
 }
 
 public final class com/apollographql/apollo/compiler/ApolloCompilerPluginEnvironment {
-	public fun <init> (Ljava/util/Map;Lcom/apollographql/apollo/compiler/ApolloCompilerPluginLogger;Ljava/io/File;)V
+	public fun <init> (Ljava/util/Map;Lcom/apollographql/apollo/compiler/ApolloCompilerPluginLogger;)V
 	public final fun getArguments ()Ljava/util/Map;
 	public final fun getLogger ()Lcom/apollographql/apollo/compiler/ApolloCompilerPluginLogger;
-	public final fun getOutputDirectory ()Ljava/io/File;
 }
 
 public abstract interface class com/apollographql/apollo/compiler/ApolloCompilerPluginLogger {
@@ -54,6 +53,7 @@ public abstract interface class com/apollographql/apollo/compiler/ApolloCompiler
 }
 
 public abstract interface class com/apollographql/apollo/compiler/ApolloCompilerRegistry {
+	public abstract fun registerExecutableDocumentTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;)V
 	public abstract fun registerExtraCodeGenerator (Lcom/apollographql/apollo/compiler/CodeGenerator;)V
 	public abstract fun registerForeignSchemas (Ljava/util/List;)V
 	public abstract fun registerIrTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/Transform;)V
@@ -61,7 +61,6 @@ public abstract interface class com/apollographql/apollo/compiler/ApolloCompiler
 	public abstract fun registerKotlinOutputTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/Transform;)V
 	public abstract fun registerLayout (Lcom/apollographql/apollo/compiler/LayoutFactory;)V
 	public abstract fun registerOperationIdsGenerator (Lcom/apollographql/apollo/compiler/OperationIdsGenerator;)V
-	public abstract fun registerOperationsTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/OperationsTransform;)V
 	public abstract fun registerSchemaTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/SchemaTransform;)V
 }
 
@@ -71,7 +70,7 @@ public final class com/apollographql/apollo/compiler/Before : com/apollographql/
 }
 
 public abstract interface class com/apollographql/apollo/compiler/CodeGenerator {
-	public abstract fun generate (Lcom/apollographql/apollo/ast/GQLDocument;)V
+	public abstract fun generate (Lcom/apollographql/apollo/ast/GQLDocument;Ljava/io/File;)V
 }
 
 public final class com/apollographql/apollo/compiler/CodegenMetadata {
@@ -213,6 +212,10 @@ public final class com/apollographql/apollo/compiler/EntryPoints {
 
 public final class com/apollographql/apollo/compiler/EntrypointsKt {
 	public static final fun findCodegenSchemaFile (Ljava/lang/Iterable;)Ljava/io/File;
+}
+
+public abstract interface class com/apollographql/apollo/compiler/ExecutableDocumentTransform {
+	public abstract fun transform (Lcom/apollographql/apollo/ast/Schema;Lcom/apollographql/apollo/ast/GQLDocument;Ljava/util/List;)Lcom/apollographql/apollo/ast/GQLDocument;
 }
 
 public final class com/apollographql/apollo/compiler/ExpressionAdapterInitializer : com/apollographql/apollo/compiler/AdapterInitializer {
@@ -370,10 +373,6 @@ public abstract interface class com/apollographql/apollo/compiler/OperationsCode
 }
 
 public abstract interface class com/apollographql/apollo/compiler/OperationsCodegenOptions : com/apollographql/apollo/compiler/JavaOperationsCodegenOptions, com/apollographql/apollo/compiler/KotlinOperationsCodegenOptions {
-}
-
-public abstract interface class com/apollographql/apollo/compiler/OperationsTransform {
-	public abstract fun transform (Lcom/apollographql/apollo/ast/Schema;Lcom/apollographql/apollo/ast/GQLDocument;Ljava/util/List;)Lcom/apollographql/apollo/ast/GQLDocument;
 }
 
 public final class com/apollographql/apollo/compiler/OptionsKt {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -34,7 +34,7 @@ import com.apollographql.apollo.compiler.codegen.kotlin.KotlinCodegen
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinOutput
 import com.apollographql.apollo.compiler.codegen.kotlin.toSourceOutput
 import com.apollographql.apollo.compiler.codegen.plus
-import com.apollographql.apollo.compiler.internal.ApolloOperationsTransform
+import com.apollographql.apollo.compiler.internal.ApolloExecutableDocumentTransform
 import com.apollographql.apollo.compiler.internal.checkApolloInlineFragmentsHaveTypeCondition
 import com.apollographql.apollo.compiler.internal.checkApolloReservedEnumValueNames
 import com.apollographql.apollo.compiler.internal.checkApolloTargetNameClashes
@@ -190,7 +190,7 @@ object ApolloCompiler {
       upstreamCodegenModels: List<String>,
       upstreamFragmentDefinitions: List<GQLFragmentDefinition>,
       options: IrOptions,
-      operationsTransform: OperationsTransform?,
+      executableDocumentTransform: ExecutableDocumentTransform?,
       logger: Logger?,
   ): IrOperations {
     val schema = codegenSchema.schema
@@ -233,13 +233,13 @@ object ApolloCompiler {
     /**
      * Step 2, Modify the AST to add typename, key fields and call any user-provided transform.
      */
-    var document = ApolloOperationsTransform(options.addTypename ?: defaultAddTypename).transform(
+    var document = ApolloExecutableDocumentTransform(options.addTypename ?: defaultAddTypename).transform(
         schema = schema,
         document = GQLDocument(userDefinitions, sourceLocation = null),
         upstreamFragmentDefinitions
     )
-    if (operationsTransform != null) {
-      document = operationsTransform.transform(schema, document, upstreamFragmentDefinitions)
+    if (executableDocumentTransform != null) {
+      document = executableDocumentTransform.transform(schema, document, upstreamFragmentDefinitions)
     }
 
     /**
@@ -394,7 +394,7 @@ object ApolloCompiler {
     }
 
     val operationOutput = descriptors.toOperationOutput(
-        (operationIdsGenerator ?: defaultOperationOutputGenerator).generate(descriptors)
+        (operationIdsGenerator ?: defaultOperationIdsGenerator).generate(descriptors)
     )
 
     check(operationOutput.size == irOperations.operations.size) {
@@ -475,7 +475,7 @@ object ApolloCompiler {
       irOperationsTransform: Transform<IrOperations>?,
       javaOutputTransform: Transform<JavaOutput>?,
       kotlinOutputTransform: Transform<KotlinOutput>?,
-      operationsTransform: OperationsTransform?,
+      executableDocumentTransform: ExecutableDocumentTransform?,
       schemaTransform: SchemaTransform?,
       logger: Logger?,
       operationManifestFile: File?,
@@ -498,7 +498,7 @@ object ApolloCompiler {
         irOperationsTransform,
         javaOutputTransform,
         kotlinOutputTransform,
-        operationsTransform,
+        executableDocumentTransform,
         logger,
         operationManifestFile
     )
@@ -517,7 +517,7 @@ object ApolloCompiler {
       irOperationsTransform: Transform<IrOperations>?,
       javaOutputTransform: Transform<JavaOutput>?,
       kotlinOutputTransform: Transform<KotlinOutput>?,
-      operationsTransform: OperationsTransform?,
+      executableDocumentTransform: ExecutableDocumentTransform?,
       logger: Logger?,
       operationManifestFile: File?,
   ): SourceOutput {
@@ -526,7 +526,7 @@ object ApolloCompiler {
         executableFiles = executableFiles,
         upstreamCodegenModels = emptyList(),
         upstreamFragmentDefinitions = emptyList(),
-        operationsTransform = operationsTransform,
+        executableDocumentTransform = executableDocumentTransform,
         options = irOptions,
         logger = logger
     )

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompilerPlugin.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompilerPlugin.kt
@@ -6,7 +6,6 @@ import com.apollographql.apollo.ast.ForeignSchema
 import com.apollographql.apollo.ast.GQLDocument
 import com.apollographql.apollo.ast.GQLFragmentDefinition
 import com.apollographql.apollo.ast.Schema
-import com.apollographql.apollo.compiler.codegen.SchemaAndOperationsLayout
 import com.apollographql.apollo.compiler.codegen.java.JavaOutput
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinOutput
 import com.apollographql.apollo.compiler.ir.IrOperations
@@ -32,7 +31,9 @@ interface ApolloCompilerPlugin {
    * @param environment options and environment for the plugin.
    * @param registry the registry where to register transformations.
    */
-  fun beforeCompilationStep(environment: ApolloCompilerPluginEnvironment, registry: ApolloCompilerRegistry)
+  fun beforeCompilationStep(environment: ApolloCompilerPluginEnvironment, registry: ApolloCompilerRegistry) {
+
+  }
 
   /**
    * Computes operation ids for persisted queries.
@@ -58,11 +59,6 @@ class ApolloCompilerPluginEnvironment(
      * A logger that can be used by the plugin.
      */
     val logger: ApolloCompilerPluginLogger,
-    /**
-     * The compiler output directory.
-     * May be null if the plugin is called from a non-codegen step like building the schema and/or the IR.
-     */
-    val outputDirectory: File?,
 )
 
 sealed interface Order
@@ -76,7 +72,7 @@ interface ApolloCompilerRegistry {
   fun registerSchemaTransform(id: String, vararg orders: Order, transform: SchemaTransform)
 
   @ApolloExperimental
-  fun registerOperationsTransform(id: String, vararg orders: Order, transform: OperationsTransform)
+  fun registerExecutableDocumentTransform(id: String, vararg orders: Order, transform: ExecutableDocumentTransform)
   @ApolloExperimental
   fun registerIrTransform(id: String, vararg orders: Order, transform: Transform<IrOperations>)
 
@@ -102,9 +98,9 @@ fun interface SchemaTransform {
 
 
 /**
- * A [OperationsTransform] transforms operations and fragments at build time. [OperationsTransform] can add or remove fields automatically, for an example.
+ * A [ExecutableDocumentTransform] transforms operations and fragments at build time. [ExecutableDocumentTransform] can add or remove fields automatically, for an example.
  */
-fun interface OperationsTransform {
+fun interface ExecutableDocumentTransform {
   /**
    * Transforms the given document.
    *
@@ -141,7 +137,7 @@ fun interface CodeGenerator {
   /**
    * Transforms the given input into an output of the same type
    */
-  fun generate(schema: GQLDocument)
+  fun generate(schema: GQLDocument, outputDirectory: File)
 }
 
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/LegacyOperationIdsGenerator.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/LegacyOperationIdsGenerator.kt
@@ -8,7 +8,7 @@ internal class LegacyOperationIdsGenerator(private val plugin: ApolloCompilerPlu
     @Suppress("DEPRECATION")
     val operationIds = plugin.operationIds(operationDescriptorList.toList())
     if (operationIds != null) {
-      println("Apollo: using ApolloCompiler.operationIds() is deprecated. Please use registry.registerOperationIdsGenerator() instead.")
+      println("Apollo: using ApolloCompilerPlugin.operationIds() is deprecated. Please use registry.registerOperationIdsGenerator() instead.")
       return operationIds
     }
     return NoList

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Options.kt
@@ -3,12 +3,10 @@ package com.apollographql.apollo.compiler
 import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.annotations.ApolloExperimental
 import com.apollographql.apollo.compiler.internal.sha256
-import com.apollographql.apollo.compiler.operationoutput.OperationDescriptor
 import com.apollographql.apollo.compiler.operationoutput.OperationId
 import com.apollographql.apollo.compiler.operationoutput.OperationOutput
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.nio.charset.StandardCharsets
 
 const val MODELS_RESPONSE_BASED = "responseBased"
 const val MODELS_OPERATION_BASED = "operationBased"
@@ -649,12 +647,9 @@ private val NoOpLogger = object : ApolloCompiler.Logger {
 
 internal val defaultAlwaysGenerateTypesMatching = emptySet<String>()
 
-internal val defaultOperationOutputGenerator = object : OperationIdsGenerator {
-
-  override fun generate(operationDescriptorList: Collection<OperationDescriptor>): List<OperationId> {
-    return operationDescriptorList.map {
-      OperationId(it.source.sha256(), it.name)
-    }
+internal val defaultOperationIdsGenerator = OperationIdsGenerator { operationDescriptorList ->
+  operationDescriptorList.map {
+    OperationId(it.source.sha256(), it.name)
   }
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
@@ -21,7 +21,7 @@ import com.apollographql.apollo.compiler.ADD_TYPENAME_ALWAYS
 import com.apollographql.apollo.compiler.ADD_TYPENAME_IF_ABSTRACT
 import com.apollographql.apollo.compiler.ADD_TYPENAME_IF_FRAGMENTS
 import com.apollographql.apollo.compiler.ADD_TYPENAME_IF_POLYMORPHIC
-import com.apollographql.apollo.compiler.OperationsTransform
+import com.apollographql.apollo.compiler.ExecutableDocumentTransform
 
 internal fun addRequiredFields(
     operation: GQLOperationDefinition,
@@ -228,7 +228,7 @@ private fun buildField(name: String): GQLField {
   )
 }
 
-internal class ApolloOperationsTransform(private val addTypename: String) : OperationsTransform {
+internal class ApolloExecutableDocumentTransform(private val addTypename: String) : ExecutableDocumentTransform {
   override fun transform(
       schema: Schema,
       document: GQLDocument,

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
@@ -229,25 +229,25 @@ internal fun String.sha256(): String {
 }
 
 private fun <T> Collection<Node<T>>.sort(): List<Node<T>> {
-  val visited = mutableSetOf<Node<T>>()
+  val visited = mutableListOf<Node<T>>()
   val result = mutableListOf<Node<T>>()
-  val visiting = mutableSetOf<Node<T>>()
 
   fun visit(node: Node<T>) {
-    if (node in visiting) {
-      throw IllegalArgumentException("Apollo: circular dependency detected on transform '${node.id}'")
-    }
-    if (node in visited) {
-      return
-    }
-
-    visiting.add(node)
-    node.dependencies.forEach { visit(it) }
-    visiting.remove(node)
     visited.add(node)
+    node.dependencies.forEach {
+      if (!visited.contains(it)) {
+        visit(it)
+      } else if (!result.contains(it)){
+        throw IllegalArgumentException("Apollo: circular dependency detected on transform '${node.id}': ${visited.map { it.id } + node.id}")
+      }
+    }
     result.add(node)
   }
 
-  forEach { visit(it) }
-  return result.reversed() // Topological sort results in reverse order
+  forEach {
+    if (!visited.contains(it)) {
+      visit(it)
+    }
+  }
+  return result
 }

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CodegenTest.kt
@@ -463,7 +463,7 @@ private fun ApolloCompiler.buildSchemaAndOperationsSourcesAndReturnIrOperations(
       executableFiles = executableFiles,
       upstreamCodegenModels = emptyList(),
       upstreamFragmentDefinitions = emptyList(),
-      operationsTransform = null,
+      executableDocumentTransform = null,
       options = irOptions,
       logger = logger
   )

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/MetadataTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/MetadataTest.kt
@@ -53,7 +53,7 @@ class MetadataTest {
         executableFiles = setOf(rootGraphQLFile(directory)).toInputFiles(),
         upstreamCodegenModels = emptyList(),
         upstreamFragmentDefinitions = emptyList(),
-        operationsTransform = null,
+        executableDocumentTransform = null,
         options = irOptionsFile.toIrOptions(),
         logger = null
     ).writeTo(rootIrOperationsFile)
@@ -63,7 +63,7 @@ class MetadataTest {
         executableFiles = setOf(leafGraphQLFile(directory)).toInputFiles(),
         upstreamCodegenModels = rootIrOperationsFile.toIrOperations().codegenModels.let { listOf(it) },
         upstreamFragmentDefinitions = rootIrOperationsFile.toIrOperations().fragmentDefinitions,
-        operationsTransform = null,
+        executableDocumentTransform = null,
         options = irOptionsFile.toIrOptions(),
         logger = null
     ).writeTo(leafIrOperationsFile)

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/conditionalFragments/ConditionalFragmentsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/conditionalFragments/ConditionalFragmentsTest.kt
@@ -38,7 +38,7 @@ class ConditionalFragmentsTest {
           irOperationsTransform = null,
           javaOutputTransform = null,
           kotlinOutputTransform = null,
-          operationsTransform = null,
+          executableDocumentTransform = null,
           schemaTransform = null
       )
     }
@@ -61,7 +61,7 @@ class ConditionalFragmentsTest {
         irOperationsTransform = null,
         javaOutputTransform = null,
         kotlinOutputTransform = null,
-        operationsTransform = null,
+        executableDocumentTransform = null,
         schemaTransform = null
     )
   }

--- a/tests/compiler-plugins/add-field/src/main/kotlin/hooks/TestPlugin.kt
+++ b/tests/compiler-plugins/add-field/src/main/kotlin/hooks/TestPlugin.kt
@@ -41,7 +41,7 @@ class TestPlugin : ApolloCompilerPlugin {
       environment: ApolloCompilerPluginEnvironment,
       registry: ApolloCompilerRegistry,
   ) {
-    registry.registerOperationsTransform("test"){ schema, document, fragments ->
+    registry.registerExecutableDocumentTransform("test"){ schema, document, fragments ->
          document.copy(
             definitions = document.definitions.map {
               when (it) {

--- a/tests/compiler-plugins/multiple/build.gradle.kts
+++ b/tests/compiler-plugins/multiple/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm")
+}
+
+apolloTest()
+
+dependencies {
+  implementation(libs.apollo.compiler)
+}

--- a/tests/compiler-plugins/multiple/src/main/kotlin/apollocompilerplugin/TestPlugin.kt
+++ b/tests/compiler-plugins/multiple/src/main/kotlin/apollocompilerplugin/TestPlugin.kt
@@ -1,0 +1,50 @@
+package apollocompilerplugin
+
+import com.apollographql.apollo.compiler.After
+import com.apollographql.apollo.compiler.ApolloCompilerPlugin
+import com.apollographql.apollo.compiler.ApolloCompilerPluginEnvironment
+import com.apollographql.apollo.compiler.ApolloCompilerRegistry
+import com.apollographql.apollo.compiler.codegen.kotlin.KotlinOutput
+
+
+val executedTransforms = mutableListOf<String>()
+
+class TestPlugin1 : ApolloCompilerPlugin {
+  override fun beforeCompilationStep(
+      environment: ApolloCompilerPluginEnvironment,
+      registry: ApolloCompilerRegistry,
+  ) {
+    registry.registerKotlinOutputTransform("test1", After("test2")) { input ->
+      executedTransforms.add("test1")
+      input
+    }
+  }
+}
+
+class TestPlugin2: ApolloCompilerPlugin {
+
+  override fun beforeCompilationStep(
+      environment: ApolloCompilerPluginEnvironment,
+      registry: ApolloCompilerRegistry,
+  ) {
+    registry.registerKotlinOutputTransform("test2") { input ->
+      executedTransforms.add("test2")
+      input
+    }
+  }
+}
+
+class TestPlugin3 : ApolloCompilerPlugin {
+
+  override fun beforeCompilationStep(
+      environment: ApolloCompilerPluginEnvironment,
+      registry: ApolloCompilerRegistry,
+  ) {
+    registry.registerKotlinOutputTransform("test3", After("test1")) { input ->
+      executedTransforms.add("test3")
+      check(listOf("test2", "test1", "test3") == executedTransforms.takeLast(3))
+      input
+    }
+  }
+}
+

--- a/tests/compiler-plugins/multiple/src/main/resources/META-INF/services/com.apollographql.apollo.compiler.ApolloCompilerPlugin
+++ b/tests/compiler-plugins/multiple/src/main/resources/META-INF/services/com.apollographql.apollo.compiler.ApolloCompilerPlugin
@@ -1,0 +1,3 @@
+apollocompilerplugin.TestPlugin1
+apollocompilerplugin.TestPlugin2
+apollocompilerplugin.TestPlugin3

--- a/tests/compiler-plugins/schema-codegen/src/main/kotlin/schema/TestPlugin.kt
+++ b/tests/compiler-plugins/schema-codegen/src/main/kotlin/schema/TestPlugin.kt
@@ -36,7 +36,7 @@ class TestPlugin(
         )
     ))
 
-    registry.registerExtraCodeGenerator { schema ->
+    registry.registerExtraCodeGenerator { schema, outputDirectory ->
       val maxAge = schema.definitions.filterIsInstance<GQLTypeDefinition>()
           .first { it.name == "Menu" }
           .directives
@@ -51,16 +51,14 @@ class TestPlugin(
           .let { it as GQLIntValue }
           .value
 
-      if (environment.outputDirectory != null) {
-        FileSpec.builder("hooks.generated", "cache")
-            .addProperty(
-                PropertySpec.builder("menuMaxAge", ClassName("kotlin", "String"))
-                    .initializer("%S", maxAge)
-                    .build()
-            )
-            .build()
-            .writeTo(environment.outputDirectory!!)
-      }
+      FileSpec.builder("hooks.generated", "cache")
+          .addProperty(
+              PropertySpec.builder("menuMaxAge", ClassName("kotlin", "String"))
+                  .initializer("%S", maxAge)
+                  .build()
+          )
+          .build()
+          .writeTo(outputDirectory)
     }
   }
 }

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -24,6 +24,7 @@ listOf(
     "compiler-plugins/prefix-names",
     "compiler-plugins/schema-codegen",
     "compiler-plugins/typename-interface",
+    "compiler-plugins/multiple",
     "data-builders-java",
     "data-builders-kotlin",
     "defer",


### PR DESCRIPTION
Keep compiler plugins in sync with https://github.com/apollographql/apollo-kotlin/pull/6546

* `OperationsTransform` -> `ExecutableDocumentTransform`
* Made `beforeCompilationStep()` default for legacy users
* Only pass `outputDirectory` in `CodgeGenerator`
* Fix sorting of transforms