### PR TITLE
WebSocket tests: fix a race condition

### DIFF
--- a/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/RetryWebSocketsTest.kt
@@ -47,10 +47,10 @@ class RetryWebSocketsTest {
                   .build()
           )
           .build().use { apolloClient ->
+            val serverWriter = mockServer.enqueueWebSocket(keepAlive = false)
             apolloClient.subscription(FooSubscription())
                 .toFlow()
                 .test {
-                  val serverWriter = mockServer.enqueueWebSocket(keepAlive = false)
                   var serverReader = mockServer.awaitWebSocketRequest()
 
                   serverReader.awaitMessage() // connection_init


### PR DESCRIPTION
See https://github.com/apollographql/apollo-kotlin/actions/runs/32076992608/job/95702298831

Enqueue the websocket response before opening the subscription.