### PR TITLE
[spec] Implement schema coordinates

### DIFF
--- a/libraries/apollo-ast/api/apollo-ast.api
+++ b/libraries/apollo-ast/api/apollo-ast.api
@@ -16,6 +16,8 @@ public final class com/apollographql/apollo/ast/ApolloParser {
 	public static synthetic fun parseAsGQLDocument$default (Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLResult;
 	public static synthetic fun parseAsGQLDocument$default (Lokio/BufferedSource;Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLResult;
 	public static synthetic fun parseAsGQLDocument$default (Lokio/Path;Lcom/apollographql/apollo/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLResult;
+	public static final fun parseAsGQLSchemaCoordinate (Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;)Lcom/apollographql/apollo/ast/GQLResult;
+	public static synthetic fun parseAsGQLSchemaCoordinate$default (Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLResult;
 	public static final fun parseAsGQLSelections (Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;)Lcom/apollographql/apollo/ast/GQLResult;
 	public static final fun parseAsGQLSelections (Lokio/BufferedSource;Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;)Lcom/apollographql/apollo/ast/GQLResult;
 	public static synthetic fun parseAsGQLSelections$default (Ljava/lang/String;Lcom/apollographql/apollo/ast/ParserOptions;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLResult;
@@ -143,6 +145,19 @@ public final class com/apollographql/apollo/ast/GQLArgument : com/apollographql/
 	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
 }
 
+public final class com/apollographql/apollo/ast/GQLArgumentCoordinate : com/apollographql/apollo/ast/GQLNode, com/apollographql/apollo/ast/GQLSchemaCoordinate {
+	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo/ast/GQLArgumentCoordinate;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/ast/GQLArgumentCoordinate;Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLArgumentCoordinate;
+	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo/ast/NodeContainer;)Lcom/apollographql/apollo/ast/GQLNode;
+	public final fun getArgument ()Ljava/lang/String;
+	public fun getChildren ()Ljava/util/List;
+	public final fun getField ()Ljava/lang/String;
+	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+	public final fun getType ()Ljava/lang/String;
+	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
+}
+
 public final class com/apollographql/apollo/ast/GQLArguments : com/apollographql/apollo/ast/GQLNode {
 	public fun <init> (Ljava/util/List;Lcom/apollographql/apollo/ast/SourceLocation;)V
 	public synthetic fun <init> (Ljava/util/List;Lcom/apollographql/apollo/ast/SourceLocation;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -183,6 +198,29 @@ public final class com/apollographql/apollo/ast/GQLDirective : com/apollographql
 	public final fun getArguments ()Ljava/util/List;
 	public fun getChildren ()Ljava/util/List;
 	public fun getName ()Ljava/lang/String;
+	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
+}
+
+public final class com/apollographql/apollo/ast/GQLDirectiveArgumentCoordinate : com/apollographql/apollo/ast/GQLNode, com/apollographql/apollo/ast/GQLSchemaCoordinate {
+	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo/ast/GQLDirectiveArgumentCoordinate;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/ast/GQLDirectiveArgumentCoordinate;Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLDirectiveArgumentCoordinate;
+	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo/ast/NodeContainer;)Lcom/apollographql/apollo/ast/GQLNode;
+	public final fun getArgument ()Ljava/lang/String;
+	public fun getChildren ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
+}
+
+public final class com/apollographql/apollo/ast/GQLDirectiveCoordinate : com/apollographql/apollo/ast/GQLNode, com/apollographql/apollo/ast/GQLSchemaCoordinate {
+	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;)V
+	public final fun copy (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;)Lcom/apollographql/apollo/ast/GQLDirectiveCoordinate;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/ast/GQLDirectiveCoordinate;Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLDirectiveCoordinate;
+	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo/ast/NodeContainer;)Lcom/apollographql/apollo/ast/GQLNode;
+	public fun getChildren ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
 	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
 	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
 }
@@ -514,6 +552,18 @@ public final class com/apollographql/apollo/ast/GQLListValue : com/apollographql
 	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
 }
 
+public final class com/apollographql/apollo/ast/GQLMemberCoordinate : com/apollographql/apollo/ast/GQLNode, com/apollographql/apollo/ast/GQLSchemaCoordinate {
+	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun copy (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;)Lcom/apollographql/apollo/ast/GQLMemberCoordinate;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/ast/GQLMemberCoordinate;Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLMemberCoordinate;
+	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo/ast/NodeContainer;)Lcom/apollographql/apollo/ast/GQLNode;
+	public fun getChildren ()Ljava/util/List;
+	public final fun getMember ()Ljava/lang/String;
+	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+	public final fun getType ()Ljava/lang/String;
+	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
+}
+
 public abstract interface class com/apollographql/apollo/ast/GQLNamed {
 	public abstract fun getName ()Ljava/lang/String;
 }
@@ -683,6 +733,9 @@ public final class com/apollographql/apollo/ast/GQLScalarTypeExtension : com/apo
 	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
 }
 
