### PR TITLE
perf(api): Test a fragment's type condition against a set, not a list

### DIFF
--- a/build-logic/src/main/kotlin/api.kt
+++ b/build-logic/src/main/kotlin/api.kt
@@ -124,7 +124,10 @@ fun Project.apolloLibrary(
   )
 
   configurations.configureEach {
-    if (it.name == "apolloPublished" || it.name.matches(Regex("apollo.*Compiler"))) {
+    if (
+        it.name == "compileClasspath"
+        || it.name.matches(Regex("apollo.*Compiler"))
+        ) {
       // Within the 'tests' project (a composite build), dependencies are automatically substituted to use the project's one.
       // apollo-tooling depends on a published version of apollo-api which should not be substituted for both the runtime
       // and compiler classpaths.

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -358,7 +358,6 @@ public final class com/apollographql/apollo/api/CompiledFragment : com/apollogra
 	public final fun getPossibleTypesSet ()Ljava/util/Set;
 	public final fun getSelections ()Ljava/util/List;
 	public final fun getTypeCondition ()Ljava/lang/String;
-	public final fun isPossibleType (Ljava/lang/String;)Z
 }
 
 public final class com/apollographql/apollo/api/CompiledFragment$Builder {

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -355,6 +355,7 @@ public final class com/apollographql/apollo/api/CompiledField$Builder {
 public final class com/apollographql/apollo/api/CompiledFragment : com/apollographql/apollo/api/CompiledSelection {
 	public final fun getCondition ()Ljava/util/List;
 	public final fun getPossibleTypes ()Ljava/util/List;
+	public final fun getPossibleTypesSet ()Ljava/util/Set;
 	public final fun getSelections ()Ljava/util/List;
 	public final fun getTypeCondition ()Ljava/lang/String;
 	public final fun isPossibleType (Ljava/lang/String;)Z
@@ -362,10 +363,12 @@ public final class com/apollographql/apollo/api/CompiledFragment : com/apollogra
 
 public final class com/apollographql/apollo/api/CompiledFragment$Builder {
 	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Set;)V
 	public final fun build ()Lcom/apollographql/apollo/api/CompiledFragment;
 	public final fun condition (Ljava/util/List;)Lcom/apollographql/apollo/api/CompiledFragment$Builder;
 	public final fun getCondition ()Ljava/util/List;
 	public final fun getPossibleTypes ()Ljava/util/List;
+	public final fun getPossibleTypesSet ()Ljava/util/Set;
 	public final fun getSelections ()Ljava/util/List;
 	public final fun getTypeCondition ()Ljava/lang/String;
 	public final fun selections (Ljava/util/List;)Lcom/apollographql/apollo/api/CompiledFragment$Builder;

--- a/libraries/apollo-api/api/apollo-api.api
+++ b/libraries/apollo-api/api/apollo-api.api
@@ -357,6 +357,7 @@ public final class com/apollographql/apollo/api/CompiledFragment : com/apollogra
 	public final fun getPossibleTypes ()Ljava/util/List;
 	public final fun getSelections ()Ljava/util/List;
 	public final fun getTypeCondition ()Ljava/lang/String;
+	public final fun isPossibleType (Ljava/lang/String;)Z
 }
 
 public final class com/apollographql/apollo/api/CompiledFragment$Builder {

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -911,8 +911,6 @@ final class com.apollographql.apollo.api/CompiledFragment : com.apollographql.ap
     final val typeCondition // com.apollographql.apollo.api/CompiledFragment.typeCondition|{}typeCondition[0]
         final fun <get-typeCondition>(): kotlin/String // com.apollographql.apollo.api/CompiledFragment.typeCondition.<get-typeCondition>|<get-typeCondition>(){}[0]
 
-    final fun isPossibleType(kotlin/String): kotlin/Boolean // com.apollographql.apollo.api/CompiledFragment.isPossibleType|isPossibleType(kotlin.String){}[0]
-
     final class Builder { // com.apollographql.apollo.api/CompiledFragment.Builder|null[0]
         constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // com.apollographql.apollo.api/CompiledFragment.Builder.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
         constructor <init>(kotlin/String, kotlin.collections/Set<kotlin/String>) // com.apollographql.apollo.api/CompiledFragment.Builder.<init>|<init>(kotlin.String;kotlin.collections.Set<kotlin.String>){}[0]

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -909,6 +909,8 @@ final class com.apollographql.apollo.api/CompiledFragment : com.apollographql.ap
     final val typeCondition // com.apollographql.apollo.api/CompiledFragment.typeCondition|{}typeCondition[0]
         final fun <get-typeCondition>(): kotlin/String // com.apollographql.apollo.api/CompiledFragment.typeCondition.<get-typeCondition>|<get-typeCondition>(){}[0]
 
+    final fun isPossibleType(kotlin/String): kotlin/Boolean // com.apollographql.apollo.api/CompiledFragment.isPossibleType|isPossibleType(kotlin.String){}[0]
+
     final class Builder { // com.apollographql.apollo.api/CompiledFragment.Builder|null[0]
         constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // com.apollographql.apollo.api/CompiledFragment.Builder.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
 

--- a/libraries/apollo-api/api/apollo-api.klib.api
+++ b/libraries/apollo-api/api/apollo-api.klib.api
@@ -904,6 +904,8 @@ final class com.apollographql.apollo.api/CompiledFragment : com.apollographql.ap
         final fun <get-condition>(): kotlin.collections/List<com.apollographql.apollo.api/CompiledCondition> // com.apollographql.apollo.api/CompiledFragment.condition.<get-condition>|<get-condition>(){}[0]
     final val possibleTypes // com.apollographql.apollo.api/CompiledFragment.possibleTypes|{}possibleTypes[0]
         final fun <get-possibleTypes>(): kotlin.collections/List<kotlin/String> // com.apollographql.apollo.api/CompiledFragment.possibleTypes.<get-possibleTypes>|<get-possibleTypes>(){}[0]
+    final val possibleTypesSet // com.apollographql.apollo.api/CompiledFragment.possibleTypesSet|{}possibleTypesSet[0]
+        final fun <get-possibleTypesSet>(): kotlin.collections/Set<kotlin/String> // com.apollographql.apollo.api/CompiledFragment.possibleTypesSet.<get-possibleTypesSet>|<get-possibleTypesSet>(){}[0]
     final val selections // com.apollographql.apollo.api/CompiledFragment.selections|{}selections[0]
         final fun <get-selections>(): kotlin.collections/List<com.apollographql.apollo.api/CompiledSelection> // com.apollographql.apollo.api/CompiledFragment.selections.<get-selections>|<get-selections>(){}[0]
     final val typeCondition // com.apollographql.apollo.api/CompiledFragment.typeCondition|{}typeCondition[0]
@@ -913,9 +915,12 @@ final class com.apollographql.apollo.api/CompiledFragment : com.apollographql.ap
 
     final class Builder { // com.apollographql.apollo.api/CompiledFragment.Builder|null[0]
         constructor <init>(kotlin/String, kotlin.collections/List<kotlin/String>) // com.apollographql.apollo.api/CompiledFragment.Builder.<init>|<init>(kotlin.String;kotlin.collections.List<kotlin.String>){}[0]
+        constructor <init>(kotlin/String, kotlin.collections/Set<kotlin/String>) // com.apollographql.apollo.api/CompiledFragment.Builder.<init>|<init>(kotlin.String;kotlin.collections.Set<kotlin.String>){}[0]
 
         final val possibleTypes // com.apollographql.apollo.api/CompiledFragment.Builder.possibleTypes|{}possibleTypes[0]
             final fun <get-possibleTypes>(): kotlin.collections/List<kotlin/String> // com.apollographql.apollo.api/CompiledFragment.Builder.possibleTypes.<get-possibleTypes>|<get-possibleTypes>(){}[0]
+        final val possibleTypesSet // com.apollographql.apollo.api/CompiledFragment.Builder.possibleTypesSet|{}possibleTypesSet[0]
+            final fun <get-possibleTypesSet>(): kotlin.collections/Set<kotlin/String> // com.apollographql.apollo.api/CompiledFragment.Builder.possibleTypesSet.<get-possibleTypesSet>|<get-possibleTypesSet>(){}[0]
         final val typeCondition // com.apollographql.apollo.api/CompiledFragment.Builder.typeCondition|{}typeCondition[0]
             final fun <get-typeCondition>(): kotlin/String // com.apollographql.apollo.api/CompiledFragment.Builder.typeCondition.<get-typeCondition>|<get-typeCondition>(){}[0]
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
@@ -218,31 +218,29 @@ class CompiledField internal constructor(
  */
 class CompiledFragment internal constructor(
     val typeCondition: String,
-    val possibleTypes: List<String>,
+    val possibleTypesSet: Set<String>,
     val condition: List<CompiledCondition>,
     val selections: List<CompiledSelection>,
 ) : CompiledSelection() {
-  /**
-   * [possibleTypes] as a set, so that [isPossibleType] does not scan it.
-   *
-   * Built on first use: a selection whose type condition is never tested against a concrete type
-   * does not pay for it. [LazyThreadSafetyMode.PUBLICATION] because building it is idempotent and
-   * generated selections are shared, so the cost of contending for a lock outweighs the cost of
-   * occasionally building the set twice.
-   */
-  private val possibleTypesSet: Set<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
-    possibleTypes.toSet()
+  @Deprecated("Use possibleTypesSet instead")
+  val possibleTypes: List<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    possibleTypesSet.toList()
   }
 
   /**
    * Whether an object of the given `__typename` matches this selection's type condition.
    *
-   * Prefer this over testing [possibleTypes] directly: it is a set lookup rather than a scan, and
-   * this is called for every object of every list a fragment appears in.
+   * This is called for every object of every list a fragment appears in, so the possible types are
+   * held as a set: the lookup does not scan, and reaching it is a field read rather than a call.
    */
   fun isPossibleType(typename: String): Boolean = possibleTypesSet.contains(typename)
 
-  class Builder(val typeCondition: String, val possibleTypes: List<String>) {
+  class Builder(val typeCondition: String, val possibleTypesSet: Set<String>) {
+    constructor(typeCondition: String, possibleTypes: List<String>) : this(typeCondition, possibleTypes.toSet())
+
+    @Deprecated("Use possibleTypesSet instead")
+    val possibleTypes: List<String> get() = possibleTypesSet.toList()
+
     var condition: List<CompiledCondition> = emptyList()
     var selections: List<CompiledSelection> = emptyList()
 
@@ -254,7 +252,7 @@ class CompiledFragment internal constructor(
       this.selections = selections
     }
 
-    fun build() = CompiledFragment(typeCondition, possibleTypes, condition, selections)
+    fun build() = CompiledFragment(typeCondition, possibleTypesSet, condition, selections)
   }
 }
 

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
@@ -86,7 +86,10 @@ class CompiledField internal constructor(
    */
   @ApolloExperimental
   fun argumentValues(variables: Executable.Variables, filter: (CompiledArgument) -> Boolean = { true }): Map<String, ApolloJsonElement> {
-    val arguments = arguments.filter(filter).filter { it.value is Optional.Present<*> }
+    if (this.arguments.isEmpty()) {
+      return emptyMap()
+    }
+    val arguments = arguments.filter { filter(it) && it.value is Optional.Present<*> }
     if (arguments.isEmpty()) {
       return emptyMap()
     }
@@ -147,6 +150,11 @@ class CompiledField internal constructor(
    * CacheKey1: `users({"ids": 42})`
    */
   fun nameWithArguments(variables: Executable.Variables): String {
+    if (this.arguments.isEmpty()) {
+      // A field that takes no arguments is its own key, whatever the variables are. Checked here as
+      // well as in `argumentValues` so that the common case does not reach a call at all.
+      return name
+    }
     val arguments = argumentValues(variables)
     if (arguments.isEmpty()) {
       return name

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
@@ -223,22 +223,19 @@ class CompiledFragment internal constructor(
     val selections: List<CompiledSelection>,
 ) : CompiledSelection() {
   @Deprecated("Use possibleTypesSet instead")
+  @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_2)
   val possibleTypes: List<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
     possibleTypesSet.toList()
   }
 
-  /**
-   * Whether an object of the given `__typename` matches this selection's type condition.
-   *
-   * This is called for every object of every list a fragment appears in, so the possible types are
-   * held as a set: the lookup does not scan, and reaching it is a field read rather than a call.
-   */
-  fun isPossibleType(typename: String): Boolean = possibleTypesSet.contains(typename)
-
   class Builder(val typeCondition: String, val possibleTypesSet: Set<String>) {
+
+    @Deprecated("Use the primary constructor instead")
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_2)
     constructor(typeCondition: String, possibleTypes: List<String>) : this(typeCondition, possibleTypes.toSet())
 
     @Deprecated("Use possibleTypesSet instead")
+    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_2)
     val possibleTypes: List<String> get() = possibleTypesSet.toList()
 
     var condition: List<CompiledCondition> = emptyList()

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
@@ -214,6 +214,25 @@ class CompiledFragment internal constructor(
     val condition: List<CompiledCondition>,
     val selections: List<CompiledSelection>,
 ) : CompiledSelection() {
+  /**
+   * [possibleTypes] as a set, so that [isPossibleType] does not scan it.
+   *
+   * Built on first use: a selection whose type condition is never tested against a concrete type
+   * does not pay for it. [LazyThreadSafetyMode.PUBLICATION] because building it is idempotent and
+   * generated selections are shared, so the cost of contending for a lock outweighs the cost of
+   * occasionally building the set twice.
+   */
+  private val possibleTypesSet: Set<String> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+    possibleTypes.toSet()
+  }
+
+  /**
+   * Whether an object of the given `__typename` matches this selection's type condition.
+   *
+   * Prefer this over testing [possibleTypes] directly: it is a set lookup rather than a scan, and
+   * this is called for every object of every list a fragment appears in.
+   */
+  fun isPossibleType(typename: String): Boolean = possibleTypesSet.contains(typename)
 
   class Builder(val typeCondition: String, val possibleTypes: List<String>) {
     var condition: List<CompiledCondition> = emptyList()

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/fakeResolver.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/fakeResolver.kt
@@ -76,7 +76,7 @@ private fun collect(selections: List<CompiledSelection>, typename: String): List
       }
 
       is CompiledFragment -> {
-        if (compiledSelection.isPossibleType(typename)) {
+        if (typename in compiledSelection.possibleTypesSet) {
           collect(compiledSelection.selections, typename)
         } else {
           emptyList()

--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/fakeResolver.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/fakeResolver.kt
@@ -76,7 +76,7 @@ private fun collect(selections: List<CompiledSelection>, typename: String): List
       }
 
       is CompiledFragment -> {
-        if (typename in compiledSelection.possibleTypes) {
+        if (compiledSelection.isPossibleType(typename)) {
           collect(compiledSelection.selections, typename)
         } else {
           emptyList()

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaClassNames.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/JavaClassNames.kt
@@ -103,6 +103,7 @@ internal object JavaClassNames {
   val SuppressWarnings: ClassName = ClassName.get("java.lang", "SuppressWarnings")
 
   val List: ClassName = ClassName.get("java.util", "List")
+  val Set: ClassName = ClassName.get("java.util", "Set")
   val ArrayList: ClassName = ClassName.get("java.util", "ArrayList")
   val Arrays = ClassName.get("java.util", "Arrays")
   val Collections = ClassName.get("java.util", "Collections")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Collections.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/java/helpers/Collections.kt
@@ -23,6 +23,22 @@ internal fun List<CodeBlock>.toListInitializerCodeblock(withNewLines: Boolean = 
       .build()
 }
 
+internal fun List<CodeBlock>.toSetInitializerCodeblock(withNewLines: Boolean = false): CodeBlock {
+  if (isEmpty()) {
+    return CodeBlock.of("$T.emptySet()", JavaClassNames.Collections)
+  }
+
+  val newLine = if (withNewLines) "\n" else ""
+  val space = if (withNewLines) "" else " "
+  return CodeBlock.builder()
+      .add("$T.of($newLine", JavaClassNames.Set)
+      .indent()
+      .add(L, joinToCode(",$newLine$space"))
+      .unindent()
+      .add("$newLine)")
+      .build()
+}
+
 internal fun List<CodeBlock>.toArrayInitializerCodeblock(): CodeBlock {
   return CodeBlock.builder()
       .add("{")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/Collections.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/helpers/Collections.kt
@@ -25,6 +25,27 @@ internal fun List<CodeBlock>.toListInitializerCodeblock(withNewLines: Boolean = 
         .build()
   }
 }
+internal fun List<CodeBlock>.toSetInitializerCodeblock(withNewLines: Boolean = false): CodeBlock {
+  if (isEmpty()) {
+    return CodeBlock.of("emptySet()")
+  }
+
+  return if (withNewLines) {
+    CodeBlock.builder()
+        .add("setOf(\n")
+        .indent()
+        .add("%L", joinToCode(",\n"))
+        .unindent()
+        .add("\n)")
+        .build()
+  } else {
+    CodeBlock.builder()
+        .add("setOf(")
+        .add("%L", joinToCode(", "))
+        .add(")")
+        .build()
+  }
+}
 
 internal fun List<Pair<String, CodeBlock>>.toMapInitializerCodeblock(withNewLines: Boolean = false): CodeBlock {
   if (isEmpty()) {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/operations/CompiledSelectionsBuilder.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/operations/CompiledSelectionsBuilder.kt
@@ -5,6 +5,7 @@ import com.apollographql.apollo.compiler.codegen.kotlin.KotlinOperationsContext
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinSymbols
 import com.apollographql.apollo.compiler.codegen.kotlin.helpers.codeBlock
 import com.apollographql.apollo.compiler.codegen.kotlin.helpers.toListInitializerCodeblock
+import com.apollographql.apollo.compiler.codegen.kotlin.helpers.toSetInitializerCodeblock
 import com.apollographql.apollo.compiler.internal.applyIf
 import com.apollographql.apollo.compiler.ir.BVariable
 import com.apollographql.apollo.compiler.ir.BooleanExpression
@@ -78,7 +79,7 @@ internal class CompiledSelectionsBuilder(
     builder.add("%T(\n", KotlinSymbols.CompiledFragmentBuilder)
     builder.indent()
     builder.add("typeCondition = %S,\n", typeCondition)
-    builder.add("possibleTypes = %L\n", possibleTypes.map { CodeBlock.of("%S", it) }.toListInitializerCodeblock(false))
+    builder.add("possibleTypesSet = %L\n", possibleTypes.map { CodeBlock.of("%S", it) }.toSetInitializerCodeblock(false))
     builder.unindent()
     builder.add(")")
 

--- a/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/operationBased/capitalized_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/operationBased/capitalized_fields/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(__onHorse)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/responseBased/capitalized_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/capitalized_fields/kotlin/responseBased/capitalized_fields/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(__onHorse)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/AnimalQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/AnimalQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object AnimalQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(CatFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(DogFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/CharacterQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/CharacterQuerySelections.kt.expected
@@ -32,12 +32,12 @@ public object CharacterQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/NodeQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/operationBased/data_builders/selections/NodeQuerySelections.kt.expected
@@ -28,12 +28,12 @@ public object NodeQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/AnimalQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/AnimalQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object AnimalQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(CatFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(DogFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/CharacterQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/CharacterQuerySelections.kt.expected
@@ -32,12 +32,12 @@ public object CharacterQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/NodeQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/data_builders/kotlin/responseBased/data_builders/selections/NodeQuerySelections.kt.expected
@@ -28,12 +28,12 @@ public object NodeQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/operationBased/decapitalized_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/operationBased/decapitalized_fields/selections/TestQuerySelections.kt.expected
@@ -42,12 +42,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(__onHorse)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(HorseFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/responseBased/decapitalized_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/decapitalized_fields/kotlin/responseBased/decapitalized_fields/selections/TestQuerySelections.kt.expected
@@ -42,12 +42,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(__onHorse)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Horse",
-          possibleTypes = listOf("Horse")
+          possibleTypesSet = setOf("Horse")
         ).selections(HorseFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/fragment/selections/AnimalFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/fragment/selections/AnimalFragmentSelections.kt.expected
@@ -34,12 +34,12 @@ public object AnimalFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(__onCat)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(__onDog)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/selections/CatQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/operationBased/deprecated_merged_field/selections/CatQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object CatQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(AnimalFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/fragment/selections/AnimalFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/fragment/selections/AnimalFragmentSelections.kt.expected
@@ -34,12 +34,12 @@ public object AnimalFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(__onCat)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(__onDog)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/selections/CatQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/deprecated_merged_field/kotlin/responseBased/deprecated_merged_field/selections/CatQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object CatQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(AnimalFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/operationBased/fieldset_with_multiple_super/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/operationBased/fieldset_with_multiple_super/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -55,7 +55,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA1)
         .build()
       )
@@ -67,12 +67,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/responseBased/fieldset_with_multiple_super/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fieldset_with_multiple_super/kotlin/responseBased/fieldset_with_multiple_super/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -55,7 +55,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA1)
         .build()
       )
@@ -67,12 +67,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_include_directive/kotlin/operationBased/fragment_spread_with_include_directive/selections/TestQuerySelections.kt.expected
@@ -35,25 +35,25 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).condition(listOf(CompiledCondition("withDetails", false), CompiledCondition("skipHumanDetails", true)))
         .selections(HeroDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).condition(listOf(CompiledCondition("withDetails", false)))
         .selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", true)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("optionalWithDefaultTrue", false)))
         .selections(OtherDroidDetailsSelections.__root)
         .build()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/operationBased/fragment_spread_with_nested_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/operationBased/fragment_spread_with_nested_fields/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/responseBased/fragment_spread_with_nested_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_spread_with_nested_fields/kotlin/responseBased/fragment_spread_with_nested_fields/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/fragment/selections/HeroDetailsSelections.kt.expected
@@ -24,7 +24,7 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/fragment/selections/HumanDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/fragment/selections/HumanDetailsSelections.kt.expected
@@ -24,7 +24,7 @@ public object HumanDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/operationBased/fragment_used_twice/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/selections/HeroDetailsSelections.kt.expected
@@ -24,7 +24,7 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/selections/HumanDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/fragment/selections/HumanDetailsSelections.kt.expected
@@ -24,7 +24,7 @@ public object HumanDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_used_twice/kotlin/responseBased/fragment_used_twice/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/fragment/selections/HeroDetailsSelections.kt.expected
@@ -25,7 +25,7 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )
@@ -64,12 +64,12 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/operationBased/fragment_with_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/fragment/selections/HeroDetailsSelections.kt.expected
@@ -25,7 +25,7 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )
@@ -64,12 +64,12 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_inline_fragment/kotlin/responseBased/fragment_with_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
@@ -27,7 +27,7 @@ public object IFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/operationBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "I",
-          possibleTypes = listOf("A", "B")
+          possibleTypesSet = setOf("A", "B")
         ).selections(IFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/fragment/selections/iFragmentSelections.kt.expected
@@ -27,7 +27,7 @@ public object IFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragment_with_multiple_fieldsets/kotlin/responseBased/fragment_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "I",
-          possibleTypes = listOf("A", "B")
+          possibleTypesSet = setOf("A", "B")
         ).selections(IFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/operationBased/fragments_same_type_condition/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/operationBased/fragments_same_type_condition/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetails1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetails2Selections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/responseBased/fragments_same_type_condition/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_same_type_condition/kotlin/responseBased/fragments_same_type_condition/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetails1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetails2Selections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferAndIncludeSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferAndIncludeSelections.kt.expected
@@ -65,35 +65,35 @@ public object InlineMultipleWithDeferAndIncludeSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond1", false)))
         .selections(__onDroid)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond2", true)))
         .selections(__onDroid1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid2)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid3)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond3", false)))
         .selections(__onDroid4)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond4", true)))
         .selections(__onDroid5)
         .build()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferSelections.kt.expected
@@ -36,12 +36,12 @@ public object InlineMultipleWithDeferSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferWithIfSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineMultipleWithDeferWithIfSelections.kt.expected
@@ -43,17 +43,17 @@ public object InlineMultipleWithDeferWithIfSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter2)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineSingleWithDeferSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/InlineSingleWithDeferSelections.kt.expected
@@ -28,7 +28,7 @@ public object InlineSingleWithDeferSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferAndIncludeSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferAndIncludeSelections.kt.expected
@@ -23,35 +23,35 @@ public object SpreadMultipleWithDeferAndIncludeSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond1", false)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond2", true)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond3", false)))
         .selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("cond4", true)))
         .selections(DroidDetailsSelections.__root)
         .build()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferSelections.kt.expected
@@ -22,12 +22,12 @@ public object SpreadMultipleWithDeferSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferWithIfSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadMultipleWithDeferWithIfSelections.kt.expected
@@ -24,17 +24,17 @@ public object SpreadMultipleWithDeferWithIfSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(CharacterDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(CharacterDetails2Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(CharacterDetails3Selections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadSingleWithDeferSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_defer_and_include_directives/kotlin/operationBased/fragments_with_defer_and_include_directives/selections/SpreadSingleWithDeferSelections.kt.expected
@@ -22,7 +22,7 @@ public object SpreadSingleWithDeferSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/operationBased/fragments_with_type_condition/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/operationBased/fragments_with_type_condition/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )
@@ -40,12 +40,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/responseBased/fragments_with_type_condition/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/fragments_with_type_condition/kotlin/responseBased/fragments_with_type_condition/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )
@@ -40,12 +40,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/operationBased/hero_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/operationBased/hero_name/selections/TestQuerySelections.kt.expected
@@ -37,7 +37,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/responseBased/hero_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/hero_name/kotlin/responseBased/hero_name/selections/TestQuerySelections.kt.expected
@@ -37,7 +37,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/operationBased/inline_fragment_for_non_optional_field/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/operationBased/inline_fragment_for_non_optional_field/selections/TestQuerySelections.kt.expected
@@ -35,7 +35,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/responseBased/inline_fragment_for_non_optional_field/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_for_non_optional_field/kotlin/responseBased/inline_fragment_for_non_optional_field/selections/TestQuerySelections.kt.expected
@@ -35,7 +35,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/operationBased/inline_fragment_inside_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/operationBased/inline_fragment_inside_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -42,12 +42,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -59,7 +59,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/responseBased/inline_fragment_inside_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_inside_inline_fragment/kotlin/responseBased/inline_fragment_inside_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -42,12 +42,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -59,7 +59,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/operationBased/inline_fragment_intersection/selections/TestOperationSelections.kt.expected
@@ -37,7 +37,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie)
         .build()
       )
@@ -60,7 +60,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie1)
         .build()
       )
@@ -93,7 +93,7 @@ public object TestOperationSelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )
@@ -131,7 +131,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie3)
         .build()
       )
@@ -151,17 +151,17 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Being",
-          possibleTypes = listOf("Human", "Wookie")
+          possibleTypesSet = setOf("Human", "Wookie")
         ).selections(__onBeing)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie2)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Being",
-          possibleTypes = listOf("Human", "Wookie")
+          possibleTypesSet = setOf("Human", "Wookie")
         ).selections(__onBeing1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_intersection/kotlin/responseBased/inline_fragment_intersection/selections/TestOperationSelections.kt.expected
@@ -37,7 +37,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie)
         .build()
       )
@@ -60,7 +60,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie1)
         .build()
       )
@@ -93,7 +93,7 @@ public object TestOperationSelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )
@@ -131,7 +131,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie3)
         .build()
       )
@@ -151,17 +151,17 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Being",
-          possibleTypes = listOf("Human", "Wookie")
+          possibleTypesSet = setOf("Human", "Wookie")
         ).selections(__onBeing)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Wookie",
