### PR TITLE
Centralize adding the kotlin-test library

### DIFF
--- a/build-logic/src/main/kotlin/Testing.kt
+++ b/build-logic/src/main/kotlin/Testing.kt
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 
 fun Project.configureTesting() {
   tasks.withType(Test::class.java) {
@@ -44,19 +45,19 @@ private fun Project.addTestDependencies() {
       is KotlinMultiplatformExtension -> {
         sourceSets.getByName("commonTest") {
           dependencies {
-            implementation(getCatalogLib("kotlin.test"))
+            implementation("org.jetbrains.kotlin:kotlin-test:${getKotlinPluginVersion()}")
           }
         }
         sourceSets.findByName("androidInstrumentedTest")?.apply {
           dependencies {
-            implementation(getCatalogLib("kotlin.test"))
+            implementation("org.jetbrains.kotlin:kotlin-test:${getKotlinPluginVersion()}")
             implementation(getCatalogLib("android.test.runner"))
           }
         }
       }
 
       is KotlinJvmProjectExtension -> {
-        dependencies.add("testImplementation", getCatalogLib("kotlin.test"))
+        dependencies.add("testImplementation", "org.jetbrains.kotlin:kotlin-test:${getKotlinPluginVersion()}")
       }
     }
   }

--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -126,8 +126,6 @@ kotlin-plugin-max = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plug
 kotlin-reflect = { group = "org.jetbrains.kotlin", name = "kotlin-reflect" } # use same version as apiVersion
 kotlin-stdlib-common = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-common" } # use same version as apiVersion
 kotlin-stdlib-jvm = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib" } # use same version as apiVersion
-kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test" } # use same version as apiVersion
-kotlin-test-js = { group = "org.jetbrains.kotlin", name = "kotlin-test-js" } # use same version as apiVersion
 kotlin-test-junit = { group = "org.jetbrains.kotlin", name = "kotlin-test-junit" } # use same version as apiVersion
 # Kotlin/JS has no apiVersion:
 # The Kotlin/JS standard library has an older version (2.0.20-release-360) than the compiler (2.1.0). Such a configuration is not supported.

--- a/libraries/apollo-ast/build.gradle.kts
+++ b/libraries/apollo-ast/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
     getByName("jvmTest") {
       dependencies {
         implementation(libs.google.testparameterinjector)
-        implementation(libs.kotlin.test)
       }
     }
   }

--- a/libraries/apollo-debug-server/build.gradle.kts
+++ b/libraries/apollo-debug-server/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
     }
     getByName("jvmTest") {
       dependencies {
-        implementation(libs.kotlin.test)
         implementation(project(":apollo-runtime"))
       }
     }

--- a/libraries/apollo-engine-tests/build.gradle.kts
+++ b/libraries/apollo-engine-tests/build.gradle.kts
@@ -12,7 +12,6 @@ kotlin {
     findByName("commonMain")?.apply {
       dependencies {
         api(project(":apollo-runtime"))
-        implementation(libs.kotlin.test)
         implementation(libs.apollo.mockserver)
       }
     }

--- a/libraries/apollo-testing-support-internal/build.gradle.kts
+++ b/libraries/apollo-testing-support-internal/build.gradle.kts
@@ -18,13 +18,11 @@ kotlin {
     }
     findByName("jsMain")?.apply {
       dependencies {
-        implementation(libs.kotlin.test.js)
         api(libs.okio.nodefilesystem)
       }
     }
     findByName("jsTest")?.apply {
       dependencies {
-        implementation(libs.kotlin.test.js)
       }
     }
   }

--- a/libraries/apollo-testing-support/build.gradle.kts
+++ b/libraries/apollo-testing-support/build.gradle.kts
@@ -28,13 +28,11 @@ kotlin {
 
     findByName("jsMain")?.apply {
       dependencies {
-        implementation(libs.kotlin.test.js)
         api(libs.okio.nodefilesystem)
       }
     }
     findByName("jsTest")?.apply {
       dependencies {
-        implementation(libs.kotlin.test.js)
       }
     }
   }

--- a/tests/cache-variables-arguments/build.gradle.kts
+++ b/tests/cache-variables-arguments/build.gradle.kts
@@ -8,7 +8,6 @@ apolloTest()
 dependencies {
   implementation(libs.apollo.runtime)
   implementation(libs.apollo.normalizedcache)
-  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/catch/build.gradle.kts
+++ b/tests/catch/build.gradle.kts
@@ -8,7 +8,6 @@ apolloTest()
 dependencies {
   implementation(libs.apollo.api)
   implementation(libs.apollo.testingsupport.internal)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
 }

--- a/tests/compiler-plugins/app/build.gradle.kts
+++ b/tests/compiler-plugins/app/build.gradle.kts
@@ -11,7 +11,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.kotlin.reflect)
 }

