### PR TITLE
Remove kotlin-node dependency

### DIFF
--- a/gradle/libraries.toml
+++ b/gradle/libraries.toml
@@ -142,10 +142,6 @@ androidx-benchmark-macro = "androidx.benchmark:benchmark-macro-junit4:1.4.1"
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
-#breaking change from JsTuple to Tuple would require recompiling mock-server
-#breaking change: https://github.com/JetBrains/kotlin-wrappers/commit/c5393273bc7c5c818dccc33ca5067f0e084c9ae0
-#noinspection NewerVersionAvailable
-kotlin-node = "org.jetbrains.kotlin-wrappers:kotlin-node:2025.3.2-22.13.1"
 kotlinx-serialization-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-serialization", version.ref = "kotlin-plugin" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-runtime" }
 kotlinx-binarycompatibilityvalidator = { group = "org.jetbrains.kotlinx", name = "binary-compatibility-validator", version = "0.18.1" }

--- a/kotlin-js-store/package-lock.json
+++ b/kotlin-js-store/package-lock.json
@@ -52,7 +52,7 @@
         "packages/apollo-kotlin-apollo-testing-support-internal-test",
         "packages/apollo-kotlin-apollo-testing-support-internal-wasm-js",
         "packages/apollo-kotlin-apollo-testing-support-internal-wasm-js-test",
-        "packages_imported/kotlin-node/2025.3.2-22.13.1",
+        "packages_imported/kotlin-node/22.5.5-pre.844",
         "packages_imported/ktor-ktor-client-core/3.2.3"
       ],
       "dependencies": {
@@ -811,7 +811,7 @@
       }
     },
     "node_modules/kotlin-node": {
-      "resolved": "packages_imported/kotlin-node/2025.3.2-22.13.1",
+      "resolved": "packages_imported/kotlin-node/22.5.5-pre.844",
       "link": true
     },
     "node_modules/kotlin-web-helpers": {
@@ -1411,6 +1411,7 @@
     "packages_imported/kotlin-node/2025.3.2-22.13.1": {
       "name": "kotlin-node",
       "version": "2025.3.2-22.13.1",
+      "extraneous": true,
       "devDependencies": {}
     },
     "packages_imported/kotlin-node/2025.6.9-22.13.10": {
@@ -1421,7 +1422,6 @@
     "packages_imported/kotlin-node/22.5.5-pre.844": {
       "name": "kotlin-node",
       "version": "22.5.5-pre.844",
-      "extraneous": true,
       "devDependencies": {}
     },
     "packages_imported/ktor-ktor-client-core/3.2.3": {

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -64,14 +64,6 @@ kotlin {
         implementation(libs.ktor.client.js.get().toString()) {
           because("We use in the ktor client in DefaultWebSocketEngine")
         }
-        /**
-         * Kotlin Node declarations
-         *
-         * The situation is a bit weird because jsMain has both browser and node dependencies but
-         * there is not much we can do about it
-         * See https://youtrack.jetbrains.com/issue/KT-47038
-         */
-        implementation(libs.kotlin.node)
       }
     }
 


### PR DESCRIPTION
Turns out we weren't actually using it