### PR TITLE
Unbreak Swift tests in CI

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -54,4 +54,4 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
       - run: |
-          /Applications/Xcode_26.app/Contents/Developer/usr/bin/xcodebuild -allowProvisioningUpdates -project swift-tests/swift-tests.xcodeproj -configuration Debug -scheme swift-tests  test -test-timeouts-enabled YES
+          /Applications/Xcode_26.0.1.app/Contents/Developer/usr/bin/xcodebuild -allowProvisioningUpdates -project swift-tests/swift-tests.xcodeproj -configuration Debug -scheme swift-tests  test -test-timeouts-enabled YES


### PR DESCRIPTION
The path of Xcode changed [here](https://github.com/actions/runner-images/commit/2ca024f189e0acf34a4aaf4072789e3a98f5abac). 

I'm not sure what compatibility guarantees are available on CI runners TBH since we didn't change the `macos-15` name. Maybe we should just use `macos-latest` if those "tags" are mutable.