### PR TITLE
Speed up Kotlin code generation and schema processing

### DIFF
--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/Schema.kt
@@ -97,13 +97,15 @@ class Schema internal constructor(
    * Without this, resolving a field definition rebuilds the field definitions of the parent type and scans them
    * linearly, and that happens for every field of every selection set.
    */
-  private val fieldDefinitionsByName: Map<String, Map<String, GQLFieldDefinition>> by lazy {
+  private val fieldDefinitionsByName: Map<String, Lazy<Map<String, GQLFieldDefinition>>> by lazy {
     typeDefinitions.mapValues { (_, typeDefinition) ->
-      buildMap {
-        typeDefinition.fieldDefinitions(this@Schema).forEach {
-          // Keep the first one, like the linear scan this replaces: an invalid schema may define a field twice
-          if (!containsKey(it.name)) {
-            put(it.name, it)
+      lazy {
+        buildMap {
+          typeDefinition.fieldDefinitions(this@Schema).forEach {
+            // Keep the first one, like the linear scan this replaces: an invalid schema may define a field twice
+            if (!containsKey(it.name)) {
+              put(it.name, it)
+            }
           }
         }
       }
@@ -115,7 +117,7 @@ class Schema internal constructor(
       // Not a type definition of this schema (a synthetic one, for an example), the index doesn't apply
       return parentTypeDefinition.fieldDefinitions(this).firstOrNull { it.name == name }
     }
-    return fieldDefinitionsByName[parentTypeDefinition.name]?.get(name)
+    return fieldDefinitionsByName[parentTypeDefinition.name]?.value?.get(name)
   }
 
   fun toGQLDocument(): GQLDocument = GQLDocument(

--- a/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
+++ b/libraries/apollo-ast/src/commonMain/kotlin/com/apollographql/apollo/ast/internal/Lexer.kt
@@ -338,76 +338,46 @@ internal class Lexer(val src: String) {
   }
 
   private fun readBlockString(): Token {
-    val start = pos - 3 // because of """
+    val start = pos - 3
     val startLine = line
     val startColumn = column(start)
-    val blockLines = mutableListOf<String>()
-    val currentLine = StringBuilder()
-
-    while (true) {
-      if (pos == len) {
-        throw LexerException("Unterminated block string", pos, line, column(pos), null)
-      }
-      val c = src[pos++]
-
-      when (c) {
-        '\n' -> {
-          line++
-          lineStart = pos
-          blockLines.add(currentLine.toString())
-          currentLine.clear()
-        }
-
-        '\r' -> {
-          if (pos + 1 < len && src[pos] == '\n') {
-            pos++
-          }
-          line++
-          lineStart = pos
-          blockLines.add(currentLine.toString())
-          currentLine.clear()
-        }
-
-        '\\' -> {
-          if (pos + 2 < len &&
-              src[pos] == '\"' &&
-              src[pos + 1] == '\"' &&
-              src[pos + 2] == '\"'
-          ) {
-            pos += 3
-            currentLine.append("\"\"\"")
-          } else {
-            currentLine.append(c)
-          }
-        }
-
-        '\"' -> {
-          if (pos + 1 < len &&
-              src[pos] == '\"' &&
-              src[pos + 1] == '\"'
-          ) {
-            pos += 2
-
-            blockLines.add(currentLine.toString())
-
-            return Token.String(
-                start = start,
-                end = pos,
-                line = startLine,
-                column = startColumn,
-                value = blockLines.dedentBlockStringLines().joinToString("\n")
-            )
-          } else {
-            currentLine.append(c)
-          }
-        }
-
-        else -> {
-          // TODO: we are lenient here and allow potentially invalid chars like invalid surrogate pairs
-          currentLine.append(c)
-        }
-      }
+    var end = src.indexOf("\"\"\"", pos)
+    while (end > pos && src[end - 1] == '\\') {
+      end = src.indexOf("\"\"\"", end + 3)
     }
+
+    if (end == -1) {
+      while (pos < len) {
+        when (src[pos++]) {
+          '\n' -> {
+            line++
+            lineStart = pos
+          }
+          '\r' -> {
+            if (pos + 1 < len && src[pos] == '\n') pos++
+            line++
+            lineStart = pos
+          }
+        }
+      }
+      throw LexerException("Unterminated block string", pos, line, column(pos), null)
+    }
+
+    // TODO: we are lenient here and allow potentially invalid chars like invalid surrogate pairs
+    val lines = src.substring(pos, end).replace("\r\n", "\n").replace('\r', '\n').split('\n')
+    if (lines.size > 1) {
+      line += lines.size - 1
+      lineStart = end - lines.last().length
+    }
+    pos = end + 3
+
+    return Token.String(
+        start = start,
+        end = pos,
+        line = startLine,
+        column = startColumn,
+        value = lines.dedentBlockString().replace("\\\"\"\"", "\"\"\"")
+    )
   }
 
   private fun Char.isDigit(): Boolean {
@@ -630,7 +600,22 @@ internal class Lexer(val src: String) {
   }
 }
 
-internal fun List<String>.dedentBlockStringLines(): List<String> {
+internal fun List<String>.dedentBlockStringLines(): List<String> = buildList {
+  this@dedentBlockStringLines.forEachDedentedBlockStringLine { line, start ->
+    add(line.substring(start))
+  }
+}
+
+private fun List<String>.dedentBlockString(): String = buildString {
+  var first = true
+  this@dedentBlockString.forEachDedentedBlockStringLine { line, start ->
+    if (!first) append('\n')
+    first = false
+    append(line, start, line.length)
+  }
+}
+
+private inline fun List<String>.forEachDedentedBlockStringLine(action: (String, Int) -> Unit) {
   var commonIndent = Int.MAX_VALUE
   var firstNonEmptyLine: Int? = null
   var lastNonEmptyLine = -1
@@ -653,13 +638,10 @@ internal fun List<String>.dedentBlockStringLines(): List<String> {
     }
   }
 
-  return mapIndexed { index, line ->
-    if (index == 0) {
-      line
-    } else {
-      line.substring(commonIndent.coerceAtMost(line.length))
-    }
-  }.subList(firstNonEmptyLine ?: 0, lastNonEmptyLine + 1)
+  for (index in (firstNonEmptyLine ?: 0)..lastNonEmptyLine) {
+    val line = get(index)
+    action(line, if (index == 0) 0 else commonIndent.coerceAtMost(line.length))
+  }
 }
 
 internal fun String.leadingWhitespace(): Int {

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Strings.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/Strings.kt
@@ -7,17 +7,7 @@ package com.apollographql.apollo.compiler
  * that uses a different 'I'
  */
 fun String.capitalizeFirstLetter(): String {
-  val builder = StringBuilder(length)
-  var isCapitalized = false
-  forEach {
-    builder.append(if (!isCapitalized && it.isLetter()) {
-      isCapitalized = true
-      it.toString().uppercase()
-    } else {
-      it.toString()
-    })
-  }
-  return builder.toString()
+  return replaceFirstLetter { it.toString().uppercase() }
 }
 
 /**
@@ -27,17 +17,19 @@ fun String.capitalizeFirstLetter(): String {
  * that uses a different 'I'
  */
 fun String.decapitalizeFirstLetter(): String {
-  val builder = StringBuilder(length)
-  var isDecapitalized = false
-  forEach {
-    builder.append(if (!isDecapitalized && it.isLetter()) {
-      isDecapitalized = true
-      it.toString().lowercase()
-    } else {
-      it.toString()
-    })
+  return replaceFirstLetter { it.toString().lowercase() }
+}
+
+private inline fun String.replaceFirstLetter(transform: (Char) -> String): String {
+  val index = indexOfFirst { it.isLetter() }
+  if (index == -1) return this
+  val replacement = transform(this[index])
+  if (replacement.length == 1 && replacement[0] == this[index]) return this
+  return buildString(length) {
+    append(this@replaceFirstLetter, 0, index)
+    append(replacement)
+    append(this@replaceFirstLetter, index + 1, this@replaceFirstLetter.length)
   }
-  return builder.toString()
 }
 
 internal fun upperCamelCaseIgnoringNonLetters(strings: Collection<String>): String {
@@ -93,4 +85,3 @@ internal fun String.toPackageName(): String {
       .dropLast(1)
       .joinToString(".")
 }
-

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/SourceOutput.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/SourceOutput.kt
@@ -2,8 +2,14 @@ package com.apollographql.apollo.compiler.codegen
 
 import com.apollographql.apollo.compiler.CodegenMetadata
 import com.apollographql.apollo.compiler.writeTo
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.OutputStream
+import java.util.ArrayDeque
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 
 class SourceOutput(
     val files: List<SourceFile>,
@@ -26,22 +32,67 @@ infix fun SourceOutput?.plus(other: SourceOutput): SourceOutput {
 }
 
 fun SourceOutput.writeTo(directory: File?, deleteDirectoryFirst: Boolean, codegenSymbolsFile: File?) {
-  if (directory != null) {
-    if (deleteDirectoryFirst) {
-      directory.deleteRecursively()
-    }
+  writeTo(directory, deleteDirectoryFirst, codegenSymbolsFile, 1)
+}
 
+internal fun SourceOutput.writeTo(
+    directory: File?,
+    deleteDirectoryFirst: Boolean,
+    codegenSymbolsFile: File?,
+    parallelism: Int,
+) {
+  if (directory == null) return
+  if (deleteDirectoryFirst) directory.deleteRecursively()
+
+  if (parallelism <= 1 || files.size < 16) {
     files.forEach { file ->
-      file.packageName.split(".").plus(file.name).fold(directory) { acc, item -> acc.resolve(item) }.run {
-        parentFile.mkdirs()
-        outputStream().use {
-          file.writeTo(it)
+      file.outputFile(directory).outputStream().use { file.writeTo(it) }
+    }
+  } else {
+    val executor = Executors.newFixedThreadPool(minOf(parallelism, files.size))
+    val pending = ArrayDeque<Pair<SourceFile, Future<ByteArrayOutputStream>>>()
+    val iterator = files.iterator()
+    fun submitNext() {
+      if (!iterator.hasNext()) return
+      val file = iterator.next()
+      pending.addLast(file to executor.submit<ByteArrayOutputStream> {
+        ByteArrayOutputStream().apply { file.writeTo(this) }
+      })
+    }
+    var interrupted = false
+    try {
+      repeat(parallelism * 2) { submitNext() }
+      while (pending.isNotEmpty()) {
+        val (file, future) = pending.removeFirst()
+        val buffer = try {
+          future.get()
+        } catch (e: ExecutionException) {
+          throw e.cause ?: e
+        }
+        file.outputFile(directory).outputStream().use { buffer.writeTo(it) }
+        submitNext()
+      }
+    } catch (e: InterruptedException) {
+      interrupted = true
+      throw e
+    } finally {
+      executor.shutdownNow()
+      while (!executor.isTerminated) {
+        try {
+          executor.awaitTermination(1, TimeUnit.DAYS)
+        } catch (_: InterruptedException) {
+          interrupted = true
         }
       }
+      if (interrupted) Thread.currentThread().interrupt()
     }
-    if (codegenSymbolsFile != null) {
-      codegenMetadata.writeTo(codegenSymbolsFile)
-    }
+  }
+  if (codegenSymbolsFile != null) codegenMetadata.writeTo(codegenSymbolsFile)
+}
+
+private fun SourceFile.outputFile(directory: File): File {
+  return packageName.split(".").plus(name).fold(directory) { acc, item -> acc.resolve(item) }.apply {
+    parentFile.mkdirs()
   }
 }
 

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/codegen/kotlin/KotlinResolver.kt
@@ -56,6 +56,8 @@ internal class KotlinResolver(
   private val classNames = mutableMapOf<ResolverKey, ClassName>()
   private val scalarAdapters = mutableMapOf<String, String>()
   private val scalarTargets = mutableMapOf<String, String>()
+  private val parsedScalarTargets = mutableMapOf<String, TypeName>()
+  private val scalarAdapterInitializers = mutableMapOf<String, CodeBlock>()
   private val inlineProperties = mutableMapOf<String, String>()
   private val scalarIsUserDefined = mutableMapOf<String, Boolean>()
   private val mapTypes = mutableMapOf<String, ClassName>()
@@ -211,7 +213,16 @@ internal class KotlinResolver(
       type.nullable -> {
         val initializer = adapterInitializer(type.nullable(false), false, requiresBuffering, jsExport)
 
-        val nonNullableBuiltin = when (initializer.toString()) {
+        val adapterExpression = when (type) {
+          is IrScalarType -> scalarAdapters[type.name] ?: upstreamScalarAdapters[type.name]
+          is IrEnumType -> if (jsExport) {
+            scalarAdapters["String"] ?: upstreamScalarAdapters["String"]
+          } else {
+            initializer.toString()
+          }
+          else -> null
+        }
+        val nonNullableBuiltin = when (adapterExpression) {
           KotlinSymbols.StringAdapter.canonicalName -> KotlinSymbols.NullableStringAdapter
           KotlinSymbols.BooleanAdapter.canonicalName -> KotlinSymbols.NullableBooleanAdapter
           KotlinSymbols.IntAdapter.canonicalName -> KotlinSymbols.NullableIntAdapter
@@ -423,7 +434,7 @@ internal class KotlinResolver(
       "Cannot resolve scalar target for '$name'"
     }
 
-    return parseType(custom)
+    return parsedScalarTargets.getOrPut(custom) { parseType(custom) }
   }
 
   fun registerScalarTarget(name: String, target: String) {
@@ -437,11 +448,14 @@ internal class KotlinResolver(
   internal fun resolveScalarAdapterInitializer(name: String): CodeBlock? {
     val customAdapter = scalarAdapters[name] ?: upstreamScalarAdapters[name]
     if (customAdapter != null) {
-      if (customAdapter.matches(Regex("com\\.apollographql\\.apollo\\.api\\.[a-zA-Z]*Adapter"))) {
-        // Make the generated code look a bit nicer in case this is one of the built-in adapters
-        return CodeBlock.of("%T", ClassName.bestGuess(customAdapter))
+      return scalarAdapterInitializers.getOrPut(customAdapter) {
+        if (customAdapter.matches(builtinAdapterPattern)) {
+          // Make the generated code look a bit nicer in case this is one of the built-in adapters
+          CodeBlock.of("%T", ClassName.bestGuess(customAdapter))
+        } else {
+          CodeBlock.of("%L", customAdapter)
+        }
       }
-      return CodeBlock.of("%L", customAdapter)
     }
 
     return null
@@ -463,3 +477,5 @@ internal class KotlinResolver(
     return scalarIsUserDefined[id] ?: upstreamScalarIsUserDefined.get(id) ?: false
   }
 }
+
+private val builtinAdapterPattern = Regex("com\\.apollographql\\.apollo\\.api\\.[a-zA-Z]*Adapter")

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/entrypoints.kt
@@ -171,7 +171,13 @@ object EntryPoints {
       ).writeTo(dataBuildersOutputDirectory, true, null)
     }
 
-    sourceOutput.writeTo(outputDirectory, true, null)
+    // Plugin-provided CodeBlock arguments can have stateful toString() implementations.
+    val parallelism = if (plugins.isEmpty() && sourceOutput.codegenMetadata.targetLanguage != TargetLanguage.JAVA) {
+      minOf(4, Runtime.getRuntime().availableProcessors())
+    } else {
+      1
+    }
+    sourceOutput.writeTo(outputDirectory, true, null, parallelism)
 
     registry.schemaCodeGenerator().generate(codegenSchema.schema.toGQLDocument(), outputDirectory)
   }

--- a/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
+++ b/libraries/apollo-compiler/src/main/kotlin/com/apollographql/apollo/compiler/internal/DefaultApolloCompilerRegistry.kt
@@ -20,8 +20,7 @@ import com.apollographql.apollo.compiler.codegen.java.JavaOutput
 import com.apollographql.apollo.compiler.codegen.kotlin.KotlinOutput
 import com.apollographql.apollo.compiler.ir.IrOperations
 import com.apollographql.apollo.compiler.operationoutput.OperationId
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
+import okio.ByteString.Companion.encodeUtf8
 
 internal class Registration<T>(val id: String, val transform: T, val orders: Array<out Order>)
 
@@ -227,10 +226,7 @@ internal class DefaultApolloCompilerRegistry : ApolloCompilerRegistry {
 }
 
 internal fun String.sha256(): String {
-  val bytes = toByteArray(charset = StandardCharsets.UTF_8)
-  val md = MessageDigest.getInstance("SHA-256")
-  val digest = md.digest(bytes)
-  return digest.fold("") { str, it -> str + "%02x".format(it) }
+  return encodeUtf8().sha256().hex()
 }
 
 private fun <T> Collection<Node<T>>.sort(): List<Node<T>> {
@@ -256,4 +252,3 @@ private fun <T> Collection<Node<T>>.sort(): List<Node<T>> {
   }
   return result
 }
-


### PR DESCRIPTION
ReAI's Shopify integration spends much of Apollo generation parsing a large schema and repeatedly processing/rendering KotlinPoet models. This reduces that work and renders independent Kotlin files concurrently, without changing generated sources or skipping validation.

- Avoid per-character copying when reading block strings and changing identifier case; use the existing Okio SHA-256 implementation.
- Build field indexes only for schema types actually queried, cache parsed scalar targets/adapter expressions, and identify built-in nullable adapters without rendering their source.
- Render at most four files concurrently, buffer at most eight, and write files in their original order. Small outputs, Java generation, custom compiler plugins, and existing public writer calls retain sequential behavior. Workers are stopped and joined on success, errors, and cancellation. No new dependency or minimum JDK requirement.

Measured on ReAI's actual `:shopify:generateShopifyApolloSources` task: a 3,052,037-byte Shopify schema, 12 operations, 129 Kotlin files and one persisted-query manifest.

| Measurement | Baseline | This PR | Reduction |
| --- | ---: | ---: | ---: |
| Median Apollo generation task | 490.166 ms | 387.434 ms | **21.0%** |
| Median complete Gradle invocation | 1.855 s | 1.797 s | 3.1% |

Both compiler/AST variants were built from `c145295b72a6b459c864e7addd686deab78cddde`. They were substituted into ReAI's existing Apollo task classpath with identical inputs/options. Thirty paired measurements followed two warmup pairs, with balanced, randomized execution order; both build and configuration caches were disabled and generation was forced. Timings use `System.nanoTime()` around task actions and Python `perf_counter()` for the command. Hardware: Mac17,6, 18 logical CPUs, 64 GiB; OpenJDK 26.0.2.1; Gradle 9.7.1. A paired bootstrap estimate for the median task reduction was 17.3–23.1%. Background activity caused some outliers; all measured runs are retained below. This is not a claim of 21% faster complete application builds.

All 130 outputs matched the baseline byte-for-byte in every run. Validation passed: 287 AST JVM tests; 308 compiler tests, including 247 code-generation/compilation cases exercised with the new writer and seven temporary checks for bounded concurrency, output ordering/duplicate paths, exceptions, cancellation, and custom-plugin thread behavior; compiler and AST API checks; and ReAI's `:shopify:clean :web-app:build`. The block-string lexer also matched the baseline on 30,000 deterministic differential cases, including invalid input and source positions.

<details>
<summary>All 30 measured task-time pairs (milliseconds; warmups excluded)</summary>

| Pair | Baseline | This PR |
| --- | ---: | ---: |
| 1 | 525.953 | 395.037 |
| 2 | 488.014 | 411.041 |
| 3 | 459.388 | 374.452 |
| 4 | 536.159 | 491.431 |
| 5 | 813.291 | 413.802 |
| 6 | 708.760 | 374.440 |
| 7 | 627.444 | 406.456 |
| 8 | 1038.177 | 438.085 |
| 9 | 461.729 | 375.730 |
| 10 | 488.309 | 379.576 |
| 11 | 482.655 | 374.848 |
| 12 | 519.414 | 425.070 |
| 13 | 466.240 | 374.162 |
| 14 | 449.337 | 407.860 |
| 15 | 501.616 | 398.385 |
| 16 | 454.570 | 366.006 |
| 17 | 492.117 | 379.667 |
| 18 | 452.253 | 415.208 |
| 19 | 481.007 | 376.405 |
| 20 | 501.718 | 415.593 |
| 21 | 490.458 | 375.836 |
| 22 | 485.213 | 369.933 |
| 23 | 492.392 | 383.885 |
| 24 | 489.873 | 360.469 |
| 25 | 448.224 | 385.825 |
| 26 | 480.357 | 416.676 |
| 27 | 462.701 | 403.019 |
| 28 | 496.593 | 371.549 |
| 29 | 492.172 | 389.043 |
| 30 | 491.301 | 392.595 |

</details>