+public abstract interface class com/apollographql/apollo/ast/GQLSchemaCoordinate {
+}
+
 public final class com/apollographql/apollo/ast/GQLSchemaDefinition : com/apollographql/apollo/ast/GQLDefinition, com/apollographql/apollo/ast/GQLDescribed, com/apollographql/apollo/ast/GQLHasDirectives {
 	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -738,6 +791,17 @@ public final class com/apollographql/apollo/ast/GQLStringValue : com/apollograph
 }
 
 public abstract class com/apollographql/apollo/ast/GQLType : com/apollographql/apollo/ast/GQLNode {
+}
+
+public final class com/apollographql/apollo/ast/GQLTypeCoordinate : com/apollographql/apollo/ast/GQLNode, com/apollographql/apollo/ast/GQLSchemaCoordinate {
+	public fun <init> (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;)V
+	public final fun copy (Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;)Lcom/apollographql/apollo/ast/GQLTypeCoordinate;
+	public static synthetic fun copy$default (Lcom/apollographql/apollo/ast/GQLTypeCoordinate;Lcom/apollographql/apollo/ast/SourceLocation;Ljava/lang/String;ILjava/lang/Object;)Lcom/apollographql/apollo/ast/GQLTypeCoordinate;
+	public fun copyWithNewChildrenInternal (Lcom/apollographql/apollo/ast/NodeContainer;)Lcom/apollographql/apollo/ast/GQLNode;
+	public fun getChildren ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+	public fun writeInternal (Lcom/apollographql/apollo/ast/SDLWriter;)V
 }
 
 public abstract class com/apollographql/apollo/ast/GQLTypeDefinition : com/apollographql/apollo/ast/GQLDefinition, com/apollographql/apollo/ast/GQLDescribed, com/apollographql/apollo/ast/GQLHasDirectives, com/apollographql/apollo/ast/GQLNamed {
@@ -816,6 +880,11 @@ public final class com/apollographql/apollo/ast/GQLVariableValue : com/apollogra
 
 public final class com/apollographql/apollo/ast/GqlKt {
 	public static final fun transform (Lcom/apollographql/apollo/ast/GQLNode;Lcom/apollographql/apollo/ast/NodeTransformer;)Lcom/apollographql/apollo/ast/GQLNode;
+}
+
+public final class com/apollographql/apollo/ast/GqlcoordinateKt {
+	public static final fun resolveSchemaCoordinate (Lcom/apollographql/apollo/ast/Schema;Lcom/apollographql/apollo/ast/GQLSchemaCoordinate;)Lcom/apollographql/apollo/ast/ResolvedSchemaElement;
+	public static final fun resolveSchemaCoordinate (Lcom/apollographql/apollo/ast/Schema;Ljava/lang/String;)Lcom/apollographql/apollo/ast/ResolvedSchemaElement;
 }
 
 public final class com/apollographql/apollo/ast/GqldirectiveKt {
@@ -1029,6 +1098,44 @@ public final class com/apollographql/apollo/ast/ReservedEnumValueName : com/apol
 	public fun <init> (Ljava/lang/String;Lcom/apollographql/apollo/ast/SourceLocation;)V
 	public fun getMessage ()Ljava/lang/String;
 	public fun getSourceLocation ()Lcom/apollographql/apollo/ast/SourceLocation;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedDirective : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLDirectiveDefinition;)V
+	public final fun getDirectiveDefinition ()Lcom/apollographql/apollo/ast/GQLDirectiveDefinition;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedDirectiveArgument : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLInputValueDefinition;)V
+	public final fun getArgument ()Lcom/apollographql/apollo/ast/GQLInputValueDefinition;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedEnumValue : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLEnumValueDefinition;)V
+	public final fun getEnumValue ()Lcom/apollographql/apollo/ast/GQLEnumValueDefinition;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedField : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLFieldDefinition;)V
+	public final fun getFieldDefinition ()Lcom/apollographql/apollo/ast/GQLFieldDefinition;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedFieldArgument : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLInputValueDefinition;)V
+	public final fun getArgument ()Lcom/apollographql/apollo/ast/GQLInputValueDefinition;
+}
+
+public final class com/apollographql/apollo/ast/ResolvedInputField : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLInputValueDefinition;)V
+	public final fun getInputField ()Lcom/apollographql/apollo/ast/GQLInputValueDefinition;
+}
+
+public abstract interface class com/apollographql/apollo/ast/ResolvedSchemaElement {
+}
+
+public final class com/apollographql/apollo/ast/ResolvedType : com/apollographql/apollo/ast/ResolvedSchemaElement {
+	public fun <init> (Lcom/apollographql/apollo/ast/GQLTypeDefinition;)V
+	public final fun getTypeDefinition ()Lcom/apollographql/apollo/ast/GQLTypeDefinition;
 }
 
 public class com/apollographql/apollo/ast/SDLWriter : java/io/Closeable {

--- a/libraries/apollo-ast/api/apollo-ast.klib.api
+++ b/libraries/apollo-ast/api/apollo-ast.klib.api
@@ -83,6 +83,8 @@ sealed interface com.apollographql.apollo.ast/GQLNode { // com.apollographql.apo
     abstract fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLNode.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
 }
 
+sealed interface com.apollographql.apollo.ast/GQLSchemaCoordinate // com.apollographql.apollo.ast/GQLSchemaCoordinate|null[0]
+
 sealed interface com.apollographql.apollo.ast/GQLTypeExtension : com.apollographql.apollo.ast/GQLNamed, com.apollographql.apollo.ast/GQLTypeSystemExtension // com.apollographql.apollo.ast/GQLTypeExtension|null[0]
 
 sealed interface com.apollographql.apollo.ast/GQLTypeSystemExtension : com.apollographql.apollo.ast/GQLDefinition // com.apollographql.apollo.ast/GQLTypeSystemExtension|null[0]
@@ -97,6 +99,8 @@ sealed interface com.apollographql.apollo.ast/Issue { // com.apollographql.apoll
     abstract val sourceLocation // com.apollographql.apollo.ast/Issue.sourceLocation|{}sourceLocation[0]
         abstract fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/Issue.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
 }
+
+sealed interface com.apollographql.apollo.ast/ResolvedSchemaElement // com.apollographql.apollo.ast/ResolvedSchemaElement|null[0]
 
 sealed interface com.apollographql.apollo.ast/TransformResult { // com.apollographql.apollo.ast/TransformResult|null[0]
     final class Replace : com.apollographql.apollo.ast/TransformResult { // com.apollographql.apollo.ast/TransformResult.Replace|null[0]
@@ -260,6 +264,25 @@ final class com.apollographql.apollo.ast/GQLArgument : com.apollographql.apollo.
     final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLArgument.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
 }
 
+final class com.apollographql.apollo.ast/GQLArgumentCoordinate : com.apollographql.apollo.ast/GQLNode, com.apollographql.apollo.ast/GQLSchemaCoordinate { // com.apollographql.apollo.ast/GQLArgumentCoordinate|null[0]
+    constructor <init>(com.apollographql.apollo.ast/SourceLocation?, kotlin/String, kotlin/String, kotlin/String) // com.apollographql.apollo.ast/GQLArgumentCoordinate.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String;kotlin.String){}[0]
+
+    final val argument // com.apollographql.apollo.ast/GQLArgumentCoordinate.argument|{}argument[0]
+        final fun <get-argument>(): kotlin/String // com.apollographql.apollo.ast/GQLArgumentCoordinate.argument.<get-argument>|<get-argument>(){}[0]
+    final val children // com.apollographql.apollo.ast/GQLArgumentCoordinate.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLNode> // com.apollographql.apollo.ast/GQLArgumentCoordinate.children.<get-children>|<get-children>(){}[0]
+    final val field // com.apollographql.apollo.ast/GQLArgumentCoordinate.field|{}field[0]
+        final fun <get-field>(): kotlin/String // com.apollographql.apollo.ast/GQLArgumentCoordinate.field.<get-field>|<get-field>(){}[0]
+    final val sourceLocation // com.apollographql.apollo.ast/GQLArgumentCoordinate.sourceLocation|{}sourceLocation[0]
+        final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/GQLArgumentCoordinate.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+    final val type // com.apollographql.apollo.ast/GQLArgumentCoordinate.type|{}type[0]
+        final fun <get-type>(): kotlin/String // com.apollographql.apollo.ast/GQLArgumentCoordinate.type.<get-type>|<get-type>(){}[0]
+
+    final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ..., kotlin/String = ..., kotlin/String = ...): com.apollographql.apollo.ast/GQLArgumentCoordinate // com.apollographql.apollo.ast/GQLArgumentCoordinate.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String;kotlin.String){}[0]
+    final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLArgumentCoordinate.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
+    final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLArgumentCoordinate.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
+}
+
 final class com.apollographql.apollo.ast/GQLArguments : com.apollographql.apollo.ast/GQLNode { // com.apollographql.apollo.ast/GQLArguments|null[0]
     constructor <init>(kotlin.collections/List<com.apollographql.apollo.ast/GQLArgument>, com.apollographql.apollo.ast/SourceLocation? = ...) // com.apollographql.apollo.ast/GQLArguments.<init>|<init>(kotlin.collections.List<com.apollographql.apollo.ast.GQLArgument>;com.apollographql.apollo.ast.SourceLocation?){}[0]
 
@@ -305,6 +328,38 @@ final class com.apollographql.apollo.ast/GQLDirective : com.apollographql.apollo
     final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ..., kotlin.collections/List<com.apollographql.apollo.ast/GQLArgument> = ...): com.apollographql.apollo.ast/GQLDirective // com.apollographql.apollo.ast/GQLDirective.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.collections.List<com.apollographql.apollo.ast.GQLArgument>){}[0]
     final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLDirective.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
     final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLDirective.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
+}
+
+final class com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate : com.apollographql.apollo.ast/GQLNode, com.apollographql.apollo.ast/GQLSchemaCoordinate { // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate|null[0]
+    constructor <init>(com.apollographql.apollo.ast/SourceLocation?, kotlin/String, kotlin/String) // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String){}[0]
+
+    final val argument // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.argument|{}argument[0]
+        final fun <get-argument>(): kotlin/String // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.argument.<get-argument>|<get-argument>(){}[0]
+    final val children // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLNode> // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.children.<get-children>|<get-children>(){}[0]
+    final val name // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.name.<get-name>|<get-name>(){}[0]
+    final val sourceLocation // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.sourceLocation|{}sourceLocation[0]
+        final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+
+    final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ..., kotlin/String = ...): com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String){}[0]
+    final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
+    final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLDirectiveArgumentCoordinate.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
+}
+
+final class com.apollographql.apollo.ast/GQLDirectiveCoordinate : com.apollographql.apollo.ast/GQLNode, com.apollographql.apollo.ast/GQLSchemaCoordinate { // com.apollographql.apollo.ast/GQLDirectiveCoordinate|null[0]
+    constructor <init>(com.apollographql.apollo.ast/SourceLocation?, kotlin/String) // com.apollographql.apollo.ast/GQLDirectiveCoordinate.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String){}[0]
+
+    final val children // com.apollographql.apollo.ast/GQLDirectiveCoordinate.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLNode> // com.apollographql.apollo.ast/GQLDirectiveCoordinate.children.<get-children>|<get-children>(){}[0]
+    final val name // com.apollographql.apollo.ast/GQLDirectiveCoordinate.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.apollographql.apollo.ast/GQLDirectiveCoordinate.name.<get-name>|<get-name>(){}[0]
+    final val sourceLocation // com.apollographql.apollo.ast/GQLDirectiveCoordinate.sourceLocation|{}sourceLocation[0]
+        final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/GQLDirectiveCoordinate.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+
+    final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ...): com.apollographql.apollo.ast/GQLDirectiveCoordinate // com.apollographql.apollo.ast/GQLDirectiveCoordinate.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String){}[0]
+    final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLDirectiveCoordinate.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
+    final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLDirectiveCoordinate.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
 }
 
 final class com.apollographql.apollo.ast/GQLDirectiveDefinition : com.apollographql.apollo.ast/GQLDefinition, com.apollographql.apollo.ast/GQLDescribed, com.apollographql.apollo.ast/GQLNamed { // com.apollographql.apollo.ast/GQLDirectiveDefinition|null[0]
@@ -706,6 +761,23 @@ final class com.apollographql.apollo.ast/GQLListValue : com.apollographql.apollo
     final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLListValue.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
 }
 