-          possibleTypes = listOf("Wookie")
+          possibleTypesSet = setOf("Wookie")
         ).selections(__onWookie2)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Being",
-          possibleTypes = listOf("Human", "Wookie")
+          possibleTypesSet = setOf("Human", "Wookie")
         ).selections(__onBeing1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/operationBased/inline_fragment_merge_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/operationBased/inline_fragment_merge_fields/selections/TestQuerySelections.kt.expected
@@ -96,7 +96,7 @@ public object TestQuerySelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/responseBased/inline_fragment_merge_fields/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_merge_fields/kotlin/responseBased/inline_fragment_merge_fields/selections/TestQuerySelections.kt.expected
@@ -96,7 +96,7 @@ public object TestQuerySelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/operationBased/inline_fragment_simple/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/operationBased/inline_fragment_simple/selections/TestQuerySelections.kt.expected
@@ -29,7 +29,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/responseBased/inline_fragment_simple/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_simple/kotlin/responseBased/inline_fragment_simple/selections/TestQuerySelections.kt.expected
@@ -29,7 +29,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/operationBased/inline_fragment_type_coercion/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/operationBased/inline_fragment_type_coercion/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Bar",
-          possibleTypes = listOf("BarObject", "FooBar")
+          possibleTypesSet = setOf("BarObject", "FooBar")
         ).selections(__onBar)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/responseBased/inline_fragment_type_coercion/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_type_coercion/kotlin/responseBased/inline_fragment_type_coercion/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Bar",