--- a/tests/deprecated-requires-opt-in/build.gradle.kts
+++ b/tests/deprecated-requires-opt-in/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/enums/build.gradle.kts
+++ b/tests/enums/build.gradle.kts
@@ -10,7 +10,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/escaping/build.gradle.kts
+++ b/tests/escaping/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/generated-methods/build.gradle.kts
+++ b/tests/generated-methods/build.gradle.kts
@@ -9,7 +9,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/input/build.gradle.kts
+++ b/tests/input/build.gradle.kts
@@ -9,7 +9,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.api)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
 }

--- a/tests/jvmoverloads/build.gradle.kts
+++ b/tests/jvmoverloads/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/models-operation-based-with-interfaces/build.gradle.kts
+++ b/tests/models-operation-based-with-interfaces/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   implementation(libs.apollo.runtime)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/multi-module-1/root/build.gradle.kts
+++ b/tests/multi-module-1/root/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/no-query-document/build.gradle.kts
+++ b/tests/no-query-document/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
   implementation(libs.apollo.runtime)
   implementation(libs.apollo.testingsupport.internal)
   implementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/no-runtime/build.gradle.kts
+++ b/tests/no-runtime/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
   implementation(libs.apollo.api)
   implementation(project(":sample-server"))
   implementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
 }

--- a/tests/normalization-tests/build.gradle.kts
+++ b/tests/normalization-tests/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   implementation(libs.apollo.normalizedcache)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/number_scalar/build.gradle.kts
+++ b/tests/number_scalar/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.api)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.apollo.testingsupport)
   testImplementation(libs.apollo.normalizedcache)
 }

--- a/tests/optimistic-data/build.gradle.kts
+++ b/tests/optimistic-data/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   implementation(libs.apollo.normalizedcache)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.turbine)
 }
 

--- a/tests/optional-variables/build.gradle.kts
+++ b/tests/optional-variables/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/outofbounds/build.gradle.kts
+++ b/tests/outofbounds/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/platform-api/build.gradle.kts
+++ b/tests/platform-api/build.gradle.kts
@@ -10,7 +10,6 @@ apolloTest()
 dependencies {
   implementation(libs.apollo.api)
   implementation(libs.apollo.tooling)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
 }

--- a/tests/runtime/build.gradle.kts
+++ b/tests/runtime/build.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
   implementation(project(":sample-server"))
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
 }

--- a/tests/scalar-adapters/build.gradle.kts
+++ b/tests/scalar-adapters/build.gradle.kts
@@ -9,7 +9,6 @@ dependencies {
   implementation(libs.apollo.runtime)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/schema-changes/build.gradle.kts
+++ b/tests/schema-changes/build.gradle.kts
@@ -10,7 +10,6 @@ dependencies {
   implementation(libs.apollo.normalizedcache)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.mockserver)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.turbine)
 }
 

--- a/tests/schema-packagename/build.gradle.kts
+++ b/tests/schema-packagename/build.gradle.kts
@@ -7,7 +7,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.api)
-  testImplementation(libs.kotlin.test)
 }
 
 apollo {

--- a/tests/schema-transform/app/build.gradle.kts
+++ b/tests/schema-transform/app/build.gradle.kts
@@ -11,7 +11,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/semantic-non-null/build.gradle.kts
+++ b/tests/semantic-non-null/build.gradle.kts
@@ -8,7 +8,6 @@ apolloTest()
 dependencies {
   implementation(libs.apollo.api)
   implementation(libs.apollo.testingsupport.internal)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.okhttp)
 }

--- a/tests/strict-mode/build.gradle.kts
+++ b/tests/strict-mode/build.gradle.kts
@@ -8,7 +8,6 @@ apolloTest()
 dependencies {
   implementation(libs.apollo.api)
   testImplementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.apollo.mockserver)
 }
 

--- a/tests/termination/build.gradle.kts
+++ b/tests/termination/build.gradle.kts
@@ -8,7 +8,6 @@ apolloTest()
 
 dependencies {
   implementation(libs.apollo.runtime)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
 }
 

--- a/tests/test-network-transport/build.gradle.kts
+++ b/tests/test-network-transport/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
   implementation(libs.apollo.runtime)
   testImplementation(libs.apollo.testingsupport.internal)
   testImplementation(libs.apollo.testingsupport)
-  testImplementation(libs.kotlin.test)
   testImplementation(libs.junit)
   testImplementation(libs.turbine)
   testImplementation(libs.apollo.mockserver)


### PR DESCRIPTION
For `kotlin-test`, we always want the same version as kotlinc or else we end up with errors such as https://youtrack.jetbrains.com/issue/KT-79627/WasmJS-NullPointerException-in-GenerateWasmTests.makeTestFunctionDeclaratorlambda4