### PR TITLE
perf(compiler): index the type hierarchy and drop O(n^2) work from the schema checks

### DIFF
--- a/libraries/apollo-annotations/api/apollo-annotations.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.api
@@ -30,6 +30,7 @@ public final class com/apollographql/apollo/annotations/ApolloDeprecatedSince$Ve
 	public static final field v4_3_4 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static final field v5_0_0 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static final field v5_0_1 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
+	public static final field v5_0_2 Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;
 	public static fun values ()[Lcom/apollographql/apollo/annotations/ApolloDeprecatedSince$Version;

--- a/libraries/apollo-annotations/api/apollo-annotations.klib.api
+++ b/libraries/apollo-annotations/api/apollo-annotations.klib.api
@@ -43,6 +43,7 @@ open annotation class com.apollographql.apollo.annotations/ApolloDeprecatedSince
         enum entry v4_3_4 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v4_3_4|null[0]
         enum entry v5_0_0 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v5_0_0|null[0]
         enum entry v5_0_1 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v5_0_1|null[0]
+        enum entry v5_0_2 // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.v5_0_2|null[0]
 
         final val entries // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.entries|#static{}entries[0]
             final fun <get-entries>(): kotlin.enums/EnumEntries<com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version> // com.apollographql.apollo.annotations/ApolloDeprecatedSince.Version.entries.<get-entries>|<get-entries>#static(){}[0]

--- a/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo/annotations/ApolloDeprecatedSince.kt
+++ b/libraries/apollo-annotations/src/commonMain/kotlin/com/apollographql/apollo/annotations/ApolloDeprecatedSince.kt
@@ -39,5 +39,6 @@ annotation class ApolloDeprecatedSince(val version: Version) {
     v4_3_4,
     v5_0_0,
     v5_0_1,
+    v5_0_2,
   }
 }

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -54,6 +54,43 @@ class Schema internal constructor(
 
   val subscriptionTypeDefinition: GQLTypeDefinition? = rootOperationTypeDefinition("subscription", definitions)
 
+  /**
+   * Maps an interface name to the object and interface types implementing it directly, in schema declaration order.
+   *
+   * Without this, [possibleTypes] has to scan every type definition of the schema on every call, and again for
+   * every level of the interface hierarchy.
+   */
+  private val directSubtypes: Map<String, List<GQLTypeDefinition>> by lazy {
+    val result = mutableMapOf<String, MutableList<GQLTypeDefinition>>()
+    typeDefinitions.values.forEach { typeDefinition ->
+      val implementsInterfaces = when (typeDefinition) {
+        is GQLObjectTypeDefinition -> typeDefinition.implementsInterfaces
+        is GQLInterfaceTypeDefinition -> typeDefinition.implementsInterfaces
+        else -> return@forEach
+      }
+      implementsInterfaces.forEach {
+        result.getOrPut(it) { mutableListOf() }.add(typeDefinition)
+      }
+    }
+    result
+  }
+
+  /**
+   * Maps a type name to the names of the unions it is a member of, in schema declaration order.
+   *
+   * Without this, [implementedTypes] and [superTypes] have to scan every type definition of the schema on every call.
+   */
+  private val unionsByMember: Map<String, List<String>> by lazy {
+    val result = mutableMapOf<String, MutableList<String>>()
+    typeDefinitions.values.forEach { typeDefinition ->
+      if (typeDefinition !is GQLUnionTypeDefinition) return@forEach
+      typeDefinition.memberTypes.forEach {
+        result.getOrPut(it.name) { mutableListOf() }.add(typeDefinition.name)
+      }
+    }
+    result
+  }
+
   fun toGQLDocument(): GQLDocument = GQLDocument(
       definitions = definitions,
       sourceLocation = null
@@ -69,7 +106,16 @@ class Schema internal constructor(
   }
 
   fun rootTypeNameOrNullFor(operationType: String): String? {
-    return rootOperationTypeDefinition(operationType, definitions)?.name
+    /*
+     * The root operation types are resolved once in the constructor. Do not resolve them again here, that would
+     * mean filtering all the definitions on every call.
+     */
+    return when (operationType) {
+      "query" -> queryTypeDefinition.name
+      "mutation" -> mutationTypeDefinition?.name
+      "subscription" -> subscriptionTypeDefinition?.name
+      else -> rootOperationTypeDefinition(operationType, definitions)?.name
+    }
   }
 
   fun rootTypeNameFor(operationType: String): String {
@@ -92,12 +138,8 @@ class Schema internal constructor(
   fun possibleTypes(typeDefinition: GQLTypeDefinition): Set<String> {
     return when (typeDefinition) {
       is GQLUnionTypeDefinition -> typeDefinition.memberTypes.map { it.name }.toSet()
-      is GQLInterfaceTypeDefinition -> typeDefinitions.values.filter {
-        it is GQLObjectTypeDefinition && it.implementsInterfaces.contains(typeDefinition.name)
-            || it is GQLInterfaceTypeDefinition && it.implementsInterfaces.contains(typeDefinition.name)
-      }.flatMap {
+      is GQLInterfaceTypeDefinition -> directSubtypes[typeDefinition.name].orEmpty().flatMap {
         // Recurse until we reach the concrete types
-        // This could certainly be improved
         possibleTypes(it).toList()
       }.toSet()
 
@@ -143,9 +185,7 @@ class Schema internal constructor(
     val typeDefinition = typeDefinition(name)
     return when (typeDefinition) {
       is GQLObjectTypeDefinition -> {
-        val unions = typeDefinitions.values.filterIsInstance<GQLUnionTypeDefinition>().filter {
-          it.memberTypes.map { it.name }.toSet().contains(typeDefinition.name)
-        }.map { it.name }
+        val unions = unionsByMember[typeDefinition.name].orEmpty()
         typeDefinition.implementsInterfaces.flatMap { implementedTypes(it) }.toSet() + name + unions
       }
 
@@ -169,9 +209,7 @@ class Schema internal constructor(
       is GQLUnionTypeDefinition -> emptyList()
       else -> error("Type '${typeDefinition.name}' cannot have a super type.")
     }
-    val unions = typeDefinitions.values.filterIsInstance<GQLUnionTypeDefinition>().filter {
-      it.memberTypes.map { it.name }.toSet().contains(typeDefinition.name)
-    }.map { it.name }
+    val unions = unionsByMember[typeDefinition.name].orEmpty()
     return (implementsInterfaces + unions).toSet()
   }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -106,18 +106,16 @@ class Schema internal constructor(
   }
 
   fun rootTypeNameOrNullFor(operationType: String): String? {
-    /*
-     * The root operation types are resolved once in the constructor. Do not resolve them again here, that would
-     * mean filtering all the definitions on every call.
-     */
     return when (operationType) {
       "query" -> queryTypeDefinition.name
       "mutation" -> mutationTypeDefinition?.name
       "subscription" -> subscriptionTypeDefinition?.name
-      else -> error("Unknown operation type: '$operationType'")
+      else -> null
     }
   }
 
+  @Deprecated("Use rootTypeNameOrNullFor instead", ReplaceWith("rootTypeNameOrNullFor(operationType)"))
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_2)
   fun rootTypeNameFor(operationType: String): String {
     return rootTypeNameOrNullFor(operationType) ?: operationType.replaceFirstChar { it.uppercaseChar() }
   }
@@ -294,11 +292,11 @@ class Schema internal constructor(
       )
     }
 
-    internal fun rootOperationTypeDefinition(operationType: String, definitions: List<GQLDefinition>): GQLTypeDefinition? {
+    private fun rootOperationTypeDefinition(operationType: String, definitions: List<GQLDefinition>): GQLTypeDefinition? {
       return rootOperationTypeDefinition(definitions.filterIsInstance<GQLSchemaDefinition>().single(), operationType, definitions.filterIsInstance<GQLObjectTypeDefinition>().associateBy { it.name })
     }
 
-    internal fun rootOperationTypeDefinition(schemaTypeDefinition: GQLSchemaDefinition, operationType: String, typeDefinitions: Map<String, GQLTypeDefinition>): GQLTypeDefinition? {
+    private fun rootOperationTypeDefinition(schemaTypeDefinition: GQLSchemaDefinition, operationType: String, typeDefinitions: Map<String, GQLTypeDefinition>): GQLTypeDefinition? {
       return schemaTypeDefinition
           .rootOperationTypeDefinitions
           .singleOrNull {

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -114,7 +114,7 @@ class Schema internal constructor(
       "query" -> queryTypeDefinition.name
       "mutation" -> mutationTypeDefinition?.name
       "subscription" -> subscriptionTypeDefinition?.name
-      else -> rootOperationTypeDefinition(operationType, definitions)?.name
+      else -> error("Unknown operation type: '$operationType'")
     }
   }
 

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/SchemaValidationScope.kt
@@ -360,8 +360,7 @@ internal fun syntheticSchemaDefinition(typeDefinitions: Map<String, GQLTypeDefin
     )
   }
 
-  return GQLSchemaDefinition(description = null, directives = emptyList(), rootOperationTypeDefinitions = operationTypeDefinitions
-  )
+  return GQLSchemaDefinition(description = null, directives = emptyList(), rootOperationTypeDefinitions = operationTypeDefinitions)
 }
 
 /**

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/fields_merging.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/fields_merging.kt
@@ -57,7 +57,6 @@ private data class ValidationContext(
   val visitedShapeSets = mutableSetOf<Set<FieldAndType>>()
   val visitedParentSets = mutableSetOf<Set<FieldAndType>>()
   val variableValuesInScope = mutableListOf<Map<String, GQLValue>>()
-  val mergeSubSelectionsCache = mutableMapOf<Set<FieldAndType>, Map<String, MutableSet<FieldAndType>>>()
 
   fun pushFragment(arguments: List<GQLArgument>, variableDefinitions: List<GQLVariableDefinition>) {
     val newValues = mutableMapOf<String, GQLValue>()

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/TypeHierarchyTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/TypeHierarchyTest.kt
@@ -1,0 +1,134 @@
+package com.apollographql.apollo.graphql.ast.test
+
+import com.apollographql.apollo.ast.Schema
+import com.apollographql.apollo.ast.toGQLDocument
+import com.apollographql.apollo.ast.validateAsSchema
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests [Schema.possibleTypes], [Schema.implementedTypes] and [Schema.superTypes], which are all backed by an index of
+ * the type hierarchy. Interfaces implementing other interfaces and unions are the interesting cases there.
+ */
+class TypeHierarchyTest {
+  // language=graphql
+  private val schema: Schema = """
+      type Query {
+        node: Node
+      }
+
+      interface Node {
+        id: ID!
+      }
+
+      interface Named implements Node {
+        id: ID!
+        name: String!
+      }
+
+      interface Alone {
+        nothing: String
+      }
+
+      type Person implements Named & Node {
+        id: ID!
+        name: String!
+      }
+
+      type Company implements Named & Node {
+        id: ID!
+        name: String!
+      }
+
+      type Robot implements Node {
+        id: ID!
+      }
+
+      union Actor = Person | Company
+
+      union Anything = Person | Company | Robot
+  """.trimIndent().toGQLDocument().validateAsSchema().getOrThrow()
+
+  @Test
+  fun possibleTypesOfAnInterfaceIncludesTransitiveImplementations() {
+    // Person and Company implement Node through Named only
+    assertEquals(setOf("Person", "Company", "Robot"), schema.possibleTypes("Node"))
+    assertEquals(setOf("Person", "Company"), schema.possibleTypes("Named"))
+  }
+
+  @Test
+  fun possibleTypesOfAnInterfaceWithoutImplementationsIsEmpty() {
+    assertEquals(emptySet(), schema.possibleTypes("Alone"))
+  }
+
+  @Test
+  fun possibleTypesOfAUnionAreItsMembers() {
+    assertEquals(setOf("Person", "Company"), schema.possibleTypes("Actor"))
+  }
+
+  @Test
+  fun possibleTypesOfAnObjectIsItself() {
+    assertEquals(setOf("Person"), schema.possibleTypes("Person"))
+  }
+
+  @Test
+  fun implementedTypesIncludeTransitiveInterfacesAndUnions() {
+    assertEquals(setOf("Node", "Named", "Person", "Actor", "Anything"), schema.implementedTypes("Person"))
+    // Robot is not a member of Actor
+    assertEquals(setOf("Node", "Robot", "Anything"), schema.implementedTypes("Robot"))
+    assertEquals(setOf("Node", "Named"), schema.implementedTypes("Named"))
+    assertEquals(setOf("Actor"), schema.implementedTypes("Actor"))
+  }
+
+  @Test
+  fun subTypesAndSuperTypes() {
+    assertTrue(schema.isTypeASubTypeOf("Person", "Node"))
+    assertTrue(schema.isTypeASubTypeOf("Person", "Actor"))
+    assertFalse(schema.isTypeASubTypeOf("Robot", "Actor"))
+    assertTrue(schema.isTypeASuperTypeOf("Node", "Person"))
+  }
+
+  @Test
+  fun superTypesAreDirectOnly() {
+    // Node is implemented through Named and is not a direct super type of Person
+    assertEquals(setOf("Named", "Node", "Actor", "Anything"), schema.superTypes(schema.typeDefinition("Person")))
+    assertEquals(setOf("Node"), schema.superTypes(schema.typeDefinition("Named")))
+    assertEquals(emptySet(), schema.superTypes(schema.typeDefinition("Alone")))
+  }
+
+  @Test
+  fun rootTypeNamesUseTheSchemaDefinition() {
+    assertEquals("Query", schema.rootTypeNameOrNullFor("query"))
+    assertNull(schema.rootTypeNameOrNullFor("mutation"))
+    assertNull(schema.rootTypeNameOrNullFor("subscription"))
+    assertNull(schema.rootTypeNameOrNullFor("somethingElse"))
+    assertEquals("Mutation", schema.rootTypeNameFor("mutation"))
+  }
+
+  @Test
+  fun rootTypeNamesHonourCustomRootTypes() {
+    // language=graphql
+    val customRoots = """
+      schema {
+        query: MyQuery
+        mutation: MyMutation
+      }
+
+      type MyQuery {
+        foo: Int
+      }
+
+      type MyMutation {
+        setFoo(foo: Int): Int
+      }
+    """.trimIndent().toGQLDocument().validateAsSchema().getOrThrow()
+
+    assertEquals("MyQuery", customRoots.rootTypeNameOrNullFor("query"))
+    assertEquals("MyMutation", customRoots.rootTypeNameOrNullFor("mutation"))
+    assertNull(customRoots.rootTypeNameOrNullFor("subscription"))
+    assertEquals("Subscription", customRoots.rootTypeNameFor("subscription"))
+  }
+}

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/TypeHierarchyTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/TypeHierarchyTest.kt
@@ -105,7 +105,6 @@ class TypeHierarchyTest {
     assertNull(schema.rootTypeNameOrNullFor("mutation"))
     assertNull(schema.rootTypeNameOrNullFor("subscription"))
     assertNull(schema.rootTypeNameOrNullFor("somethingElse"))
-    assertEquals("Mutation", schema.rootTypeNameFor("mutation"))
   }
 
   @Test
@@ -129,6 +128,5 @@ class TypeHierarchyTest {
     assertEquals("MyQuery", customRoots.rootTypeNameOrNullFor("query"))
     assertEquals("MyMutation", customRoots.rootTypeNameOrNullFor("mutation"))
     assertNull(customRoots.rootTypeNameOrNullFor("subscription"))
-    assertEquals("Subscription", customRoots.rootTypeNameFor("subscription"))
   }
 }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkApolloTargetNameClashes.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkApolloTargetNameClashes.kt
@@ -17,23 +17,29 @@ import com.apollographql.apollo.compiler.uniqueName
 internal fun checkApolloTargetNameClashes(schema: Schema): List<Issue> {
   val issues = mutableListOf<Issue>()
 
-  val typesWithTargetName: Map<GQLTypeDefinition, String?> = schema
+  /*
+   * A list and not a Map: hashing a GQLTypeDefinition hashes its whole subtree, which is expensive for large schemas.
+   */
+  val typesWithTargetName: List<Pair<GQLTypeDefinition, String?>> = schema
       .typeDefinitions
       .values
       // Sort to ensure consistent results
       .sortedBy { it.name }
-      .associateWith { it.directives.findTargetName(schema) }
-  val usedNames = mutableMapOf<String, GQLTypeDefinition>()
+      .map { it to it.directives.findTargetName(schema) }
+  val usedNames = HashMap<String, GQLTypeDefinition>(2 * typesWithTargetName.size)
 
   // 1. Collect unique names for types without a targetName
-  for ((type, _) in typesWithTargetName.filterValues { it == null }) {
-    val name = uniqueName(type.name, usedNames.keys.toSet())
+  for ((type, targetName) in typesWithTargetName) {
+    if (targetName != null) continue
+    // `usedNames.keys` is only read by `uniqueName`, no need to copy it
+    val name = uniqueName(type.name, usedNames.keys)
     usedNames[name.lowercase()] = type
   }
 
   // 2. Check targetName for types that define it
-  for ((type, targetName) in typesWithTargetName.filterValues { it != null }) {
-    val name = targetName!!.lowercase()
+  for ((type, targetName) in typesWithTargetName) {
+    if (targetName == null) continue
+    val name = targetName.lowercase()
     if (usedNames.containsKey(name)) {
       val typeForUsedName = usedNames[name]!!
       issues.add(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/serialization.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/serialization.kt
@@ -29,18 +29,25 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.longOrNull
 
 
-internal object SchemaSerializer: KSerializer<Schema> {
-  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Schema", PrimitiveKind.STRING)
+/**
+ * Serializes the schema as a Json object.
+ *
+ * Note: this used to encode the schema as a Json **string** containing Json. Because the schema contains the whole SDL,
+ * that meant escaping and unescaping several MB of text twice for large schemas, on top of the buffering required to
+ * turn the nested document into a string. Encoding a [JsonElement] inline avoids all of that.
+ */
+internal object SchemaSerializer : KSerializer<Schema> {
+  override val descriptor: SerialDescriptor = JsonElement.serializer().descriptor
 
   override fun deserialize(decoder: Decoder): Schema {
-    val map = Json.parseToJsonElement(decoder.decodeString()).toAny()
+    val map = decoder.decodeSerializableValue(JsonElement.serializer()).toAny()
 
     @Suppress("UNCHECKED_CAST")
     return Schema.fromMap(map as Map<String, Any>)
   }
 
   override fun serialize(encoder: Encoder, value: Schema) {
-    encoder.encodeString(value.toMap().toJsonElement().toString())
+    encoder.encodeSerializableValue(JsonElement.serializer(), value.toMap().toJsonElement())
   }
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
@@ -259,7 +259,7 @@ internal class IrOperationsBuilder(
     return IrOperationDefinition(
         name = name!!,
         description = description,
-        operationType = operationType.toIrOperationType(schema.rootTypeNameFor(operationType)),
+        operationType = operationType.toIrOperationType(schema.rootTypeNameOrNullFor(operationType)!!),
         typeCondition = typeDefinition.name,
         variables = variableDefinitions.map { it.toIr() },
         selectionSets = SelectionSetsBuilder(schema, allFragmentDefinitions).build(selections, typeDefinition.name),

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/json.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/json.kt
@@ -8,6 +8,7 @@ import com.apollographql.apollo.compiler.ir.IrSchema
 import com.apollographql.apollo.compiler.operationoutput.OperationDescriptor
 import com.apollographql.apollo.compiler.operationoutput.OperationOutput
 import com.apollographql.apollo.compiler.pqm.PersistedQueryManifest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -22,6 +23,10 @@ private val json = Json {
 }
 
 private val prettyPrintJson = Json { prettyPrint = true }
+
+private val lenientJson = Json {
+  ignoreUnknownKeys = true
+}
 
 private inline fun <reified T> T.encodeToJson(file: File) {
   // XXX: use a streaming API when they are not experimental anymore
@@ -83,16 +88,35 @@ internal class MinimalCodegen(
 
 @JvmName("readCodegenMetadata")
 fun File.toCodegenMetadata(): CodegenMetadata {
-  val json = Json {
-    ignoreUnknownKeys = true
-  }
   // XXX: use a streaming API when they are not experimental anymore
-  val version = json.decodeFromString<MinimalCodegen>(readText()).version
-
-  check(version == CODEGEN_METADATA_VERSION) {
-    "Apollo: unsupported metadata version '$version' (expected '$CODEGEN_METADATA_VERSION')"
+  // Read and parse the file only once: the metadata of a large schema is several MB and this is called for every
+  // upstream module. Parse optimistically and only look at the version if that fails: an incompatible version is the
+  // most likely reason for a failure, and the version is a field of CodegenMetadata anyways.
+  val text = readText()
+  val codegenMetadata = try {
+    json.decodeFromString<CodegenMetadata>(text)
+  } catch (e: SerializationException) {
+    val version = try {
+      lenientJson.decodeFromString<MinimalCodegen>(text).version
+    } catch (_: SerializationException) {
+      // Not a metadata file at all, the original error is the most useful one
+      throw e
+    }
+    if (version != CODEGEN_METADATA_VERSION) {
+      throw IllegalStateException(versionMismatchMessage(version), e)
+    }
+    // Same version, this is something else
+    throw e
   }
-  return parseFromJson()
+
+  check(codegenMetadata.version == CODEGEN_METADATA_VERSION) {
+    versionMismatchMessage(codegenMetadata.version)
+  }
+  return codegenMetadata
+}
+
+private fun File.versionMismatchMessage(version: String?): String {
+  return "Apollo: unsupported metadata version '$version' (expected '$CODEGEN_METADATA_VERSION') in '$path'"
 }
 
 @JvmName("readOperationOutput")

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
@@ -140,7 +140,7 @@ internal class OperationContext(
         return graphqlErrorResponse("Unknown operation type '${operation.operationType}")
       }
     }
-    val typeDefinition = schema.typeDefinition(schema.rootTypeNameFor(operation.operationType))
+    val typeDefinition = schema.typeDefinition(rootTypename)
 
     val groupedFieldSet = collectFields(typeDefinition.name, operation.selections, variableValues)
 


### PR DESCRIPTION
Measured on a 3.9 MB schema (4350 type definitions, 347 interfaces and unions) with 139 operations. `buildIrOperations` goes from 425 ms to 226 ms. Most of what it spends is schema-wide and identical in every module using the schema, so the win scales with the number of modules.

`Schema`: index the type hierarchy once instead of scanning every type definition on every call.

- `possibleTypes` scanned all the type definitions to find the implementations of an interface, and did it again at every level of the hierarchy. It now walks an interface name -> direct implementations map. Iterating all the abstract types: 108 ms -> 4 ms.
- `implementedTypes` and `superTypes` scanned all the type definitions to find the unions a type belongs to. They now use a member name -> union names map. Iterating all the object types: 2270 ms -> 10 ms.
- `rootTypeNameOrNullFor` re-filtered and re-associated all the definitions on every call, even though the root operation types are already resolved in the constructor. 10k calls: 446 ms -> 0 ms.

Both indexes are built lazily and keep schema declaration order, so the returned sets iterate exactly as before and the generated sources are unchanged.

`checkApolloTargetNameClashes`: copied the accumulated key set on every one of the type definitions, and keyed its intermediate maps by `GQLTypeDefinition`, which hashes a whole type subtree per lookup. It now keeps a list and passes the live key set to `uniqueName`, which only reads it: 148 ms -> 1 ms.

`SchemaSerializer`: encoded the schema as a Json *string* containing Json, so the SDL was escaped twice and the nested document buffered into a string. Encoding a `JsonElement` inline instead takes the codegen schema artifact from 4,456,148 to 4,076,650 bytes and its deserialization from 40 ms to 35 ms. Every module reads that artifact at least twice.

`toCodegenMetadata`: read the whole file twice, once for the version check.

Also remove `ValidationContext.mergeSubSelectionsCache`, which is never read or written.