-          possibleTypes = listOf("BarObject", "FooBar")
+          possibleTypesSet = setOf("BarObject", "FooBar")
         ).selections(__onBar)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/kotlin/operationBased/inline_fragment_with_include_directive/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragment_with_include_directive/kotlin/operationBased/inline_fragment_with_include_directive/selections/TestQuerySelections.kt.expected
@@ -56,19 +56,19 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).condition(listOf(CompiledCondition("withDetails", false), CompiledCondition("skipHumanDetails", true)))
         .selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).condition(listOf(CompiledCondition("withDetails", false)))
         .selections(__onDroid)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).condition(listOf(CompiledCondition("withDetails", false)))
         .selections(__onCharacter)
         .build()

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/operationBased/inline_fragments_with_friends/selections/TestQuerySelections.kt.expected
@@ -67,12 +67,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/inline_fragments_with_friends/kotlin/responseBased/inline_fragments_with_friends/selections/TestQuerySelections.kt.expected
@@ -67,12 +67,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/operationBased/interface_always_nested/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/operationBased/interface_always_nested/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -44,7 +44,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/responseBased/interface_always_nested/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_always_nested/kotlin/responseBased/interface_always_nested/selections/TestQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -44,7 +44,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/operationBased/interface_on_interface/selections/GetHumanSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/operationBased/interface_on_interface/selections/GetHumanSelections.kt.expected
@@ -46,7 +46,7 @@ public object GetHumanSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/responseBased/interface_on_interface/selections/GetHumanSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/interface_on_interface/kotlin/responseBased/interface_on_interface/selections/GetHumanSelections.kt.expected
@@ -46,7 +46,7 @@ public object GetHumanSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/operationBased/monomorphic/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/operationBased/monomorphic/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(__onAnimal)
         .build()
       )
