### PR TITLE
[gradle-plugin] Simplify task wiring

### DIFF
--- a/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
+++ b/libraries/apollo-gradle-plugin-external/src/main/kotlin/com/apollographql/apollo/gradle/internal/AndroidPluginFacade.kt
@@ -70,29 +70,15 @@ private fun Project.getTestVariants(): NamedDomainObjectContainer<BaseVariant> {
   return container
 }
 
-
 fun connectToAndroidSourceSet(
     project: Project,
     sourceSetName: String,
     outputDir: Provider<Directory>,
     taskProvider: TaskProvider<out Task>,
 ) {
-  val kotlinSourceSet = project.kotlinProjectExtension?.sourceSets?.getByName(sourceSetName)?.kotlin
-  if (kotlinSourceSet != null) {
-    kotlinSourceSet.srcDir(outputDir)
-  }
-
   project.getMainVariants().configureEach {
     if (it.sourceSets.any { it.name == sourceSetName }) {
-      if (kotlinSourceSet == null) {
-        it.registerJavaGeneratingTask(taskProvider, outputDir.get().asFile)
-      } else {
-        // The kotlinSourceSet carries task dependencies, calling srcDir() above is enough
-        // to setup task dependencies
-        // addJavaSourceFoldersToModel is still required for AS to see the sources
-        // See https://github.com/apollographql/apollo-kotlin/issues/3351
-        it.addJavaSourceFoldersToModel(outputDir.get().asFile)
-      }
+      it.registerJavaGeneratingTask(taskProvider, outputDir.get().asFile)
     }
   }
 }


### PR DESCRIPTION
`registerJavaGeneratingTask()` works for Kotlin sources as well, no need to distinguish the cases. Fixes `connectToAndroidSourceSet` that broke with https://github.com/apollographql/apollo-kotlin/pull/6442.


As a workaround until this is release, you can set up explicit dependencies:

```kotlin
apollo {
    service("service") {
        packageName.set("com.example")
        outputDirConnection {
            tasks.withType(KotlinCompile::class.java).configureEach {
                dependsOn(task)
            }
            connectToAndroidSourceSet("main")
        }
    }
}
```