### PR TITLE
Allow custom JVM HTTP engines without OkHttp

### DIFF
--- a/docs/source/advanced/http-engine.mdx
+++ b/docs/source/advanced/http-engine.mdx
@@ -77,6 +77,22 @@ val client = ApolloClient.Builder()
 
 With this configuration, Apollo Kotlin sends all of its GraphQL operation requests with `MyHttpEngine`.
 
+### Excluding OkHttp on JVM
+
+If you provide a custom `HttpEngine` and only use HTTP operations, you can exclude OkHttp from the runtime dependency:
+
+```kotlin
+dependencies {
+  implementation("com.apollographql.apollo:apollo-runtime:$apolloVersion") {
+    exclude(group = "com.squareup.okhttp3")
+  }
+}
+```
+
+The default WebSocket engine is initialized only when a WebSocket connection is opened. If you use WebSocket subscriptions, you must also provide a custom `WebSocketEngine` through `WebSocketNetworkTransport` before excluding OkHttp.
+
+This exclusion only applies to Apollo's dependency on OkHttp; other dependencies may still require it. Apollo still requires Okio for its HTTP bodies and JSON readers.
+
 
 ## Ktor engine
 

--- a/libraries/apollo-runtime/build.gradle.kts
+++ b/libraries/apollo-runtime/build.gradle.kts
@@ -97,3 +97,16 @@ kotlin {
     }
   }
 }
+
+val jvmTest = tasks.named<Test>("jvmTest")
+val jvmTestWithoutOkHttp = tasks.register<Test>("jvmTestWithoutOkHttp") {
+  testClassesDirs = jvmTest.get().testClassesDirs
+  classpath = jvmTest.get().classpath.filter { !it.name.startsWith("okhttp") }
+  filter.includeTestsMatching("NoOkHttpTest")
+}
+jvmTest.configure {
+  filter.excludeTestsMatching("NoOkHttpTest")
+}
+tasks.named("check") {
+  dependsOn(jvmTestWithoutOkHttp)
+}

--- a/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.jvm.kt
+++ b/libraries/apollo-runtime/src/jvmCommonMain/kotlin/com/apollographql/apollo/network/websocket/WebSocketEngine.jvm.kt
@@ -113,7 +113,32 @@ internal class JvmWebSocket(
 }
 
 