+final class com.apollographql.apollo.ast/GQLMemberCoordinate : com.apollographql.apollo.ast/GQLNode, com.apollographql.apollo.ast/GQLSchemaCoordinate { // com.apollographql.apollo.ast/GQLMemberCoordinate|null[0]
+    constructor <init>(com.apollographql.apollo.ast/SourceLocation?, kotlin/String, kotlin/String) // com.apollographql.apollo.ast/GQLMemberCoordinate.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String){}[0]
+
+    final val children // com.apollographql.apollo.ast/GQLMemberCoordinate.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLNode> // com.apollographql.apollo.ast/GQLMemberCoordinate.children.<get-children>|<get-children>(){}[0]
+    final val member // com.apollographql.apollo.ast/GQLMemberCoordinate.member|{}member[0]
+        final fun <get-member>(): kotlin/String // com.apollographql.apollo.ast/GQLMemberCoordinate.member.<get-member>|<get-member>(){}[0]
+    final val sourceLocation // com.apollographql.apollo.ast/GQLMemberCoordinate.sourceLocation|{}sourceLocation[0]
+        final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/GQLMemberCoordinate.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+    final val type // com.apollographql.apollo.ast/GQLMemberCoordinate.type|{}type[0]
+        final fun <get-type>(): kotlin/String // com.apollographql.apollo.ast/GQLMemberCoordinate.type.<get-type>|<get-type>(){}[0]
+
+    final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ..., kotlin/String = ...): com.apollographql.apollo.ast/GQLMemberCoordinate // com.apollographql.apollo.ast/GQLMemberCoordinate.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String;kotlin.String){}[0]
+    final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLMemberCoordinate.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
+    final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLMemberCoordinate.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
+}
+
 final class com.apollographql.apollo.ast/GQLNamedType : com.apollographql.apollo.ast/GQLNamed, com.apollographql.apollo.ast/GQLType { // com.apollographql.apollo.ast/GQLNamedType|null[0]
     constructor <init>(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String) // com.apollographql.apollo.ast/GQLNamedType.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String){}[0]
 
@@ -971,6 +1043,21 @@ final class com.apollographql.apollo.ast/GQLStringValue : com.apollographql.apol
     final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLStringValue.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
 }
 