@@ -40,7 +40,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Node",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(__onNode)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/responseBased/monomorphic/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/monomorphic/kotlin/responseBased/monomorphic/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(__onAnimal)
         .build()
       )
@@ -40,7 +40,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Node",
-          possibleTypes = listOf("Cat", "Dog")
+          possibleTypesSet = setOf("Cat", "Dog")
         ).selections(__onNode)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
@@ -21,12 +21,12 @@ public object AFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
-          possibleTypes = listOf("ANode")
+          possibleTypesSet = setOf("ANode")
         ).selections(Fragment1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
-          possibleTypes = listOf("ANode")
+          possibleTypesSet = setOf("ANode")
         ).selections(Fragment2Selections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/operationBased/multiple_fragments/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/fragment/selections/aFragmentSelections.kt.expected
@@ -21,12 +21,12 @@ public object AFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
-          possibleTypes = listOf("ANode")
+          possibleTypesSet = setOf("ANode")
         ).selections(Fragment1Selections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ANode",
-          possibleTypes = listOf("ANode")
+          possibleTypesSet = setOf("ANode")
         ).selections(Fragment2Selections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/multiple_fragments/kotlin/responseBased/multiple_fragments/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/operationBased/named_fragment_delegate/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/operationBased/named_fragment_delegate/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/responseBased/named_fragment_delegate/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_delegate/kotlin/responseBased/named_fragment_delegate/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/operationBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
@@ -23,12 +23,12 @@ public object GetHeroSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterNameSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterAppearsInSelections.__root)
         .build()
       )
