### PR TITLE
Fix JvmFileUploadTest

### DIFF
--- a/tests/integration-tests/src/jvmTest/kotlin/test/JvmFileUploadTest.kt
+++ b/tests/integration-tests/src/jvmTest/kotlin/test/JvmFileUploadTest.kt
@@ -4,11 +4,11 @@ import com.apollographql.apollo.ApolloClient
 import com.apollographql.apollo.api.Upload
 import com.apollographql.apollo.api.toUpload
 import com.apollographql.apollo.integration.upload.SingleUploadTwiceMutation
+import com.apollographql.apollo.network.okHttpClient
+import com.apollographql.apollo.testing.internal.runTest
 import com.apollographql.mockserver.MockServer
 import com.apollographql.mockserver.awaitRequest
 import com.apollographql.mockserver.enqueueString
-import com.apollographql.apollo.network.okHttpClient
-import com.apollographql.apollo.testing.internal.runTest
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.File
@@ -53,7 +53,7 @@ class JvmFileUploadTest {
     val request = mockServer.awaitRequest()
     val parts = request.parts()
 
-    val expectedBodyLength = 1092
+    val expectedBodyLength = 1100
     assertEquals(expectedBodyLength, request.body.size)
     assertEquals(expectedBodyLength.toString(), request.headers["Content-Length"])
     assertEquals(4, parts.size)


### PR DESCRIPTION
Small regression introduced [here](https://github.com/apollographql/apollo-kotlin/pull/6581/files?w=1#diff-731c79854e920476a065378ba36ca1d7b52695e41cbcfe1436b8f71b648caa54R1) (not sure why we didn't catch it before).