### PR TITLE
[compiler] Allow empty deprecationReasons

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/SDLWriter.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/SDLWriter.kt
@@ -47,7 +47,7 @@ open class SDLWriter(
 }
 
 internal fun SDLWriter.writeDescription(description: String?) {
-  if (!description.isNullOrBlank()) {
+  if (description != null) {
     write("\"\"\"${description.encodeToGraphQLTripleQuoted()}\"\"\"\n")
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Doc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Doc.kt
@@ -9,7 +9,7 @@ import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.TypeSpec
 
 internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 
@@ -17,7 +17,7 @@ internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpe
 }
 
 internal fun FieldSpec.Builder.maybeAddDescription(description: String?): FieldSpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Doc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Doc.kt
@@ -1,18 +1,15 @@
 package com.apollographql.apollo.compiler.codegen.java.helpers
 
 
-import com.apollographql.apollo.compiler.internal.applyIf
-import com.apollographql.apollo.compiler.codegen.java.JavaClassNames
 import com.apollographql.apollo.compiler.codegen.java.L
-import com.apollographql.apollo.compiler.codegen.java.S
+import com.apollographql.apollo.compiler.internal.applyIf
 import com.apollographql.apollo.compiler.ir.IrEnum
-import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.FieldSpec
 import com.squareup.javapoet.MethodSpec
 import com.squareup.javapoet.TypeSpec
 
 internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -20,7 +17,7 @@ internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpe
 }
 
 internal fun FieldSpec.Builder.maybeAddDescription(description: String?): FieldSpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -28,7 +25,7 @@ internal fun FieldSpec.Builder.maybeAddDescription(description: String?): FieldS
 }
 
 internal fun TypeSpec.Builder.maybeAddDeprecation(deprecationReason: String?): TypeSpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
@@ -36,13 +33,13 @@ internal fun TypeSpec.Builder.maybeAddDeprecation(deprecationReason: String?): T
 }
 
 internal fun FieldSpec.Builder.maybeAddDeprecation(deprecationReason: String?): FieldSpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
   return addJavadoc("$L\n", deprecationReason).addAnnotation(deprecatedAnnotation())
 }
 
-internal fun MethodSpec.Builder.maybeSuppressDeprecation(enumValues: List<IrEnum.Value>): MethodSpec.Builder = applyIf(enumValues.any { !it.deprecationReason.isNullOrBlank() }) {
+internal fun MethodSpec.Builder.maybeSuppressDeprecation(enumValues: List<IrEnum.Value>): MethodSpec.Builder = applyIf(enumValues.any { it.deprecationReason != null }) {
   addAnnotation(suppressDeprecatedAnnotation())
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/KDoc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/KDoc.kt
@@ -14,7 +14,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -22,7 +22,7 @@ internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpe
 }
 
 internal fun PropertySpec.Builder.maybeAddDescription(description: String?): PropertySpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -30,7 +30,7 @@ internal fun PropertySpec.Builder.maybeAddDescription(description: String?): Pro
 }
 
 internal fun ParameterSpec.Builder.maybeAddDescription(description: String?): ParameterSpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -38,7 +38,7 @@ internal fun ParameterSpec.Builder.maybeAddDescription(description: String?): Pa
 }
 
 internal fun FunSpec.Builder.maybeAddDescription(description: String?): FunSpec.Builder {
-  if (description.isNullOrBlank()) {
+  if (description == null) {
     return this
   }
 
@@ -47,7 +47,7 @@ internal fun FunSpec.Builder.maybeAddDescription(description: String?): FunSpec.
 
 
 internal fun TypeSpec.Builder.maybeAddDeprecation(deprecationReason: String?): TypeSpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
@@ -55,7 +55,7 @@ internal fun TypeSpec.Builder.maybeAddDeprecation(deprecationReason: String?): T
 }
 
 internal fun PropertySpec.Builder.maybeAddDeprecation(deprecationReason: String?): PropertySpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
@@ -63,7 +63,7 @@ internal fun PropertySpec.Builder.maybeAddDeprecation(deprecationReason: String?
 }
 
 internal fun ParameterSpec.Builder.maybeAddDeprecation(deprecationReason: String?): ParameterSpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
@@ -71,7 +71,7 @@ internal fun ParameterSpec.Builder.maybeAddDeprecation(deprecationReason: String
 }
 
 internal fun FunSpec.Builder.maybeAddDeprecation(deprecationReason: String?): FunSpec.Builder {
-  if (deprecationReason.isNullOrBlank()) {
+  if (deprecationReason == null) {
     return this
   }
 
@@ -79,7 +79,7 @@ internal fun FunSpec.Builder.maybeAddDeprecation(deprecationReason: String?): Fu
 }
 
 internal fun TypeSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): TypeSpec.Builder {
-  if (optInFeature.isNullOrBlank()) {
+  if (optInFeature == null) {
     return this
   }
 
@@ -88,7 +88,7 @@ internal fun TypeSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, op
 }
 
 internal fun PropertySpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): PropertySpec.Builder {
-  if (optInFeature.isNullOrBlank()) {
+  if (optInFeature == null) {
     return this
   }
 
@@ -97,7 +97,7 @@ internal fun PropertySpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver
 }
 
 internal fun ParameterSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): ParameterSpec.Builder {
-  if (optInFeature.isNullOrBlank()) {
+  if (optInFeature == null) {
     return this
   }
 
@@ -106,7 +106,7 @@ internal fun ParameterSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolve
 }
 
 internal fun FunSpec.Builder.maybeAddRequiresOptIn(resolver: KotlinResolver, optInFeature: String?): FunSpec.Builder {
-  if (optInFeature.isNullOrBlank()) {
+  if (optInFeature == null) {
     return this
   }
 
@@ -123,7 +123,7 @@ internal fun requiresOptInAnnotation(annotation: ClassName): AnnotationSpec {
 internal fun <T: Annotatable.Builder<*>> T.maybeAddOptIn(
     resolver: KotlinResolver,
     enumValues: List<IrEnum.Value>,
-): T = applyIf(enumValues.any { !it.optInFeature.isNullOrBlank() }) {
+): T = applyIf(enumValues.any { it.optInFeature != null }) {
   val annotation = resolver.resolveRequiresOptInAnnotation() ?: return@applyIf
   addAnnotation(requiresOptInAnnotation(annotation))
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/KDoc.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/KDoc.kt
@@ -14,7 +14,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 
 internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 
@@ -22,7 +22,7 @@ internal fun TypeSpec.Builder.maybeAddDescription(description: String?): TypeSpe
 }
 
 internal fun PropertySpec.Builder.maybeAddDescription(description: String?): PropertySpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 
@@ -30,7 +30,7 @@ internal fun PropertySpec.Builder.maybeAddDescription(description: String?): Pro
 }
 
 internal fun ParameterSpec.Builder.maybeAddDescription(description: String?): ParameterSpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 
@@ -38,7 +38,7 @@ internal fun ParameterSpec.Builder.maybeAddDescription(description: String?): Pa
 }
 
 internal fun FunSpec.Builder.maybeAddDescription(description: String?): FunSpec.Builder {
-  if (description == null) {
+  if (description.isNullOrBlank()) {
     return this
   }
 


### PR DESCRIPTION
Some users are doing this:

```graphql
type Query {
  foo: Int @deprecated(reason: "")
}
```

The motivation is questionable but nevertheless, [`empty` != `absent`](https://external-preview.redd.it/kRt0jItRkbMkJLfQRXpAc_oj-9O9nlVMsYCMWZmgedE.jpg?auto=webp&s=3e1170f8c4935f53d18a76c098dba919e0c646cc) and we should be consistent here.