### PR TITLE
perf(ast): stop re-hashing whole AST subtrees in fieldsInSetCanMerge

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/fields_merging.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/fields_merging.kt
@@ -233,7 +233,13 @@ private fun groupByCommonParents(fields: Set<FieldAndType>): List<Set<FieldAndTy
     return listOf(abstractTypes)
   }
 
-  val groupsByConcreteParent = concreteTypes.groupBy { it.parentType }
+  /**
+   * Group by name and not by the definition itself: type definitions are name-unique within a
+   * schema, so this yields the same grouping, but hashing a `GQLObjectTypeDefinition` means
+   * recursively hashing all of its field definitions, their input values and their types. Only
+   * the groups are used below — the keys are discarded.
+   */
+  val groupsByConcreteParent = concreteTypes.groupBy { it.parentType.name }
   return groupsByConcreteParent.values.map { concreteGroup ->
     concreteGroup.toSet() + abstractTypes
   }
@@ -383,10 +389,18 @@ private data class FieldAndType(
     return field == other.field
   }
 
-  override fun hashCode(): Int {
-    return field.hashCode()
-  }
+  /**
+   * `GQLField` is a `@Poko` class, so its hash covers `selections` and therefore the whole
+   * subtree below the field. Instances of this class are put in sets, grouped, and — via
+   * [ValidationContext.visitedShapeSets] / [ValidationContext.visitedParentSets], which hold
+   * sets *of* sets — re-hashed as members of every group they belong to. The AST is immutable,
+   * so compute that hash once per instance instead of once per lookup.
+   */
+  private val fieldHashCode: Int = field.hashCode()
 
+  override fun hashCode(): Int {
+    return fieldHashCode
+  }
 
   override fun toString(): String {
     return "${field.sourceLocation.pretty()}: ${field.toUtf8()} (${parentType.name})"


### PR DESCRIPTION
Profiling `generateApolloIrOperations` on a large module put most of the `apollo-ast` time under `groupByCommonParents`, and almost all of that in `HashMap.put`/`getNode` computing hashes of AST nodes. Two things make the same hash get recomputed over and over.

### `FieldAndType` hashes the subtree below its field

`FieldAndType.hashCode()` delegates to `GQLField.hashCode()`. `GQLField` is a `@Poko` class whose hash covers `selections`, so hashing one field costs a walk of the entire subtree beneath it.

The cost is paid per lookup rather than per field. Instances are held in sets, grouped by parent, and then re-hashed as members of every group they join — `visitedShapeSets` and `visitedParentSets` are sets *of* sets, so testing membership hashes every element of the candidate set. A field near the root of a deep operation gets its subtree walked again on each of those tests.

The AST is immutable once parsed, so the hash is now computed once per instance. Equality is unchanged — it still compares `field` — and the `hashCode` contract holds, since equal instances still derive their hash from the same field.

### `groupByCommonParents` keys on the type definition

It grouped by the `GQLTypeDefinition` itself, so every `put` and `get` recursively hashed an object type's field definitions, their input values and their types. Type definitions are name-unique within a schema and only the grouped values are used — the keys are discarded — so grouping by name gives the same grouping for the cost of a string hash.

### Measurements

`BuildIrOperationsBenchmark` (100 generated operations over the GitHub schema), baseline measured by reverting the same file:

```
baseline   55.716 ± 1.048 ops/s
this PR    67.025 ± 4.083 ops/s
this PR    72.316 ± 1.195 ops/s   (second run)
```

Between 20% and 30% throughput. The two runs of this branch differ by more than I would like — both are well clear of the baseline interval, but the honest read is "20%+" rather than a precise figure.

Note the benchmark corpus is fragment-free (every generated field gets a unique alias), so these numbers come purely from field-merging validation and do not depend on fragment structure.

### Tests

281 `apollo-ast` and 300 `apollo-compiler` tests pass unchanged, including the expected-output validation suites that would catch any change in reported issues or grouping.