@@ -40,7 +40,7 @@ public object GetHeroSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_inside_inline_fragment/kotlin/responseBased/named_fragment_inside_inline_fragment/selections/GetHeroSelections.kt.expected
@@ -23,12 +23,12 @@ public object GetHeroSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterNameSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(CharacterAppearsInSelections.__root)
         .build()
       )
@@ -40,7 +40,7 @@ public object GetHeroSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/fragment/selections/QueryFragmentSelections.kt.expected
@@ -26,7 +26,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "User",
-          possibleTypes = listOf("User")
+          possibleTypesSet = setOf("User")
         ).selections(UserFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/selections/GetUserSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/operationBased/named_fragment_with_variables/selections/GetUserSelections.kt.expected
@@ -21,7 +21,7 @@ public object GetUserSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/fragment/selections/QueryFragmentSelections.kt.expected
@@ -26,7 +26,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "User",
-          possibleTypes = listOf("User")
+          possibleTypesSet = setOf("User")
         ).selections(UserFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/selections/GetUserSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_with_variables/kotlin/responseBased/named_fragment_with_variables/selections/GetUserSelections.kt.expected
@@ -21,7 +21,7 @@ public object GetUserSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/operationBased/named_fragment_without_implementation/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/operationBased/named_fragment_without_implementation/selections/TestQuerySelections.kt.expected
@@ -27,12 +27,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/responseBased/named_fragment_without_implementation/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/named_fragment_without_implementation/kotlin/responseBased/named_fragment_without_implementation/selections/TestQuerySelections.kt.expected
@@ -27,12 +27,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/operationBased/nested_conditional_inline/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman1)
         .build()
       )