+final class com.apollographql.apollo.ast/GQLTypeCoordinate : com.apollographql.apollo.ast/GQLNode, com.apollographql.apollo.ast/GQLSchemaCoordinate { // com.apollographql.apollo.ast/GQLTypeCoordinate|null[0]
+    constructor <init>(com.apollographql.apollo.ast/SourceLocation?, kotlin/String) // com.apollographql.apollo.ast/GQLTypeCoordinate.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String){}[0]
+
+    final val children // com.apollographql.apollo.ast/GQLTypeCoordinate.children|{}children[0]
+        final fun <get-children>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLNode> // com.apollographql.apollo.ast/GQLTypeCoordinate.children.<get-children>|<get-children>(){}[0]
+    final val name // com.apollographql.apollo.ast/GQLTypeCoordinate.name|{}name[0]
+        final fun <get-name>(): kotlin/String // com.apollographql.apollo.ast/GQLTypeCoordinate.name.<get-name>|<get-name>(){}[0]
+    final val sourceLocation // com.apollographql.apollo.ast/GQLTypeCoordinate.sourceLocation|{}sourceLocation[0]
+        final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/GQLTypeCoordinate.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+
+    final fun copy(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String = ...): com.apollographql.apollo.ast/GQLTypeCoordinate // com.apollographql.apollo.ast/GQLTypeCoordinate.copy|copy(com.apollographql.apollo.ast.SourceLocation?;kotlin.String){}[0]
+    final fun copyWithNewChildrenInternal(com.apollographql.apollo.ast/NodeContainer): com.apollographql.apollo.ast/GQLNode // com.apollographql.apollo.ast/GQLTypeCoordinate.copyWithNewChildrenInternal|copyWithNewChildrenInternal(com.apollographql.apollo.ast.NodeContainer){}[0]
+    final fun writeInternal(com.apollographql.apollo.ast/SDLWriter) // com.apollographql.apollo.ast/GQLTypeCoordinate.writeInternal|writeInternal(com.apollographql.apollo.ast.SDLWriter){}[0]
+}
+
 final class com.apollographql.apollo.ast/GQLUnionTypeDefinition : com.apollographql.apollo.ast/GQLTypeDefinition { // com.apollographql.apollo.ast/GQLUnionTypeDefinition|null[0]
     constructor <init>(com.apollographql.apollo.ast/SourceLocation? = ..., kotlin/String?, kotlin/String, kotlin.collections/List<com.apollographql.apollo.ast/GQLDirective>, kotlin.collections/List<com.apollographql.apollo.ast/GQLNamedType>) // com.apollographql.apollo.ast/GQLUnionTypeDefinition.<init>|<init>(com.apollographql.apollo.ast.SourceLocation?;kotlin.String?;kotlin.String;kotlin.collections.List<com.apollographql.apollo.ast.GQLDirective>;kotlin.collections.List<com.apollographql.apollo.ast.GQLNamedType>){}[0]
 
@@ -1188,6 +1275,55 @@ final class com.apollographql.apollo.ast/ReservedEnumValueName : com.apollograph
         final fun <get-message>(): kotlin/String // com.apollographql.apollo.ast/ReservedEnumValueName.message.<get-message>|<get-message>(){}[0]
     final val sourceLocation // com.apollographql.apollo.ast/ReservedEnumValueName.sourceLocation|{}sourceLocation[0]
         final fun <get-sourceLocation>(): com.apollographql.apollo.ast/SourceLocation? // com.apollographql.apollo.ast/ReservedEnumValueName.sourceLocation.<get-sourceLocation>|<get-sourceLocation>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedDirective : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedDirective|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLDirectiveDefinition) // com.apollographql.apollo.ast/ResolvedDirective.<init>|<init>(com.apollographql.apollo.ast.GQLDirectiveDefinition){}[0]
+
+    final val directiveDefinition // com.apollographql.apollo.ast/ResolvedDirective.directiveDefinition|{}directiveDefinition[0]
+        final fun <get-directiveDefinition>(): com.apollographql.apollo.ast/GQLDirectiveDefinition // com.apollographql.apollo.ast/ResolvedDirective.directiveDefinition.<get-directiveDefinition>|<get-directiveDefinition>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedDirectiveArgument : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedDirectiveArgument|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLInputValueDefinition) // com.apollographql.apollo.ast/ResolvedDirectiveArgument.<init>|<init>(com.apollographql.apollo.ast.GQLInputValueDefinition){}[0]
+
+    final val argument // com.apollographql.apollo.ast/ResolvedDirectiveArgument.argument|{}argument[0]
+        final fun <get-argument>(): com.apollographql.apollo.ast/GQLInputValueDefinition // com.apollographql.apollo.ast/ResolvedDirectiveArgument.argument.<get-argument>|<get-argument>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedEnumValue : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedEnumValue|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLEnumValueDefinition) // com.apollographql.apollo.ast/ResolvedEnumValue.<init>|<init>(com.apollographql.apollo.ast.GQLEnumValueDefinition){}[0]
+
+    final val enumValue // com.apollographql.apollo.ast/ResolvedEnumValue.enumValue|{}enumValue[0]
+        final fun <get-enumValue>(): com.apollographql.apollo.ast/GQLEnumValueDefinition // com.apollographql.apollo.ast/ResolvedEnumValue.enumValue.<get-enumValue>|<get-enumValue>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedField : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedField|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLFieldDefinition) // com.apollographql.apollo.ast/ResolvedField.<init>|<init>(com.apollographql.apollo.ast.GQLFieldDefinition){}[0]
+
+    final val fieldDefinition // com.apollographql.apollo.ast/ResolvedField.fieldDefinition|{}fieldDefinition[0]
+        final fun <get-fieldDefinition>(): com.apollographql.apollo.ast/GQLFieldDefinition // com.apollographql.apollo.ast/ResolvedField.fieldDefinition.<get-fieldDefinition>|<get-fieldDefinition>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedFieldArgument : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedFieldArgument|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLInputValueDefinition) // com.apollographql.apollo.ast/ResolvedFieldArgument.<init>|<init>(com.apollographql.apollo.ast.GQLInputValueDefinition){}[0]
+
+    final val argument // com.apollographql.apollo.ast/ResolvedFieldArgument.argument|{}argument[0]
+        final fun <get-argument>(): com.apollographql.apollo.ast/GQLInputValueDefinition // com.apollographql.apollo.ast/ResolvedFieldArgument.argument.<get-argument>|<get-argument>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedInputField : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedInputField|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLInputValueDefinition) // com.apollographql.apollo.ast/ResolvedInputField.<init>|<init>(com.apollographql.apollo.ast.GQLInputValueDefinition){}[0]
+
+    final val inputField // com.apollographql.apollo.ast/ResolvedInputField.inputField|{}inputField[0]
+        final fun <get-inputField>(): com.apollographql.apollo.ast/GQLInputValueDefinition // com.apollographql.apollo.ast/ResolvedInputField.inputField.<get-inputField>|<get-inputField>(){}[0]
+}
+
+final class com.apollographql.apollo.ast/ResolvedType : com.apollographql.apollo.ast/ResolvedSchemaElement { // com.apollographql.apollo.ast/ResolvedType|null[0]
+    constructor <init>(com.apollographql.apollo.ast/GQLTypeDefinition) // com.apollographql.apollo.ast/ResolvedType.<init>|<init>(com.apollographql.apollo.ast.GQLTypeDefinition){}[0]
+
+    final val typeDefinition // com.apollographql.apollo.ast/ResolvedType.typeDefinition|{}typeDefinition[0]
+        final fun <get-typeDefinition>(): com.apollographql.apollo.ast/GQLTypeDefinition // com.apollographql.apollo.ast/ResolvedType.typeDefinition.<get-typeDefinition>|<get-typeDefinition>(){}[0]
 }
 
 final class com.apollographql.apollo.ast/Schema { // com.apollographql.apollo.ast/Schema|null[0]
@@ -1462,6 +1598,7 @@ final fun (kotlin/String).com.apollographql.apollo.ast/decodeAsGraphQLTripleQuot
 final fun (kotlin/String).com.apollographql.apollo.ast/encodeToGraphQLSingleQuoted(): kotlin/String // com.apollographql.apollo.ast/encodeToGraphQLSingleQuoted|encodeToGraphQLSingleQuoted@kotlin.String(){}[0]
 final fun (kotlin/String).com.apollographql.apollo.ast/encodeToGraphQLTripleQuoted(): kotlin/String // com.apollographql.apollo.ast/encodeToGraphQLTripleQuoted|encodeToGraphQLTripleQuoted@kotlin.String(){}[0]
 final fun (kotlin/String).com.apollographql.apollo.ast/parseAsGQLDocument(com.apollographql.apollo.ast/ParserOptions = ...): com.apollographql.apollo.ast/GQLResult<com.apollographql.apollo.ast/GQLDocument> // com.apollographql.apollo.ast/parseAsGQLDocument|parseAsGQLDocument@kotlin.String(com.apollographql.apollo.ast.ParserOptions){}[0]
+final fun (kotlin/String).com.apollographql.apollo.ast/parseAsGQLSchemaCoordinate(com.apollographql.apollo.ast/ParserOptions = ...): com.apollographql.apollo.ast/GQLResult<com.apollographql.apollo.ast/GQLSchemaCoordinate> // com.apollographql.apollo.ast/parseAsGQLSchemaCoordinate|parseAsGQLSchemaCoordinate@kotlin.String(com.apollographql.apollo.ast.ParserOptions){}[0]
 final fun (kotlin/String).com.apollographql.apollo.ast/parseAsGQLSelections(com.apollographql.apollo.ast/ParserOptions = ...): com.apollographql.apollo.ast/GQLResult<kotlin.collections/List<com.apollographql.apollo.ast/GQLSelection>> // com.apollographql.apollo.ast/parseAsGQLSelections|parseAsGQLSelections@kotlin.String(com.apollographql.apollo.ast.ParserOptions){}[0]
 final fun (kotlin/String).com.apollographql.apollo.ast/parseAsGQLType(com.apollographql.apollo.ast/ParserOptions = ...): com.apollographql.apollo.ast/GQLResult<com.apollographql.apollo.ast/GQLType> // com.apollographql.apollo.ast/parseAsGQLType|parseAsGQLType@kotlin.String(com.apollographql.apollo.ast.ParserOptions){}[0]
 final fun (kotlin/String).com.apollographql.apollo.ast/parseAsGQLValue(com.apollographql.apollo.ast/ParserOptions = ...): com.apollographql.apollo.ast/GQLResult<com.apollographql.apollo.ast/GQLValue> // com.apollographql.apollo.ast/parseAsGQLValue|parseAsGQLValue@kotlin.String(com.apollographql.apollo.ast.ParserOptions){}[0]
@@ -1483,3 +1620,5 @@ final fun com.apollographql.apollo.ast/builtinForeignSchemas(): kotlin.collectio
 final fun com.apollographql.apollo.ast/kotlinLabsDefinitions(kotlin/String): kotlin.collections/List<com.apollographql.apollo.ast/GQLDefinition> // com.apollographql.apollo.ast/kotlinLabsDefinitions|kotlinLabsDefinitions(kotlin.String){}[0]
 final fun com.apollographql.apollo.ast/linkDefinitions(): kotlin.collections/List<com.apollographql.apollo.ast/GQLDefinition> // com.apollographql.apollo.ast/linkDefinitions|linkDefinitions(){}[0]
 final fun com.apollographql.apollo.ast/nullabilityDefinitions(kotlin/String): kotlin.collections/List<com.apollographql.apollo.ast/GQLDefinition> // com.apollographql.apollo.ast/nullabilityDefinitions|nullabilityDefinitions(kotlin.String){}[0]
+final fun com.apollographql.apollo.ast/resolveSchemaCoordinate(com.apollographql.apollo.ast/Schema, com.apollographql.apollo.ast/GQLSchemaCoordinate): com.apollographql.apollo.ast/ResolvedSchemaElement? // com.apollographql.apollo.ast/resolveSchemaCoordinate|resolveSchemaCoordinate(com.apollographql.apollo.ast.Schema;com.apollographql.apollo.ast.GQLSchemaCoordinate){}[0]
+final fun com.apollographql.apollo.ast/resolveSchemaCoordinate(com.apollographql.apollo.ast/Schema, kotlin/String): com.apollographql.apollo.ast/ResolvedSchemaElement? // com.apollographql.apollo.ast/resolveSchemaCoordinate|resolveSchemaCoordinate(com.apollographql.apollo.ast.Schema;kotlin.String){}[0]

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/api.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/api.kt
@@ -114,6 +114,11 @@ fun String.parseAsGQLValue(options: ParserOptions = ParserOptions.Default): GQLR
   return parseInternal(null, options) { parseValue() }
 }
 
