### PR TITLE
[gradle-plugin] Remove checkApolloVersion

### DIFF
--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ModelNames.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/ModelNames.kt
@@ -27,7 +27,6 @@ internal object ModelNames {
   fun downloadApolloSchemaRegistry(service: Service) = camelCase("download", service.name, "ApolloSchemaFromRegistry")
   fun registerApolloOperations(service: Service) = camelCase("register", service.name, "ApolloOperations")
   fun pushApolloSchema() = camelCase("pushApolloSchema")
-  fun checkApolloVersions() = "checkApolloVersions"
   fun convertApolloSchema() = "convertApolloSchema"
 
   fun scopeConfiguration(

--- a/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServiceTests.kt
+++ b/libraries/apollo-gradle-plugin/src/test/kotlin/test/ServiceTests.kt
@@ -170,26 +170,6 @@ class ServiceTests {
   }
 
   @Test
-  fun `changing a dependency checks versions again`() {
-    withSimpleProject { dir ->
-
-      TestUtils.executeTaskAndAssertSuccess(":generateApolloSources", dir)
-
-      val result = TestUtils.executeTask("checkApolloVersions", dir)
-      assert(result.task(":checkApolloVersions")?.outcome == TaskOutcome.UP_TO_DATE)
-
-      File(dir, "build.gradle").replaceInText("libs.apollo.api", "\"com.apollographql.apollo:apollo-api:1.2.0\"")
-
-      try {
-        TestUtils.executeTask("checkApolloVersions", dir)
-        fail("An exception was expected")
-      } catch (e: UnexpectedBuildFailure) {
-        Truth.assertThat(e.message).contains("All apollo versions should be the same")
-      }
-    }
-  }
-
-  @Test
   fun `versions are enforced even in rootProject`() {
     withTestProject("mismatchedVersions") { dir ->
       var exception: Exception? = null


### PR DESCRIPTION
This check is too restrictive as `apollo-api` is compatible with sources generated from a large range of compilers. It also creates issues like https://github.com/apollographql/apollo-kotlin/issues/6315. 

And overall, because it's only checking the declared versions in the current build, it was missing some cases where a transitive dependency would require an "old" version of `apollo-api`.
