### PR TITLE
Fix error reporting on invalid documents

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
@@ -240,7 +240,7 @@ internal class ApolloExecutableDocumentTransform(private val addTypename: String
   ): GQLField {
     val typeDefinition = definitionFromScope(schema, parentType)
     if (typeDefinition == null) {
-      // This will trigger a validation error alter in the build
+      // This will trigger a validation error later in the build
       return this
     }
     val newSelectionSet = selections.addRequiredFields(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/ApolloExecutableDocumentTransform.kt
@@ -238,7 +238,11 @@ internal class ApolloExecutableDocumentTransform(private val addTypename: String
       fragments: Map<String, GQLFragmentDefinition>,
       parentType: String,
   ): GQLField {
-    val typeDefinition = definitionFromScope(schema, parentType)!!
+    val typeDefinition = definitionFromScope(schema, parentType)
+    if (typeDefinition == null) {
+      // This will trigger a validation error alter in the build
+      return this
+    }
     val newSelectionSet = selections.addRequiredFields(
         schema = schema,
         fragments = fragments,


### PR DESCRIPTION
Because we now run the document transform before the validation, there are some assumptions that can't be made in the transform code.