### PR TITLE
[build] Simplify build logic

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Build with Gradle
         run: |
           ./gradlew -p tests build 
-          ./gredlew -p tests checkGitStatus
+          ./gradlew -p tests checkGitStatus
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -78,7 +78,8 @@ jobs:
           gradle-home-cache-cleanup: true
       - name: Build with Gradle
         run: |
-          ./gradlew -p tests ciBuild
+          ./gradlew -p tests build 
+          ./gredlew -p tests checkGitStatus
       - name: Collect Diagnostics
         if: always()
         run: ./scripts/collect-diagnostics.main.kts

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.kotlin.sam)
   alias(libs.plugins.compat.patrouille)
-  id("java-gradle-plugin")
 }
 
 plugins.apply(SamWithReceiverGradleSubplugin::class.java)
@@ -13,7 +12,7 @@ extensions.configure(SamWithReceiverExtension::class.java) {
   annotations(HasImplicitReceiver::class.qualifiedName!!)
 }
 
-group = "com.apollographql.apollo.build"
+group = "com.apollographql.apollo"
 
 dependencies {
   compileOnly(gradleApi())
@@ -54,19 +53,7 @@ dependencies {
   runtimeOnly(libs.kotlinx.binarycompatibilityvalidator)
 }
 
-
 compatPatrouille {
   java(17)
   kotlin(embeddedKotlinVersion)
-}
-
-gradlePlugin {
-  plugins {
-    register("build.logic") {
-      id = "build.logic"
-      // This plugin is only used for loading the jar using the Marker but never applied
-      // We don't need it.
-      implementationClass = "build.logic.Unused"
-    }
-  }
 }

--- a/build-logic/src/main/kotlin/RootProject.kt
+++ b/build-logic/src/main/kotlin/RootProject.kt
@@ -13,7 +13,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import java.io.File
 
-fun Project.rootSetup(ciBuild: TaskProvider<Task>) {
+fun Project.rootSetup() {
   val apolloTestAggregationConsumer = configurations.create("apolloTestAggregationConsumer") {
     isCanBeConsumed = false
     isCanBeResolved = true
@@ -33,7 +33,7 @@ fun Project.rootSetup(ciBuild: TaskProvider<Task>) {
     output = file("build/apolloTestAggregation.txt")
   }
 
-  ciBuild.configure {
+  tasks.named("build").configure {
     dependsOn(task)
   }
 }

--- a/build-logic/src/main/kotlin/api.kt
+++ b/build-logic/src/main/kotlin/api.kt
@@ -137,9 +137,9 @@ fun Project.apolloTest(
   configureTesting()
 }
 
-fun Project.apolloRoot(ciBuild: TaskProvider<Task>) {
+fun Project.apolloRoot() {
   configureNode()
-  rootSetup(ciBuild)
+  rootSetup()
 
   pluginManager.apply("com.gradleup.nmcp.aggregation")
   val nmcpAggregation = extensions.getByType(NmcpAggregationExtension::class.java)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,13 @@ import kotlinx.validation.ExperimentalBCVApi
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeHostTest
 
 plugins {
-  id("build.logic") apply false
+  id("base")
+}
+
+buildscript {
+  dependencies {
+    classpath("com.apollographql.apollo:build-logic")
+  }
 }
 
 apply(plugin = "com.github.ben-manes.versions")
@@ -15,20 +21,6 @@ fun subprojectTasks(name: String): List<Task> {
     subproject.tasks.matching { it.name == name }
   }
 }
-
-fun isTag(): Boolean {
-  val ref = System.getenv("GITHUB_REF")
-
-  return ref?.startsWith("refs/tags/") == true
-}
-
-fun shouldPublishSnapshots(): Boolean {
-  val eventName = System.getenv("GITHUB_EVENT_NAME")
-  val ref = System.getenv("GITHUB_REF")
-
-  return eventName == "push" && (ref == "refs/heads/main")
-}
-
 
 tasks.register("ciTestsGradle") {
   description = "Execute the Gradle tests (slow)"
@@ -76,11 +68,6 @@ tasks.register("ctg") {
   dependsOn("ciTestsGradle")
 }
 
-val ciBuild = tasks.register("ciBuild") {
-  description = "Execute the 'build' task in each subproject"
-  dependsOn(subprojectTasks("build"))
-}
-
 tasks.named("dependencyUpdates").configure {
   (this as com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask)
   rejectVersionIf {
@@ -125,4 +112,4 @@ tasks.register("rmbuild") {
   }
 }
 
-apolloRoot(ciBuild)
+apolloRoot()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,3 @@
-pluginManagement {
-  includeBuild("build-logic")
-}
-
 plugins {
   id("com.gradle.develocity") version "4.1" // sync with libraries.toml
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.3"
@@ -33,6 +29,8 @@ dependencyResolutionManagement {
     }
   }
 }
+
+includeBuild("build-logic")
 
 apply(from = "./gradle/repositories.gradle.kts")
 apply(from = "./gradle/ge.gradle")

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,21 +1,18 @@
 plugins {
-  id("build.logic") apply false
+  id("base")
 }
 
 buildscript {
   dependencies {
+    classpath("com.apollographql.apollo:build-logic")
     classpath("com.apollographql.apollo:apollo-gradle-plugin")
   }
 }
-val ciBuild = tasks.register("ciBuild") {
-  description = """Execute the 'build' task in subprojects and the `termination:run` task too"""
-  subprojects {
-    this@register.dependsOn(tasks.matching { it.name == "build" })
-  }
-  dependsOn(":termination:run")
+
+tasks.register("checkGitStatus") {
   doLast {
     checkGitStatus()
   }
 }
 
-apolloRoot(ciBuild)
+apolloRoot()

--- a/tests/settings.gradle.kts
+++ b/tests/settings.gradle.kts
@@ -1,7 +1,3 @@
-pluginManagement {
-  includeBuild("../build-logic")
-}
-
 plugins {
   id("com.gradle.develocity") version "4.1" // sync with libraries.toml
   id("com.gradle.common-custom-user-data-gradle-plugin") version "2.3"
@@ -90,6 +86,7 @@ listOf(
   project(":$project").projectDir = rootProject.projectDir.resolve(it)
 }
 
+includeBuild("../build-logic")
 includeBuild("../")
 
 dependencyResolutionManagement {

--- a/tests/termination/build.gradle.kts
+++ b/tests/termination/build.gradle.kts
@@ -21,3 +21,7 @@ apollo {
 application {
   mainClass.set("termination.MainKt")
 }
+
+tasks.named("build").configure {
+  dependsOn("run")
+}


### PR DESCRIPTION
Use `build` more consistently instead of `ciBuild`, remove empty Gradle plugins that were only used for classloading purposes.