### PR TITLE
[apollo-compiler] Do not generate the version as const

### DIFF
--- a/libraries/apollo-compiler/build.gradle.kts
+++ b/libraries/apollo-compiler/build.gradle.kts
@@ -55,7 +55,8 @@ abstract class GeneratePluginVersion : DefaultTask() {
     versionFile.parentFile.mkdirs()
     versionFile.writeText("""// Generated file. Do not edit!
 package com.apollographql.apollo.compiler
-const val APOLLO_VERSION = "${version.get()}"
+@JvmField
+val APOLLO_VERSION = "${version.get()}"
 """)
   }
 }


### PR DESCRIPTION
This was merged in `release-4.x` but I forgot to add it here.