### PR TITLE
Expose compiler plugin dependencies in ServiceModel + expose apolloCompilerRegistry

### DIFF
--- a/libraries/apollo-compiler/api/apollo-compiler.api
+++ b/libraries/apollo-compiler/api/apollo-compiler.api
@@ -217,6 +217,8 @@ public final class com/apollographql/apollo/compiler/EntryPoints {
 }
 
 public final class com/apollographql/apollo/compiler/EntrypointsKt {
+	public static final fun apolloCompilerRegistry (Ljava/util/Map;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;ZLjava/lang/ClassLoader;)Lcom/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry;
+	public static synthetic fun apolloCompilerRegistry$default (Ljava/util/Map;Lcom/apollographql/apollo/compiler/ApolloCompiler$Logger;ZLjava/lang/ClassLoader;ILjava/lang/Object;)Lcom/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry;
 	public static final fun findCodegenSchemaFile (Ljava/lang/Iterable;)Ljava/io/File;
 }
 
@@ -672,6 +674,29 @@ public final class com/apollographql/apollo/compiler/codegen/kotlin/KotlinOutput
 
 public final class com/apollographql/apollo/compiler/codegen/kotlin/helpers/Add_internalKt {
 	public static final fun addInternal (Lcom/squareup/kotlinpoet/FileSpec$Builder;Ljava/util/List;)Lcom/squareup/kotlinpoet/FileSpec$Builder;
+}
+
+public final class com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry : com/apollographql/apollo/compiler/ApolloCompilerRegistry {
+	public fun <init> ()V
+	public final fun executableDocumentTransform ()Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;
+	public final fun foreignSchemas ()Ljava/util/List;
+	public final fun irOperationsTransform ()Lcom/apollographql/apollo/compiler/Transform;
+	public final fun javaOutputTransform ()Lcom/apollographql/apollo/compiler/Transform;
+	public final fun kotlinOutputTransform ()Lcom/apollographql/apollo/compiler/Transform;
+	public final fun layout (Lcom/apollographql/apollo/compiler/CodegenSchema;)Lcom/apollographql/apollo/compiler/codegen/SchemaAndOperationsLayout;
+	public fun registerExecutableDocumentTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/ExecutableDocumentTransform;)V
+	public fun registerForeignSchemas (Ljava/util/List;)V
+	public fun registerIrTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/Transform;)V
+	public fun registerJavaOutputTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/Transform;)V
+	public fun registerKotlinOutputTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/Transform;)V
+	public fun registerLayout (Lcom/apollographql/apollo/compiler/LayoutFactory;)V
+	public fun registerOperationIdsGenerator (Lcom/apollographql/apollo/compiler/OperationIdsGenerator;)V
+	public final fun registerPlugin (Lcom/apollographql/apollo/compiler/ApolloCompilerPlugin;)V
+	public fun registerSchemaCodeGenerator (Lcom/apollographql/apollo/compiler/SchemaCodeGenerator;)V
+	public fun registerSchemaTransform (Ljava/lang/String;[Lcom/apollographql/apollo/compiler/Order;Lcom/apollographql/apollo/compiler/SchemaDocumentTransform;)V
+	public final fun schemaCodeGenerator ()Lcom/apollographql/apollo/compiler/SchemaCodeGenerator;
+	public final fun schemaDocumentTransform ()Lcom/apollographql/apollo/compiler/SchemaDocumentTransform;
+	public final fun toOperationIdsGenerator ()Lcom/apollographql/apollo/compiler/OperationIdsGenerator;
 }
 
 public final class com/apollographql/apollo/compiler/ir/BLabel : com/apollographql/apollo/compiler/ir/BTerm {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
@@ -212,12 +212,12 @@ fun Iterable<File>.findCodegenSchemaFile(): File {
   } ?: error("Cannot find CodegenSchema in $this")
 }
 