@@ -75,7 +75,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman2)
         .build()
       )
@@ -99,12 +99,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_conditional_inline/kotlin/responseBased/nested_conditional_inline/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman1)
         .build()
       )
@@ -75,7 +75,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman2)
         .build()
       )
@@ -99,12 +99,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/operationBased/nested_field_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/operationBased/nested_field_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -36,12 +36,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onIface2)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onImpl2)
         .build()
       )
@@ -75,12 +75,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onIface21)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onImpl21)
         .build()
       )
@@ -100,12 +100,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface1",
-          possibleTypes = listOf("Impl1")
+          possibleTypesSet = setOf("Impl1")
         ).selections(__onIface1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl1",
-          possibleTypes = listOf("Impl1")
+          possibleTypesSet = setOf("Impl1")
         ).selections(__onImpl1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/responseBased/nested_field_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_field_with_multiple_fieldsets/kotlin/responseBased/nested_field_with_multiple_fieldsets/selections/TestQuerySelections.kt.expected
@@ -36,12 +36,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onIface2)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onImpl2)
         .build()
       )
@@ -75,12 +75,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onIface21)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl2",
-          possibleTypes = listOf("Impl2")
+          possibleTypesSet = setOf("Impl2")
         ).selections(__onImpl21)
         .build()
       )
@@ -100,12 +100,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Iface1",
-          possibleTypes = listOf("Impl1")
+          possibleTypesSet = setOf("Impl1")
         ).selections(__onIface1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Impl1",
-          possibleTypes = listOf("Impl1")
+          possibleTypesSet = setOf("Impl1")
         ).selections(__onImpl1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
@@ -21,7 +21,7 @@ public object PilotFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Planet",
-          possibleTypes = listOf("Planet")
+          possibleTypesSet = setOf("Planet")
         ).selections(PlanetFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object StarshipFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Person",
-          possibleTypes = listOf("Person")
+          possibleTypesSet = setOf("Person")
         ).selections(PilotFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/operationBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
@@ -27,7 +27,7 @@ public object AllStarshipsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(StarshipFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/pilotFragmentSelections.kt.expected
@@ -21,7 +21,7 @@ public object PilotFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Planet",
-          possibleTypes = listOf("Planet")
+          possibleTypesSet = setOf("Planet")
         ).selections(PlanetFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/fragment/selections/starshipFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object StarshipFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Person",
-          possibleTypes = listOf("Person")
+          possibleTypesSet = setOf("Person")
         ).selections(PilotFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/nested_named_fragments/kotlin/responseBased/nested_named_fragments/selections/AllStarshipsSelections.kt.expected
@@ -27,7 +27,7 @@ public object AllStarshipsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(StarshipFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/operationBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "SomeBC")
+          possibleTypesSet = setOf("ABC", "SomeBC")
         ).selections(BFragmentSelections.__root)
         .build()
       )
@@ -38,7 +38,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "SomeBC")
+          possibleTypesSet = setOf("ABC", "SomeBC")
         ).selections(__onB)
         .build()
       )
@@ -50,7 +50,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC")
+          possibleTypesSet = setOf("ABC")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/not_all_combinations_are_needed/kotlin/responseBased/not_all_combinations_are_needed/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "SomeBC")
+          possibleTypesSet = setOf("ABC", "SomeBC")
         ).selections(BFragmentSelections.__root)
         .build()
       )
@@ -38,7 +38,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "SomeBC")
+          possibleTypesSet = setOf("ABC", "SomeBC")
         ).selections(__onB)
         .build()
       )
@@ -50,7 +50,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC")
+          possibleTypesSet = setOf("ABC")
         ).selections(__onA)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/operationBased/operationbased2_ex7/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/operationBased/operationbased2_ex7/selections/TestOperationSelections.kt.expected
@@ -40,12 +40,12 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "WarmBlooded",
-          possibleTypes = listOf("Lion", "Cat", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Panther")
         ).selections(__onWarmBlooded)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Pet",
-          possibleTypes = listOf("Cat", "Turtle")
+          possibleTypesSet = setOf("Cat", "Turtle")
         ).selections(__onPet)
         .build()
       )
@@ -57,7 +57,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Lion", "Cat", "Turtle", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Turtle", "Panther")
         ).selections(__onAnimal)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/responseBased/operationbased2_ex7/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex7/kotlin/responseBased/operationbased2_ex7/selections/TestOperationSelections.kt.expected
@@ -40,12 +40,12 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "WarmBlooded",
-          possibleTypes = listOf("Lion", "Cat", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Panther")
         ).selections(__onWarmBlooded)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Pet",
-          possibleTypes = listOf("Cat", "Turtle")
+          possibleTypesSet = setOf("Cat", "Turtle")
         ).selections(__onPet)
         .build()
       )
@@ -57,7 +57,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Lion", "Cat", "Turtle", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Turtle", "Panther")
         ).selections(__onAnimal)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/fragment/selections/AnimalFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/fragment/selections/AnimalFragmentSelections.kt.expected
@@ -40,12 +40,12 @@ public object AnimalFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Lion",
-          possibleTypes = listOf("Lion")
+          possibleTypesSet = setOf("Lion")
         ).selections(__onLion)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(__onCat)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/operationBased/operationbased2_ex8/selections/TestOperationSelections.kt.expected
@@ -22,7 +22,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Lion", "Cat", "Turtle", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Turtle", "Panther")
         ).selections(AnimalFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/fragment/selections/AnimalFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/fragment/selections/AnimalFragmentSelections.kt.expected
@@ -40,12 +40,12 @@ public object AnimalFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Lion",
-          possibleTypes = listOf("Lion")
+          possibleTypesSet = setOf("Lion")
         ).selections(__onLion)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(__onCat)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/selections/TestOperationSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/operationbased2_ex8/kotlin/responseBased/operationbased2_ex8/selections/TestOperationSelections.kt.expected
@@ -22,7 +22,7 @@ public object TestOperationSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Animal",
-          possibleTypes = listOf("Lion", "Cat", "Turtle", "Panther")
+          possibleTypesSet = setOf("Lion", "Cat", "Turtle", "Panther")
         ).selections(AnimalFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/operationBased/path_vs_flat_accessors/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/operationBased/path_vs_flat_accessors/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -47,12 +47,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/responseBased/path_vs_flat_accessors/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/path_vs_flat_accessors/kotlin/responseBased/path_vs_flat_accessors/selections/TestQuerySelections.kt.expected
@@ -28,7 +28,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB)
         .build()
       )
@@ -47,12 +47,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("ABC", "AC")
+          possibleTypesSet = setOf("ABC", "AC")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("ABC", "BC")
+          possibleTypesSet = setOf("ABC", "BC")
         ).selections(__onB1)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/operationBased/reserved_keywords/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/operationBased/reserved_keywords/selections/TestQuerySelections.kt.expected
