### PR TITLE
[gradle plugin] Use the more lenient dependencies API

### DIFF
--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultService.kt
@@ -236,7 +236,7 @@ abstract class DefaultService @Inject constructor(val project: Project, override
   internal fun isSchemaModule(): Boolean = upstreamDependencies.isEmpty()
 
   override fun plugin(dependencyNotation: Any) {
-    compilerConfiguration.dependencies.add(project.dependencies.create(dependencyNotation))
+    project.dependencies.add(compilerConfiguration.name, dependencyNotation)
     hasPlugin = true
   }
 


### PR DESCRIPTION
`project.dependencies.add()` will make its magic and turn the `Any` into a palatable `Dependency`

Fixes #216