### PR TITLE
Add ApolloCompiler.Logger.warn as deprecated in case v4 users where using it

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -26,6 +26,7 @@ public abstract interface class com/apollographql/apollo/compiler/ApolloCompiler
 	public abstract fun debug (Ljava/lang/String;)V
 	public abstract fun error (Ljava/lang/String;)V
 	public abstract fun info (Ljava/lang/String;)V
+	public fun warn (Ljava/lang/String;)V
 	public abstract fun warning (Ljava/lang/String;)V
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ApolloCompiler.kt
@@ -1,5 +1,6 @@
 package com.apollographql.apollo.compiler
 
+import com.apollographql.apollo.annotations.ApolloDeprecatedSince
 import com.apollographql.apollo.ast.DeprecatedUsage
 import com.apollographql.apollo.ast.DifferentShape
 import com.apollographql.apollo.ast.DirectiveRedefinition
@@ -54,6 +55,11 @@ object ApolloCompiler {
     fun debug(message: String)
     fun info(message: String)
     fun warning(message: String)
+    @Deprecated("use warning instead", replaceWith = ReplaceWith("warning(message)"))
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_0)
+    fun warn(message: String) {
+      warning(message)
+    }
     fun error(message: String)
   }
 

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsExec
 
 plugins {
   id("org.jetbrains.kotlin.multiplatform")


### PR DESCRIPTION
This makes the v5 compiler API mostly source compatible with v4 (but not binary compatible). For anyone updating their compiler plugin, they will get a warning instead of a "symbol not found" error.