-actual fun WebSocketEngine(): WebSocketEngine = JvmWebSocketEngine { defaultOkHttpClientBuilder.build() }
+actual fun WebSocketEngine(): WebSocketEngine = LazyWebSocketEngine {
+  // Loading JvmWebSocketEngine links OkHttp classes, even though its client is lazy.
+  JvmWebSocketEngine { defaultOkHttpClientBuilder.build() }
+}
+
+internal class LazyWebSocketEngine(private val factory: () -> WebSocketEngine) : WebSocketEngine {
+  private var delegate: WebSocketEngine? = null
+  private var closed = false
+
+  override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket = synchronized(this) {
+    require(!closed) {
+      "JvmWebSocketEngine is closed"
+    }
+    val engine = delegate ?: factory().also { delegate = it }
+    engine.newWebSocket(url, headers, listener)
+  }
+
+  override fun close() {
+    synchronized(this) {
+      if (!closed) {
+        closed = true
+        delegate?.close()
+      }
+    }
+  }
+}
 
 /**
  * Creates a new [WebSocketEngine] from [webSocketFactory]

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/LazyWebSocketEngineTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/LazyWebSocketEngineTest.kt
@@ -1,0 +1,71 @@
+import com.apollographql.apollo.api.http.HttpHeader
+import com.apollographql.apollo.exception.ApolloException
+import com.apollographql.apollo.network.websocket.LazyWebSocketEngine
+import com.apollographql.apollo.network.websocket.WebSocket
+import com.apollographql.apollo.network.websocket.WebSocketEngine
+import com.apollographql.apollo.network.websocket.WebSocketListener
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class LazyWebSocketEngineTest {
+  @Test
+  fun closingBeforeUseDoesNotCreateTheDelegate() {
+    val engine = LazyWebSocketEngine { error("Must not initialize the delegate") }
+    engine.close()
+    engine.close()
+
+    assertFailsWith<IllegalArgumentException> {
+      engine.newWebSocket("wss://example.com", emptyList(), listener)
+    }
+  }
+
+  @Test
+  fun createsTheDelegateOnceAndClosesItOnce() {
+    var creations = 0
+    var closes = 0
+    val headers = listOf(HttpHeader("Authorization", "token"))
+    val engine = LazyWebSocketEngine {
+      creations++
+      object : WebSocketEngine {
+        override fun newWebSocket(url: String, headers: List<HttpHeader>, listener: WebSocketListener): WebSocket {
+          assertEquals("wss://example.com", url)
+          assertEquals(listOf(HttpHeader("Authorization", "token")), headers)
+          assertSame(this@LazyWebSocketEngineTest.listener, listener)
+          return webSocket
+        }
+
+        override fun close() {
+          closes++
+        }
+      }
+    }
+
+    assertEquals(0, creations)
+    repeat(2) {
+      assertSame(webSocket, engine.newWebSocket("wss://example.com", headers, listener))
+    }
+    assertEquals(1, creations)
+    engine.close()
+    engine.close()
+    assertEquals(1, closes)
+    assertFailsWith<IllegalArgumentException> {
+      engine.newWebSocket("wss://example.com", headers, listener)
+    }
+  }
+
+  private val listener = object : WebSocketListener {
+    override fun onOpen() = Unit
+    override fun onMessage(text: String) = Unit
+    override fun onMessage(data: ByteArray) = Unit
+    override fun onError(cause: ApolloException) = Unit
+    override fun onClosed(code: Int?, reason: String?) = Unit
+  }
+
+  private val webSocket = object : WebSocket {
+    override fun send(data: ByteArray) = Unit
+    override fun send(text: String) = Unit
+    override fun close(code: Int, reason: String) = Unit
+  }
+}

--- a/libraries/apollo-runtime/src/jvmTest/kotlin/NoOkHttpTest.kt
+++ b/libraries/apollo-runtime/src/jvmTest/kotlin/NoOkHttpTest.kt
@@ -1,0 +1,56 @@
+import com.apollographql.apollo.ApolloClient
+import com.apollographql.apollo.api.http.HttpRequest
+import com.apollographql.apollo.api.http.HttpResponse
+import com.apollographql.apollo.network.http.HttpEngine
+import com.apollographql.apollo.testing.internal.runTest
+import okio.Buffer
+import okio.use
+import test.FooMutation
+import test.FooQuery
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class NoOkHttpTest {
+  @Test
+  fun customHttpEngineExecutesQueriesAndMutationsWithoutOkHttp() = runTest {
+    assertFailsWith<ClassNotFoundException> {
+      Class.forName("okhttp3.OkHttpClient")
+    }
+    val requests = mutableListOf<String>()
+    var closed = false
+    val httpEngine = object : HttpEngine {
+      override suspend fun execute(request: HttpRequest): HttpResponse {
+        requests.add(Buffer().apply { request.body!!.writeTo(this) }.readUtf8())
+        return HttpResponse.Builder(200)
+            .body(Buffer().writeUtf8(FooQuery.successResponse))
+            .build()
+      }
+
+      override fun close() {
+        closed = true
+      }
+    }
+
+    ApolloClient.Builder()
+        .serverUrl("https://example.com/graphql")
+        .httpEngine(httpEngine)
+        .build()
+        .use { client ->
+          val queryResponse = client.query(FooQuery()).execute()
+          assertNull(queryResponse.exception)
+          assertEquals(42, queryResponse.data?.foo)
+
+          val mutationResponse = client.mutation(FooMutation()).execute()
+          assertNull(mutationResponse.exception)
+          assertEquals(42, mutationResponse.data?.foo)
+        }
+
+    assertEquals(2, requests.size)
+    assertTrue(requests[0].contains("query FooOperation"))
+    assertTrue(requests[1].contains("mutation FooOperation"))
+    assertTrue(closed)
+  }
+}


### PR DESCRIPTION
HTTP-only JVM consumers cannot currently exclude OkHttp even after supplying a custom `HttpEngine`: `ApolloClient` eagerly creates its unused default WebSocket engine, which links `okhttp3.WebSocket.Factory` and fails with `NoClassDefFoundError` during construction.

Defer the default JVM WebSocket engine until its first connection. Closing an unused engine does not initialize it, creation and closure are synchronized, and existing public APIs and the default OkHttp dependency remain unchanged. Document the dependency exclusion for consumers providing their own engines.

This helps ReAI's Kotlin/Spring Boot backend retain Apollo's generated parsing and runtime while reusing its existing HTTP stack for ten Shopify queries/mutations, with no subscriptions. It makes the roughly 848 KiB OkHttp JVM JAR removable from that distribution. Related to the engine extraction item in #6078; this is a focused fix rather than the full module split.

Validation:
- A separate `jvmTestWithoutOkHttp` task, included in `check`, runs query/mutation execution and client closure with OkHttp JARs removed from the test JVM. Confirmed failure with the original factory and success with this change.
- Lifecycle tests cover deferred initialization, repeated use, closure before use, repeated closure, and rejection after closure.
- All 66 JVM runtime tests, the isolated no-OkHttp test, and `:apollo-runtime:apiCheck` pass.
