### PR TITLE
[IJ Plugin] Remove references to GradleExecutionHelper, use Gradle Tooling APIs directly instead

### DIFF
--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/DownloadSchemaAction.kt
@@ -46,8 +46,8 @@ private class DownloadSchemaTask(project: Project) : Task.Backgroundable(
   override fun run(indicator: ProgressIndicator) {
     val gradleProjectPath = project.getGradleRootPath() ?: return
 
-    val rootGradleProject = try {
-      getGradleModel(project, gradleProjectPath, GradleProject::class.java) { it }
+    val rootGradleProject: GradleProject = try {
+      getGradleModel(project, gradleProjectPath) { it }
     } catch (t: Throwable) {
       logw(t, "Couldn't fetch Gradle project model")
       null

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -16,7 +16,6 @@ import com.apollographql.ijplugin.util.newDisposable
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
-import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.progress.ProcessCanceledException
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
@@ -29,9 +28,6 @@ import kotlinx.coroutines.launch
 import org.gradle.tooling.CancellationTokenSource
 import org.gradle.tooling.GradleConnector
 import org.gradle.tooling.model.GradleProject
-import org.jetbrains.plugins.gradle.service.execution.GradleExecutionHelper
-import org.jetbrains.plugins.gradle.settings.GradleExecutionSettings
-import org.jetbrains.plugins.gradle.util.GradleConstants
 import java.io.File
 
 @Service(Service.Level.PROJECT)
@@ -160,24 +156,22 @@ class GradleToolingModelService(
 
     private fun doRun() {
       logd()
-      val rootProjectPath = project.getGradleRootPath() ?: return
-      val gradleExecutionHelper = GradleExecutionHelper()
-      val executionSettings =
-        ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, rootProjectPath, GradleConstants.SYSTEM_ID)
-      val rootGradleProject = gradleExecutionHelper.execute(rootProjectPath, executionSettings) { connection ->
-        gradleCancellation = GradleConnector.newCancellationTokenSource()
-        logd("Fetch Gradle project model")
-        return@execute try {
-          connection.model<GradleProject>(GradleProject::class.java)
-              .setJavaHome(executionSettings.javaHome?.let { File(it) })
-              .withCancellationToken(gradleCancellation!!.token())
-              .get()
-        } catch (t: Throwable) {
-          logw(t, "Couldn't fetch Gradle project model")
-          null
-        } finally {
-          gradleCancellation = null
+      gradleCancellation = GradleConnector.newCancellationTokenSource()
+      logd("Fetch Gradle project model")
+      val gradleProjectPath = project.getGradleRootPath()
+      if (gradleProjectPath == null) {
+        logw("Could not get Gradle root project path")
+        return
+      }
+      val rootGradleProject = try {
+        getGradleModel(project, gradleProjectPath, GradleProject::class.java) {
+          it.withCancellationToken(gradleCancellation!!.token())
         }
+      } catch (t: Throwable) {
+        logw(t, "Couldn't fetch Gradle project model")
+        null
+      } finally {
+        gradleCancellation = null
       } ?: return
       project.telemetryService.gradleModuleCount = rootGradleProject.children.size + 1
 
@@ -189,27 +183,25 @@ class GradleToolingModelService(
 
       val allToolingModels = allApolloGradleProjects.mapIndexedNotNull { index, gradleProject ->
         if (isAbortRequested()) return@doRun
-        gradleExecutionHelper.execute(gradleProject.projectDirectory.canonicalPath, executionSettings) { connection ->
-          gradleCancellation = GradleConnector.newCancellationTokenSource()
-          logd("Fetch tooling model for ${gradleProject.path}")
-          return@execute try {
-            connection.model<ApolloGradleToolingModel>(ApolloGradleToolingModel::class.java)
-                .setJavaHome(executionSettings.javaHome?.let { File(it) })
-                .withCancellationToken(gradleCancellation!!.token())
-                .get()
-                .takeIf {
-                  val isCompatibleVersion = it.versionMajor == ApolloGradleToolingModel.VERSION_MAJOR
-                  if (!isCompatibleVersion) {
-                    logw("Incompatible version of Apollo Gradle plugin in module ${gradleProject.path}: ${it.versionMajor} != ${ApolloGradleToolingModel.VERSION_MAJOR}, ignoring")
-                  }
-                  isCompatibleVersion
-                }
-          } catch (t: Throwable) {
-            logw(t, "Couldn't fetch tooling model for ${gradleProject.path}")
-            null
-          } finally {
-            gradleCancellation = null
+
+        gradleCancellation = GradleConnector.newCancellationTokenSource()
+        logd("Fetch tooling model for ${gradleProject.path}")
+        try {
+          getGradleModel(project, gradleProject.projectDirectory.canonicalPath, ApolloGradleToolingModel::class.java) {
+            it.withCancellationToken(gradleCancellation!!.token())
           }
+              ?.takeIf {
+                val isCompatibleVersion = it.versionMajor == ApolloGradleToolingModel.VERSION_MAJOR
+                if (!isCompatibleVersion) {
+                  logw("Incompatible version of Apollo Gradle plugin in module ${gradleProject.path}: ${it.versionMajor} != ${ApolloGradleToolingModel.VERSION_MAJOR}, ignoring")
+                }
+                isCompatibleVersion
+              }
+        } catch (t: Throwable) {
+          logw(t, "Couldn't fetch tooling model for ${gradleProject.path}")
+          null
+        } finally {
+          gradleCancellation = null
         }
       }
 
@@ -226,7 +218,7 @@ class GradleToolingModelService(
       }
       try {
         ProgressManager.checkCanceled()
-      } catch (e: ProcessCanceledException) {
+      } catch (@Suppress("IncorrectCancellationExceptionHandling") _: ProcessCanceledException) {
         logd("Canceled by user")
         return true
       }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleToolingModelService.kt
@@ -163,8 +163,8 @@ class GradleToolingModelService(
         logw("Could not get Gradle root project path")
         return
       }
-      val rootGradleProject = try {
-        getGradleModel(project, gradleProjectPath, GradleProject::class.java) {
+      val rootGradleProject: GradleProject = try {
+        getGradleModel(project, gradleProjectPath) {
           it.withCancellationToken(gradleCancellation!!.token())
         }
       } catch (t: Throwable) {
@@ -187,7 +187,7 @@ class GradleToolingModelService(
         gradleCancellation = GradleConnector.newCancellationTokenSource()
         logd("Fetch tooling model for ${gradleProject.path}")
         try {
-          getGradleModel(project, gradleProject.projectDirectory.canonicalPath, ApolloGradleToolingModel::class.java) {
+          getGradleModel<ApolloGradleToolingModel>(project, gradleProject.projectDirectory.canonicalPath ) {
             it.withCancellationToken(gradleCancellation!!.token())
           }
               ?.takeIf {

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
@@ -31,9 +31,11 @@ fun runGradleBuild(
     gradleProjectPath: String,
     configureBuildLauncher: (BuildLauncher) -> BuildLauncher,
 ) {
-  val executionSettings =
-    ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, gradleProjectPath, GradleConstants.SYSTEM_ID)
-
+  val executionSettings = ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(
+      project,
+      gradleProjectPath,
+      GradleConstants.SYSTEM_ID
+  )
   val connection = GradleConnector.newConnector()
       .forProjectDirectory(File(gradleProjectPath))
       .connect()
@@ -53,18 +55,20 @@ inline fun <reified T> getGradleModel(
     gradleProjectPath: String,
     configureModelBuilder: (ModelBuilder<T>) -> ModelBuilder<T>,
 ): T? {
-  val executionSettings =
-    ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, gradleProjectPath, GradleConstants.SYSTEM_ID)
-
+  val executionSettings = ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(
+      project,
+      gradleProjectPath,
+      GradleConstants.SYSTEM_ID
+  )
   val connection = GradleConnector.newConnector()
       .forProjectDirectory(File(gradleProjectPath))
       .connect()
-  val buildLauncher = configureModelBuilder(
+  val modelBuilder = configureModelBuilder(
       connection.model(T::class.java)
           .setJavaHome(executionSettings.javaHome?.let { File(it) })
   )
   try {
-    return buildLauncher.get()
+    return modelBuilder.get()
   } finally {
     connection.close()
   }

--- a/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
+++ b/intellij-plugin/src/main/kotlin/com/apollographql/ijplugin/gradle/GradleUtil.kt
@@ -26,7 +26,11 @@ fun GradleProject.allChildrenRecursively(): List<GradleProject> {
   return listOf(this) + children.flatMap { it.allChildrenRecursively() }
 }
 
-fun runGradleBuild(project: Project, gradleProjectPath: String, configureBuildLauncher: (BuildLauncher) -> BuildLauncher) {
+fun runGradleBuild(
+    project: Project,
+    gradleProjectPath: String,
+    configureBuildLauncher: (BuildLauncher) -> BuildLauncher,
+) {
   val executionSettings =
     ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, gradleProjectPath, GradleConstants.SYSTEM_ID)
 
@@ -44,7 +48,11 @@ fun runGradleBuild(project: Project, gradleProjectPath: String, configureBuildLa
   }
 }
 
-fun <T> getGradleModel(project: Project, gradleProjectPath: String, modelClass: Class<T>, configureModelBuilder: (ModelBuilder<T>) -> ModelBuilder<T>): T? {
+inline fun <reified T> getGradleModel(
+    project: Project,
+    gradleProjectPath: String,
+    configureModelBuilder: (ModelBuilder<T>) -> ModelBuilder<T>,
+): T? {
   val executionSettings =
     ExternalSystemApiUtil.getExecutionSettings<GradleExecutionSettings>(project, gradleProjectPath, GradleConstants.SYSTEM_ID)
 
@@ -52,7 +60,7 @@ fun <T> getGradleModel(project: Project, gradleProjectPath: String, modelClass: 
       .forProjectDirectory(File(gradleProjectPath))
       .connect()
   val buildLauncher = configureModelBuilder(
-      connection.model(modelClass)
+      connection.model(T::class.java)
           .setJavaHome(executionSettings.javaHome?.let { File(it) })
   )
   try {


### PR DESCRIPTION
As it as been [marked internal](https://github.com/JetBrains/intellij-community/commit/97f9e72472e2528f3231c2373f99e5361de4ae56) which makes the plugin verifier unhappy