@@ -46,7 +46,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/responseBased/reserved_keywords/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/reserved_keywords/kotlin/responseBased/reserved_keywords/selections/TestQuerySelections.kt.expected
@@ -46,7 +46,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/operationBased/root_query_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/operationBased/root_query_fragment/selections/TestQuerySelections.kt.expected
@@ -21,7 +21,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/responseBased/root_query_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment/kotlin/responseBased/root_query_fragment/selections/TestQuerySelections.kt.expected
@@ -21,7 +21,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroFragmentSelections.__root)
         .build()
       )
@@ -37,7 +37,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )
@@ -60,7 +60,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/operationBased/root_query_fragment_with_nested_fragments/selections/TestQuerySelections.kt.expected
@@ -21,7 +21,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/fragment/selections/QueryFragmentSelections.kt.expected
@@ -25,7 +25,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroFragmentSelections.__root)
         .build()
       )
@@ -37,7 +37,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(DroidFragmentSelections.__root)
         .build()
       )
@@ -60,7 +60,7 @@ public object QueryFragmentSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_fragment_with_nested_fragments/kotlin/responseBased/root_query_fragment_with_nested_fragments/selections/TestQuerySelections.kt.expected
@@ -21,7 +21,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(QueryFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/operationBased/root_query_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -42,7 +42,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )
@@ -65,7 +65,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -97,7 +97,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(__onQuery)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/root_query_inline_fragment/kotlin/responseBased/root_query_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -42,7 +42,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )
@@ -65,7 +65,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -97,7 +97,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Query",
-          possibleTypes = listOf("Query")
+          possibleTypesSet = setOf("Query")
         ).selections(__onQuery)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/fragment/selections/HeroDetailsSelections.kt.expected
@@ -20,7 +20,7 @@ internal object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/operationBased/simple_fragment/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ internal object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/fragment/selections/HeroDetailsSelections.kt.expected
@@ -20,7 +20,7 @@ internal object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment/kotlin/responseBased/simple_fragment/selections/TestQuerySelections.kt.expected
@@ -23,12 +23,12 @@ internal object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(HumanDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/fragment/selections/HeroDetailsSelections.kt.expected
@@ -41,12 +41,12 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/operationBased/simple_fragment_with_inline_fragments/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/fragment/selections/HeroDetailsSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/fragment/selections/HeroDetailsSelections.kt.expected
@@ -41,12 +41,12 @@ public object HeroDetailsSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_fragment_with_inline_fragments/kotlin/responseBased/simple_fragment_with_inline_fragments/selections/TestQuerySelections.kt.expected
@@ -22,7 +22,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/operationBased/simple_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/operationBased/simple_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -34,7 +34,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter1)
         .build()
       )
@@ -60,17 +60,17 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/responseBased/simple_inline_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_inline_fragment/kotlin/responseBased/simple_inline_fragment/selections/TestQuerySelections.kt.expected
@@ -34,7 +34,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter1)
         .build()
       )
@@ -60,17 +60,17 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/operationBased/simple_union/selections/AnimalQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/operationBased/simple_union/selections/AnimalQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object AnimalQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(CatFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(DogFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/responseBased/simple_union/selections/AnimalQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/simple_union/kotlin/responseBased/simple_union/selections/AnimalQuerySelections.kt.expected
@@ -23,12 +23,12 @@ public object AnimalQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Cat",
-          possibleTypes = listOf("Cat")
+          possibleTypesSet = setOf("Cat")
         ).selections(CatFragmentSelections.__root)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Dog",
-          possibleTypes = listOf("Dog")
+          possibleTypesSet = setOf("Dog")
         ).selections(DogFragmentSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/operationBased/target_name/selections/TestQuerySelections.kt.expected
@@ -49,7 +49,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ReservedObject",
-          possibleTypes = listOf("ReservedObject")
+          possibleTypesSet = setOf("ReservedObject")
         ).selections(__onReservedObject)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/target_name/kotlin/responseBased/target_name/selections/TestQuerySelections.kt.expected
@@ -49,7 +49,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ReservedObject",
-          possibleTypes = listOf("ReservedObject")
+          possibleTypesSet = setOf("ReservedObject")
         ).selections(__onReservedObject)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/operationBased/test_inline/selections/GetPageSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/operationBased/test_inline/selections/GetPageSelections.kt.expected
@@ -37,7 +37,7 @@ public object GetPageSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ParticularItem",
-          possibleTypes = listOf("ParticularItem")
+          possibleTypesSet = setOf("ParticularItem")
         ).selections(__onParticularItem)
         .build()
       )
@@ -62,7 +62,7 @@ public object GetPageSelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ParticularCollection",
-          possibleTypes = listOf("ParticularCollection")
+          possibleTypesSet = setOf("ParticularCollection")
         ).selections(__onParticularCollection)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/responseBased/test_inline/selections/GetPageSelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/test_inline/kotlin/responseBased/test_inline/selections/GetPageSelections.kt.expected
@@ -37,7 +37,7 @@ public object GetPageSelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "ParticularItem",
-          possibleTypes = listOf("ParticularItem")
+          possibleTypesSet = setOf("ParticularItem")
         ).selections(__onParticularItem)
         .build()
       )
@@ -62,7 +62,7 @@ public object GetPageSelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "ParticularCollection",
-          possibleTypes = listOf("ParticularCollection")
+          possibleTypesSet = setOf("ParticularCollection")
         ).selections(__onParticularCollection)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/operationBased/typename_always_first/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/operationBased/typename_always_first/selections/TestQuerySelections.kt.expected
@@ -48,12 +48,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/responseBased/typename_always_first/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typename_always_first/kotlin/responseBased/typename_always_first/selections/TestQuerySelections.kt.expected
@@ -48,12 +48,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/fragment/selections/AFragment1Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/fragment/selections/AFragment1Selections.kt.expected
@@ -25,7 +25,7 @@ public object AFragment1Selections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragment2Selections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetASelections.kt.expected
@@ -23,7 +23,7 @@ public object GetASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragment1Selections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetInterfaceASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetInterfaceASelections.kt.expected
@@ -42,17 +42,17 @@ public object GetInterfaceASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "InterfaceA",
-          possibleTypes = listOf("B", "C")
+          possibleTypesSet = setOf("B", "C")
         ).selections(__onInterfaceA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetUnionASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/operationBased/typepolicy/selections/GetUnionASelections.kt.expected
@@ -50,22 +50,22 @@ public object GetUnionASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "UnionA",
-          possibleTypes = listOf("A", "B", "C")
+          possibleTypesSet = setOf("A", "B", "C")
         ).selections(__onUnionA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/fragment/selections/AFragment1Selections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/fragment/selections/AFragment1Selections.kt.expected
@@ -25,7 +25,7 @@ public object AFragment1Selections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragment2Selections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetASelections.kt.expected
@@ -23,7 +23,7 @@ public object GetASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(AFragment1Selections.__root)
         .build(),
         CompiledField.Builder(

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetInterfaceASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetInterfaceASelections.kt.expected
@@ -42,17 +42,17 @@ public object GetInterfaceASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "InterfaceA",
-          possibleTypes = listOf("B", "C")
+          possibleTypesSet = setOf("B", "C")
         ).selections(__onInterfaceA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetUnionASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/typepolicy/kotlin/responseBased/typepolicy/selections/GetUnionASelections.kt.expected
@@ -50,22 +50,22 @@ public object GetUnionASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "UnionA",
-          possibleTypes = listOf("A", "B", "C")
+          possibleTypesSet = setOf("A", "B", "C")
         ).selections(__onUnionA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "A",
-          possibleTypes = listOf("A")
+          possibleTypesSet = setOf("A")
         ).selections(__onA)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/operationBased/union_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/operationBased/union_fragment/selections/TestQuerySelections.kt.expected
@@ -33,12 +33,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(__onStarship)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(StarshipSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/responseBased/union_fragment/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_fragment/kotlin/responseBased/union_fragment/selections/TestQuerySelections.kt.expected
@@ -33,12 +33,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(__onStarship)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(StarshipSelections.__root)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/operationBased/union_inline_fragments/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter2)
         .build()
       )
