### PR TITLE
perf(ast): skip the @defer walk and index field definitions

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -91,6 +91,33 @@ class Schema internal constructor(
     result
   }
 
+  /**
+   * Maps a type name to its field definitions by name, including the meta fields (see [GQLTypeDefinition.fieldDefinitions]).
+   *
+   * Without this, resolving a field definition rebuilds the field definitions of the parent type and scans them
+   * linearly, and that happens for every field of every selection set.
+   */
+  private val fieldDefinitionsByName: Map<String, Map<String, GQLFieldDefinition>> by lazy {
+    typeDefinitions.mapValues { (_, typeDefinition) ->
+      buildMap {
+        typeDefinition.fieldDefinitions(this@Schema).forEach {
+          // Keep the first one, like the linear scan this replaces: an invalid schema may define a field twice
+          if (!containsKey(it.name)) {
+            put(it.name, it)
+          }
+        }
+      }
+    }
+  }
+
+  internal fun fieldDefinition(parentTypeDefinition: GQLTypeDefinition, name: String): GQLFieldDefinition? {
+    if (typeDefinitions[parentTypeDefinition.name] !== parentTypeDefinition) {
+      // Not a type definition of this schema (a synthetic one, for an example), the index doesn't apply
+      return parentTypeDefinition.fieldDefinitions(this).firstOrNull { it.name == name }
+    }
+    return fieldDefinitionsByName[parentTypeDefinition.name]?.get(name)
+  }
+
   fun toGQLDocument(): GQLDocument = GQLDocument(
       definitions = definitions,
       sourceLocation = null

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqlfield.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/gqlfield.kt
@@ -71,7 +71,7 @@ fun GQLTypeDefinition.fieldDefinitions(schema: Schema): List<GQLFieldDefinition>
 }
 
 fun GQLField.definitionFromScope(schema: Schema, parentTypeDefinition: GQLTypeDefinition): GQLFieldDefinition? {
-  return parentTypeDefinition.fieldDefinitions(schema).firstOrNull { it.name == name }
+  return schema.fieldDefinition(parentTypeDefinition, name)
 }
 
 fun GQLField.responseName() = alias ?: name

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/ExecutableValidationScope.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/ExecutableValidationScope.kt
@@ -45,6 +45,7 @@ import com.apollographql.apollo.ast.findCatch
 import com.apollographql.apollo.ast.findDeprecationReason
 import com.apollographql.apollo.ast.getArgumentValueOrDefault
 import com.apollographql.apollo.ast.internal.pretty
+import com.apollographql.apollo.ast.internal.validation.hasDeferDirective
 import com.apollographql.apollo.ast.internal.validation.validateDeferLabels
 import com.apollographql.apollo.ast.isInputType
 import com.apollographql.apollo.ast.pretty
