### PR TITLE
Fix warning in Java generated code

### DIFF
--- a/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
+++ b/libraries/apollo-api/src/commonMain/kotlin/com/apollographql/apollo/api/CompiledGraphQL.kt
@@ -228,10 +228,15 @@ class CompiledFragment internal constructor(
     possibleTypesSet.toList()
   }
 
+  /**
+   * @param possibleTypesSet the possible types. The set must be robust to calling `set.contains(null)`
+   */
   class Builder(val typeCondition: String, val possibleTypesSet: Set<String>) {
 
-    @Deprecated("Use the primary constructor instead")
-    @ApolloDeprecatedSince(ApolloDeprecatedSince.Version.v5_0_2)
+    /**
+     * If you have a [Set] around, use the primary constructor instead.
+     * This constructor is not deprecated because it's convenient to call from Java codegen.
+     */
     constructor(typeCondition: String, possibleTypes: List<String>) : this(typeCondition, possibleTypes.toSet())
 
     @Deprecated("Use possibleTypesSet instead")


### PR DESCRIPTION
Closes #7023

OK this was an interesting one. I initially thought we could use `Set.of()` but we can't because we rely on `set.contains(null)` in multiple places. Using `new LinkedHashSet<>(Arrays.asList(...))` would be the same thing as calling the existing constructor so I'm undeprecating it.

We _could_ maybe save the intermediate `List` but that'd have to be benchmarked.