### PR TITLE
WebSocket tests: robustify the sample server

### DIFF
--- a/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/SampleServer.kt
+++ b/tests/sample-server/src/main/kotlin/com/apollographql/apollo/sample/server/SampleServer.kt
@@ -21,6 +21,7 @@ import okio.Buffer
 import okio.buffer
 import okio.source
 import okio.withLock
+import org.eclipse.jetty.websocket.api.exceptions.WebSocketException
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.PolyHandler
@@ -165,7 +166,12 @@ fun ApolloWebsocketHandler(executableSchema: ExecutableSchema, webSocketRegistry
       }
 
       val sendMessage = { webSocketMessage: WebSocketMessage ->
-        ws.send(webSocketMessage.toWsMessage())
+        try {
+          ws.send(webSocketMessage.toWsMessage())
+        } catch (e: WebSocketException) {
+          System.err.println("Error sending message: $webSocketMessage")
+          e.printStackTrace()
+        }
       }
 
       val handler = SubscriptionWebSocketHandler(


### PR DESCRIPTION
Do not crash if trying to send a message after the connection has been closed. 

Should fix issues like this:

```
SampleServerTest[jvm] > canResumeAfterGraphQLError[jvm] STANDARD_ERROR
    Exception in thread "DefaultDispatcher-worker-5 @coroutine#95" org.eclipse.jetty.websocket.api.exceptions.WebSocketException: Connection to /subscriptions is closed.
    	at org.http4k.server.Http4kJettyServerWebSocketEndpoint$onWebSocketOpen$1.send(Http4kJettyServerWebSocketEndpoint.kt:23)
    	at com.apollographql.apollo.sample.server.SampleServerKt.ApolloWebsocketHandler$lambda$0$0$0(SampleServer.kt:168)
    	at com.apollographql.apollo.sample.server.SampleServerKt.ApolloWebsocketHandler$lambda$0$0$suspendConversion0(SampleServer.kt:175)
    	at com.apollographql.apollo.sample.server.SampleServerKt.access$ApolloWebsocketHandler$lambda$0$0$suspendConversion0(SampleServer.kt:1)
    	at com.apollographql.apollo.sample.server.SampleServerKt$ApolloWebsocketHandler$1$1$handler$1.invoke(SampleServer.kt:175)
    	at com.apollographql.apollo.sample.server.SampleServerKt$ApolloWebsocketHandler$1$1$handler$1.invoke(SampleServer.kt:175)
    	at com.apollographql.execution.websocket.SubscriptionWebSocketHandler$handleMessage$job$1$1.emit(SubscriptionWebSocketHandler.kt:84)
    	at com.apollographql.execution.websocket.SubscriptionWebSocketHandler$handleMessage$job$1$1.emit(SubscriptionWebSocketHandler.kt:81)
    	at kotlinx.coroutines.flow.FlowKt__ErrorsKt$catchImpl$2.emit(Errors.kt:154)

```