### PR TITLE
docs: update linuxX64 as supported for apollo-runtime

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -120,7 +120,7 @@ Here's the current matrix of supported features per platform:
 |                                                      | `jvm` | `Apple¹` | `js` | `wasmJs` | `linuxX64` |
 |------------------------------------------------------|:-----:|:--------:|:----:|:--------:|:----------:|
 | `apollo-api` (models)                                |   ✅   |    ✅     |  ✅   |    ✅     |     ✅      |
-| `apollo-runtime` (network, query batching, apq, ...) |   ✅   |    ✅     |  ✅   |    ✅     |     🚫     |
+| `apollo-runtime` (network, query batching, apq, ...) |   ✅   |    ✅     |  ✅   |    ✅     |     ✅     |
 | `apollo-normalized-cache`                            |   ✅   |    ✅     |  ✅   |    ✅     |     🚫     |
 | `apollo-normalized-cache-sqlite`                     |   ✅   |    ✅     |  🚫  |    🚫    |     🚫     |
 | `apollo-http-cache`                                  |   ✅   |    🚫    |  🚫  |    🚫    |     🚫     |


### PR DESCRIPTION
Per [this issue/comment](https://github.com/apollographql/apollo-kotlin/issues/3483#issuecomment-3094605479) & my usage