### PR TITLE
perf(api): stop using exceptions to guess JSON number types

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Adapters.kt
@@ -409,7 +409,8 @@ class ObjectAdapter<T>(
 
 private class ErrorAwareAdapter<T>(private val wrappedAdapter: Adapter<T>) : Adapter<T> {
   override fun fromJson(reader: JsonReader, customScalarAdapters: CustomScalarAdapters): T {
-    if (reader.peek() == JsonReader.Token.NULL) {
+    // reader.getPath() allocates, only compute it if there are errors that could match
+    if (!customScalarAdapters.errors.isNullOrEmpty() && reader.peek() == JsonReader.Token.NULL) {
       val error = customScalarAdapters.firstErrorStartingWith(reader.getPath())
       if (error != null) {
         reader.skipValue()

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CustomScalarAdapters.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CustomScalarAdapters.kt
@@ -38,46 +38,25 @@ class CustomScalarAdapters private constructor(
   }
 
   fun <T : Any> responseAdapterFor(customScalar: CustomScalarType): Adapter<T> {
+    val registered = adaptersMap[customScalar.name]
+    if (registered != null) {
+      @Suppress("UNCHECKED_CAST")
+      return registered as Adapter<T>
+    }
+
+    /**
+     * Below are shortcuts to save the users a call to `registerCustomScalarAdapter`
+     */
     @Suppress("UNCHECKED_CAST")
-    return when {
-      adaptersMap[customScalar.name] != null -> {
-        adaptersMap[customScalar.name]
-      }
-      /**
-       * Below are shortcuts to save the users a call to `registerCustomScalarAdapter`
-       */
-      customScalar.className == "com.apollographql.apollo.api.Upload" -> {
-        UploadAdapter
-      }
-
-      customScalar.className in listOf("kotlin.String", "java.lang.String") -> {
-        StringAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Boolean", "java.lang.Boolean") -> {
-        BooleanAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Int", "java.lang.Int") -> {
-        IntAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Double", "java.lang.Double") -> {
-        DoubleAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Long", "java.lang.Long") -> {
-        LongAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Float", "java.lang.Float") -> {
-        FloatAdapter
-      }
-
-      customScalar.className in listOf("kotlin.Any", "java.lang.Object") -> {
-        AnyAdapter
-      }
-
+    return when (customScalar.className) {
+      "com.apollographql.apollo.api.Upload" -> UploadAdapter
+      "kotlin.String", "java.lang.String" -> StringAdapter
+      "kotlin.Boolean", "java.lang.Boolean" -> BooleanAdapter
+      "kotlin.Int", "java.lang.Int" -> IntAdapter
+      "kotlin.Double", "java.lang.Double" -> DoubleAdapter
+      "kotlin.Long", "java.lang.Long" -> LongAdapter
+      "kotlin.Float", "java.lang.Float" -> FloatAdapter
+      "kotlin.Any", "java.lang.Object" -> AnyAdapter
       else -> error("Can't map GraphQL type: `${customScalar.name}` to: `${customScalar.className}`. Did you forget to add a scalar Adapter?")
     } as Adapter<T>
   }
@@ -120,6 +99,33 @@ class CustomScalarAdapters private constructor(
       }
     }
     return true
+  }
+
+  /**
+   * Returns a copy of this [CustomScalarAdapters] with the given parsing context. The adapters are
+   * shared with this instance, making this much cheaper than going through [newBuilder], which
+   * copies the whole adapters map.
+   */
+  internal fun copyWithParsingContext(
+      falseVariables: Set<String>?,
+      deferredFragmentIdentifiers: Set<DeferredFragmentIdentifier>?,
+      errors: List<Error>?,
+  ): CustomScalarAdapters {
+    if (falseVariables == null &&
+        deferredFragmentIdentifiers == null &&
+        errors == null &&
+        this.falseVariables == null &&
+        this.deferredFragmentIdentifiers == null &&
+        this.errors == null
+    ) {
+      return this
+    }
+    return CustomScalarAdapters(
+        adaptersMap,
+        falseVariables,
+        deferredFragmentIdentifiers,
+        errors,
+    )
   }
 
   fun newBuilder(): Builder {

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Executables.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/Executables.kt
@@ -49,7 +49,14 @@ fun <D : Executable.Data> Executable<D>.variablesJson(customScalarAdapters: Cust
  */
 @ApolloInternal
 fun <D : Executable.Data> Executable<D>.falseVariables(customScalarAdapters: CustomScalarAdapters): Set<String> {
-  return variables(customScalarAdapters, true).valueMap.filter { it.value == false }.keys
+  // Most operations have no boolean variables at all, avoid allocating in that case
+  var falseVariables: MutableSet<String>? = null
+  for ((name, value) in variables(customScalarAdapters, true).valueMap) {
+    if (value == false) {
+      (falseVariables ?: mutableSetOf<String>().also { falseVariables = it }).add(name)
+    }
+  }
+  return falseVariables ?: emptySet()
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -74,12 +81,17 @@ fun <D : Executable.Data> Executable<D>.parseData(
     deferredFragmentIds: Set<DeferredFragmentIdentifier>? = null,
     errors: List<Error>? = null
 ): D? {
-  val customScalarAdapters1 = customScalarAdapters.newBuilder()
-      .falseVariables(falseVariables)
-      .deferredFragmentIdentifiers(deferredFragmentIds)
-      .errors(errors)
-      .build()
-  return adapter().nullable().fromJson(jsonReader, customScalarAdapters1)
+  val customScalarAdapters1 = customScalarAdapters.copyWithParsingContext(
+      falseVariables = falseVariables,
+      deferredFragmentIdentifiers = deferredFragmentIds,
+      errors = errors,
+  )
+  // Same as adapter().nullable() but without allocating a NullableAdapter for every response
+  if (jsonReader.peek() == JsonReader.Token.NULL) {
+    jsonReader.skipValue()
+    return null
+  }
+  return adapter().fromJson(jsonReader, customScalarAdapters1)
 }
 
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/JsonReaders.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/JsonReaders.kt
@@ -3,6 +3,8 @@
 package com.apollographql.apollo.api.json
 
 import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.api.json.internal.toIntExactOrNull
+import com.apollographql.apollo.api.json.internal.toLongExactOrNull
 import okio.BufferedSource
 import kotlin.jvm.JvmName
 
@@ -53,6 +55,49 @@ fun JsonReader.readAny(): ApolloJsonElement {
 }
 
 private fun JsonReader.guessNumber(): Any {
+  /**
+   * The generic implementation below relies on exceptions for control flow, which is very costly
+   * when parsing large responses. The two built-in readers know their number representation, so
+   * they can narrow the value without ever throwing. Other [JsonReader] implementations fall back
+   * to the generic path.
+   */
+  return when (this) {
+    is MapJsonReader -> nextGuessedNumber()
+    is BufferedSourceJsonReader -> guessNumberNoThrow()
+    else -> guessNumberOrThrow()
+  }
+}
+
+/**
+ * Same as [guessNumberOrThrow] but without using exceptions for control flow.
+ *
+ * [BufferedSourceJsonReader] only uses [JsonReader.Token.LONG] for values that fit a `Long`, so
+ * anything else has to go through a `Double`.
+ */
+private fun BufferedSourceJsonReader.guessNumberNoThrow(): Any {
+  if (peek() == JsonReader.Token.LONG) {
+    val asLong = nextLong()
+    return asLong.toIntExactOrNull() ?: asLong
+  }
+
+  /**
+   * XXX: this can lose precision on large numbers (String.toDouble() may approximate)
+   * This hasn't been an issue so far, and it's used quite extensively, so I'm keeping it
+   * as is for the time being.
+   * If you're reading this, it probably means it became an issue. In that case, nextDouble()
+   * here should be skipped and the calling code be adapted.
+   */
+  val asDouble = try {
+    nextDouble()
+  } catch (_: Exception) {
+    // NaN, Infinity, or a value that isn't a valid Double: keep the original representation
+    return nextNumber()
+  }
+
+  return asDouble.toIntExactOrNull() ?: asDouble.toLongExactOrNull() ?: asDouble
+}
+
+private fun JsonReader.guessNumberOrThrow(): Any {
   try {
     return nextInt()
   } catch (_: Exception) {
@@ -62,13 +107,6 @@ private fun JsonReader.guessNumber(): Any {
   } catch (_: Exception) {
   }
   try {
-    /**
-     * XXX: this can lose precision on large numbers (String.toDouble() may approximate)
-     * This hasn't been an issue so far, and it's used quite extensively, so I'm keeping it
-     * as is for the time being.
-     * If you're reading this, it probably means it became an issue. In that case, nextDouble()
-     * here should be skipped and the calling code be adapted.
-     */
     return nextDouble()
   } catch (_: Exception) {
   }

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/MapJsonReader.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/MapJsonReader.kt
@@ -4,7 +4,9 @@ import com.apollographql.apollo.api.json.BufferedSourceJsonReader.Companion.INIT
 import com.apollographql.apollo.api.json.MapJsonReader.Companion.buffer
 import com.apollographql.apollo.api.json.internal.toDoubleExact
 import com.apollographql.apollo.api.json.internal.toIntExact
+import com.apollographql.apollo.api.json.internal.toIntExactOrNull
 import com.apollographql.apollo.api.json.internal.toLongExact
+import com.apollographql.apollo.api.json.internal.toLongExactOrNull
 import com.apollographql.apollo.exception.JsonDataException
 import kotlin.jvm.JvmOverloads
 
@@ -317,6 +319,35 @@ constructor(
     return data.also {
       advanceIterator()
     }
+  }
+
+  /**
+   * Reads the current number, narrowed to `Int`, `Long`, `Double` or [JsonNumber], in that order of
+   * preference.
+   *
+   * This is the same as calling [nextInt], [nextLong], [nextDouble] and [nextNumber] in turn and
+   * keeping the first one that doesn't throw, but without paying for the exceptions. Only call this
+   * when [peek] is [JsonReader.Token.NUMBER] or [JsonReader.Token.LONG].
+   */
+  internal fun nextGuessedNumber(): Any {
+    val result = when (val value = peekedData) {
+      is Int -> value
+      is Long -> value.toIntExactOrNull() ?: value
+      is Double -> value.toIntExactOrNull() ?: value.toLongExactOrNull() ?: value
+      is JsonNumber -> {
+        // Keep the String based semantics of nextInt()/nextLong()/nextDouble() for JsonNumber
+        val asString = value.value
+        asString.toIntOrNull() ?: asString.toLongOrNull() ?: asString.toDoubleOrNull() ?: value
+      }
+      is String -> {
+        val asString = value
+        asString.toIntOrNull() ?: asString.toLongOrNull() ?: asString.toDoubleOrNull() ?: JsonNumber(asString)
+      }
+      else -> error("Expected a Number but got $value instead")
+    }
+
+    advanceIterator()
+    return result
   }
 
   override fun skipValue() {

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/MapJsonReader.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/MapJsonReader.kt
@@ -331,9 +331,9 @@ constructor(
    */
   internal fun nextGuessedNumber(): Any {
     val result = when (val value = peekedData) {
+      is Double -> value.toIntExactOrNull() ?: value.toLongExactOrNull() ?: value
       is Int -> value
       is Long -> value.toIntExactOrNull() ?: value
-      is Double -> value.toIntExactOrNull() ?: value.toLongExactOrNull() ?: value
       is JsonNumber -> {
         // Keep the String based semantics of nextInt()/nextLong()/nextDouble() for JsonNumber
         val asString = value.value

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/internal/Utils.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/json/internal/Utils.kt
@@ -38,3 +38,25 @@ internal fun Double.toLongExact(): Long {
   }
   return result
 }
+
+/**
+ * Same as [toIntExact] but returns null instead of throwing. Useful in hot paths where the
+ * conversion is expected to fail routinely.
+ */
+@JvmName("-LongToIntExactOrNull")
+internal fun Long.toIntExactOrNull(): Int? {
+  val result = toInt()
+  return if (result.toLong() == this) result else null
+}
+
+@JvmName("-DoubleToIntExactOrNull")
+internal fun Double.toIntExactOrNull(): Int? {
+  val result = toInt()
+  return if (result.toDouble() == this) result else null
+}
+
+@JvmName("-DoubleToLongExactOrNull")
+internal fun Double.toLongExactOrNull(): Long? {
+  val result = toLong()
+  return if (result.toDouble() == this) result else null
+}

--- a/libraries/apollo-api/src/commonTest/kotlin/test/ReadAnyNumbersTest.kt
+++ b/libraries/apollo-api/src/commonTest/kotlin/test/ReadAnyNumbersTest.kt
@@ -1,0 +1,112 @@
+@file:OptIn(ApolloInternal::class)
+
+package test
+
+import com.apollographql.apollo.annotations.ApolloInternal
+import com.apollographql.apollo.api.json.JsonNumber
+import com.apollographql.apollo.api.json.MapJsonReader
+import com.apollographql.apollo.api.json.jsonReader
+import com.apollographql.apollo.api.json.readAny
+import okio.Buffer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * `readAny()` maps JSON numbers to Int, Long, Double or JsonNumber, in that order of preference.
+ *
+ * This is exercised for both readers because they have different number representations.
+ */
+class ReadAnyNumbersTest {
+  private fun fromSource(literal: String): Any? {
+    return Buffer().writeUtf8("""{"v":$literal}""").jsonReader().run {
+      beginObject()
+      nextName()
+      readAny().also {
+        endObject()
+      }
+    }
+  }
+
+  private fun fromMap(value: Any?): Any? {
+    return MapJsonReader(mapOf("v" to value)).run {
+      beginObject()
+      nextName()
+      readAny().also {
+        endObject()
+      }
+    }
+  }
+
+  @Test
+  fun integralValuesAreNarrowedToInt() {
+    assertEquals(0, fromSource("0"))
+    assertEquals(42, fromSource("42"))
+    assertEquals(-1, fromSource("-1"))
+    assertEquals(Int.MAX_VALUE, fromSource("2147483647"))
+    assertEquals(Int.MIN_VALUE, fromSource("-2147483648"))
+
+    assertEquals(0, fromMap(0))
+    assertEquals(1, fromMap(1L))
+    assertEquals(1, fromMap(JsonNumber("1")))
+  }
+
+  @Test
+  fun valuesThatDoNotFitAnIntAreLongs() {
+    assertEquals(2147483648L, fromSource("2147483648"))
+    assertEquals(-2147483649L, fromSource("-2147483649"))
+    assertEquals(Long.MAX_VALUE, fromSource("9223372036854775807"))
+    assertEquals(Long.MIN_VALUE, fromSource("-9223372036854775808"))
+
+    assertEquals(1099511627776L, fromMap(1099511627776L))
+    assertEquals(2147483648L, fromMap(JsonNumber("2147483648")))
+  }
+
+  @Test
+  fun integralValuedDoublesAreNarrowed() {
+    // "1.0" and "1e2" are integral values, they are narrowed like any other integral value
+    assertEquals(1, fromSource("1.0"))
+    assertEquals(0, fromSource("-0.0"))
+    assertEquals(100, fromSource("1E+2"))
+    assertEquals(1000000000000L, fromSource("1e12"))
+
+    assertEquals(1, fromMap(1.0))
+    assertEquals(100, fromMap(1e2))
+    assertEquals(1000000000000L, fromMap(1e12))
+  }
+
+  @Test
+  fun fractionalValuesAreDoubles() {
+    assertEquals(1.5, fromSource("1.5"))
+    assertEquals(0.1, fromSource("0.1"))
+    assertEquals(0.0025, fromSource("2.5e-3"))
+    assertEquals(1e100, fromSource("1e100"))
+    assertEquals(1e19, fromSource("1e19"))
+
+    assertEquals(1.5, fromMap(1.5))
+    assertEquals(1e100, fromMap(1e100))
+    assertEquals(1.5, fromMap(JsonNumber("1.5")))
+  }
+
+  @Test
+  fun valuesThatDoNotFitADoubleAreJsonNumbers() {
+    // JsonNumber doesn't implement equals(), compare the raw values
+    assertEquals("1e400", (fromSource("1e400") as JsonNumber).value)
+    assertEquals("-1e400", (fromSource("-1e400") as JsonNumber).value)
+
+    // MapJsonReader doesn't check for NaN and infinities
+    assertEquals(Double.POSITIVE_INFINITY, fromMap(JsonNumber("1e400")))
+    assertEquals(Double.NaN, fromMap(Double.NaN))
+    // But it keeps values that are not numbers at all
+    assertEquals("not a number", (fromMap(JsonNumber("not a number")) as JsonNumber).value)
+  }
+
+  @Test
+  fun veryLargeValuesLosePrecision() {
+    /**
+     * XXX: this is not great but has been the behaviour for a long time.
+     * See the comment in `guessNumber`.
+     */
+    assertEquals(1.2345678901234568E29, fromSource("123456789012345678901234567890"))
+    assertEquals(Long.MAX_VALUE, fromSource("9223372036854775808"))
+  }
+}

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/ApolloClient.kt
@@ -233,6 +233,30 @@ private constructor(
   )
 
   /**
+   * The interceptors are the same for every request, compute the chain once. This is lazy because
+   * [networkInterceptor] is initialized after the constructor.
+   */
+  private val allInterceptors: List<ApolloInterceptor> by lazy {
+    buildList {
+      addAll(builder._beforeCacheInterceptors)
+      if (cacheInterceptor != null) {
+        add(cacheInterceptor)
+      }
+
+      addAll(builder._beforeAutoPersistedQueriesInterceptors)
+      if (autoPersistedQueryInterceptor != null) {
+        add(autoPersistedQueryInterceptor)
+      }
+
+      addAll(builder._beforeRetryOnErrorInterceptors)
+      add(retryOnErrorInterceptor ?: RetryOnErrorInterceptor())
+
+      addAll(builder._beforeNetworkInterceptors)
+      add(networkInterceptor)
+    }
+  }
+
+  /**
    * Low level API to execute the given [apolloRequest] and return a [Flow].
    *
    * Prefer [query], [mutation] or [subscription] when possible.
@@ -303,23 +327,6 @@ private constructor(
       url(url ?: apolloClient.url)
     }.build()
 
-    val allInterceptors = buildList {
-      addAll(builder._beforeCacheInterceptors)
-      if (cacheInterceptor != null) {
-        add(cacheInterceptor)
-      }
-
-      addAll(builder._beforeAutoPersistedQueriesInterceptors)
-      if (autoPersistedQueryInterceptor != null) {
-        add(autoPersistedQueryInterceptor)
-      }
-
-      addAll(builder._beforeRetryOnErrorInterceptors)
-      add(retryOnErrorInterceptor ?: RetryOnErrorInterceptor())
-
-      addAll(builder._beforeNetworkInterceptors)
-      add(networkInterceptor)
-    }
     return DefaultInterceptorChain(allInterceptors, 0)
         .proceed(request)
         .let {

--- a/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
+++ b/libraries/apollo-runtime/src/commonMain/kotlin/com/apollographql/apollo/network/http/HttpNetworkTransport.kt
@@ -53,12 +53,17 @@ private constructor(
   private val engineInterceptor = EngineInterceptor()
   private val incrementalDeliveryProtocolImpl: IncrementalDeliveryProtocolImpl = incrementalDeliveryProtocol.impl
 
+  /**
+   * [interceptors] is immutable, compute the chain interceptors once instead of on every request
+   */
+  private val chainInterceptors: List<HttpInterceptor> = interceptors + engineInterceptor
+
   override fun <D : Operation.Data> execute(
       request: ApolloRequest<D>,
   ): Flow<ApolloResponse<D>> {
     val customScalarAdapters = request.executionContext[CustomScalarAdapters]!!
 
-    val request = if (request.httpHeaders.orEmpty().none { it.name.lowercase() == "accept" }) {
+    val request = if (request.httpHeaders.orEmpty().none { it.name.equals("accept", ignoreCase = true) }) {
       val accept = if (request.operation is Subscription<*>) {
         "multipart/mixed;subscriptionSpec=1.0, application/graphql-response+json, application/json"
       } else {
@@ -83,7 +88,7 @@ private constructor(
       var throwable: Throwable? = null
       val httpResponse: HttpResponse? = try {
         DefaultHttpInterceptorChain(
-            interceptors = interceptors + engineInterceptor,
+            interceptors = chainInterceptors,
             index = 0
         ).proceed(httpRequest)
       } catch (t: Throwable) {
@@ -177,9 +182,14 @@ private constructor(
             operation,
             customScalarAdapters = customScalarAdapters,
             deferredFragmentIdentifiers = null,
-        ).newBuilder().addExecutionContext(httpResponse.executionContext).build()
+        )
+        // Only rebuild the response once
+        .newBuilder()
+        .addExecutionContext(httpResponse.executionContext)
+        .isLast(true)
+        .build()
 
-    return flowOf(response.newBuilder().isLast(true).build())
+    return flowOf(response)
   }
 
   private fun <D : Operation.Data> multipleResponses(


### PR DESCRIPTION
# What changed

The dominant cost in response parsing was readAny()'s guessNumber(), which called nextInt() → nextLong() → nextDouble() in sequence and kept the first that didn't throw. Every Long paid for one JVM exception, every fractional Double for two. For projects with queries that use fragments heavily, nearly every object goes through obj(buffered = true) → readAny(), so this ran on every number in every response.

A single generic rewrite would not have been behavior-preserving — MapJsonReader holds JsonNumber values whose semantics are String-based (JsonNumber("1.0") narrows to Double today, but to Int under a naive double-ladder). So the fix dispatches on the concrete reader (each knows its own number representation and can narrow without throwing) and leaves third-party JsonReader implementations on the original try-chain.

Secondary allocation removals: ErrorAwareAdapter skips getPath() when the response has no errors; parseData() inlines the null check instead of allocating a NullableAdapter and shares the adapters map instead of copying it via newBuilder(); falseVariables() returns emptySet() when an operation has no boolean variables; responseAdapterFor() does one map lookup and a when on the class name instead of a listOf(...) per branch test; ApolloClient/HttpNetworkTransport build their interceptor chain lists once instead of per request.

# Numbers

392,777-byte response (40 rows × 30 entities, epoch-millis Longs + fractional Doubles), median of 11 rounds:

```
┌─────────────────┬──────────┬──────────┬──────┐
│                 │ baseline │   new    │      │
├─────────────────┼──────────┼──────────┼──────┤
│ parseResponse   │ 6310 µs  │ 1981 µs  │ 3.2x │
├─────────────────┼──────────┼──────────┼──────┤
│ readAny         │ 4075 µs  │ 1472 µs  │ 2.8x │
├─────────────────┼──────────┼──────────┼──────┤
│ allocated/parse │ 9165 KiB │ 3073 KiB │ 3.0x │
└─────────────────┴──────────┴──────────┴──────┘
```

An Int-only-numbers control with the same response shape gives 1970 → 1896 µs and 3030 → 2993 KiB, which attributes the wall-clock win entirely to removing the exceptions; the other changes are allocation reductions too small to see at this granularity.