-
-
-internal fun apolloCompilerRegistry(
+@ApolloInternal
+fun apolloCompilerRegistry(
     arguments: Map<String, Any?>,
     logger: ApolloCompiler.Logger,
     warnIfNotFound: Boolean = false,
+    classLoader: ClassLoader = ApolloCompilerPlugin::class.java.classLoader,
 ): DefaultApolloCompilerRegistry {
   val registry = DefaultApolloCompilerRegistry()
   val environment = ApolloCompilerPluginEnvironment(
@@ -225,7 +225,7 @@ internal fun apolloCompilerRegistry(
       logger,
   )
   var hasPlugin = false
-  val plugins = ServiceLoader.load(ApolloCompilerPlugin::class.java, ApolloCompilerPlugin::class.java.classLoader).toList()
+  val plugins = ServiceLoader.load(ApolloCompilerPlugin::class.java, classLoader).toList()
   plugins.forEach {
     hasPlugin = true
     it.beforeCompilationStep(environment, registry)
@@ -233,7 +233,7 @@ internal fun apolloCompilerRegistry(
   }
 
   @Suppress("DEPRECATION")
-  val pluginProviders = ServiceLoader.load(ApolloCompilerPluginProvider::class.java, ApolloCompilerPluginProvider::class.java.classLoader).toList()
+  val pluginProviders = ServiceLoader.load(ApolloCompilerPluginProvider::class.java, classLoader).toList()
   pluginProviders.forEach {
     // we make an exception for our own cache plugin because we want to display a nice error message to users before 4.3
     if (it.javaClass.name != "com.apollographql.cache.apollocompilerplugin.ApolloCacheCompilerPluginProvider") {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
@@ -2,6 +2,7 @@
 
 package com.apollographql.apollo.compiler.internal
 
+import com.apollographql.apollo.annotations.ApolloInternal
 import com.apollographql.apollo.ast.ForeignSchema
 import com.apollographql.apollo.compiler.After
 import com.apollographql.apollo.compiler.ApolloCompilerPlugin
@@ -63,7 +64,8 @@ private class Node<T>(val id: String, val transform: T) {
   val dependencies = mutableListOf<Node<T>>()
 }
 
-internal class DefaultApolloCompilerRegistry : ApolloCompilerRegistry {
+@ApolloInternal
+class DefaultApolloCompilerRegistry : ApolloCompilerRegistry {
   private val foreignSchemas = mutableListOf<ForeignSchema>()
   private val schemaTransforms = mutableListOf<Registration<SchemaDocumentTransform>>()
   private val executableDocumentTransforms = mutableListOf<Registration<ExecutableDocumentTransform>>()

--- a/libraries/apollo-gradle-plugin-tasks/api/apollo-gradle-plugin-tasks.api
+++ b/libraries/apollo-gradle-plugin-tasks/api/apollo-gradle-plugin-tasks.api
@@ -75,11 +75,11 @@ public final class com/apollographql/apollo/gradle/task/ApolloGenerateProjectMod
 public final class com/apollographql/apollo/gradle/task/ApolloGenerateServiceModelEntryPoint {
 	public static final field Companion Lcom/apollographql/apollo/gradle/task/ApolloGenerateServiceModelEntryPoint$Companion;
 	public fun <init> ()V
-	public static final fun run (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;Ljava/io/File;)V
+	public static final fun run (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;Ljava/io/File;)V
 }
 
 public final class com/apollographql/apollo/gradle/task/ApolloGenerateServiceModelEntryPoint$Companion {
-	public final fun run (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;Ljava/io/File;)V
+	public final fun run (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;Ljava/io/File;)V
 }
 
 public final class com/apollographql/apollo/gradle/task/ApolloGenerateSourcesEntryPoint {

--- a/libraries/apollo-gradle-plugin-tasks/src/main/kotlin/com/apollographql/apollo/gradle/task/apolloGenerateServiceModel.kt
+++ b/libraries/apollo-gradle-plugin-tasks/src/main/kotlin/com/apollographql/apollo/gradle/task/apolloGenerateServiceModel.kt
@@ -16,6 +16,7 @@ internal fun apolloGenerateServiceModel(
     downstreamGradleProjectPaths: Set<String>,
     endpointUrl: String?,
     endpointHeaders: Map<String, String>?,
+    pluginDependencies: Set<String>,
     telemetryUsedOptions: Set<String>,
 
     // Outputs
@@ -30,6 +31,7 @@ internal fun apolloGenerateServiceModel(
       downstreamGradleProjectPaths = downstreamGradleProjectPaths,
       endpointUrl = endpointUrl,
       endpointHeaders = endpointHeaders,
+      pluginDependencies = pluginDependencies,
       telemetryUsedOptions = telemetryUsedOptions,
   )
       .writeTo(serviceModelFile)

--- a/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
+++ b/libraries/apollo-gradle-plugin/src/main/kotlin/com/apollographql/apollo/gradle/internal/DefaultApolloExtension.kt
@@ -459,6 +459,7 @@ abstract class DefaultApolloExtension(
         },
         endpointUrl = project.provider { service.introspection?.endpointUrl?.orNull },
         endpointHeaders = project.provider { service.introspection?.headers?.orNull },
+        pluginDependencies = project.provider { service.compilerConfiguration.files.map { it.absolutePath }.toSet() },
         telemetryUsedOptions = project.provider { service.telemetryUsedOptions() },
     )
     generateApolloProjectModel.configure {

--- a/libraries/apollo-tooling/api/apollo-tooling.api
+++ b/libraries/apollo-tooling/api/apollo-tooling.api
@@ -182,12 +182,13 @@ public final class com/apollographql/apollo/tooling/model/ProjectModelKt {
 
 public final class com/apollographql/apollo/tooling/model/ServiceModel {
 	public static final field Companion Lcom/apollographql/apollo/tooling/model/ServiceModel$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/util/Set;Ljava/lang/String;Ljava/util/Map;Ljava/util/Set;Ljava/util/Set;)V
 	public final fun getDownstreamGradleProjectPaths ()Ljava/util/Set;
 	public final fun getEndpointHeaders ()Ljava/util/Map;
 	public final fun getEndpointUrl ()Ljava/lang/String;
 	public final fun getGradleProjectPath ()Ljava/lang/String;
 	public final fun getGraphqlSrcDirs ()Ljava/util/Set;
+	public final fun getPluginDependencies ()Ljava/util/Set;
 	public final fun getSchemaFiles ()Ljava/util/Set;
 	public final fun getServiceName ()Ljava/lang/String;
 	public final fun getTelemetryUsedOptions ()Ljava/util/Set;

--- a/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/model/ServiceModel.kt
+++ b/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo/tooling/model/ServiceModel.kt
@@ -29,6 +29,11 @@ class ServiceModel(
     val endpointUrl: String?,
     val endpointHeaders: Map<String, String>?,
 
+    /**
+     * Absolute paths to Apollo Compiler Plugin dependencies.
+     */
+    val pluginDependencies: Set<String>,
+
     val telemetryUsedOptions: Set<String>,
 )
 


### PR DESCRIPTION
In order to do something like [this](https://github.com/apollographql/apollo-intellij-plugin/pull/62/files?w=1#diff-40c14cadd3e04d5c30c6868041266432098251aecc6e31f0b7f463f7a79d027dR56)