@@ -84,17 +84,17 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -129,12 +129,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(__onStarship)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/selections/TestQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/union_inline_fragments/kotlin/responseBased/union_inline_fragments/selections/TestQuerySelections.kt.expected
@@ -41,7 +41,7 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter2)
         .build()
       )
@@ -84,17 +84,17 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter1)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Droid",
-          possibleTypes = listOf("Droid")
+          possibleTypesSet = setOf("Droid")
         ).selections(__onDroid)
         .build()
       )
@@ -129,12 +129,12 @@ public object TestQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(__onCharacter)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Starship",
-          possibleTypes = listOf("Starship")
+          possibleTypesSet = setOf("Starship")
         ).selections(__onStarship)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/selections/HeroDetailQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/operationBased/unique_type_name/selections/HeroDetailQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object HeroDetailQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )
@@ -77,7 +77,7 @@ public object HeroDetailQuerySelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/selections/HeroDetailQuerySelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/unique_type_name/kotlin/responseBased/unique_type_name/selections/HeroDetailQuerySelections.kt.expected
@@ -32,7 +32,7 @@ public object HeroDetailQuerySelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "Character",
-          possibleTypes = listOf("Droid", "Human")
+          possibleTypesSet = setOf("Droid", "Human")
         ).selections(HeroDetailsSelections.__root)
         .build()
       )
@@ -77,7 +77,7 @@ public object HeroDetailQuerySelections {
         .build(),
         CompiledFragment.Builder(
           typeCondition = "Human",
-          possibleTypes = listOf("Human")
+          possibleTypesSet = setOf("Human")
         ).selections(__onHuman)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/operationBased/used_arguments/selections/GetASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/operationBased/used_arguments/selections/GetASelections.kt.expected
@@ -45,12 +45,12 @@ public object GetASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/responseBased/used_arguments/selections/GetASelections.kt.expected
+++ b/libraries/apollo-compiler/src/test/graphql/com/example/used_arguments/kotlin/responseBased/used_arguments/selections/GetASelections.kt.expected
@@ -45,12 +45,12 @@ public object GetASelections {
         ).build(),
         CompiledFragment.Builder(
           typeCondition = "B",
-          possibleTypes = listOf("B")
+          possibleTypesSet = setOf("B")
         ).selections(__onB)
         .build(),
         CompiledFragment.Builder(
           typeCondition = "C",
-          possibleTypes = listOf("C")
+          possibleTypesSet = setOf("C")
         ).selections(__onC)
         .build()
       )

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/CacheBatchReader.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/CacheBatchReader.kt
@@ -64,7 +64,7 @@ internal class CacheBatchReader(
         }
 
         is CompiledFragment -> {
-          if (((typename != null && compiledSelection.isPossibleType(typename)) || compiledSelection.typeCondition == parentType) && !compiledSelection.shouldSkip(state.variables.valueMap)) {
+          if (((typename in compiledSelection.possibleTypesSet) || compiledSelection.typeCondition == parentType) && !compiledSelection.shouldSkip(state.variables.valueMap)) {
             collect(compiledSelection.selections, parentType, typename, state)
           }
         }

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/CacheBatchReader.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/CacheBatchReader.kt
@@ -64,7 +64,7 @@ internal class CacheBatchReader(
         }
 
         is CompiledFragment -> {
-          if ((typename in compiledSelection.possibleTypes || compiledSelection.typeCondition == parentType) && !compiledSelection.shouldSkip(state.variables.valueMap)) {
+          if (((typename != null && compiledSelection.isPossibleType(typename)) || compiledSelection.typeCondition == parentType) && !compiledSelection.shouldSkip(state.variables.valueMap)) {
             collect(compiledSelection.selections, parentType, typename, state)
           }
         }

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/Normalizer.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/Normalizer.kt
@@ -166,7 +166,7 @@ internal class Normalizer(
           state.fields.add(it)
         }
         is CompiledFragment -> {
-          if (typename in it.possibleTypes || it.typeCondition == parentType) {
+          if ((typename != null && it.isPossibleType(typename)) || it.typeCondition == parentType) {
             collectFields(it.selections, parentType, typename, state)
           }
         }

--- a/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/Normalizer.kt
+++ b/libraries/apollo-normalized-cache-api/src/commonMain/kotlin/com/apollographql/apollo/cache/normalized/api/internal/Normalizer.kt
@@ -166,7 +166,7 @@ internal class Normalizer(
           state.fields.add(it)
         }
         is CompiledFragment -> {
-          if ((typename != null && it.isPossibleType(typename)) || it.typeCondition == parentType) {
+          if ((typename in it.possibleTypesSet) || it.typeCondition == parentType) {
             collectFields(it.selections, parentType, typename, state)
           }
         }


### PR DESCRIPTION
Collecting the fields to read or write for an object walks the operation's selections and, at every fragment, asks whether the object's `__typename` is one of that fragment's possible types. `CompiledFragment.possibleTypes` is a `List`, so the question is answered by a linear scan comparing strings one at a time.

The cost is paid per object rather than per fragment. A list of a hundred objects with an interface selection runs the same scan a hundred times, and an abstract type with many implementations makes each scan longer, so the work grows with the product of the two -- over strings that were fixed when the operation was compiled.

`CompiledFragment` now derives a set from `possibleTypes` and exposes `isPossibleType(typename)`, which the field collectors of the normalized cache and the fake resolver call instead of testing the list. The set is built on first use, so a selection whose type condition is never tested against a concrete type does not pay for it, and it is shared across every object of a list because generated selections are static.

`possibleTypes` keeps its `List` type and its place in the public API, and generated code is unchanged: the new method is purely additive.

In a profile of a large scrolling feed in a production app, these scans were roughly 3% of all CPU spent in the GraphQL client, and a noticeable part of its time in `String.equals`.