### PR TITLE
execution: Introduce `PreparedRequest` and allow to execute fragments

### DIFF
--- a/libraries/apollo-execution/api/apollo-execution.api
+++ b/libraries/apollo-execution/api/apollo-execution.api
@@ -21,9 +21,13 @@ public final class com/apollographql/apollo/execution/ErrorPersistedDocument : c
 
 public final class com/apollographql/apollo/execution/ExecutableSchema {
 	public final fun execute (Lcom/apollographql/apollo/execution/GraphQLRequest;Lcom/apollographql/apollo/api/ExecutionContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun execute (Lcom/apollographql/apollo/execution/PreparedRequest;Lcom/apollographql/apollo/api/ExecutionContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun execute$default (Lcom/apollographql/apollo/execution/ExecutableSchema;Lcom/apollographql/apollo/execution/GraphQLRequest;Lcom/apollographql/apollo/api/ExecutionContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun execute$default (Lcom/apollographql/apollo/execution/ExecutableSchema;Lcom/apollographql/apollo/execution/PreparedRequest;Lcom/apollographql/apollo/api/ExecutionContext;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun subscribe (Lcom/apollographql/apollo/execution/GraphQLRequest;Lcom/apollographql/apollo/api/ExecutionContext;)Lkotlinx/coroutines/flow/Flow;
+	public final fun subscribe (Lcom/apollographql/apollo/execution/PreparedRequest;Lcom/apollographql/apollo/api/ExecutionContext;)Lkotlinx/coroutines/flow/Flow;
 	public static synthetic fun subscribe$default (Lcom/apollographql/apollo/execution/ExecutableSchema;Lcom/apollographql/apollo/execution/GraphQLRequest;Lcom/apollographql/apollo/api/ExecutionContext;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
+	public static synthetic fun subscribe$default (Lcom/apollographql/apollo/execution/ExecutableSchema;Lcom/apollographql/apollo/execution/PreparedRequest;Lcom/apollographql/apollo/api/ExecutionContext;ILjava/lang/Object;)Lkotlinx/coroutines/flow/Flow;
 }
 
 public final class com/apollographql/apollo/execution/ExecutableSchema$Builder {
@@ -149,11 +153,12 @@ public abstract interface class com/apollographql/apollo/execution/OperationCall
 }
 
 public final class com/apollographql/apollo/execution/OperationInfo {
-	public fun <init> (Lcom/apollographql/apollo/ast/GQLOperationDefinition;Ljava/util/Map;Lcom/apollographql/apollo/ast/Schema;Lcom/apollographql/apollo/api/ExecutionContext;)V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/util/Map;Lcom/apollographql/apollo/ast/Schema;Lcom/apollographql/apollo/api/ExecutionContext;)V
 	public final fun getExecutionContext ()Lcom/apollographql/apollo/api/ExecutionContext;
 	public final fun getFragments ()Ljava/util/Map;
-	public final fun getOperation ()Lcom/apollographql/apollo/ast/GQLOperationDefinition;
+	public final fun getRootSelections ()Ljava/util/List;
 	public final fun getSchema ()Lcom/apollographql/apollo/ast/Schema;
+	public final fun getTypename ()Ljava/lang/String;
 }
 
 public abstract interface class com/apollographql/apollo/execution/PersistedDocument {
@@ -162,6 +167,40 @@ public abstract interface class com/apollographql/apollo/execution/PersistedDocu
 public abstract interface class com/apollographql/apollo/execution/PersistedDocumentCache {
 	public abstract fun get (Ljava/lang/String;)Lcom/apollographql/apollo/execution/PersistedDocument;
 	public abstract fun put (Ljava/lang/String;Lcom/apollographql/apollo/execution/PersistedDocument;)V
+}
+
+public final class com/apollographql/apollo/execution/PreparedRequest {
+	public final fun getFragments ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnError ()Lcom/apollographql/apollo/api/OnError;
+	public final fun getRootSelections ()Ljava/util/List;
+	public final fun getType ()Lcom/apollographql/apollo/execution/RequestType;
+	public final fun getTypename ()Ljava/lang/String;
+	public final fun getVariables ()Ljava/util/Map;
+}
+
+public final class com/apollographql/apollo/execution/PreparedRequest$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/apollographql/apollo/execution/PreparedRequest;
+	public final fun fragments (Ljava/util/Map;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun id (Ljava/lang/String;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun name (Ljava/lang/String;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun onError (Lcom/apollographql/apollo/api/OnError;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun rootSelections (Ljava/util/List;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun type (Lcom/apollographql/apollo/execution/RequestType;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun typename (Ljava/lang/String;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+	public final fun variables (Ljava/util/Map;)Lcom/apollographql/apollo/execution/PreparedRequest$Builder;
+}
+
+public final class com/apollographql/apollo/execution/RequestType : java/lang/Enum {
+	public static final field Fragment Lcom/apollographql/apollo/execution/RequestType;
+	public static final field Mutation Lcom/apollographql/apollo/execution/RequestType;
+	public static final field Query Lcom/apollographql/apollo/execution/RequestType;
+	public static final field Subscription Lcom/apollographql/apollo/execution/RequestType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/apollographql/apollo/execution/RequestType;
+	public static fun values ()[Lcom/apollographql/apollo/execution/RequestType;
 }
 
 public final class com/apollographql/apollo/execution/ResolveInfo {

--- a/libraries/apollo-execution/api/apollo-execution.klib.api
+++ b/libraries/apollo-execution/api/apollo-execution.klib.api
@@ -6,6 +6,19 @@
 // - Show declarations: true
 
 // Library unique name: <com.apollographql.apollo:apollo-execution>
+final enum class com.apollographql.apollo.execution/RequestType : kotlin/Enum<com.apollographql.apollo.execution/RequestType> { // com.apollographql.apollo.execution/RequestType|null[0]
+    enum entry Fragment // com.apollographql.apollo.execution/RequestType.Fragment|null[0]
+    enum entry Mutation // com.apollographql.apollo.execution/RequestType.Mutation|null[0]
+    enum entry Query // com.apollographql.apollo.execution/RequestType.Query|null[0]
+    enum entry Subscription // com.apollographql.apollo.execution/RequestType.Subscription|null[0]
+
+    final val entries // com.apollographql.apollo.execution/RequestType.entries|#static{}entries[0]
+        final fun <get-entries>(): kotlin.enums/EnumEntries<com.apollographql.apollo.execution/RequestType> // com.apollographql.apollo.execution/RequestType.entries.<get-entries>|<get-entries>#static(){}[0]
+
+    final fun valueOf(kotlin/String): com.apollographql.apollo.execution/RequestType // com.apollographql.apollo.execution/RequestType.valueOf|valueOf#static(kotlin.String){}[0]
+    final fun values(): kotlin/Array<com.apollographql.apollo.execution/RequestType> // com.apollographql.apollo.execution/RequestType.values|values#static(){}[0]
+}
+
 abstract fun interface com.apollographql.apollo.execution/FieldCallback { // com.apollographql.apollo.execution/FieldCallback|null[0]
     abstract fun onFieldCompleted(kotlin/Any?) // com.apollographql.apollo.execution/FieldCallback.onFieldCompleted|onFieldCompleted(kotlin.Any?){}[0]
 }
@@ -57,7 +70,9 @@ final class com.apollographql.apollo.execution/ErrorPersistedDocument : com.apol
 
 final class com.apollographql.apollo.execution/ExecutableSchema { // com.apollographql.apollo.execution/ExecutableSchema|null[0]
     final fun subscribe(com.apollographql.apollo.execution/GraphQLRequest, com.apollographql.apollo.api/ExecutionContext = ...): kotlinx.coroutines.flow/Flow<com.apollographql.apollo.execution/SubscriptionEvent> // com.apollographql.apollo.execution/ExecutableSchema.subscribe|subscribe(com.apollographql.apollo.execution.GraphQLRequest;com.apollographql.apollo.api.ExecutionContext){}[0]
+    final fun subscribe(com.apollographql.apollo.execution/PreparedRequest, com.apollographql.apollo.api/ExecutionContext = ...): kotlinx.coroutines.flow/Flow<com.apollographql.apollo.execution/SubscriptionEvent> // com.apollographql.apollo.execution/ExecutableSchema.subscribe|subscribe(com.apollographql.apollo.execution.PreparedRequest;com.apollographql.apollo.api.ExecutionContext){}[0]
     final suspend fun execute(com.apollographql.apollo.execution/GraphQLRequest, com.apollographql.apollo.api/ExecutionContext = ...): com.apollographql.apollo.execution/GraphQLResponse // com.apollographql.apollo.execution/ExecutableSchema.execute|execute(com.apollographql.apollo.execution.GraphQLRequest;com.apollographql.apollo.api.ExecutionContext){}[0]
+    final suspend fun execute(com.apollographql.apollo.execution/PreparedRequest, com.apollographql.apollo.api/ExecutionContext = ...): com.apollographql.apollo.execution/GraphQLResponse // com.apollographql.apollo.execution/ExecutableSchema.execute|execute(com.apollographql.apollo.execution.PreparedRequest;com.apollographql.apollo.api.ExecutionContext){}[0]
 
     final class Builder { // com.apollographql.apollo.execution/ExecutableSchema.Builder|null[0]
         constructor <init>() // com.apollographql.apollo.execution/ExecutableSchema.Builder.<init>|<init>(){}[0]
@@ -158,16 +173,51 @@ final class com.apollographql.apollo.execution/InMemoryPersistedDocumentCache : 
 }
 
 final class com.apollographql.apollo.execution/OperationInfo { // com.apollographql.apollo.execution/OperationInfo|null[0]
-    constructor <init>(com.apollographql.apollo.ast/GQLOperationDefinition, kotlin.collections/Map<kotlin/String, com.apollographql.apollo.ast/GQLFragmentDefinition>, com.apollographql.apollo.ast/Schema, com.apollographql.apollo.api/ExecutionContext) // com.apollographql.apollo.execution/OperationInfo.<init>|<init>(com.apollographql.apollo.ast.GQLOperationDefinition;kotlin.collections.Map<kotlin.String,com.apollographql.apollo.ast.GQLFragmentDefinition>;com.apollographql.apollo.ast.Schema;com.apollographql.apollo.api.ExecutionContext){}[0]
+    constructor <init>(kotlin.collections/List<com.apollographql.apollo.ast/GQLSelection>, kotlin/String, kotlin.collections/Map<kotlin/String, com.apollographql.apollo.ast/GQLFragmentDefinition>, com.apollographql.apollo.ast/Schema, com.apollographql.apollo.api/ExecutionContext) // com.apollographql.apollo.execution/OperationInfo.<init>|<init>(kotlin.collections.List<com.apollographql.apollo.ast.GQLSelection>;kotlin.String;kotlin.collections.Map<kotlin.String,com.apollographql.apollo.ast.GQLFragmentDefinition>;com.apollographql.apollo.ast.Schema;com.apollographql.apollo.api.ExecutionContext){}[0]
 
     final val executionContext // com.apollographql.apollo.execution/OperationInfo.executionContext|{}executionContext[0]
         final fun <get-executionContext>(): com.apollographql.apollo.api/ExecutionContext // com.apollographql.apollo.execution/OperationInfo.executionContext.<get-executionContext>|<get-executionContext>(){}[0]
     final val fragments // com.apollographql.apollo.execution/OperationInfo.fragments|{}fragments[0]
         final fun <get-fragments>(): kotlin.collections/Map<kotlin/String, com.apollographql.apollo.ast/GQLFragmentDefinition> // com.apollographql.apollo.execution/OperationInfo.fragments.<get-fragments>|<get-fragments>(){}[0]
-    final val operation // com.apollographql.apollo.execution/OperationInfo.operation|{}operation[0]
-        final fun <get-operation>(): com.apollographql.apollo.ast/GQLOperationDefinition // com.apollographql.apollo.execution/OperationInfo.operation.<get-operation>|<get-operation>(){}[0]
+    final val rootSelections // com.apollographql.apollo.execution/OperationInfo.rootSelections|{}rootSelections[0]
+        final fun <get-rootSelections>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLSelection> // com.apollographql.apollo.execution/OperationInfo.rootSelections.<get-rootSelections>|<get-rootSelections>(){}[0]
     final val schema // com.apollographql.apollo.execution/OperationInfo.schema|{}schema[0]
         final fun <get-schema>(): com.apollographql.apollo.ast/Schema // com.apollographql.apollo.execution/OperationInfo.schema.<get-schema>|<get-schema>(){}[0]
+    final val typename // com.apollographql.apollo.execution/OperationInfo.typename|{}typename[0]
+        final fun <get-typename>(): kotlin/String // com.apollographql.apollo.execution/OperationInfo.typename.<get-typename>|<get-typename>(){}[0]
+}
+
+final class com.apollographql.apollo.execution/PreparedRequest { // com.apollographql.apollo.execution/PreparedRequest|null[0]
+    final val fragments // com.apollographql.apollo.execution/PreparedRequest.fragments|{}fragments[0]
+        final fun <get-fragments>(): kotlin.collections/Map<kotlin/String, com.apollographql.apollo.ast/GQLFragmentDefinition> // com.apollographql.apollo.execution/PreparedRequest.fragments.<get-fragments>|<get-fragments>(){}[0]
+    final val id // com.apollographql.apollo.execution/PreparedRequest.id|{}id[0]
+        final fun <get-id>(): kotlin/String? // com.apollographql.apollo.execution/PreparedRequest.id.<get-id>|<get-id>(){}[0]
+    final val name // com.apollographql.apollo.execution/PreparedRequest.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // com.apollographql.apollo.execution/PreparedRequest.name.<get-name>|<get-name>(){}[0]
+    final val onError // com.apollographql.apollo.execution/PreparedRequest.onError|{}onError[0]
+        final fun <get-onError>(): com.apollographql.apollo.api/OnError? // com.apollographql.apollo.execution/PreparedRequest.onError.<get-onError>|<get-onError>(){}[0]
+    final val rootSelections // com.apollographql.apollo.execution/PreparedRequest.rootSelections|{}rootSelections[0]
+        final fun <get-rootSelections>(): kotlin.collections/List<com.apollographql.apollo.ast/GQLSelection> // com.apollographql.apollo.execution/PreparedRequest.rootSelections.<get-rootSelections>|<get-rootSelections>(){}[0]
+    final val type // com.apollographql.apollo.execution/PreparedRequest.type|{}type[0]
+        final fun <get-type>(): com.apollographql.apollo.execution/RequestType // com.apollographql.apollo.execution/PreparedRequest.type.<get-type>|<get-type>(){}[0]
+    final val typename // com.apollographql.apollo.execution/PreparedRequest.typename|{}typename[0]
+        final fun <get-typename>(): kotlin/String // com.apollographql.apollo.execution/PreparedRequest.typename.<get-typename>|<get-typename>(){}[0]
+    final val variables // com.apollographql.apollo.execution/PreparedRequest.variables|{}variables[0]
+        final fun <get-variables>(): kotlin.collections/Map<kotlin/String, kotlin/Any?> // com.apollographql.apollo.execution/PreparedRequest.variables.<get-variables>|<get-variables>(){}[0]
+
+    final class Builder { // com.apollographql.apollo.execution/PreparedRequest.Builder|null[0]
+        constructor <init>() // com.apollographql.apollo.execution/PreparedRequest.Builder.<init>|<init>(){}[0]
+
+        final fun build(): com.apollographql.apollo.execution/PreparedRequest // com.apollographql.apollo.execution/PreparedRequest.Builder.build|build(){}[0]
+        final fun fragments(kotlin.collections/Map<kotlin/String, com.apollographql.apollo.ast/GQLFragmentDefinition>): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.fragments|fragments(kotlin.collections.Map<kotlin.String,com.apollographql.apollo.ast.GQLFragmentDefinition>){}[0]
+        final fun id(kotlin/String?): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.id|id(kotlin.String?){}[0]
+        final fun name(kotlin/String?): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.name|name(kotlin.String?){}[0]
+        final fun onError(com.apollographql.apollo.api/OnError?): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.onError|onError(com.apollographql.apollo.api.OnError?){}[0]
+        final fun rootSelections(kotlin.collections/List<com.apollographql.apollo.ast/GQLSelection>): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.rootSelections|rootSelections(kotlin.collections.List<com.apollographql.apollo.ast.GQLSelection>){}[0]
+        final fun type(com.apollographql.apollo.execution/RequestType): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.type|type(com.apollographql.apollo.execution.RequestType){}[0]
+        final fun typename(kotlin/String): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.typename|typename(kotlin.String){}[0]
+        final fun variables(kotlin.collections/Map<kotlin/String, kotlin/Any?>): com.apollographql.apollo.execution/PreparedRequest.Builder // com.apollographql.apollo.execution/PreparedRequest.Builder.variables|variables(kotlin.collections.Map<kotlin.String,kotlin.Any?>){}[0]
+    }
 }
 
 final class com.apollographql.apollo.execution/ResolveInfo { // com.apollographql.apollo.execution/ResolveInfo|null[0]

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
@@ -137,7 +137,10 @@ class ExecutableSchema internal constructor(
         raise("Cannot resolve the fragment root: ${e.message}")
       }
     } else {
-      resolveRootNoFragment(preparedRequest)
+      resolveRootNoFragment(preparedRequest).fold(
+          ifLeft = { raise(it) },
+          ifRight = { it }
+      )
     }
   }
 

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/ExecutableSchema.kt
@@ -2,48 +2,73 @@ package com.apollographql.apollo.execution
 
 import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.api.OnError
-import com.apollographql.apollo.ast.*
+import com.apollographql.apollo.ast.GQLArgument
+import com.apollographql.apollo.ast.GQLCapability
+import com.apollographql.apollo.ast.GQLDefinition
+import com.apollographql.apollo.ast.GQLDirectiveDefinition
+import com.apollographql.apollo.ast.GQLDocument
+import com.apollographql.apollo.ast.GQLField
+import com.apollographql.apollo.ast.GQLListType
+import com.apollographql.apollo.ast.GQLSchemaDefinition
+import com.apollographql.apollo.ast.GQLServiceDefinition
+import com.apollographql.apollo.ast.GQLStringValue
+import com.apollographql.apollo.ast.GQLTypeDefinition
+import com.apollographql.apollo.ast.ParserOptions
+import com.apollographql.apollo.ast.Schema
+import com.apollographql.apollo.ast.builtinDefinitions
+import com.apollographql.apollo.ast.fieldDefinitions
+import com.apollographql.apollo.ast.rawType
+import com.apollographql.apollo.ast.serviceCapabilitiesDefinitions
+import com.apollographql.apollo.ast.toGQLDocument
+import com.apollographql.apollo.ast.toSchema
+import com.apollographql.apollo.execution.internal.Either
 import com.apollographql.apollo.execution.internal.OperationContext
-import com.apollographql.apollo.execution.internal.PreparedRequest
+import com.apollographql.apollo.execution.internal.either
+import com.apollographql.apollo.execution.internal.graphqlErrorResponse
 import com.apollographql.apollo.execution.internal.introspectionCoercings
 import com.apollographql.apollo.execution.internal.introspectionResolver
 import com.apollographql.apollo.execution.internal.prepareRequest
+import com.apollographql.apollo.execution.internal.subscriptionError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
 /**
- * A GraphQL schema with execution information:
- * - root values
- * - coercings
- * - resolvers
+ * The entry point to serve GraphQL requests:
+ * - validates the document (or retrieves and validates a persisted document)
+ * - coerces variables
+ * - executes the resulting [PreparedRequest]
  *
- * [ExecutableSchema] also includes handling for persisted documents. This part is not technically part of the main GraphQL spec but is popular that we add first party support to it.
+ * [ExecutableSchema] also includes handling for persisted documents. This part is not technically part of the main GraphQL spec, but it is popular that we add first party support to it.
  */
 class ExecutableSchema internal constructor(
     private val schema: Schema,
     private val coercings: Map<String, Coercing<*>>,
-    private val queryRoot: RootResolver?,
-    private val mutationRoot: RootResolver?,
-    private val subscriptionRoot: RootResolver?,
     private val resolver: Resolver,
     private val typeResolver: TypeResolver,
     private val instrumentations: List<Instrumentation>,
-    private val persistedDocumentCache: PersistedDocumentCache?,
     private val onError: OnError,
-    private val parserOptions: ParserOptions
+    private val queryRoot: RootResolver?,
+    private val mutationRoot: RootResolver?,
+    private val subscriptionRoot: RootResolver?,
+    private val persistedDocumentCache: PersistedDocumentCache?,
+    private val parserOptions: ParserOptions,
 ) {
   private val introspectionResolver: Resolver = introspectionResolver(schema)
+
+  private fun prepareRequest(
+      request: GraphQLRequest
+  ) = prepareRequest(schema, coercings, persistedDocumentCache, parserOptions, request)
 
   suspend fun execute(
       request: GraphQLRequest,
       executionContext: ExecutionContext = ExecutionContext.Empty,
   ): GraphQLResponse {
-    return prepareRequest(schema, coercings, persistedDocumentCache, parserOptions, request).fold(
+    return prepareRequest(request).fold(
         ifLeft = {
-          GraphQLResponse.Builder().errors(it).build()
+          graphqlErrorResponse(it)
         },
         ifRight = {
-          operationContext(it, executionContext).execute()
+          execute(it, executionContext)
         }
     )
   }
@@ -52,32 +77,108 @@ class ExecutableSchema internal constructor(
       request: GraphQLRequest,
       executionContext: ExecutionContext = ExecutionContext.Empty,
   ): Flow<SubscriptionEvent> {
-    return prepareRequest(schema, coercings, persistedDocumentCache, parserOptions, request).fold(
+    return prepareRequest(request).fold(
         ifLeft = {
-          flowOf(SubscriptionResponse(GraphQLResponse.Builder().errors(it).build()))
+          flowOf(SubscriptionResponse(graphqlErrorResponse(it)))
         },
         ifRight = {
-          operationContext(it, executionContext).subscribe()
+          subscribe(it, executionContext)
         }
     )
   }
 
-  private fun operationContext(preparedRequest: PreparedRequest, executionContext: ExecutionContext): OperationContext {
+  private fun resolveRootNoFragment(preparedRequest: PreparedRequest): Either<String, Any?> = either {
+    val rootResolver = when (preparedRequest.type) {
+      RequestType.Query -> queryRoot
+      RequestType.Mutation -> mutationRoot
+      RequestType.Subscription -> subscriptionRoot
+      RequestType.Fragment -> error("resolveRoot can")
+    }
+    try {
+      rootResolver?.resolveRoot()
+    } catch (e: Exception) {
+      raise("Error resolving root object: ${e.message}")
+    }
+  }
+
+  private suspend fun resolveRoot(preparedRequest: PreparedRequest): Either<String, Any?> = either {
+    if (preparedRequest.type == RequestType.Fragment) {
+      when(preparedRequest.typename) {
+        schema.queryTypeDefinition.name -> return@either queryRoot?.resolveRoot()
+        schema.mutationTypeDefinition?.name -> return@either mutationRoot?.resolveRoot()
+        schema.subscriptionTypeDefinition?.name -> return@either subscriptionRoot?.resolveRoot()
+      }
+
+      val id = preparedRequest.id
+      if (id == null) {
+        raise("Resolving a fragment on non-root types requires an 'id'.")
+      }
+
+      val root = queryRoot?.resolveRoot()
+
+      val candidates = schema.queryTypeDefinition.fieldDefinitions(schema)
+          .filter {
+            if (it.type is GQLListType) {
+              return@filter false
+            }
+            it.type.rawType().name == preparedRequest.typename && it.arguments.size == 1 && it.arguments[0].name == "id"
+          }
+
+      if (candidates.isEmpty()) {
+        raise("Cannot resolve fragment: no root query field found returning '${preparedRequest.typename}' and having a single 'id' argument.")
+      } else if (candidates.size > 1) {
+        raise("Cannot resolve fragment: cannot disambiguate between these root fields: ${candidates.joinToString { it.name }}.")
+      }
+
+      val field = GQLField(null, null, candidates.single().name, emptyList(), emptyList(), emptyList(), false)
+      try {
+        resolver.resolve(ResolveInfo(root, preparedRequest.typename, ExecutionContext.Empty, listOf(field), schema, mapOf("id" to id), emptyList()))
+      } catch (e: Exception) {
+        raise("Cannot resolve the fragment root: ${e.message}")
+      }
+    } else {
+      resolveRootNoFragment(preparedRequest)
+    }
+  }
+
+  suspend fun execute(preparedRequest: PreparedRequest, executionContext: ExecutionContext = ExecutionContext.Empty): GraphQLResponse {
+    if (preparedRequest.type == RequestType.Subscription) {
+      return graphqlErrorResponse("Cannot execute subscription '${preparedRequest.name}', use subscribe(), not execute() ")
+    }
+    return resolveRoot(preparedRequest).fold(
+        ifLeft = { graphqlErrorResponse(it) },
+        ifRight = { operationContext(preparedRequest, it, executionContext).execute() }
+    )
+  }
+
+  fun subscribe(preparedRequest: PreparedRequest, executionContext: ExecutionContext = ExecutionContext.Empty): Flow<SubscriptionEvent> {
+    if (preparedRequest.type != RequestType.Subscription) {
+      return subscriptionError("Cannot subscribe to operation '${preparedRequest.name}', use execute(), not subscribe() ")
+    }
+
+    return resolveRootNoFragment(preparedRequest).fold(
+        ifLeft = { subscriptionError(it) },
+        ifRight = { operationContext(preparedRequest, it, executionContext).subscribe() }
+    )
+  }
+
+  private fun operationContext(preparedRequest: PreparedRequest, rootObject: Any?, executionContext: ExecutionContext): OperationContext {
     return OperationContext(
-        schema,
-        coercings + introspectionCoercings,
-        introspectionResolver,
-        queryRoot,
-        mutationRoot,
-        subscriptionRoot,
-        resolver,
-        typeResolver,
-        instrumentations,
-        preparedRequest.operation,
-        preparedRequest.fragments,
-        preparedRequest.variables,
-        executionContext,
-        preparedRequest.onError ?: onError
+        schema = schema,
+        coercings = coercings + introspectionCoercings,
+        introspectionResolver = introspectionResolver,
+        resolver = resolver,
+        typeResolver = typeResolver,
+        instrumentations = instrumentations,
+        rootObject = rootObject,
+        rootSelections = preparedRequest.rootSelections,
+        typename = preparedRequest.typename,
+        fragments = preparedRequest.fragments,
+        variableValues = preparedRequest.variables,
+        onError = preparedRequest.onError ?: onError,
+        debugName = preparedRequest.name,
+        serial = preparedRequest.type == RequestType.Mutation,
+        executionContext = executionContext,
     )
   }
 
@@ -142,7 +243,7 @@ class ExecutableSchema internal constructor(
     }
 
     /**
-     * Configures the parsing options for this executable schema.
+     * Configures the parsing options for this schema.
      */
     fun parserOptions(parserOptions: ParserOptions): Builder = apply {
       this.parserOptions = parserOptions
@@ -153,32 +254,38 @@ class ExecutableSchema internal constructor(
         "A schema is required to build an ExecutableSchema"
       }
 
-      val ourDefinitions = builtinDefinitions() + serviceCapabilitiesDefinitions() + serviceDefinition(onError)
-      val reservedNames = ourDefinitions.mapNotNull { it.definitionName() }.toSet()
-      val sourceDefinitions = schema!!.definitions
-      sourceDefinitions.forEach {
-        val definitionName = it.definitionName()
-        if (definitionName in reservedNames) {
-          error("Source schema cannot contain definition '$definitionName'. It is provided by the implementation")
-        }
-      }
-      val schema = GQLDocument(ourDefinitions + schema!!.definitions, null).toSchema()
-
       return ExecutableSchema(
-          schema,
+          buildSchema(schema!!, onError),
           coercings,
-          queryRoot,
-          mutationRoot,
-          subscriptionRoot,
           resolver ?: ThrowingResolver,
           typeResolver ?: ThrowingTypeResolver,
           instrumentations,
-          persistedDocumentCache,
           onError,
-          parserOptions
+          queryRoot,
+          mutationRoot,
+          subscriptionRoot,
+          persistedDocumentCache,
+          parserOptions,
       )
     }
   }
+}
+
+/**
+ * Merges [document] with the definitions required to serve introspection and the `service` capabilities query,
+ * and turns the result into a [Schema].
+ */
+internal fun buildSchema(document: GQLDocument, onError: OnError): Schema {
+  val ourDefinitions = builtinDefinitions() + serviceCapabilitiesDefinitions() + serviceDefinition(onError)
+  val reservedNames = ourDefinitions.mapNotNull { it.definitionName() }.toSet()
+  val sourceDefinitions = document.definitions
+  sourceDefinitions.forEach {
+    val definitionName = it.definitionName()
+    if (definitionName in reservedNames) {
+      error("Source schema cannot contain definition '$definitionName'. It is provided by the implementation")
+    }
+  }
+  return GQLDocument(ourDefinitions + document.definitions, null).toSchema()
 }
 
 private fun serviceDefinition(onError: OnError): GQLDefinition {

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/Instrumentation.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/Instrumentation.kt
@@ -2,7 +2,7 @@ package com.apollographql.apollo.execution
 
 import com.apollographql.apollo.api.ExecutionContext
 import com.apollographql.apollo.ast.GQLFragmentDefinition
-import com.apollographql.apollo.ast.GQLOperationDefinition
+import com.apollographql.apollo.ast.GQLSelection
 import com.apollographql.apollo.ast.Schema
 
 
@@ -34,7 +34,8 @@ abstract class Instrumentation {
 }
 
 class OperationInfo(
-  val operation: GQLOperationDefinition,
+  val rootSelections: List<GQLSelection>,
+  val typename: String,
   val fragments: Map<String, GQLFragmentDefinition>,
   val schema: Schema,
   val executionContext: ExecutionContext

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/PreparedRequest.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/PreparedRequest.kt
@@ -1,0 +1,90 @@
+package com.apollographql.apollo.execution
+
+import com.apollographql.apollo.api.OnError
+import com.apollographql.apollo.ast.GQLFragmentDefinition
+import com.apollographql.apollo.ast.GQLSelection
+
+/**
+ * Represents a request just before it is executed.
+ *
+ * The document is validated and variables are coerced.
+ */
+class PreparedRequest internal constructor(
+    val rootSelections: List<GQLSelection>,
+    val typename: String,
+    /**
+     * Required if [type] is [RequestType.Fragment] to resolve the root object
+     */
+    val id: String?,
+    val fragments: Map<String, GQLFragmentDefinition>,
+    val variables: Map<String, InternalValue>,
+    val onError: OnError?,
+    val type: RequestType,
+    val name: String?,
+) {
+  class Builder {
+    private var rootSelections: List<GQLSelection>? = null
+    private var typename: String? = null
+    private var id: String? = null
+    private var fragments: Map<String, GQLFragmentDefinition>? = null
+    private var variables: Map<String, InternalValue>? = null
+    private var onError: OnError? = null
+    private var type: RequestType? = null
+    private var name: String? = null
+
+    fun rootSelections(rootSelections: List<GQLSelection>): Builder = apply {
+      this.rootSelections = rootSelections
+    }
+
+    fun typename(typename: String): Builder = apply {
+      this.typename = typename
+    }
+
+    /**
+     * Required if [type] is [RequestType.Fragment] to resolve the root object
+     */
+    fun id(id: String?): Builder = apply {
+      this.id = id
+    }
+
+    fun fragments(fragments: Map<String, GQLFragmentDefinition>): Builder = apply {
+      this.fragments = fragments
+    }
+
+    fun variables(variables: Map<String, InternalValue>): Builder = apply {
+      this.variables = variables
+    }
+
+    fun onError(onError: OnError?): Builder = apply {
+      this.onError = onError
+    }
+
+    fun type(type: RequestType): Builder = apply {
+      this.type = type
+    }
+
+    fun name(name: String?): Builder = apply {
+      this.name = name
+    }
+
+    fun build(): PreparedRequest {
+      return PreparedRequest(
+          rootSelections = checkNotNull(rootSelections) { "rootSelections is required" },
+          typename = checkNotNull(typename) { "typename is required" },
+          id = id,
+          fragments = fragments.orEmpty(),
+          variables = variables.orEmpty(),
+          onError = onError,
+          type = checkNotNull(type) { "type is required" },
+          name = name,
+      )
+    }
+  }
+}
+
+enum class RequestType {
+  Query,
+  Mutation,
+  Subscription,
+  Fragment
+}

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/OperationContext.kt
@@ -16,7 +16,6 @@ import com.apollographql.apollo.ast.GQLListType
 import com.apollographql.apollo.ast.GQLNamedType
 import com.apollographql.apollo.ast.GQLNonNullType
 import com.apollographql.apollo.ast.GQLObjectTypeDefinition
-import com.apollographql.apollo.ast.GQLOperationDefinition
 import com.apollographql.apollo.ast.GQLScalarTypeDefinition
 import com.apollographql.apollo.ast.GQLSelection
 import com.apollographql.apollo.ast.GQLType
@@ -39,7 +38,6 @@ import com.apollographql.apollo.execution.ResolveTypeInfo
 import com.apollographql.apollo.execution.Resolver
 import com.apollographql.apollo.execution.ResolverValue
 import com.apollographql.apollo.execution.ResolverValueOrError
-import com.apollographql.apollo.execution.RootResolver
 import com.apollographql.apollo.execution.SubscriptionError
 import com.apollographql.apollo.execution.SubscriptionEvent
 import com.apollographql.apollo.execution.SubscriptionResponse
@@ -76,17 +74,18 @@ internal class OperationContext(
     private val schema: Schema,
     private val coercings: Map<String, Coercing<*>>,
     private val introspectionResolver: Resolver,
-    private val queryRoot: RootResolver?,
-    private val mutationRoot: RootResolver?,
-    private val subscriptionRoot: RootResolver?,
     private val resolver: Resolver,
     private val typeResolver: TypeResolver,
     private val instrumentations: List<Instrumentation>,
-    private val operation: GQLOperationDefinition,
+    private val rootSelections: List<GQLSelection>,
+    private val typename: String,
+    private val rootObject: ResolverValue,
     private val fragments: Map<String, GQLFragmentDefinition>,
     private val variableValues: Map<String, InternalValue>,
     private val executionContext: ExecutionContext,
     private val onError: OnError,
+    private val serial: Boolean,
+    private val debugName: String?,
 ) {
   /**
    * Executes the given operation and awaits its result.
@@ -98,7 +97,8 @@ internal class OperationContext(
     var instrumentationException: Exception? = null
     val operationCallbacks = mutableListOf<OperationCallback>()
     val operationInfo = OperationInfo(
-        operation,
+        rootSelections,
+        typename,
         fragments,
         schema,
         executionContext
@@ -123,26 +123,11 @@ internal class OperationContext(
       }
     }
     if (instrumentationException != null) {
-      return graphqlErrorResponse("An error happened while instrumenting '${operation.name}': ${instrumentationException.message}")
+      return graphqlErrorResponse("An error happened while instrumenting '${debugName}': ${instrumentationException.message}")
     }
-    val rootTypename = schema.rootTypeNameOrNullFor(operation.operationType)
-    if (rootTypename == null) {
-      return graphqlErrorResponse("'${operation.operationType}' is not supported")
-    }
-    val rootObject = when (operation.operationType) {
-      "query" -> queryRoot?.resolveRoot()
-      "mutation" -> mutationRoot?.resolveRoot()
-      "subscription" -> {
-        return graphqlErrorResponse("Use subscribe() to execute subscriptions")
-      }
+    val typeDefinition = schema.typeDefinition(typename)
 
-      else -> {
-        return graphqlErrorResponse("Unknown operation type '${operation.operationType}")
-      }
-    }
-    val typeDefinition = schema.typeDefinition(rootTypename)
-
-    val groupedFieldSet = collectFields(typeDefinition.name, operation.selections, variableValues)
+    val groupedFieldSet = collectFields(typeDefinition.name, rootSelections, variableValues)
 
     return coroutineScope {
       async(start = CoroutineStart.UNDISPATCHED) {
@@ -153,20 +138,15 @@ internal class OperationContext(
             rootObject,
             variableValues,
             emptyList(),
-            operation.operationType == "mutation"
+            serial
         )
       }.toGraphQLResponse(callbacks = operationCallbacks)
     }
   }
 
   fun subscribe(): Flow<SubscriptionEvent> {
-    val rootObject = when (operation.operationType) {
-      "subscription" -> subscriptionRoot?.resolveRoot()
-      else -> return subscriptionError("Unknown operation type '${operation.operationType}.")
-    }
-
     val eventStream = try {
-      createSourceEventStream(operation, rootObject)
+      createSourceEventStream(rootObject)
     } catch (e: Exception) {
       return subscriptionError("Cannot create source event stream: ${e.message}")
     }
@@ -250,20 +230,13 @@ internal class OperationContext(
   ) : FieldEvent
 
   private fun createSourceEventStream(
-      subscription: GQLOperationDefinition,
       rootValue: ResolverValue,
   ): Flow<FieldEvent> {
-    val rootTypename = schema.rootTypeNameOrNullFor(subscription.operationType)
-    if (rootTypename == null) {
-      return flowOf(FieldEventError("'${subscription.operationType}' is not supported"))
-    }
-
-    val typeDefinition = schema.typeDefinition(rootTypename)
+    val typeDefinition = schema.typeDefinition(typename)
     check(typeDefinition is GQLObjectTypeDefinition) {
       "Root typename '${typeDefinition.name} must be of object type"
     }
-    val selections = subscription.selections
-    val groupedFieldsSet = collectFields(typeDefinition.name, selections, variableValues)
+    val groupedFieldsSet = collectFields(typeDefinition.name, rootSelections, variableValues)
     check(groupedFieldsSet.size == 1) {
       return flowOf(FieldEventError("Subscriptions must have a single root field"))
     }

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/errors.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/errors.kt
@@ -3,11 +3,15 @@ package com.apollographql.apollo.execution.internal
 import com.apollographql.apollo.api.Error
 import com.apollographql.apollo.ast.Issue
 import com.apollographql.apollo.execution.GraphQLResponse
+import com.apollographql.apollo.execution.SubscriptionResponse
+import kotlinx.coroutines.flow.flowOf
 
 internal fun graphQLError(message: String) = Error.Builder(message).build()
 internal fun singleGraphQLError(message: String) = listOf(Error.Builder(message).build())
 
-internal fun graphqlErrorResponse(message: String) = GraphQLResponse.Builder().errors(listOf(graphQLError(message))).build()
+internal fun graphqlErrorResponse(message: String) = graphqlErrorResponse(listOf(graphQLError(message)))
+internal fun graphqlErrorResponse(errors: List<Error>) = GraphQLResponse.Builder().errors(errors).build()
+internal fun subscriptionError(message: String) = flowOf(SubscriptionResponse(graphqlErrorResponse(message)))
 
 internal fun List<Issue>.toErrors(): List<Error> {
   return map {

--- a/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/prepare.kt
+++ b/libraries/apollo-execution/src/commonMain/kotlin/com/apollographql/apollo/execution/internal/prepare.kt
@@ -11,17 +11,12 @@ import com.apollographql.apollo.execution.Coercing
 import com.apollographql.apollo.execution.ErrorPersistedDocument
 import com.apollographql.apollo.execution.ExternalValue
 import com.apollographql.apollo.execution.GraphQLRequest
-import com.apollographql.apollo.execution.InternalValue
 import com.apollographql.apollo.execution.PersistedDocument
 import com.apollographql.apollo.execution.PersistedDocumentCache
+import com.apollographql.apollo.execution.PreparedRequest
+import com.apollographql.apollo.execution.RequestType
+import com.apollographql.apollo.execution.RootResolver
 import com.apollographql.apollo.execution.ValidPersistedDocument
-
-internal class PreparedRequest(
-    val operation: GQLOperationDefinition,
-    val fragments: Map<String, GQLFragmentDefinition>,
-    val variables: Map<String, InternalValue>,
-    val onError: OnError?,
-)
 
 /**
  * Parses and validates a document. When using persisted documents, the result of this function may be
@@ -61,7 +56,7 @@ internal fun Raise<String>.prepareRequest(
     document: GQLDocument,
     operationName: String?,
     variables: Map<String, ExternalValue>,
-    onError: OnError?
+    onError: OnError?,
 ): PreparedRequest {
   val operations = document.definitions.filterIsInstance<GQLOperationDefinition>()
   val operation = when {
@@ -79,7 +74,7 @@ internal fun Raise<String>.prepareRequest(
       }
       val ret = operations.firstOrNull { it.name == operationName }
       if (ret == null) {
-        raise("No operation named '${operationName}' found. Double check operationName.")
+        raise("No operation named '${operationName}' found. Double check 'operationName'.")
       }
       ret
     }
@@ -91,7 +86,28 @@ internal fun Raise<String>.prepareRequest(
   } catch (e: Exception) {
     raise("Cannot coerce variable values: '${e.message}'")
   }
-  return PreparedRequest(operation, fragments, variableValues, onError)
+
+  val typename = schema.rootTypeNameOrNullFor(operation.operationType)
+  if (typename == null) {
+    raise("'${operation.operationType}' is not supported")
+  }
+
+  val type = when (operation.operationType) {
+    "query" -> RequestType.Query
+    "mutation" -> RequestType.Mutation
+    "subscription" -> RequestType.Subscription
+    else -> raise("Unknown operation type '${operation.operationType}'.")
+  }
+
+  return PreparedRequest.Builder()
+      .rootSelections(operation.selections)
+      .typename(typename)
+      .fragments(fragments)
+      .variables(variableValues)
+      .onError(onError)
+      .type(type)
+      .name(operation.name)
+      .build()
 }
 
 /**
@@ -177,7 +193,14 @@ internal fun Raise<List<Error>>.prepareRequest(
   return withError({
     singleGraphQLError(it)
   }) {
-    prepareRequest(schema, coercings, persistedDocument.document, request.operationName, request.variables, request.onError)
+    prepareRequest(
+        schema,
+        coercings,
+        persistedDocument.document,
+        request.operationName,
+        request.variables,
+        request.onError,
+    )
   }
 }
 
@@ -188,5 +211,5 @@ internal fun prepareRequest(
     parserOptions: ParserOptions,
     request: GraphQLRequest,
 ): Either<List<Error>, PreparedRequest> = either {
-  prepareRequest(schema, coercings, persistedDocumentCache, parserOptions, request)
+  prepareRequest(schema, coercings, persistedDocumentCache, parserOptions, request, )
 }

--- a/libraries/apollo-execution/src/concurrentTest/kotlin/test/ExecutionTest.kt
+++ b/libraries/apollo-execution/src/concurrentTest/kotlin/test/ExecutionTest.kt
@@ -191,7 +191,7 @@ class ExecutionTest {
     val schema = """
             type Query {
                 foo: String!
-            } 
+            }
         """.trimIndent()
 
     val document = """
@@ -232,7 +232,7 @@ class ExecutionTest {
             {
                 ...queryDetails(first: 42)
             }
-            
+
             fragment queryDetails(${'$'}first: Int) on Query {
                 foo(first: ${'$'}first)
             }
@@ -263,7 +263,7 @@ class ExecutionTest {
             query GetFoo(${'$'}first: Int!) {
                 ...queryDetails(first: ${'$'}first)
             }
-            
+
             fragment queryDetails(${'$'}first: Int) on Query {
                 foo(first: ${'$'}first)
             }
@@ -295,7 +295,7 @@ class ExecutionTest {
                 a: foo(first: ${'$'}first)
                 ...queryDetails(first: 42)
             }
-            
+
             fragment queryDetails(${'$'}first: Int) on Query {
                 foo(first: ${'$'}first)
             }
@@ -326,7 +326,7 @@ class ExecutionTest {
             query GetFoo(${'$'}first: Int!) {
                 ...queryDetails
             }
-            
+
             fragment queryDetails on Query {
                 foo(first: ${'$'}first)
             }

--- a/libraries/apollo-execution/src/jvmTest/kotlin/test/FragmentExecutionTest.kt
+++ b/libraries/apollo-execution/src/jvmTest/kotlin/test/FragmentExecutionTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package test
+
+import com.apollographql.apollo.ast.GQLFragmentDefinition
+import com.apollographql.apollo.ast.GQLOperationDefinition
+import com.apollographql.apollo.ast.toGQLDocument
+import com.apollographql.apollo.execution.ExecutableSchema
+import com.apollographql.apollo.execution.PreparedRequest
+import com.apollographql.apollo.execution.RequestType
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class FragmentExecutionTest {
+  private fun String.toFragmentPreparedRequest(id: String?): PreparedRequest {
+    val document = this.toGQLDocument()
+    val fragments = document.definitions.filterIsInstance<GQLFragmentDefinition>()
+
+    val fragment = fragments.firstOrNull()
+    require(fragment != null) {
+      "No fragment found in document: $this"
+    }
+    return PreparedRequest.Builder()
+        .type(RequestType.Fragment)
+        .name(fragment.name)
+        .rootSelections(fragment.selections)
+        .typename(fragment.typeCondition.name)
+        .fragments(fragments.drop(1).associateBy { it.name })
+        .id(id)
+        .build()
+  }
+  @Test
+  fun fragmentOnQueryType() {
+    // language=graphql
+    val schema = """
+      type Query {
+        foo: Int
+      }
+    """.trimIndent()
+
+    val executableSchema = ExecutableSchema.Builder()
+      .schema(schema.toGQLDocument())
+      .resolver {
+        when (it.field.name) {
+          "foo" -> 42
+          else -> error("Unknown field '${it.field.name}'")
+        }
+      }
+      .build()
+
+    val response = runBlocking {
+      executableSchema.execute(
+        """
+        fragment queryFragment on Query { foo }
+      """.toFragmentPreparedRequest(null)
+      )
+    }
+
+    assertEquals(mapOf("foo" to 42), response.data)
+  }
+
+  @Test
+  fun fragmentOnOtehrType() {
+    // language=graphql
+    val schema = """
+      type Query {
+        user(id: ID!): User
+      }
+      type User {
+        id: ID!
+        name: String
+      }
+    """.trimIndent()
+
+    val executableSchema = ExecutableSchema.Builder()
+        .schema(schema.toGQLDocument())
+        .resolver {
+          when (it.field.name) {
+            "user" -> {
+              check(it.getArgument<String>("id").getOrThrow() == "42")
+              Unit
+            }
+            "id" -> "42"
+            "name" -> "Foobar"
+            else -> error("Unknown field '${it.field.name}'")
+          }
+        }
+        .build()
+
+    val response = runBlocking {
+      executableSchema.execute(
+          """
+        fragment userFragment on User { id name }
+      """.toFragmentPreparedRequest("42")
+      )
+    }
+
+    assertEquals(mapOf("id" to "42", "name" to "Foobar"), response.data)
+  }
+
+}

--- a/libraries/apollo-execution/src/jvmTest/kotlin/test/ParallelExecutionTest.kt
+++ b/libraries/apollo-execution/src/jvmTest/kotlin/test/ParallelExecutionTest.kt
@@ -127,11 +127,11 @@ class ParallelExecutionTest {
         {
             field1 {
                 subField1
-                subField2            
+                subField2
             }
             field2 {
                 subField1
-                subField2            
+                subField2
             }
         }
       """.trimIndent().toGraphQLRequest()
@@ -163,7 +163,7 @@ class ParallelExecutionTest {
       }
     """.trimIndent()
 
-        val executableSchema = ExecutableSchema.Builder()
+    val executableSchema = ExecutableSchema.Builder()
       .schema(schema.toGQLDocument())
       .resolver {
         return@resolver when (it.fieldName) {

--- a/tests/empty-selection-sets/build.gradle.kts
+++ b/tests/empty-selection-sets/build.gradle.kts
@@ -1,5 +1,3 @@
-@file:OptIn(ApolloExperimental::class)
-
 import com.apollographql.apollo.annotations.ApolloExperimental
 
 plugins {


### PR DESCRIPTION
Fragments do not have validation yet but `PreparedRequest` allows to bypass validation and go straight to execution given an id:

```kotlin
executableSchema.execute(
      """
        fragment userFragment on User { id name }
      """.toFragmentPreparedRequest("42")
)
```

