### PR TITLE
fix(compiler): report capitalized field issues once per field

### DIFF
--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkCapitalizedFields.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/checkCapitalizedFields.kt
@@ -15,13 +15,17 @@ import com.apollographql.apollo.ast.UpperCaseField
 internal fun checkCapitalizedFields(definitions: List<GQLDefinition>, checkFragmentsOnly: Boolean): List<Issue> {
   val scope = object : ValidationScope {
     override val issues = mutableListOf<Issue>()
-    override val fragmentsByName = definitions.filterIsInstance<GQLFragmentDefinition>().associateBy { it.name }
   }
 
+  /**
+   * Every fragment definition is checked here, on its own. Fragment spreads are therefore not
+   * followed: the spread target is either one of these definitions, and already checked, or it
+   * belongs to an upstream module and was checked when that module was compiled.
+   */
   definitions.forEach { definition ->
     when {
-      definition is GQLOperationDefinition && !checkFragmentsOnly -> scope.checkCapitalizedFields(definition.selections, emptyList())
-      definition is GQLFragmentDefinition -> scope.checkCapitalizedFields(definition.selections, emptyList())
+      definition is GQLOperationDefinition && !checkFragmentsOnly -> scope.checkCapitalizedFields(definition.selections)
+      definition is GQLFragmentDefinition -> scope.checkCapitalizedFields(definition.selections)
     }
   }
 
@@ -31,7 +35,7 @@ internal fun checkCapitalizedFields(definitions: List<GQLDefinition>, checkFragm
 /**
  * Fields named with a capital first letter clash with the corresponding model name, unless flatten.
  */
-private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection>, checkedFragments: List<String>) {
+private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection>) {
   selections.forEach {
     when (it) {
       is GQLField -> {
@@ -61,22 +65,19 @@ private fun ValidationScope.checkCapitalizedFields(selections: List<GQLSelection
               )
           )
         }
-        checkCapitalizedFields(it.selections, checkedFragments)
+        checkCapitalizedFields(it.selections)
       }
 
-      is GQLInlineFragment -> checkCapitalizedFields(it.selections, checkedFragments)
-      // it might be that the fragment is defined in an upstream module. In that case, it is validated
-      // already, no need to check it again
-      is GQLFragmentSpread -> if (!checkedFragments.contains(it.name)) {
-        fragmentsByName[it.name]?.let { fragment -> checkCapitalizedFields(fragment.selections, checkedFragments + it.name) }
-      }
+      is GQLInlineFragment -> checkCapitalizedFields(it.selections)
+      // The spread target is checked on its own: either it is one of the definitions checked
+      // above, or it is defined in an upstream module and was validated there.
+      is GQLFragmentSpread -> Unit
     }
   }
 }
 
 private interface ValidationScope {
   val issues: MutableList<Issue>
-  val fragmentsByName: Map<String, GQLFragmentDefinition>
 }
 
 private fun isFirstLetterUpperCase(name: String): Boolean {

--- a/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CheckCapitalizedFieldsTest.kt
+++ b/libraries/apollo-compiler/src/test/kotlin/com/apollographql/apollo/compiler/CheckCapitalizedFieldsTest.kt
@@ -16,7 +16,9 @@ class CheckCapitalizedFieldsTest(name: String, private val graphQLFile: File) {
 
   @Test
   fun testValidation() = checkExpected(graphQLFile) { _ ->
-    val checkFragmentsOnly = graphQLFile.name != "capitalized_fields_disallowed.graphql"
+    // The "disallowed" fixtures are checked with checkFragmentsOnly = false so that operations
+    // are checked too, which is what happens when flattenModels is off.
+    val checkFragmentsOnly = !graphQLFile.name.startsWith("capitalized_fields_disallowed")
 
     checkCapitalizedFields(graphQLFile.toGQLDocument().definitions, checkFragmentsOnly = checkFragmentsOnly).serialize()
   }

--- a/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed_with_fragment_spread.expected
+++ b/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed_with_fragment_spread.expected
@@ -1,0 +1,5 @@
+UpperCaseField (2:3)
+Capitalized field 'Horse' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.
+------------
+UpperCaseField (9:3)
+Capitalized field 'Cow' is not supported as it causes name clashes with the generated models. Use an alias instead or the 'flattenModels' or 'decapitalizeFields' compiler option.

--- a/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed_with_fragment_spread.graphql
+++ b/libraries/apollo-compiler/src/test/validation/operation/capitalized_fields/capitalized_fields_disallowed_with_fragment_spread.graphql
@@ -1,0 +1,12 @@
+query TestQuery {
+  Horse {
+    Donkey
+    ...HorseFragment
+  }
+}
+
+fragment HorseFragment on Horse {
+  Cow {
+    Moo
+  }
+}


### PR DESCRIPTION
`checkCapitalizedFields` reports the same issue several times for fields inside fragments.

Every fragment definition is checked on its own by the top-level loop, and then fragment spreads are followed into those same definitions. A capitalized field inside a fragment is therefore reported once for each path that reaches it, plus once for the definition itself. Apollo's own `capitalized_fields_allowed_with_fragment_spread` fixture shows it — checked with `checkFragmentsOnly = false`, `Cow` at (15:3) is reported twice:

```
before   4 issues at [(2,3), (5,7), (15,3), (15,3)]
after    3 issues at [(2,3), (5,7), (15,3)]
```

That fixture never caught this because it only runs with `checkFragmentsOnly = true`, which skips operations and so never follows the spread. `checkFragmentsOnly` is `flattenModels`, which is off for `responseBased` codegen, so this is reachable in a normal build.

Following spreads cannot find anything the direct pass misses. The target is always either one of the definitions already being checked in the same pass, or a fragment from an upstream module that was validated when that module was compiled — which is what the comment on that branch already said. So the recursion is removed, along with the `checkedFragments` parameter that existed only to keep it from looping.

### Performance

The removed recursion enumerated every simple path through the fragment graph. `checkedFragments` was a `List<String>` rebuilt as `checkedFragments + name` at each spread, so membership was a linear scan and the list was copied once per spread — but the dominant cost was the path enumeration itself, which grows combinatorially with fragment fan-out.

Measured on a production module with 149 fragments and 478 spreads, timing the call directly:

```
checkFragmentsOnly = true    8.39 ms  ->  0.017 ms
checkFragmentsOnly = false  13.24 ms  ->  0.059 ms
```

This came out of profiling `generateApolloIrOperations` on that module, where `checkCapitalizedFields` was the largest single `apollo-compiler` frame.

### Tests

`capitalized_fields_disallowed_with_fragment_spread` covers the duplicate: it runs with `checkFragmentsOnly = false` and fails on the extra issue before this change. The mode is now selected by fixture name prefix rather than one exact filename, so "disallowed" fixtures generally get operations checked too.

281 `apollo-ast` and 301 `apollo-compiler` tests pass. No other expected output changed, which is consistent with the recursion only ever having produced duplicates.