@@ -76,6 +77,15 @@ internal class ExecutableValidationScope(
   private val fragmentOperationVariableUsages = mutableMapOf<String, List<VariableUsage>>()
   private val cyclicFragments = mutableSetOf<String>()
   private val usedFragments = mutableSetOf<String>()
+
+  /**
+   * Whether a `@defer` directive occurs anywhere in the document being validated.
+   *
+   * `@defer` validation walks the fully expanded selection set of every operation, which is expensive on documents with
+   * many fragments. If the document has no `@defer` at all then no operation of that document can have one either, so
+   * the whole walk can be skipped.
+   */
+  private var documentHasDeferDirective = false
   private val hasCatchByDefault = schema.directiveDefinitions.any { schema.originalDirectiveName(it.key) == Schema.CATCH_BY_DEFAULT }
 
   /**
@@ -157,6 +167,7 @@ internal class ExecutableValidationScope(
     }
 
     val operations = document.definitions.filterIsInstance<GQLOperationDefinition>()
+    documentHasDeferDirective = operations.any { hasDeferDirective(it.selections) } || fragments.any { hasDeferDirective(it.selections) }
     operations.checkDuplicateOperations()
     operations.forEach {
       it.validate()
@@ -492,7 +503,9 @@ internal class ExecutableValidationScope(
     validateDirectives(directives, this) {
       variableUsages.add(it)
     }
-    issues.addAll(validateDeferLabels(this, rootTypeDefinition.name, schema, fragmentDefinitions))
+    if (documentHasDeferDirective) {
+      issues.addAll(validateDeferLabels(this, rootTypeDefinition.name, schema, fragmentDefinitions))
+    }
 
     val allVariableUsages = selections.collectFragmentSpreads().flatMap { fragmentOperationVariableUsages.get(it) ?: emptyList() } + variableUsages
     validateVariableUsages(variableDefinitions, allVariableUsages, context = this.pretty())

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/validation/defer_labels.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/validation/defer_labels.kt
@@ -20,6 +20,33 @@ import com.apollographql.apollo.ast.definitionFromScope
 import com.apollographql.apollo.ast.rawType
 import com.apollographql.apollo.ast.responseName
 
+/**
+ * The label is used in the name of a synthetic field, so it must be a valid Kotlin/Java identifier.
+ *
+ * Top-level: compiling a [Regex] is expensive and this one is a constant.
+ */
+private val labelRegex = Regex("[a-zA-Z0-9_]+")
+
+private fun List<GQLDirective>.hasDefer(): Boolean = any { it.name == Schema.DEFER }
+
+/**
+ * Returns true if a `@defer` directive occurs anywhere in [selections].
+ *
+ * Fragment spreads are not expanded: callers are expected to scan the fragment definitions of the document too. This
+ * makes the scan linear in the size of the document as written, and lets [validateDeferLabels] be skipped altogether
+ * for the documents that do not use `@defer` at all (by far the most common case). [validateDeferLabels] expands every
+ * fragment spread inline, so it is orders of magnitude more expensive on fragment-heavy documents.
+ */
+internal fun hasDeferDirective(selections: List<GQLSelection>): Boolean {
+  return selections.any {
+    when (it) {
+      is GQLField -> it.directives.hasDefer() || hasDeferDirective(it.selections)
+      is GQLInlineFragment -> it.directives.hasDefer() || hasDeferDirective(it.selections)
+      is GQLFragmentSpread -> it.directives.hasDefer()
+    }
+  }
+}
+
 private class Scope(
     val schema: Schema,
     val fragments: Map<String, GQLFragmentDefinition>,
@@ -141,7 +168,7 @@ private class Scope(
       labelStringValue = label.value
 
       // We use the label in part of the synthetic field's name in the generated model, so it needs to be a valid Kotlin/Java identifier
-      if (!labelStringValue.matches(Regex("[a-zA-Z0-9_]+"))) {
+      if (!labelStringValue.matches(labelRegex)) {
         issues.add(
             InvalidDeferLabel(
                 message = "@defer label '$labelStringValue' must only contain letters, numbers, or underscores",

--- a/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/FieldDefinitionTest.kt
+++ b/libraries/apollo-ast/src/commonTest/kotlin/com/apollographql/apollo/graphql/ast/test/FieldDefinitionTest.kt
@@ -1,0 +1,96 @@
+package com.apollographql.apollo.graphql.ast.test
+
+import com.apollographql.apollo.ast.GQLField
+import com.apollographql.apollo.ast.GQLFieldDefinition
+import com.apollographql.apollo.ast.GQLNamedType
+import com.apollographql.apollo.ast.GQLObjectTypeDefinition
+import com.apollographql.apollo.ast.Schema
+import com.apollographql.apollo.ast.definitionFromScope
+import com.apollographql.apollo.ast.rawType
+import com.apollographql.apollo.ast.toGQLDocument
+import com.apollographql.apollo.ast.validateAsSchema
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Tests [definitionFromScope], which is backed by an index of the field definitions of every type of the schema.
+ */
+class FieldDefinitionTest {
+  // language=graphql
+  private val schema: Schema = """
+      type Query {
+        animal: Animal
+      }
+
+      interface Animal {
+        id: ID!
+      }
+
+      type Cat implements Animal {
+        id: ID!
+        meow: String
+      }
+
+      union Pet = Cat
+  """.trimIndent().toGQLDocument().validateAsSchema().getOrThrow()
+
+  private fun field(name: String) = GQLField(alias = null, name = name, arguments = emptyList(), directives = emptyList(), selections = emptyList())
+
+  @Test
+  fun fieldsOfAnObjectAreResolved() {
+    assertEquals("meow", field("meow").definitionFromScope(schema, "Cat")?.name)
+    assertEquals("ID", field("id").definitionFromScope(schema, "Cat")?.type?.rawType()?.name)
+    assertNull(field("bark").definitionFromScope(schema, "Cat"))
+  }
+
+  @Test
+  fun metaFieldsAreResolved() {
+    // __typename is available everywhere
+    assertEquals("String", field("__typename").definitionFromScope(schema, "Cat")?.type?.rawType()?.name)
+    assertEquals("String", field("__typename").definitionFromScope(schema, "Animal")?.type?.rawType()?.name)
+    assertEquals("String", field("__typename").definitionFromScope(schema, "Pet")?.type?.rawType()?.name)
+
+    // __schema and __type are only available on the query root type
+    assertEquals("__Schema", field("__schema").definitionFromScope(schema, "Query")?.type?.rawType()?.name)
+    assertEquals("__Type", field("__type").definitionFromScope(schema, "Query")?.type?.rawType()?.name)
+    assertNull(field("__schema").definitionFromScope(schema, "Cat"))
+    assertNull(field("__type").definitionFromScope(schema, "Cat"))
+  }
+
+  @Test
+  fun fieldsOfAnInterfaceAreResolved() {
+    assertEquals("id", field("id").definitionFromScope(schema, "Animal")?.name)
+    // 'meow' is only on Cat
+    assertNull(field("meow").definitionFromScope(schema, "Animal"))
+  }
+
+  @Test
+  fun unionsOnlyHaveTypename() {
+    assertNull(field("id").definitionFromScope(schema, "Pet"))
+  }
+
+  @Test
+  fun typeDefinitionsForeignToTheSchemaAreResolvedToo() {
+    val syntheticTypeDefinition = GQLObjectTypeDefinition(
+        description = null,
+        name = "Cat",
+        directives = emptyList(),
+        implementsInterfaces = emptyList(),
+        fields = listOf(
+            GQLFieldDefinition(
+                name = "purr",
+                type = GQLNamedType(name = "String"),
+                arguments = emptyList(),
+                directives = emptyList(),
+                description = null,
+            )
+        )
+    )
+
+    // Same name as a type of the schema, but a different definition: the definition wins
+    assertEquals("purr", field("purr").definitionFromScope(schema, syntheticTypeDefinition)?.name)
+    assertNull(field("meow").definitionFromScope(schema, syntheticTypeDefinition))
+    assertEquals("__typename", field("__typename").definitionFromScope(schema, syntheticTypeDefinition)?.name)
+  }
+}

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/IrOperationsBuilder.kt
@@ -68,6 +68,12 @@ internal class IrOperationsBuilder(
     private val fragmentVariableUsages: Map<String, List<VariableUsage>>,
 ) : FieldMerger {
   private val usedCoordinates = UsedCoordinates()
+
+  /**
+   * Shared by all the operations: the fragments used by a fragment do not depend on the operation spreading it.
+   */
+  private val usedFragmentsCache = mutableMapOf<String, Set<String>>()
+
   private val responseBasedBuilder = ResponseBasedModelGroupBuilder(
       schema,
       allFragmentDefinitions,
@@ -238,6 +244,7 @@ internal class IrOperationsBuilder(
         allFragmentDefinitions = allFragmentDefinitions,
         selections = selections,
         rawTypename = typeDefinition.name,
+        cache = usedFragmentsCache,
     )
 
     val sourceWithFragments = (formatToString() + "\n" + usedFragments.joinToString(

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/usedFragments.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/ir/usedFragments.kt
@@ -9,25 +9,35 @@ import com.apollographql.apollo.ast.Schema
 import com.apollographql.apollo.ast.definitionFromScope
 import com.apollographql.apollo.ast.rawType
 
+/**
+ * Returns the names of the fragments used by [selections], transitively.
+ *
+ * @param cache the fragments used by a given fragment, by fragment name. The result for a fragment only depends on the
+ * fragment definition, so it can be reused across operations. Pass the same map for all the operations of a compilation
+ * unit: without it, a fragment spread by n operations is walked n times, and nested spreads multiply that.
+ */
 internal fun usedFragments(
     schema: Schema,
     allFragmentDefinitions: Map<String, GQLFragmentDefinition>,
     selections: List<GQLSelection>,
     rawTypename: String,
+    cache: MutableMap<String, Set<String>> = mutableMapOf(),
 ): Set<String> {
   return selections.flatMap {
     when (it) {
       is GQLField -> {
         val fieldDefinition = it.definitionFromScope(schema, rawTypename)!!
-        usedFragments(schema, allFragmentDefinitions, it.selections, fieldDefinition.type.rawType().name)
+        usedFragments(schema, allFragmentDefinitions, it.selections, fieldDefinition.type.rawType().name, cache)
       }
       is GQLInlineFragment -> {
         val tc = it.typeCondition?.name ?: rawTypename
-        usedFragments(schema, allFragmentDefinitions, it.selections, tc)
+        usedFragments(schema, allFragmentDefinitions, it.selections, tc, cache)
       }
       is GQLFragmentSpread -> {
-        val fragmentDefinition = allFragmentDefinitions[it.name]!!
-        usedFragments(schema, allFragmentDefinitions, fragmentDefinition.selections, fragmentDefinition.typeCondition.name) + it.name
+        cache.getOrPut(it.name) {
+          val fragmentDefinition = allFragmentDefinitions[it.name]!!
+          usedFragments(schema, allFragmentDefinitions, fragmentDefinition.selections, fragmentDefinition.typeCondition.name, cache) + it.name
+        }
       }
     }
   }.toSet()


### PR DESCRIPTION
- `@defer` walk skipped — ExecutableValidationScope computes documentHasDeferDirective once per document with a cheap non-expanding scan of the operations and fragment definitions (hasDeferDirective in defer_labels.kt), and only then calls validateDeferLabels, which inlines every fragment spread per operation. Also hoisted the label Regex to a top-level val.
- Field-definition index — Schema holds a lazy Map<typeName, Map<fieldName, GQLFieldDefinition>> (meta fields included); definitionFromScope delegates to it. A GQLTypeDefinition that isn't identical to the schema's own definition falls back to the old rebuild-and-scan, so the public API keeps working for synthetic definitions.
- usedFragments memoized per fragment name, with the map owned by IrOperationsBuilder so it spans all operations in a module.

Measured on a schema (3.9 MB, 4350 types) with 139 operations:

```
┌───────────────────────────────────────┬─────────────┬────────────┬────────────┐
│                metric                 │  upstream   │  PR 6994   │ This PR    │
├───────────────────────────────────────┼─────────────┼────────────┼────────────┤
│ buildIrOperations                     │ 450 ms      │ 226 ms     │ 69 ms      │
├───────────────────────────────────────┼─────────────┼────────────┼────────────┤
│ toCodegenSchema (per module)          │ 53 ms       │ 48 ms      │ 48 ms      │
├───────────────────────────────────────┼─────────────┼────────────┼────────────┤
│ possibleTypes over all abstract types │ 7 ms        │ 0 ms       │ 0 ms       │
├───────────────────────────────────────┼─────────────┼────────────┼────────────┤
│ serialized IR size                    │ 2,955,473 B │ same       │ same       │
└───────────────────────────────────────┴─────────────┴────────────┴────────────┘
```

The IR serializes byte-for-byte identically, which is the strongest signal that codegen output is unchanged. Green: :apollo-ast:jvmTest (incl. the 144 ExecutableValidationTest fixtures — duplicate_path_and_labels_spread covers `@defer` living only inside fragment definitions, exactly the case the early-out could have broken), :apollo-compiler:test (247 golden CodegenTest cases), apiCheck on both modules, and tests/defer:jvmTest via the composite build. Added FieldDefinitionTest (5 tests) for the field index, including the foreign-type-definition fallback.