+@ApolloExperimental
+fun String.parseAsGQLSchemaCoordinate(options: ParserOptions = ParserOptions.Default): GQLResult<GQLSchemaCoordinate> {
+  return parseInternal(null, options) { parseSchemaCoordinate() }
+}
+
 fun String.toGQLValue(options: ParserOptions = ParserOptions.Default): GQLValue {
   return parseAsGQLValue(options).getOrThrow()
 }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gql.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gql.kt
@@ -2026,6 +2026,155 @@ enum class GQLDirectiveLocation {
   INPUT_FIELD_DEFINITION,
 }
 
+sealed interface GQLSchemaCoordinate
+
+class GQLTypeCoordinate(
+    override val sourceLocation: SourceLocation?,
+    val name: String,
+): GQLNode, GQLSchemaCoordinate {
+  override val children: List<GQLNode> = emptyList()
+
+  override fun writeInternal(writer: SDLWriter) {
+    writer.write(name)
+  }
+
+  fun copy(
+      sourceLocation: SourceLocation? = this.sourceLocation,
+      name: String = this.name
+  ): GQLTypeCoordinate {
+    return GQLTypeCoordinate(
+        sourceLocation,
+        name
+    )
+  }
+  override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
+    return copy()
+  }
+}
+
+class GQLDirectiveCoordinate(
+    override val sourceLocation: SourceLocation?,
+    val name: String,
+): GQLNode, GQLSchemaCoordinate {
+  override val children: List<GQLNode> = emptyList()
+
+  override fun writeInternal(writer: SDLWriter) {
+    writer.write("@")
+    writer.write(name)
+  }
+
+  fun copy(
+      sourceLocation: SourceLocation? = this.sourceLocation,
+      name: String = this.name
+  ): GQLDirectiveCoordinate {
+    return GQLDirectiveCoordinate(
+        sourceLocation,
+        name
+    )
+  }
+  override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
+    return copy()
+  }
+}
+
+class GQLMemberCoordinate(
+    override val sourceLocation: SourceLocation?,
+    val type: String,
+    val member: String
+): GQLNode, GQLSchemaCoordinate {
+  override val children: List<GQLNode> = emptyList()
+
+  override fun writeInternal(writer: SDLWriter) {
+    writer.write(type)
+    writer.write(".")
+    writer.write(member)
+  }
+
+  fun copy(
+      sourceLocation: SourceLocation? = this.sourceLocation,
+      type: String = this.type,
+      name: String = this.member
+  ): GQLMemberCoordinate {
+    return GQLMemberCoordinate(
+        sourceLocation,
+        type,
+        name
+    )
+  }
+
+  override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
+    return copy()
+  }
+}
+
+class GQLArgumentCoordinate(
+    override val sourceLocation: SourceLocation?,
+    val type: String,
+    val field: String,
+    val argument: String,
+): GQLNode, GQLSchemaCoordinate {
+  override val children: List<GQLNode> = emptyList()
+
+  override fun writeInternal(writer: SDLWriter) {
+    writer.write(type)
+    writer.write(".")
+    writer.write(field)
+    writer.write("(")
+    writer.write(argument)
+    writer.write(":)")
+  }
+
+  fun copy(
+      sourceLocation: SourceLocation? = this.sourceLocation,
+      type: String = this.type,
+      name: String = this.field,
+      argument: String = this.argument
+  ): GQLArgumentCoordinate {
+    return GQLArgumentCoordinate(
+        sourceLocation,
+        type,
+        name,
+        argument
+    )
+  }
+
+  override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
+    return copy()
+  }
+}
+
+class GQLDirectiveArgumentCoordinate(
+    override val sourceLocation: SourceLocation?,
+    val name: String,
+    val argument: String,
+): GQLNode, GQLSchemaCoordinate {
+  override val children: List<GQLNode> = emptyList()
+
+  override fun writeInternal(writer: SDLWriter) {
+    writer.write("@")
+    writer.write(name)
+    writer.write("(")
+    writer.write(argument)
+    writer.write(":)")
+  }
+
+  fun copy(
+      sourceLocation: SourceLocation? = this.sourceLocation,
+      name: String = this.name,
+      argument: String = this.argument
+  ): GQLDirectiveArgumentCoordinate {
+    return GQLDirectiveArgumentCoordinate(
+        sourceLocation,
+        name,
+        argument
+    )
+  }
+
+  override fun copyWithNewChildrenInternal(container: NodeContainer): GQLNode {
+    return copy()
+  }
+}
+
 
 @Suppress("UNCHECKED_CAST")
 class NodeContainer(nodes: List<GQLNode>) {

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqlcoordinate.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqlcoordinate.kt
@@ -1,0 +1,80 @@
+package com.apollographql.apollo.ast
+
+import com.apollographql.apollo.annotations.ApolloExperimental
+
+fun resolveSchemaCoordinate(schema: Schema, coordinate: String): ResolvedSchemaElement? {
+  return resolveSchemaCoordinate(schema, coordinate.parseAsGQLSchemaCoordinate().getOrThrow())
+}
+
+sealed interface ResolvedSchemaElement
+
+class ResolvedType(val typeDefinition: GQLTypeDefinition) : ResolvedSchemaElement
+class ResolvedField(val fieldDefinition: GQLFieldDefinition) : ResolvedSchemaElement
+class ResolvedInputField(val inputField: GQLInputValueDefinition) : ResolvedSchemaElement
+class ResolvedEnumValue(val enumValue: GQLEnumValueDefinition) : ResolvedSchemaElement
+class ResolvedFieldArgument(val argument: GQLInputValueDefinition) : ResolvedSchemaElement
+class ResolvedDirective(val directiveDefinition: GQLDirectiveDefinition) : ResolvedSchemaElement
+class ResolvedDirectiveArgument(val argument: GQLInputValueDefinition) : ResolvedSchemaElement
+
+/**
+ * Resolves the given schema coordinate according to [schema].
+ *
+ * @return the [ResolvedSchemaElement] or `null` if not found.
+ *
+ * @throws IllegalArgumentException if any of the containing elements is not found or is of an unexpected type.
+ */
+@ApolloExperimental
+fun resolveSchemaCoordinate(schema: Schema, coordinate: GQLSchemaCoordinate): ResolvedSchemaElement? {
+  return when (coordinate) {
+    is GQLArgumentCoordinate -> {
+      val typeDefinition =
+        schema.typeDefinitions.get(coordinate.type) ?: throw IllegalArgumentException("Unknow type '${coordinate.type}'")
+
+      val fieldDefinition = when (typeDefinition) {
+        is GQLObjectTypeDefinition, is GQLInterfaceTypeDefinition -> {
+          typeDefinition.fieldDefinitions(schema).firstOrNull { it.name == coordinate.field }
+              ?: throw IllegalArgumentException("Unknow field '${coordinate.field}' in type '${typeDefinition.name}'")
+        }
+
+        else -> throw IllegalArgumentException("Expected '${typeDefinition.name}' to be an object or interface type")
+      }
+      fieldDefinition.arguments.firstOrNull { it.name == coordinate.argument }?.let { ResolvedFieldArgument(it) }
+    }
+
+    is GQLMemberCoordinate -> {
+      val typeDefinition =
+        schema.typeDefinitions.get(coordinate.type) ?: throw IllegalArgumentException("Unknow type '${coordinate.type}'")
+
+      when (typeDefinition) {
+        is GQLObjectTypeDefinition, is GQLInterfaceTypeDefinition -> {
+          typeDefinition.fieldDefinitions(schema).firstOrNull { it.name == coordinate.member }?.let { ResolvedField(it) }
+        }
+
+        is GQLInputObjectTypeDefinition -> {
+          typeDefinition.inputFields.firstOrNull { it.name == coordinate.member }?.let { ResolvedInputField(it) }
+        }
+
+        is GQLEnumTypeDefinition -> {
+          typeDefinition.enumValues.firstOrNull { it.name == coordinate.member }?.let { ResolvedEnumValue(it) }
+        }
+
+        else -> throw IllegalArgumentException("Expected '${typeDefinition.name}' to be an object, input object, interface or enum type")
+      }
+    }
+
+    is GQLTypeCoordinate -> {
+      schema.typeDefinitions.get(coordinate.name)?.let { ResolvedType(it) }
+    }
+
+    is GQLDirectiveArgumentCoordinate -> {
+      val directive =
+        schema.directiveDefinitions.get(coordinate.name) ?: throw IllegalArgumentException("Unknow directive '@${coordinate.name}'")
+
+      directive.arguments.firstOrNull { it.name == coordinate.argument }?.let { ResolvedDirectiveArgument(it) }
+    }
+
+    is GQLDirectiveCoordinate -> {
+      schema.directiveDefinitions.get(coordinate.name)?.let { ResolvedDirective(it) }
+    }
+  }
+}

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqltypedefinition.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqltypedefinition.kt
@@ -2,6 +2,7 @@ package com.apollographql.apollo.ast
 
 import com.apollographql.apollo.annotations.ApolloInternal
 import com.apollographql.apollo.ast.Schema.Companion.NONNULL
+import kotlin.reflect.KClass
 
 // 5.5.2.3 Fragment spread is possible
 internal fun GQLTypeDefinition.sharesPossibleTypesWith(other: GQLTypeDefinition, schema: Schema): Boolean {
@@ -67,5 +68,18 @@ fun GQLTypeDefinition.canHaveKeyFields(): Boolean {
       -> true
 
     else -> false
+  }
+}
+
+
+internal fun KClass<out GQLTypeDefinition>.prettyName(): String {
+  return when (this) {
+    GQLObjectTypeDefinition::class -> "object"
+    GQLInterfaceTypeDefinition::class -> "interface"
+    GQLUnionTypeDefinition::class -> "union"
+    GQLEnumTypeDefinition::class -> "enum"
+    GQLScalarTypeDefinition::class -> "scalar"
+    GQLInputValueDefinition::class -> "input object"
+    else -> error("")
   }
 }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
@@ -107,13 +107,26 @@ internal class Lexer(val src: String) {
         '(' -> return Token.LeftParenthesis(start, line, column(start))
         ')' -> return Token.RightParenthesis(start, line, column(start))
         '.' -> {
-          if (pos == len || src[pos] != '.') {
+          val nextChar = if (pos < len) {
+            src[pos]
+          } else {
+            null
+          }
+          if (nextChar != '.') {
+            if (nextChar?.isDigit() == true) {
+              val digitStart = pos
+              pos++
+              while (pos < len && src[pos].isDigit()) {
+                pos++
+              }
+              throw LexerException("Invalid number, expected digit before '.', did you mean '0.${src.substring(digitStart, pos)}'", start, line, column(start), null)
+            }
             return Token.Dot(start, line, column(start))
-          } else if (pos + 1 < len && src[pos] == '.' && src[pos + 1] == '.') {
+          } else if (pos + 1 < len && src[pos + 1] == '.') {
             pos += 2
             return Token.Spread(start, line, column(start))
           } else {
-            throw LexerException("Unterminated spread operator", start, line, column(start), null)
+            throw LexerException("Unexpected '..', did you mean '...'?", start, line, column(start), null)
           }
         }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
@@ -107,7 +107,9 @@ internal class Lexer(val src: String) {
         '(' -> return Token.LeftParenthesis(start, line, column(start))
         ')' -> return Token.RightParenthesis(start, line, column(start))
         '.' -> {
-          if (pos + 1 < len && src[pos] == '.' && src[pos + 1] == '.') {
+          if (pos == len || src[pos] != '.') {
+            return Token.Dot(start, line, column(start))
+          } else if (pos + 1 < len && src[pos] == '.' && src[pos + 1] == '.') {
             pos += 2
             return Token.Spread(start, line, column(start))
           } else {

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Token.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Token.kt
@@ -90,4 +90,8 @@ internal sealed class Token(val start: kotlin.Int, val end: kotlin.Int, val line
   class String(start: kotlin.Int, end: kotlin.Int, line: kotlin.Int, column: kotlin.Int, val value: kotlin.String) : Token(start, end, line, column) {
     override fun toString() = "string: \"$value\""
   }
+
+  class Dot(start: kotlin.Int, line: kotlin.Int, column: kotlin.Int) : Token(start, start + 1, line, column) {
+    override fun toString() = "."
+  }
 }

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/LexerTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/LexerTest.kt
@@ -14,15 +14,15 @@ import kotlin.test.assertIs
 class LexerTest {
   private fun lexFirst(string: String): Token {
     return Lexer(string).run {
-      nextToken()
+      nextToken() // Beginning of file
       nextToken()
     }
   }
 
   private fun lexSecond(string: String): Token {
     return Lexer(string).run {
-      nextToken()
-      nextToken()
+      nextToken() // Beginning of file
+      nextToken() // First token (ignored)
       nextToken()
     }
   }
@@ -108,6 +108,28 @@ class LexerTest {
 
     lexFirst(",,,foo,,,").apply {
       assertName("foo")
+    }
+  }
+
+  @Test
+  fun lexesSpreads() {
+    expectLexerException(".. on Foo") {
+      assertEquals("Unexpected '..', did you mean '...'?", message)
+    }
+
+    Lexer("... on Foo").apply {
+      nextToken()
+      nextToken().apply {
+        assertIs<Token.Spread>(this)
+      }
+      nextToken().apply {
+        assertIs<Token.Name>(this)
+        assertEquals("on", value)
+      }
+      nextToken().apply {
+        assertIs<Token.Name>(this)
+        assertEquals("Foo", value)
+      }
     }
   }
 
@@ -559,7 +581,7 @@ class LexerTest {
       assertEquals(3, column)
     }
     expectLexerException(".123") {
-      assertEquals("Unterminated spread operator", message)
+      assertEquals("Invalid number, expected digit before '.', did you mean '0.123'", message)
       assertEquals(1, line)
       assertEquals(1, column)
     }

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/ResolveCoordinateTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/ResolveCoordinateTest.kt
@@ -1,0 +1,223 @@
+package com.apollographql.apollo.graphql.ast.test
+
+import com.apollographql.apollo.ast.ResolvedDirective
+import com.apollographql.apollo.ast.ResolvedDirectiveArgument
+import com.apollographql.apollo.ast.ResolvedEnumValue
+import com.apollographql.apollo.ast.ResolvedField
+import com.apollographql.apollo.ast.ResolvedFieldArgument
+import com.apollographql.apollo.ast.ResolvedInputField
+import com.apollographql.apollo.ast.ResolvedType
+import com.apollographql.apollo.ast.parseAsGQLDocument
+import com.apollographql.apollo.ast.resolveSchemaCoordinate
+import com.apollographql.apollo.ast.toSchema
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class ResolveCoordinateTest {
+  val schema = """
+        type Query {
+          searchBusiness(criteria: SearchCriteria!): [Business]
+        }
+        input SearchCriteria {
+          name: String
+          filter: SearchFilter
+        }
+        enum SearchFilter {
+          OPEN_NOW
+          DELIVERS_TAKEOUT
+          VEGETARIAN_MENU
+        }
+        type Business {
+          id: ID
+          name: String
+          email: String @private(scope: "loggedIn")
+        }
+        directive @private(scope: String!) on FIELD_DEFINITION
+  """.trimIndent().parseAsGQLDocument().getOrThrow().toSchema()
+
+  @Test
+  fun typeBusiness() {
+    resolveSchemaCoordinate(schema, "Business").apply {
+      assertIs<ResolvedType>(this)
+      assertEquals("Business", typeDefinition.name)
+    }
+  }
+
+  @Test
+  fun typeString() {
+    resolveSchemaCoordinate(schema, "String").apply {
+      assertIs<ResolvedType>(this)
+      assertEquals("String", typeDefinition.name)
+    }
+  }
+
+  @Test
+  fun typeNotFound() {
+    resolveSchemaCoordinate(schema, "notFound").apply {
+      assertNull(this)
+    }
+  }
+
+  @Test
+  fun fieldBusinessName() {
+    resolveSchemaCoordinate(schema, "Business.name").apply {
+      assertIs<ResolvedField>(this)
+      assertEquals("name", fieldDefinition.name)
+    }
+  }
+
+  @Test
+  fun fieldBusiness__typename() {
+    resolveSchemaCoordinate(schema, "Business.__typename").apply {
+      assertIs<ResolvedField>(this)
+      assertEquals("__typename", fieldDefinition.name)
+    }
+  }
+
+  @Test
+  fun fieldBusinessNotFound() {
+    resolveSchemaCoordinate(schema, "Business.notFound").apply {
+      assertNull(this)
+    }
+  }
+
+  @Test
+  fun fieldNotFoundName() {
+    expectException {
+      resolveSchemaCoordinate(schema, "NotFound.name")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Unknow type 'NotFound'", message)
+    }
+  }
+
+  @Test
+  fun fieldStringName() {
+    expectException {
+      resolveSchemaCoordinate(schema, "String.name")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Expected 'String' to be an object, input object, interface or enum type", message)
+    }
+  }
+
+  @Test
+  fun inputFieldSearchCriteriaFilter() {
+    resolveSchemaCoordinate(schema, "SearchCriteria.filter").apply {
+      assertIs<ResolvedInputField>(this)
+      assertEquals("filter", inputField.name)
+    }
+  }
+
+  @Test
+  fun enumValueSearchFilterOPEN_NOW() {
+    resolveSchemaCoordinate(schema, "SearchFilter.OPEN_NOW").apply {
+      assertIs<ResolvedEnumValue>(this)
+      assertEquals("OPEN_NOW", enumValue.name)
+    }
+  }
+
+  @Test
+  fun fieldArgumentQuerySearchBusinessCriteria() {
+    resolveSchemaCoordinate(schema, "Query.searchBusiness(criteria:)").apply {
+      assertIs<ResolvedFieldArgument>(this)
+      assertEquals("criteria", argument.name)
+    }
+  }
+
+  @Test
+  fun fieldArgumentQuerySearchBusinessNotFound() {
+    resolveSchemaCoordinate(schema, "Query.searchBusiness(notFound:)").apply {
+      assertNull(this)
+    }
+  }
+
+  @Test
+  fun fieldArgument_notFound_arg() {
+    expectException {
+      resolveSchemaCoordinate(schema, "NotFound.field(arg:)")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Unknow type 'NotFound'", message)
+    }
+  }
+
+  @Test
+  fun fieldArgument_Business_notFound_Arg() {
+    expectException {
+      resolveSchemaCoordinate(schema, "Business.notFound(arg:)")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Unknow field 'notFound' in type 'Business'", message)
+    }
+  }
+
+  @Test
+  fun fieldArgument_SearchCriteria_notFound_Arg() {
+    expectException {
+      resolveSchemaCoordinate(schema, "SearchCriteria.field(arg:)")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Expected 'SearchCriteria' to be an object or interface type", message)
+    }
+  }
+
+  @Test
+  fun directive_private() {
+    resolveSchemaCoordinate(schema, "@private").apply {
+      assertIs<ResolvedDirective>(this)
+      assertEquals("private", directiveDefinition.name)
+    }
+  }
+
+  @Test
+  fun directive_deprecated() {
+    resolveSchemaCoordinate(schema, "@deprecated").apply {
+      assertIs<ResolvedDirective>(this)
+      assertEquals("deprecated", directiveDefinition.name)
+    }
+  }
+
+  @Test
+  fun directive_unknown() {
+    resolveSchemaCoordinate(schema, "@unknown").apply {
+      assertNull(this)
+    }
+  }
+
+  @Test
+  fun directiveArgument_private_scope() {
+    resolveSchemaCoordinate(schema, "@private(scope:)").apply {
+      assertIs<ResolvedDirectiveArgument>(this)
+      assertEquals("scope", argument.name)
+    }
+  }
+
+  @Test
+  fun directiveArgument_private_scope_private_unknown() {
+    resolveSchemaCoordinate(schema, "@private(unknown:)").apply {
+      assertNull(this)
+    }
+  }
+
+  @Test
+  fun directiveArgument_private_scope_unknown_arg() {
+    expectException {
+      resolveSchemaCoordinate(schema, "@unknown(arg:)")
+    }.apply {
+      assertIs<IllegalArgumentException>(this)
+      assertEquals("Unknow directive '@unknown'", message)
+    }
+  }
+}
+
+private fun expectException(block: () -> Unit): Exception {
+  try {
+    block()
+  } catch (e: Exception) {
+    return e
+  }
+  error("Expected an error but the block completed successfully")
+}


### PR DESCRIPTION
See https://github.com/graphql/graphql-spec/pull/794
This is still RFC2 in the spec but the symbols are all `@ApolloExperimental` and v5 is pre-release anyways so I'd suggest we merge it nevertheless.