### PR TITLE
Make sure that the introspection endpoint property value is checked at execution time

### DIFF
--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -65,10 +65,6 @@ abstract class DefaultService @Inject constructor(val project: Project, override
 
     configure.execute(introspection)
 
-    if (!introspection.endpointUrl.isPresent) {
-      throw IllegalArgumentException("introspection must have a url")
-    }
-
     this.introspection = introspection
   }
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-kotlin/issues/6656

Honestly I didn't find a better place to move the existing check.
There is already [a check performed by the SchemaDownloader](https://github.com/apollographql/apollo-kotlin/blob/main/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/SchemaDownloader.kt#L92). 
It seemed redundant adding another one, but let me know what you think @martinbonnin.